### PR TITLE
fix(create): do not auto-stage untracked files when using -m

### DIFF
--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -183,7 +183,7 @@ pub fn run(
 
                 println!("Committed: {}", msg.cyan());
             } else {
-                println!("{}", "No staged changes to commit".dimmed());
+                println!("{}", "No changes to commit".dimmed());
             }
         } else if stage_mode == StageMode::All {
             println!("{}", "Changes staged".dimmed());


### PR DESCRIPTION
## What
Fixes #73 by changing `stax create -m` to commit only already-staged changes by default.

## Why
Current behavior can unexpectedly include unrelated/untracked files, which is risky in daily workflows.

## Changes
- Introduce explicit stage modes in `branch create`:
  - `None`
  - `ExistingOnly` (default for `-m`)
  - `All` (explicit `-a/--all` or wizard stage-all choice)
- Keep `-a/--all` as the explicit opt-in for staging everything.
- Improve output text to clarify when there are no staged changes to commit.

## Notes
I was not able to run the full test suite in this environment due runtime limits, so this should get CI validation in PR.