### PR TITLE
improving TUI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+{{brief_summary_of_the_change}}
+
+## Key changes
+
+### {{change_area_1}}
+
+{{what_changed_and_why}}
+
+### {{change_area_2}}
+
+{{what_changed_and_why}}
+
+## How it works
+
+- **Behavior**: {{runtime_or_user_facing_behavior}}
+- **Implementation**: {{technical_approach}}
+- **Tradeoffs**: {{limits_or_design_decisions}}
+
+## Configuration changes
+
+- [ ] No config changes
+- [ ] Config changes included (describe below)
+
+```toml
+# add or update config examples here when relevant
+```
+
+## Testing
+
+- [ ] `cargo test` (or `cargo nextest run`)
+- [ ] `cargo check`
+- [ ] `cargo clippy -- -D warnings`
+- [ ] `cargo fmt -- --check`
+- [ ] Manual verification (if applicable)
+
+Commands/output (if relevant):
+
+```bash
+# paste commands run and notable output
+```

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -46,11 +46,15 @@ pub fn write_metadata(repo: &Repository, branch: &str, json: &str) -> Result<()>
 
     // Update the ref to point to the blob
     let ref_name = format!("{}{}", METADATA_REF_PREFIX, branch);
-    Command::new("git")
+    let status = Command::new("git")
         .args(["update-ref", &ref_name, &hash])
         .current_dir(workdir)
         .status()
         .context("Failed to update ref")?;
+
+    if !status.success() {
+        anyhow::bail!("Failed to update ref {}", ref_name);
+    }
 
     Ok(())
 }
@@ -62,11 +66,15 @@ pub fn delete_metadata(repo: &Repository, branch: &str) -> Result<()> {
         .workdir()
         .context("Repository has no working directory")?;
 
-    Command::new("git")
+    let status = Command::new("git")
         .args(["update-ref", "-d", &ref_name])
         .current_dir(workdir)
         .status()
         .context("Failed to delete ref")?;
+
+    if !status.success() {
+        anyhow::bail!("Failed to delete ref {}", ref_name);
+    }
 
     Ok(())
 }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -494,8 +494,11 @@ impl GitRepo {
 
     /// Get diff between a branch and its parent
     pub fn diff_against_parent(&self, branch: &str, parent: &str) -> Result<Vec<String>> {
+        // Use merge-base diff (A...B) to match PR semantics and avoid showing unrelated
+        // parent-side changes when the parent branch has advanced.
+        let range = format!("{}...{}", parent, branch);
         let output = Command::new("git")
-            .args(["diff", "--color=never", parent, branch])
+            .args(["diff", "--color=never", &range])
             .current_dir(self.workdir()?)
             .output()
             .context("Failed to get diff")?;
@@ -510,8 +513,9 @@ impl GitRepo {
 
     /// Get diff stat (numstat) between a branch and its parent
     pub fn diff_stat(&self, branch: &str, parent: &str) -> Result<Vec<(String, usize, usize)>> {
+        let range = format!("{}...{}", parent, branch);
         let output = Command::new("git")
-            .args(["diff", "--numstat", parent, branch])
+            .args(["diff", "--numstat", &range])
             .current_dir(self.workdir()?)
             .output()
             .context("Failed to get diff stat")?;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,17 +1,14 @@
 # Plan
-- [x] Add submit scope support in `src/commands/submit.rs` (`SubmitScope`, scoped branch selection, and narrow-scope safety checks).
-- [x] Wire scoped submit subcommands in `src/main.rs` for `branch submit`, `upstack submit`, and `downstack submit` while keeping top-level `submit` stack-scoped.
-- [x] Update docs in `README.md` and `skills.md` for scoped submit commands and freephite mapping.
-- [x] Add/adjust CLI and integration tests for new help/output and scope behavior.
-- [x] Run requested test suites and document review results.
+- [x] Make stack loading ignore/prune metadata entries for branches that no longer exist locally.
+- [x] Make metadata ref deletion/writes fail on git errors (so stale metadata cannot silently survive).
+- [x] Switch TUI diff/stat generation to PR-style merge-base diffs instead of direct parent-vs-branch tree diffs.
+- [x] Add TUI diff caching so up/down navigation doesn’t recompute expensive diffs on every keypress.
+- [x] Run focused tests and document review results.
 
 # Review
-- [x] Added `SubmitScope` and scope-aware submit branch selection in `/Users/cesarferreira/code/github/stax/src/commands/submit.rs`.
-- [x] Added narrow-scope safety guards for `branch`/`upstack` submit and explicit trunk submit failure in `/Users/cesarferreira/code/github/stax/src/commands/submit.rs`.
-- [x] Added `--no-pr` push-only planning path that avoids mandatory GitHub API calls while preserving best-effort PR metadata refresh in `/Users/cesarferreira/code/github/stax/src/commands/submit.rs`.
-- [x] Added reusable `SubmitOptions` plus subcommand wiring for `stax branch submit`, `stax upstack submit`, `stax downstack submit` in `/Users/cesarferreira/code/github/stax/src/main.rs`.
-- [x] Updated cascade submit invocation to pass stack scope in `/Users/cesarferreira/code/github/stax/src/commands/cascade.rs`.
-- [x] Updated user-facing docs and parity mappings in `/Users/cesarferreira/code/github/stax/README.md` and `/Users/cesarferreira/code/github/stax/skills.md`.
-- [x] Added scoped submit help coverage in `/Users/cesarferreira/code/github/stax/tests/cli_tests.rs`.
-- [x] Added integration coverage for scoped submit behaviors and narrow-scope safety in `/Users/cesarferreira/code/github/stax/tests/integration_tests.rs`.
-- [x] Validation run: `cargo test --test cli_tests` and `cargo test --test integration_tests` (both passing).
+- [x] `Stack::load` now skips metadata entries whose local branch no longer exists and best-effort deletes those stale metadata refs (`/Users/cesarferreira/code/github/stax/src/engine/stack.rs`).
+- [x] Metadata git-ref operations now fail loudly on non-zero `git update-ref` exit status (`/Users/cesarferreira/code/github/stax/src/git/refs.rs`).
+- [x] TUI diff/stat now uses merge-base diff range (`parent...branch`) to match PR semantics and avoid pulling in unrelated parent-side changes (`/Users/cesarferreira/code/github/stax/src/git/repo.rs`).
+- [x] Added in-memory diff cache keyed by `parent...branch`, and clear cache on refresh so navigation reuses previously loaded diffs (`/Users/cesarferreira/code/github/stax/src/tui/app.rs`).
+- [x] Verification: `cargo test --test tui_commands_tests` passed; focused suites `cargo test engine::stack::tests::` and `cargo test git::repo::tests::` passed.
+- [x] Note: `cargo test --lib` has pre-existing unrelated failures in config tests (`test_github_token_roundtrip`, `test_github_token_trims_whitespace_from_file`, `test_format_template_empty_user_message_only_format`).


### PR DESCRIPTION
## Summary

Improve TUI diff behavior and performance, and harden stack metadata handling so stale branch metadata is cleaned up and git ref failures are surfaced instead of silently ignored.

## Key changes

### Stack metadata resilience

`Stack::load` now checks whether each tracked branch still exists locally before loading metadata. If the branch is gone (for example after an interrupted delete), the stale metadata ref is pruned best-effort and skipped.  
`git update-ref` write/delete calls now fail on non-zero exit status, preventing silent metadata corruption or leftovers.

### PR-style diff semantics in TUI

Diff and numstat generation now use `parent...branch` (merge-base range) instead of direct `parent branch` comparison. This aligns TUI output with PR semantics and avoids showing unrelated changes introduced only by parent branch advancement.

### TUI diff caching

Added an in-memory diff cache keyed by `parent...branch`. When navigating between branches, previously computed diff/stat data is reused instead of recomputed on each selection. Cache is cleared on refresh to avoid stale views.

## How it works

- **Behavior**: TUI diff panel is faster during branch navigation and shows PR-like diffs; stale metadata for deleted branches is automatically ignored/cleaned; metadata ref command failures now surface as errors.
- **Implementation**: Added local-branch existence checks in stack loading, explicit subprocess exit-status validation in metadata ref helpers, merge-base diff ranges in git repo diff methods, and `HashMap`-backed cached diff storage in TUI app state.
- **Tradeoffs**: Diff caching increases memory usage proportional to visited branch diffs; stale metadata pruning during load is best-effort (cleanup failures are ignored at prune time but future write/delete operations now fail loudly).

## Configuration changes

- [x] No config changes
- [ ] Config changes included (describe below)

```toml
# add or update config examples here when relevant
```

## Testing

- [ ] `cargo test` (or `cargo nextest run`)
- [ ] `cargo check`
- [ ] `cargo clippy -- -D warnings`
- [ ] `cargo fmt -- --check`
- [x] Manual verification (if applicable)

Commands/output (if relevant):

```bash
cargo test --test tui_commands_tests
# passed

cargo test engine::stack::tests::
# passed

cargo test git::repo::tests::
# passed

# Note: cargo test --lib still has pre-existing unrelated failures in config tests:
# - test_github_token_roundtrip
# - test_github_token_trims_whitespace_from_file
# - test_format_template_empty_user_message_only_format
```