### PR TITLE
feat: AI-powered PR body generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,15 +580,46 @@ stax config  # Show config path and current settings
 Config at `~/.config/stax/config.toml`:
 
 ```toml
+# ~/.config/stax/config.toml — full reference with defaults
+
 [branch]
-prefix = "cesar/"      # Auto-prefix branches: "auth" → "cesar/auth"
+# DEPRECATED: Use `format` instead. Auto-prefix for branches.
+# prefix = "cesar/"
+
+# Branch name format template. Placeholders: {user}, {date}, {message}
+# format = "{user}/{date}/{message}"
+
+# Username for branch naming (default: git config user.name)
+# user = "cesar"
+
+# Date format for {date} placeholder (default: "%m-%d")
+# Uses chrono strftime: %Y=year, %m=month, %d=day
+# date_format = "%m-%d"
+
+# Character to replace spaces and special chars (default: "-")
+# replacement = "-"
 
 [remote]
-name = "origin"
-provider = "github"    # github, gitlab, gitea
+# Git remote name (default: "origin")
+# name = "origin"
+
+# Base web URL for GitHub (default: "https://github.com")
+# base_url = "https://github.com"
+
+# API base URL for GitHub Enterprise
+# api_base_url = "https://github.company.com/api/v3"
 
 [ui]
-tips = true            # Show contextual suggestions (default: true)
+# Show contextual tips/suggestions (default: true)
+# tips = true
+
+[ai]
+# AI agent for PR body generation: "claude" or "codex"
+# If not set, stax auto-detects installed agents and prompts on first use
+# agent = "claude"
+
+# Model to use with the AI agent (default: agent's own default)
+# model = "claude-sonnet-4-5-20250929"
 ```
 
 ### Branch Name Format
@@ -703,6 +734,46 @@ stax submit --no-template      # Empty body
 stax submit --edit             # Force editor open
 ```
 
+## AI-Powered PR Body Generation
+
+Generate a PR description using AI, based on your diff, commit messages, and the repo's PR template:
+
+```bash
+stax generate --pr-body
+```
+
+stax collects the diff, commit messages, and PR template for the current branch, sends them to an AI agent (Claude or Codex CLI), and updates the PR body on GitHub.
+
+### First Run
+
+If no AI agent is configured, stax auto-detects what's installed and walks you through setup:
+
+```
+? Select AI agent:
+> claude (default)
+  codex
+
+? Select model for claude:
+> claude-sonnet-4-5-20250929 — Sonnet 4.5 (default, balanced)
+  claude-haiku-4-5-20251001 — Haiku 4.5 (fastest, cheapest)
+  claude-opus-4-6 — Opus 4.6 (most capable)
+
+? Save choices to config? (Y/n): Y
+✓ Saved ai.agent = "claude", ai.model = "claude-sonnet-4-5-20250929"
+```
+
+### Options
+
+- `--agent <name>`: Override the configured agent for this invocation
+- `--model <name>`: Override the model (e.g., `claude-haiku-4-5-20251001`, `gpt-4.1-mini`)
+- `--edit`: Open $EDITOR to review/tweak the generated body before updating the PR
+
+```bash
+stax generate --pr-body --agent codex                        # Use codex this time
+stax generate --pr-body --model claude-haiku-4-5-20251001    # Use a specific model
+stax generate --pr-body --edit                               # Review in editor first
+```
+
 ## All Commands
 
 <details>
@@ -784,6 +855,8 @@ stax submit --edit             # Force editor open
 | `stax changelog <from> [to]` | Generate changelog between two refs |
 | `stax changelog v1.0 --path src/` | Changelog filtered by path (monorepo) |
 | `stax changelog v1.0 --json` | Output changelog as JSON |
+| `stax generate --pr-body` | Generate PR body with AI and update the PR |
+| `stax generate --pr-body --edit` | Generate and review in editor before updating |
 
 ### Common Flags
 - `stax create -m "msg"` - Create branch with commit message
@@ -811,6 +884,9 @@ stax submit --edit             # Force editor open
 - `stax status --json` - Output as JSON
 - `stax undo --yes` - Undo without prompts
 - `stax undo --no-push` - Undo locally only, skip remote
+- `stax generate --pr-body --edit` - Generate and review in editor
+- `stax generate --pr-body --agent codex` - Use specific AI agent
+- `stax generate --pr-body --model claude-haiku-4-5-20251001` - Use specific model
 
 **CI/Automation example:**
 ```bash

--- a/src/commands/cascade.rs
+++ b/src/commands/cascade.rs
@@ -38,6 +38,7 @@ pub fn run(no_submit: bool, no_pr: bool) -> Result<()> {
             None,   // template
             false,  // no_template
             false,  // edit
+            false,  // ai_body
         )?;
     }
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,0 +1,545 @@
+use crate::config::Config;
+use crate::engine::{BranchMetadata, Stack};
+use crate::git::GitRepo;
+use crate::github::pr_template::discover_pr_templates;
+use crate::github::GitHubClient;
+use crate::remote;
+use anyhow::{bail, Context, Result};
+use colored::Colorize;
+use dialoguer::{theme::ColorfulTheme, Confirm, Editor, Select};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+// ---------------------------------------------------------------------------
+// Known models per agent (for validation and interactive picker)
+// ---------------------------------------------------------------------------
+
+const CLAUDE_MODELS: &[(&str, &str)] = &[
+    (
+        "claude-sonnet-4-5-20250929",
+        "Sonnet 4.5 (default, balanced)",
+    ),
+    ("claude-haiku-4-5-20251001", "Haiku 4.5 (fastest, cheapest)"),
+    ("claude-opus-4-6", "Opus 4.6 (most capable)"),
+    ("claude-sonnet-4-20250514", "Sonnet 4"),
+];
+
+const CODEX_MODELS: &[(&str, &str)] = &[
+    ("gpt-5.3-codex", "GPT-5.3 Codex (default)"),
+    ("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark (Pro)"),
+    ("gpt-4.1-mini", "GPT-4.1 Mini"),
+];
+
+const SUPPORTED_AGENTS: &[&str] = &["claude", "codex"];
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+pub fn run(edit: bool, agent_flag: Option<String>, model_flag: Option<String>) -> Result<()> {
+    let config = Config::load()?;
+    let repo = GitRepo::open()?;
+    let workdir = repo.workdir()?.to_path_buf();
+    let stack = Stack::load(&repo)?;
+    let current_branch = repo.current_branch()?;
+
+    // Ensure current branch is tracked
+    let branch_info = stack
+        .branches
+        .get(&current_branch)
+        .context("Current branch is not tracked by stax. Run `stax branch track` first.")?;
+
+    let parent = branch_info
+        .parent
+        .as_deref()
+        .context("Current branch has no parent set")?;
+
+    // Read metadata to find existing PR
+    let meta = BranchMetadata::read(repo.inner(), &current_branch)?
+        .context("No metadata for current branch")?;
+
+    let pr_number = meta
+        .pr_info
+        .as_ref()
+        .filter(|p| p.number > 0)
+        .map(|p| p.number)
+        .context("No PR found for current branch. Submit first with `stax submit` or `stax ss`.")?;
+
+    // Resolve AI agent and model (interactive if needed)
+    let mut config = config;
+    let agent = resolve_agent(agent_flag.as_deref(), &mut config)?;
+    let model = resolve_model(model_flag.as_deref(), &config, &agent)?;
+
+    // Collect context for the prompt
+    println!("{}", "Collecting context...".dimmed());
+    let diff_stat = get_diff_stat(&workdir, parent, &current_branch);
+    let diff = get_full_diff(&workdir, parent, &current_branch);
+    let commits = collect_commit_messages(&workdir, parent, &current_branch);
+    let templates = discover_pr_templates(&workdir).unwrap_or_default();
+    let template_content = templates.first().map(|t| t.content.as_str());
+
+    if diff.trim().is_empty() && commits.is_empty() {
+        bail!("No changes found between {} and {}", parent, current_branch);
+    }
+
+    // Build the AI prompt
+    let prompt = build_ai_prompt(&diff_stat, &diff, &commits, template_content);
+
+    // Invoke AI agent
+    let model_display = model.as_deref().unwrap_or("default");
+    println!(
+        "  {} {} (model: {})...",
+        "Generating PR body with".dimmed(),
+        agent.cyan().bold(),
+        model_display.dimmed()
+    );
+
+    let generated_body = invoke_ai_agent(&agent, model.as_deref(), &prompt)?;
+
+    if generated_body.trim().is_empty() {
+        bail!("AI agent returned an empty response");
+    }
+
+    // Let user review/edit the generated body
+    let final_body = if edit {
+        Editor::new()
+            .edit(&generated_body)?
+            .unwrap_or(generated_body)
+    } else {
+        // Show preview and confirm
+        println!();
+        println!("{}", "─── Generated PR Body ───".blue().bold());
+        println!("{}", generated_body);
+        println!("{}", "──────────────────────────".blue().bold());
+        println!();
+
+        let options = vec!["Use as-is", "Edit in $EDITOR", "Cancel"];
+        let choice = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("What would you like to do?")
+            .items(&options)
+            .default(0)
+            .interact()?;
+
+        match choice {
+            0 => generated_body,
+            1 => Editor::new()
+                .edit(&generated_body)?
+                .unwrap_or(generated_body),
+            _ => {
+                println!("{}", "Cancelled.".yellow());
+                return Ok(());
+            }
+        }
+    };
+
+    // Update the PR body on GitHub
+    print!("  Updating PR #{} body... ", pr_number.to_string().cyan());
+    std::io::stdout().flush().ok();
+
+    let remote_info = remote::RemoteInfo::from_repo(&repo, &config)?;
+    let owner = remote_info.owner().to_string();
+    let repo_name = remote_info.repo.clone();
+
+    let runtime = tokio::runtime::Runtime::new()?;
+    let client = runtime.block_on(async {
+        GitHubClient::new(&owner, &repo_name, remote_info.api_base_url.clone())
+    })?;
+
+    runtime.block_on(async { client.update_pr_body(pr_number, &final_body).await })?;
+
+    println!("{}", "done".green());
+    println!(
+        "  {} PR #{} body updated successfully",
+        "✓".green().bold(),
+        pr_number
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Agent resolution
+// ---------------------------------------------------------------------------
+
+fn resolve_agent(cli_flag: Option<&str>, config: &mut Config) -> Result<String> {
+    // 1. CLI flag takes priority
+    if let Some(agent) = cli_flag {
+        validate_agent_name(agent)?;
+        return Ok(agent.to_string());
+    }
+
+    // 2. Config value
+    if let Some(ref agent) = config.ai.agent {
+        if !agent.is_empty() {
+            return Ok(agent.clone());
+        }
+    }
+
+    // 3. Auto-detect from PATH
+    let available = detect_available_agents();
+
+    match available.len() {
+        0 => {
+            bail!(
+                "No AI agent found on PATH.\n  \
+                 Install one of:\n    \
+                 - claude (https://docs.anthropic.com)\n    \
+                 - codex  (https://github.com/openai/codex)\n  \
+                 Or set manually in ~/.config/stax/config.toml:\n    \
+                 [ai]\n    \
+                 agent = \"claude\""
+            );
+        }
+        1 => {
+            let agent = available[0].clone();
+            println!(
+                "  {} {}",
+                "Detected AI agent:".dimmed(),
+                agent.cyan().bold()
+            );
+
+            // Still show model picker, then offer to save
+            let model = pick_model_interactive(&agent)?;
+            let save = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Save choices to config?")
+                .default(true)
+                .interact()?;
+
+            if save {
+                config.ai.agent = Some(agent.clone());
+                config.ai.model = model.clone();
+                config.save()?;
+                let model_display = model.as_deref().unwrap_or("agent default");
+                println!(
+                    "  {} Saved ai.agent = \"{}\", ai.model = \"{}\"",
+                    "✓".green().bold(),
+                    agent,
+                    model_display
+                );
+            }
+
+            Ok(agent)
+        }
+        _ => {
+            // Multiple agents: show picker
+            let items: Vec<String> = available
+                .iter()
+                .enumerate()
+                .map(|(i, name)| {
+                    if i == 0 {
+                        format!("{} (default)", name)
+                    } else {
+                        name.to_string()
+                    }
+                })
+                .collect();
+
+            let selection = Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Select AI agent")
+                .items(&items)
+                .default(0)
+                .interact()?;
+
+            let agent = available[selection].clone();
+
+            // Show model picker
+            let model = pick_model_interactive(&agent)?;
+
+            let save = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Save choices to config?")
+                .default(true)
+                .interact()?;
+
+            if save {
+                config.ai.agent = Some(agent.clone());
+                config.ai.model = model.clone();
+                config.save()?;
+                let model_display = model.as_deref().unwrap_or("agent default");
+                println!(
+                    "  {} Saved ai.agent = \"{}\", ai.model = \"{}\"",
+                    "✓".green().bold(),
+                    agent,
+                    model_display
+                );
+            }
+
+            Ok(agent)
+        }
+    }
+}
+
+fn validate_agent_name(agent: &str) -> Result<()> {
+    if !SUPPORTED_AGENTS.contains(&agent) {
+        bail!(
+            "Unsupported AI agent: '{}'. Supported agents: {}",
+            agent,
+            SUPPORTED_AGENTS.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn detect_available_agents() -> Vec<String> {
+    SUPPORTED_AGENTS
+        .iter()
+        .filter(|&&name| which_exists(name))
+        .map(|&name| name.to_string())
+        .collect()
+}
+
+fn which_exists(command: &str) -> bool {
+    Command::new("which")
+        .arg(command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Model resolution
+// ---------------------------------------------------------------------------
+
+fn resolve_model(cli_flag: Option<&str>, config: &Config, agent: &str) -> Result<Option<String>> {
+    // 1. CLI flag takes priority
+    if let Some(model) = cli_flag {
+        validate_model_soft(agent, model);
+        return Ok(Some(model.to_string()));
+    }
+
+    // 2. Config value
+    if let Some(ref model) = config.ai.model {
+        if !model.is_empty() {
+            validate_model_soft(agent, model);
+            return Ok(Some(model.clone()));
+        }
+    }
+
+    // 3. No model specified — let agent use its own default
+    Ok(None)
+}
+
+fn pick_model_interactive(agent: &str) -> Result<Option<String>> {
+    let models = known_models_for(agent);
+    if models.is_empty() {
+        return Ok(None);
+    }
+
+    let items: Vec<String> = models
+        .iter()
+        .map(|(id, desc)| format!("{} — {}", id, desc))
+        .collect();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Select model for {}", agent))
+        .items(&items)
+        .default(0)
+        .interact()?;
+
+    Ok(Some(models[selection].0.to_string()))
+}
+
+fn validate_model_soft(agent: &str, model: &str) {
+    let models = known_models_for(agent);
+    if !models.is_empty() && !models.iter().any(|(id, _)| *id == model) {
+        eprintln!(
+            "  {} Unknown model '{}' for agent '{}', proceeding anyway...",
+            "⚠".yellow(),
+            model.yellow(),
+            agent
+        );
+    }
+}
+
+fn known_models_for(agent: &str) -> &'static [(&'static str, &'static str)] {
+    match agent {
+        "claude" => CLAUDE_MODELS,
+        "codex" => CODEX_MODELS,
+        _ => &[],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Context collection
+// ---------------------------------------------------------------------------
+
+pub fn get_diff_stat(workdir: &Path, parent: &str, branch: &str) -> String {
+    let output = Command::new("git")
+        .args(["diff", "--stat", &format!("{}..{}", parent, branch)])
+        .current_dir(workdir)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+pub fn get_full_diff(workdir: &Path, parent: &str, branch: &str) -> String {
+    let output = Command::new("git")
+        .args(["diff", &format!("{}..{}", parent, branch)])
+        .current_dir(workdir)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+fn collect_commit_messages(workdir: &Path, parent: &str, branch: &str) -> Vec<String> {
+    let output = Command::new("git")
+        .args([
+            "log",
+            "--reverse",
+            "--format=%s",
+            &format!("{}..{}", parent, branch),
+        ])
+        .current_dir(workdir)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(|line| line.trim().to_string())
+            .filter(|line| !line.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+const MAX_DIFF_BYTES: usize = 80_000; // ~80KB limit to stay within context windows
+
+pub fn build_ai_prompt(
+    diff_stat: &str,
+    diff: &str,
+    commits: &[String],
+    template: Option<&str>,
+) -> String {
+    let mut prompt = String::new();
+
+    prompt.push_str("Generate a pull request description for the following changes.\n\n");
+
+    if let Some(tmpl) = template {
+        prompt.push_str(
+            "Use this PR template as the structure. Fill in each section based on the changes:\n\n",
+        );
+        prompt.push_str(tmpl);
+        prompt.push_str("\n\n");
+    } else {
+        prompt.push_str("Use a clear markdown format with a Summary section.\n\n");
+    }
+
+    if !commits.is_empty() {
+        prompt.push_str("Commit messages:\n");
+        for msg in commits {
+            prompt.push_str(&format!("- {}\n", msg));
+        }
+        prompt.push('\n');
+    }
+
+    if !diff_stat.is_empty() {
+        prompt.push_str("Diff stat (file-level summary):\n```\n");
+        prompt.push_str(diff_stat);
+        prompt.push_str("\n```\n\n");
+    }
+
+    if !diff.is_empty() {
+        let truncated = if diff.len() > MAX_DIFF_BYTES {
+            let safe = &diff[..MAX_DIFF_BYTES];
+            // Cut at last newline to avoid splitting a line
+            let cut = safe.rfind('\n').unwrap_or(MAX_DIFF_BYTES);
+            format!(
+                "{}\n\n... (diff truncated, showing first ~80KB of {} total) ...",
+                &diff[..cut],
+                format_bytes(diff.len())
+            )
+        } else {
+            diff.to_string()
+        };
+
+        prompt.push_str("Full diff:\n```diff\n");
+        prompt.push_str(&truncated);
+        prompt.push_str("\n```\n\n");
+    }
+
+    prompt.push_str("Write only the PR body in markdown. Do not include any preamble, explanation, or wrapping code fences.");
+
+    prompt
+}
+
+fn format_bytes(bytes: usize) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1}MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1}KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{}B", bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AI agent invocation
+// ---------------------------------------------------------------------------
+
+pub fn invoke_ai_agent(agent: &str, model: Option<&str>, prompt: &str) -> Result<String> {
+    let mut args: Vec<String> = Vec::new();
+
+    match agent {
+        "claude" => {
+            args.extend(["-p".into(), "--output-format".into(), "text".into()]);
+            if let Some(m) = model {
+                args.extend(["--model".into(), m.into()]);
+            }
+        }
+        "codex" => {
+            args.push("exec".into());
+            if let Some(m) = model {
+                args.extend(["--model".into(), m.into()]);
+            }
+        }
+        _ => bail!("Unsupported agent: {}", agent),
+    }
+
+    let mut child = Command::new(agent)
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context(format!(
+            "Failed to start '{}'. Is it installed and on your PATH?",
+            agent
+        ))?;
+
+    // Write prompt to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt.as_bytes())
+            .context("Failed to write prompt to AI agent stdin")?;
+        // stdin is dropped here, closing the pipe
+    }
+
+    let output = child
+        .wait_with_output()
+        .context("Failed to read AI agent output")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "AI agent '{}' exited with status {}:\n{}",
+            agent,
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(body)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod continue_cmd;
 pub mod copy;
 pub mod diff;
 pub mod doctor;
+pub mod generate;
 pub mod init;
 pub mod log;
 pub mod merge;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -528,11 +528,12 @@ pub fn run(
 
         // Scope restacking to the stack we started on, even if sync switched branches
         // (for example, if the current branch was deleted after merge).
-        let scope_order: Vec<String> = if current != stack.trunk && stack.branches.contains_key(&current) {
-            stack.current_stack(&current)
-        } else {
-            Vec::new()
-        };
+        let scope_order: Vec<String> =
+            if current != stack.trunk && stack.branches.contains_key(&current) {
+                stack.current_stack(&current)
+            } else {
+                Vec::new()
+            };
         // Reload stack to use fresh metadata after sync/deletion steps.
         let restack_stack = Stack::load(&repo)?;
         let branches_to_restack: Vec<String> = scope_order

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub remote: RemoteConfig,
     #[serde(default)]
     pub ui: UiConfig,
+    #[serde(default)]
+    pub ai: AiConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,6 +37,7 @@ pub struct BranchConfig {
     /// - {user}: Git username (from config.branch.user or git user.name)
     /// - {date}: Current date (formatted by date_format)
     /// - {message}: The branch name/message input
+    ///
     /// Examples: "{message}", "{user}/{message}", "{user}/{date}/{message}"
     #[serde(default)]
     pub format: Option<String>,
@@ -61,6 +64,16 @@ pub struct UiConfig {
     /// Whether to show contextual tips/suggestions (default: true)
     #[serde(default = "default_tips")]
     pub tips: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AiConfig {
+    /// AI agent to use: "claude" or "codex" (default: auto-detect)
+    #[serde(default)]
+    pub agent: Option<String>,
+    /// Model to use with the AI agent (default: agent's own default)
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 impl Default for BranchConfig {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -323,8 +323,7 @@ fn test_github_token_env_takes_priority_over_file() {
     let orig_github = env::var("GITHUB_TOKEN").ok();
 
     // Create temp directory with credentials file
-    let temp_dir =
-        std::env::temp_dir().join(format!("stax-test-priority-{}", std::process::id()));
+    let temp_dir = std::env::temp_dir().join(format!("stax-test-priority-{}", std::process::id()));
     let config_dir = temp_dir.join(".config").join("stax");
     fs::create_dir_all(&config_dir).unwrap();
 

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -467,6 +467,18 @@ impl GitHubClient {
         Ok(())
     }
 
+    /// Update PR body text
+    pub async fn update_pr_body(&self, pr_number: u64, body: &str) -> Result<()> {
+        self.octocrab
+            .pulls(&self.owner, &self.repo)
+            .update(pr_number)
+            .body(body)
+            .send()
+            .await
+            .context("Failed to update PR body")?;
+        Ok(())
+    }
+
     /// Add or update the stack comment on a PR
     pub async fn update_stack_comment(&self, pr_number: u64, stack_comment: &str) -> Result<()> {
         let comments = self


### PR DESCRIPTION
## Summary

Adds AI-powered PR body generation using Claude or Codex CLI. stax collects the diff, commit messages, and repo PR template, sends them to an AI agent, and updates the PR body on GitHub.

## New commands

### `stax generate --pr-body`

Generates a PR description for the current branch and updates the existing PR on GitHub.

- **First run**: If no AI agent is configured, stax auto-detects what's installed (claude/codex) and walks you through setup with an interactive picker. You can save your choices to `~/.config/stax/config.toml`.
- **Options**: `--agent`, `--model`, `--edit` (review in $EDITOR before updating)

### `stax submit --ai-body`

Generates the PR body using AI during PR creation instead of using the default template/commit-based body. Falls back to the default body if AI generation fails.

## How it works

- **Shell-out only**: No API keys in stax. Uses the claude or codex CLI (you must have one installed and authenticated).
- **Template-aware**: If the repo has a PR template (e.g. `.github/PULL_REQUEST_TEMPLATE.md`), it's passed to the AI so the output follows the template structure.
- **Diff truncation**: Large diffs are capped at ~80KB to stay within context limits; `git diff --stat` is always included for overview.
- **Model selection**: Supports `--model` flag and `[ai] model = "..."` in config. Known models are validated with a soft warning for unknowns.

## Config

```toml
[ai]
agent = "claude"   # or "codex"
model = "claude-haiku-4-5-20251001"   # optional, uses agent default if not set
```

## README updates

- Full config reference with all fields and defaults (replaces incomplete example)
- New AI-Powered PR Body Generation section with usage and first-run flow
- Added `[ai]` section to config docs

