### PR TITLE
Fix restack cascading and cascade auto-stash behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Split uses the transaction system, so you can `stax undo` if needed.
 | `stax merge` | Merge PRs from bottom of stack up to current branch |
 | `stax rs` | Repo sync - pull trunk, clean up merged branches |
 | `stax rs --restack` | Sync and rebase all branches onto updated trunk |
+| `stax restack` | Restack current stack (ancestors + current + descendants) |
 | `stax restack --auto-stash-pop` | Restack even when target worktrees are dirty (auto-stash/pop) |
 | `stax rs --restack --auto-stash-pop` | Sync, restack, auto-stash/pop dirty worktrees |
 | `stax cascade` | Restack from bottom, push, and create/update PRs |
@@ -941,7 +942,7 @@ stax generate --pr-body --edit                               # Review in editor 
 | `stax submit` | `ss` | Submit full current stack (ancestors + current + descendants) |
 | `stax merge` | | Merge PRs from bottom of stack to current |
 | `stax sync` | `rs` | Pull trunk, delete merged branches |
-| `stax restack` | | Rebase current branch onto parent |
+| `stax restack` | | Restack current stack (ancestors + current + descendants) |
 | `stax diff` | | Show diffs for each branch vs parent |
 | `stax range-diff` | | Show range-diff for branches needing restack |
 


### PR DESCRIPTION
## Summary
- Fix `stax restack` to evaluate `needs_restack` live while walking the selected scope, so one run can restack descendants that become stale after parent rebases.
- Fix quiet-mode restack dirty-worktree handling to honor `--auto-stash-pop`, which makes `stax cascade --no-submit --auto-stash-pop` behave as documented.
- Clarify README command descriptions for `stax restack` to describe current-stack behavior.

## Test plan
- [x] Rebuilt and installed local binary: `cargo install --path . --force --bin stax`
- [x] Reproduced and validated in a real repo: `/workspace/forest/gaia-x`
- [x] `stax cascade --no-submit --auto-stash-pop` now succeeds on dirty worktree (no fast-fail)
- [x] `stax ls -c` confirms current simulator stack no longer marked `needs restack`
- [x] Focused unit tests pass: `cargo test --lib test_needs_restack && cargo test --lib test_current_stack_from_leaf`
- [ ] Full `cargo test` still has unrelated existing config/env test failures in this environment

Made with [Cursor](https://cursor.com)