### PR TITLE
Add OpenCode support for AI PR generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ Config at `~/.config/stax/config.toml`:
 # tips = true
 
 [ai]
-# AI agent for PR body generation: "claude", "codex", or "gemini"
+# AI agent for PR body generation: "claude", "codex", "gemini", or "opencode"
 # If not set, stax auto-detects installed agents and prompts on first use
 # agent = "claude"
 
@@ -798,6 +798,17 @@ curl -o GEMINI.md https://raw.githubusercontent.com/cesarferreira/stax/main/skil
 
 Gemini CLI loads project instructions from `GEMINI.md`, so this gives it stack-aware workflow guidance for branch creation, submit flows, and related operations.
 
+## OpenCode Integration
+
+Teach OpenCode how to use stax by installing the skill file in OpenCode's skills directory:
+
+```bash
+mkdir -p ~/.config/opencode/skills/stax
+curl -o ~/.config/opencode/skills/stax/SKILL.md https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md
+```
+
+This enables OpenCode to help with stax workflows, stack operations, and PR generation.
+
 ## Freephite/Graphite Compatibility
 
 stax uses the same metadata format as freephite and supports similar commands:
@@ -870,7 +881,7 @@ Generate a PR description using AI, based on your diff, commit messages, and the
 stax generate --pr-body
 ```
 
-stax collects the diff, commit messages, and PR template for the current branch, sends them to an AI agent (Claude, Codex, or Gemini CLI), and updates the PR body on GitHub.
+stax collects the diff, commit messages, and PR template for the current branch, sends them to an AI agent (Claude, Codex, Gemini CLI, or OpenCode), and updates the PR body on GitHub.
 
 Prerequisites:
 - Current branch must be tracked by stax
@@ -891,6 +902,7 @@ If no AI agent is configured, stax auto-detects what's installed and walks you t
 > claude (default)
   codex
   gemini
+  opencode
 
 ? Select model for claude:
 > claude-sonnet-4-5-20250929 — Sonnet 4.5 (default, balanced)
@@ -903,7 +915,7 @@ If no AI agent is configured, stax auto-detects what's installed and walks you t
 
 ### Options
 
-- `--agent <name>`: Override the configured agent for this invocation (`claude`, `codex`, `gemini`)
+- `--agent <name>`: Override the configured agent for this invocation (`claude`, `codex`, `gemini`, `opencode`)
 - `--model <name>`: Override the model (e.g., `claude-haiku-4-5-20251001`, `gpt-4.1-mini`, `gemini-2.5-flash`)
 - `--edit`: Open $EDITOR to review/tweak the generated body before updating the PR
 
@@ -911,6 +923,7 @@ If no AI agent is configured, stax auto-detects what's installed and walks you t
 stax generate --pr-body --agent codex                        # Use codex this time
 stax generate --pr-body --model claude-haiku-4-5-20251001    # Use a specific model
 stax generate --pr-body --agent gemini --model gemini-2.5-flash
+stax generate --pr-body --agent opencode
 stax generate --pr-body --edit                               # Review in editor first
 ```
 
@@ -1070,6 +1083,7 @@ stax generate --pr-body --edit                               # Review in editor 
 - `stax generate --pr-body --edit` - Generate and review in editor
 - `stax generate --pr-body --agent codex` - Use specific AI agent
 - `stax generate --pr-body --agent gemini` - Use Gemini CLI as the agent
+- `stax generate --pr-body --agent opencode` - Use OpenCode as the agent
 - `stax generate --pr-body --model claude-haiku-4-5-20251001` - Use specific model
 
 **CI/Automation example:**

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -29,7 +29,7 @@ Main config path: `~/.config/stax/config.toml`
 # tips = true
 
 [ai]
-# agent = "claude" # or "codex" / "gemini"
+# agent = "claude" # or "codex" / "gemini" / "opencode"
 # model = "claude-sonnet-4-5-20250929"
 ```
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -9,4 +9,4 @@ curl -o ~/.claude/skills/stax.md https://raw.githubusercontent.com/cesarferreira
 
 This enables workflow assistance for stacked branch creation, submit flows, and related operations.
 
-For Codex setup, see [Codex Integration](codex.md). For Gemini setup, see [Gemini CLI Integration](gemini-cli.md).
+For Codex setup, see [Codex Integration](codex.md). For Gemini setup, see [Gemini CLI Integration](gemini-cli.md). For OpenCode setup, see [OpenCode Integration](opencode.md).

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -9,4 +9,4 @@ curl -o "${CODEX_HOME:-$HOME/.codex}/skills/stax/SKILL.md" https://raw.githubuse
 
 This enables Codex to help with stacked branch creation, submit flows, and related operations.
 
-For Claude Code setup, see [Claude Code Integration](claude-code.md). For Gemini setup, see [Gemini CLI Integration](gemini-cli.md).
+For Claude Code setup, see [Claude Code Integration](claude-code.md). For Gemini setup, see [Gemini CLI Integration](gemini-cli.md). For OpenCode setup, see [OpenCode Integration](opencode.md).

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -25,4 +25,4 @@ stax generate --pr-body --agent gemini
 stax generate --pr-body --agent gemini --model gemini-2.5-flash
 ```
 
-For Claude setup, see [Claude Code Integration](claude-code.md). For Codex setup, see [Codex Integration](codex.md).
+For Claude setup, see [Claude Code Integration](claude-code.md). For Codex setup, see [Codex Integration](codex.md). For OpenCode setup, see [OpenCode Integration](opencode.md).

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,0 +1,27 @@
+# OpenCode Integration
+
+Install OpenCode and add the stax skill so OpenCode can operate stax workflows correctly.
+
+## 1) Install OpenCode
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+## 2) Add stax skill instructions
+
+```bash
+mkdir -p ~/.config/opencode/skills/stax
+curl -o ~/.config/opencode/skills/stax/SKILL.md https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md
+```
+
+OpenCode loads skills from `~/.config/opencode/skills/<name>/SKILL.md`, so this gives it stax-aware workflow guidance.
+
+## 3) Use OpenCode with AI PR body generation
+
+```bash
+stax generate --pr-body --agent opencode
+stax generate --pr-body --agent opencode --model opencode/gpt-5.1-codex
+```
+
+For Claude setup, see [Claude Code Integration](claude-code.md). For Codex setup, see [Codex Integration](codex.md). For Gemini setup, see [Gemini CLI Integration](gemini-cli.md).

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -53,7 +53,7 @@ stax generate --pr-body
 - `--agent <name>` override configured agent for one run
 - `--model <name>` override model for one run
 - `--edit` review/edit generated body before update
-- Supported agents: `claude`, `codex`, `gemini`
+- Supported agents: `claude`, `codex`, `gemini`, `opencode`
 
 You can also generate during submit:
 
@@ -65,5 +65,6 @@ stax submit --ai-body
 stax generate --pr-body --agent codex
 stax generate --pr-body --model claude-haiku-4-5-20251001
 stax generate --pr-body --agent gemini --model gemini-2.5-flash
+stax generate --pr-body --agent opencode
 stax generate --pr-body --edit
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Claude Code: integrations/claude-code.md
       - Codex: integrations/codex.md
       - Gemini CLI: integrations/gemini-cli.md
+      - OpenCode: integrations/opencode.md
   - Compatibility:
       - Freephite and Graphite: compatibility/freephite-graphite.md
   - Benchmarks: reference/benchmarks.md

--- a/skills.md
+++ b/skills.md
@@ -1,6 +1,6 @@
 # Stax Skills for AI Coding Agents
 
-This document teaches AI coding agents (Claude Code, Codex, Gemini CLI) how to use `stax` - a CLI for managing stacked Git branches and PRs.
+This document teaches AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) how to use `stax` - a CLI for managing stacked Git branches and PRs.
 
 ## Use with Gemini CLI
 
@@ -8,6 +8,15 @@ Gemini CLI reads project instructions from `GEMINI.md`. To use this guidance wit
 
 ```bash
 curl -o GEMINI.md https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md
+```
+
+## Use with OpenCode
+
+OpenCode loads skills from `~/.config/opencode/skills/<name>/SKILL.md`. To install this guidance:
+
+```bash
+mkdir -p ~/.config/opencode/skills/stax
+curl -o ~/.config/opencode/skills/stax/SKILL.md https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md
 ```
 
 ## What is Stax?

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1206,7 +1206,7 @@ fn generate_ai_body(
         .filter(|a| !a.is_empty())
         .context(
             "No AI agent configured. Run `stax generate --pr-body` first to set up, \
-             or add [ai] agent = \"claude\" (or \"codex\" / \"gemini\") to ~/.config/stax/config.toml",
+             or add [ai] agent = \"claude\" (or \"codex\" / \"gemini\" / \"opencode\") to ~/.config/stax/config.toml",
         )?
         .to_string();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,7 +71,7 @@ pub struct UiConfig {
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct AiConfig {
-    /// AI agent to use: "claude", "codex", or "gemini" (default: auto-detect)
+    /// AI agent to use: "claude", "codex", "gemini", or "opencode" (default: auto-detect)
     #[serde(default)]
     pub agent: Option<String>,
     /// Model to use with the AI agent (default: agent's own default)

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,7 +415,7 @@ enum Commands {
         /// Open editor to review before updating
         #[arg(long)]
         edit: bool,
-        /// AI agent to use (claude, codex, gemini). Defaults to config or auto-detect
+        /// AI agent to use (claude, codex, gemini, opencode). Defaults to config or auto-detect
         #[arg(long)]
         agent: Option<String>,
         /// Model to use with the AI agent. Defaults to config or agent's default


### PR DESCRIPTION
## Summary
- add opencode as a supported AI agent for `stax generate --pr-body`
- wire model resolution and command invocation to run `opencode run` with model support
- update CLI/config/help and docs to include OpenCode integration guidance

## Testing
- cargo test

Closes #54

Issue: https://github.com/cesarferreira/stax/issues/54
