### PR TITLE
feat: fuzzy search for branch selection prompts

### DIFF
--- a/src/commands/branch/reparent.rs
+++ b/src/commands/branch/reparent.rs
@@ -3,7 +3,7 @@ use crate::git::GitRepo;
 use crate::remote;
 use anyhow::Result;
 use colored::Colorize;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 
 /// Update the parent of a tracked branch
 pub fn run(branch: Option<String>, parent: Option<String>) -> Result<()> {
@@ -55,7 +55,7 @@ pub fn run(branch: Option<String>, parent: Option<String>) -> Result<()> {
                 })
                 .collect();
 
-            let selection = Select::with_theme(&ColorfulTheme::default())
+            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
                 .with_prompt(format!("Select new parent branch for '{}'", target))
                 .items(&items)
                 .default(0)

--- a/src/commands/branch/track.rs
+++ b/src/commands/branch/track.rs
@@ -5,7 +5,7 @@ use crate::github::client::GitHubClient;
 use crate::remote::{self, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 use std::process::Command;
 
 pub fn run(parent: Option<String>, all_prs: bool) -> Result<()> {
@@ -75,7 +75,7 @@ pub fn run(parent: Option<String>, all_prs: bool) -> Result<()> {
                 })
                 .collect();
 
-            let selection = Select::with_theme(&ColorfulTheme::default())
+            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
                 .with_prompt(format!("Select parent branch for '{}'", current))
                 .items(&items)
                 .default(0)

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,7 +1,7 @@
 use crate::git::GitRepo;
 use anyhow::Result;
 use colored::Colorize;
-use dialoguer::{theme::ColorfulTheme, Confirm, Select};
+use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect};
 use std::io::IsTerminal;
 
 /// Run initialization if needed, returns true if initialized (or already was)
@@ -76,7 +76,7 @@ fn run_init(repo: &GitRepo) -> Result<bool> {
 
         let default_idx = branches.iter().position(|b| b == detected).unwrap_or(0);
 
-        let selection = Select::with_theme(&ColorfulTheme::default())
+        let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
             .with_prompt(&prompt)
             .items(&branches)
             .default(default_idx)
@@ -85,7 +85,7 @@ fn run_init(repo: &GitRepo) -> Result<bool> {
         branches[selection].clone()
     } else {
         // No auto-detection, must select
-        let selection = Select::with_theme(&ColorfulTheme::default())
+        let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
             .with_prompt("Select trunk branch (PRs target this)")
             .items(&branches)
             .interact()?;

--- a/src/commands/navigate.rs
+++ b/src/commands/navigate.rs
@@ -2,7 +2,7 @@ use crate::engine::Stack;
 use crate::git::{refs, GitRepo};
 use anyhow::{bail, Result};
 use colored::Colorize;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 
 /// Move up the stack (to child branches)
 /// If count > 1, moves up multiple branches
@@ -41,7 +41,7 @@ pub fn up(count: Option<usize>) -> Result<()> {
             children[0].clone()
         } else {
             // Multiple children - let user choose
-            let selection = Select::with_theme(&ColorfulTheme::default())
+            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
                 .with_prompt("Multiple child branches - select one")
                 .items(&children)
                 .default(0)
@@ -125,7 +125,7 @@ pub fn top() -> Result<()> {
             children[0].clone()
         } else {
             // Multiple children - let user choose
-            let selection = Select::with_theme(&ColorfulTheme::default())
+            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
                 .with_prompt("Multiple child branches - select one")
                 .items(&children)
                 .default(0)


### PR DESCRIPTION
Replace `dialoguer::Select` with `FuzzySelect` in all branch selection prompts so users can type to filter branches instead of only using arrow keys.

**Affected commands:**
- `stax branch reparent` — parent branch selection
- `stax branch track` — parent branch selection
- `stax up` / `stax top` — child branch selection
- `stax init` — trunk branch selection