### PR TITLE
Fix restack cascading and auto-stash behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Split uses the transaction system, so you can `stax undo` if needed.
 | `stax merge` | Merge PRs from bottom of stack up to current branch |
 | `stax rs` | Repo sync - pull trunk, clean up merged branches |
 | `stax rs --restack` | Sync and rebase all branches onto updated trunk |
+| `stax restack` | Restack current stack (ancestors + current + descendants) |
 | `stax restack --auto-stash-pop` | Restack even when target worktrees are dirty (auto-stash/pop) |
 | `stax rs --restack --auto-stash-pop` | Sync, restack, auto-stash/pop dirty worktrees |
 | `stax cascade` | Restack from bottom, push, and create/update PRs |
@@ -870,7 +871,7 @@ stax generate --pr-body --edit                               # Review in editor 
 | `stax submit` | `ss` | Submit full current stack (ancestors + current + descendants) |
 | `stax merge` | | Merge PRs from bottom of stack to current |
 | `stax sync` | `rs` | Pull trunk, delete merged branches |
-| `stax restack` | | Rebase current branch onto parent |
+| `stax restack` | | Restack current stack (ancestors + current + descendants) |
 | `stax diff` | | Show diffs for each branch vs parent |
 | `stax range-diff` | | Show range-diff for branches needing restack |
 


### PR DESCRIPTION
Re-evaluate needs_restack live within the selected scope so one restack run can cascade through descendants that become stale mid-operation. Also honor --auto-stash-pop in quiet mode so cascade --no-submit works on dirty worktrees as documented.

## Summary

{{brief_summary_of_the_change}}

## Key changes

### {{change_area_1}}

{{what_changed_and_why}}

### {{change_area_2}}

{{what_changed_and_why}}

## How it works

- **Behavior**: {{runtime_or_user_facing_behavior}}
- **Implementation**: {{technical_approach}}
- **Tradeoffs**: {{limits_or_design_decisions}}

## Configuration changes

- [ ] No config changes
- [ ] Config changes included (describe below)

```toml
# add or update config examples here when relevant
```

## Testing

- [ ] `cargo test` (or `cargo nextest run`)
- [ ] `cargo check`
- [ ] `cargo clippy -- -D warnings`
- [ ] `cargo fmt -- --check`
- [ ] Manual verification (if applicable)

Commands/output (if relevant):

```bash
# paste commands run and notable output
```
