### PR TITLE
Add stax open command to open repo in browser

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod log;
 pub mod merge;
 pub mod modify;
 pub mod navigate;
+pub mod open;
 pub mod pr;
 pub mod range_diff;
 pub mod redo;

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -1,0 +1,42 @@
+use crate::config::Config;
+use crate::git::GitRepo;
+use crate::remote::RemoteInfo;
+use anyhow::Result;
+use colored::Colorize;
+
+/// Open the repository in the default browser
+pub fn run() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    let repo_url = remote_info.repo_url();
+
+    println!("Opening {} in browser...", repo_url.cyan());
+
+    // Open in default browser
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&repo_url)
+            .spawn()
+            .ok();
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(&repo_url)
+            .spawn()
+            .ok();
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/c", "start", &repo_url])
+            .spawn()
+            .ok();
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,6 +309,9 @@ enum Commands {
     /// Open the PR for the current branch in browser
     Pr,
 
+    /// Open the repository in browser
+    Open,
+
     /// Show comments on the current branch's PR
     Comments {
         /// Output raw markdown without rendering
@@ -688,6 +691,7 @@ fn main() -> Result<()> {
             prefix,
         } => commands::branch::create::run(name, message, from, prefix, all),
         Commands::Pr => commands::pr::run(),
+        Commands::Open => commands::open::run(),
         Commands::Comments { plain } => commands::comments::run(plain),
         Commands::Ci { all, json, refresh } => commands::ci::run(all, json, refresh),
         Commands::Split => commands::split::run(),


### PR DESCRIPTION
## Summary
- Adds new `stax open` command that opens the repository in the default browser
- Works cross-platform (macOS, Linux, Windows)
- Reuses existing `RemoteInfo::repo_url()` method for URL generation

## Test plan
- [ ] Run `stax open` and verify browser opens to the repo URL
- [ ] Test on different platforms if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)