### PR TITLE
fix: resolve pipe deadlock in patch-id provenance inference

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -418,15 +418,28 @@ impl GitRepo {
             .spawn()
             .context("Failed to run git patch-id --stable")?;
 
-        if let Some(stdin) = patch_id.stdin.as_mut() {
-            stdin
-                .write_all(input)
-                .context("Failed to stream diff to git patch-id")?;
-        }
+        // Write stdin on a background thread to avoid a deadlock: git patch-id
+        // buffers output as it reads input. If its stdout pipe fills up before
+        // we start reading stdout, both processes stall (git patch-id can't
+        // write, so it stops reading, so write_all blocks forever). Spawning a
+        // writer thread lets us drain stdout on the main thread concurrently.
+        let input = input.to_vec();
+        let mut stdin = patch_id.stdin.take().context("Failed to open stdin")?;
+        let writer = std::thread::spawn(move || -> std::io::Result<()> {
+            stdin.write_all(&input)?;
+            // Drop stdin here so git patch-id sees EOF and flushes output.
+            Ok(())
+        });
 
         let output = patch_id
             .wait_with_output()
             .context("Failed to read git patch-id output")?;
+
+        writer
+            .join()
+            .map_err(|_| anyhow::anyhow!("stdin writer thread panicked"))?
+            .context("Failed to write to git patch-id stdin")?;
+
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             anyhow::bail!("git patch-id --stable failed: {}", stderr);


### PR DESCRIPTION
## Summary

- Fixes a deadlock in `run_patch_id_from_input` that caused `stax restack` to hang indefinitely (observed as 30+ minute hangs) when a branch was many commits behind its parent (e.g. 1000+ commits in a large monorepo)
- Spawns a background thread to write to `git patch-id`'s stdin so the main thread can drain stdout concurrently via `wait_with_output()`

## Root Cause

When `infer_patch_id_upstream` processes a branch that is far behind trunk, it computes patch IDs for all commits between the stored parent revision and the current trunk tip. On a large monorepo this can produce 27MB+ of diff data piped to `git patch-id`.

The original code called `write_all(27MB)` on `git patch-id`'s stdin before reading any stdout:

```rust
stdin.write_all(input)?;  // blocks if git patch-id can't consume fast enough
// ...
patch_id.wait_with_output()  // never reached
```

The deadlock sequence:
1. Stax calls `write_all(27MB)` to `git patch-id`'s stdin
2. `git patch-id` starts writing output to its stdout pipe
3. The stdout pipe buffer fills (~64KB) — `git patch-id` blocks on `pipe_write`
4. Since `git patch-id` is blocked writing stdout, it stops reading stdin
5. Since stax is blocked in `write_all` waiting for stdin to drain, it never reads stdout
6. **Both processes wait forever**

## Fix

Spawn a background thread to write stdin, so the main thread can concurrently drain stdout via `wait_with_output()`:

```rust
let writer = std::thread::spawn(move || -> std::io::Result<()> {
    stdin.write_all(&input)?;
    Ok(()) // dropping stdin signals EOF to git patch-id
});

let output = patch_id.wait_with_output()?; // drains stdout while thread writes stdin

writer.join()??;
```

## Test Plan

- [ ] Tested on a branch 1014 commits behind `main` in a large monorepo — restack completed in ~14s instead of hanging
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)