### PR TITLE
fix(merge): preserve upstack chain after partial merge

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,6 +1,7 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
 use crate::commands::merge_rebase::{
-    fetch_remote_for_descendant_rebase, rebase_descendant_onto_remote_trunk_with_provenance,
+    fetch_remote_for_descendant_rebase, rebase_descendant_onto_parent_with_provenance,
+    rebase_descendant_onto_remote_trunk_with_provenance,
 };
 use crate::config::Config;
 use crate::engine::Stack;
@@ -368,14 +369,23 @@ pub fn run(
         }
     }
 
-    // Rebase remaining branches onto trunk if any PRs were merged
+    // Rebase remaining branches while preserving their relative stack chain.
+    // First remaining branch is rebased onto trunk, then each subsequent branch
+    // is rebased onto the previous remaining branch.
     if !merged_prs.is_empty() && !scope.remaining.is_empty() && failed_pr.is_none() {
         if !quiet {
             println!();
             println!("{}", "Rebasing remaining stack branches...".dimmed());
         }
 
-        for remaining in &scope.remaining {
+        for (idx, remaining) in scope.remaining.iter().enumerate() {
+            let parent_branch = if idx == 0 {
+                scope.trunk.clone()
+            } else {
+                scope.remaining[idx - 1].branch.clone()
+            };
+            let parent_is_trunk = idx == 0;
+
             let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching latest...");
             let fetch_ok = fetch_remote_for_descendant_rebase(&repo, &remote_info.name)?;
             if !fetch_ok {
@@ -384,23 +394,36 @@ pub fn run(
                 LiveTimer::maybe_finish_ok(fetch_timer, "done");
             }
 
-            let remaining_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Rebasing {}...", remaining.branch));
+            let remaining_timer = LiveTimer::maybe_new(
+                !quiet,
+                &format!("Rebasing {} onto {}...", remaining.branch, parent_branch),
+            );
 
             repo.checkout(&remaining.branch)?;
-            let rebase_result = rebase_descendant_onto_remote_trunk_with_provenance(
-                &repo,
-                &remaining.branch,
-                &scope.trunk,
-                &remote_info.name,
-            );
+            let rebase_result = if parent_is_trunk {
+                rebase_descendant_onto_remote_trunk_with_provenance(
+                    &repo,
+                    &remaining.branch,
+                    &scope.trunk,
+                    &remote_info.name,
+                )
+            } else {
+                rebase_descendant_onto_parent_with_provenance(
+                    &repo,
+                    &remaining.branch,
+                    &parent_branch,
+                    &remote_info.name,
+                    false,
+                )
+            };
 
             match rebase_result {
                 Ok(RebaseResult::Success) => {
-                    // Update PR base
+                    // Update PR base to the actual parent in the preserved chain.
                     if let Some(pr_num) = remaining.pr_number {
-                        let _ = rt
-                            .block_on(async { client.update_pr_base(pr_num, &scope.trunk).await });
+                        let _ = rt.block_on(async {
+                            client.update_pr_base(pr_num, &parent_branch).await
+                        });
                     }
 
                     // Push

--- a/src/commands/merge_rebase.rs
+++ b/src/commands/merge_rebase.rs
@@ -15,26 +15,37 @@ pub(crate) fn rebase_descendant_onto_remote_trunk_with_provenance(
     trunk: &str,
     remote_name: &str,
 ) -> Result<RebaseResult> {
-    let remote_trunk_ref = format!("{}/{}", remote_name, trunk);
+    rebase_descendant_onto_parent_with_provenance(repo, branch, trunk, remote_name, true)
+}
+
+pub(crate) fn rebase_descendant_onto_parent_with_provenance(
+    repo: &GitRepo,
+    branch: &str,
+    parent: &str,
+    remote_name: &str,
+    use_remote_parent_ref: bool,
+) -> Result<RebaseResult> {
+    let onto_ref = if use_remote_parent_ref {
+        format!("{}/{}", remote_name, parent)
+    } else {
+        parent.to_string()
+    };
+
     let fallback_upstream = BranchMetadata::read(repo.inner(), branch)?
         .map(|meta| meta.parent_branch_revision)
         .unwrap_or_default();
 
-    let result = repo.rebase_branch_onto_with_provenance(
-        branch,
-        &remote_trunk_ref,
-        &fallback_upstream,
-        false,
-    )?;
+    let result =
+        repo.rebase_branch_onto_with_provenance(branch, &onto_ref, &fallback_upstream, false)?;
 
     if result == RebaseResult::Success {
         if let Some(meta) = BranchMetadata::read(repo.inner(), branch)? {
-            let trunk_commit = repo
-                .resolve_ref(&remote_trunk_ref)
-                .unwrap_or_else(|_| repo.branch_commit(trunk).unwrap_or_default());
+            let parent_commit = repo
+                .resolve_ref(&onto_ref)
+                .unwrap_or_else(|_| repo.branch_commit(parent).unwrap_or_default());
             let updated_meta = BranchMetadata {
-                parent_branch_name: trunk.to_string(),
-                parent_branch_revision: trunk_commit,
+                parent_branch_name: parent.to_string(),
+                parent_branch_revision: parent_commit,
                 ..meta
             };
             updated_meta.write(repo.inner(), branch)?;


### PR DESCRIPTION
## What
Fixes #87 by preserving the parent chain of remaining upstack branches when merging from the middle of a stack.

## Why
Previously, remaining branches were all rebased onto trunk and had PR base updated to trunk, which flattened/broke the stack relationship.

## Changes
- Added `rebase_descendant_onto_parent_with_provenance(...)` helper in `merge_rebase.rs`.
- Updated remaining-branch merge flow in `merge.rs`:
  - first remaining branch rebases onto trunk
  - each subsequent remaining branch rebases onto the previous remaining branch
- Update each remaining PR base to its actual preserved parent branch.
- Keep metadata parent pointers aligned with the preserved chain.

## Notes
Could not run full test suite here due environment/runtime limits; CI should validate.
