### PR TITLE
feat(init): add explicit trunk reconfiguration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ st rs --restack
 
 Result: two stacked branches, submitted as two linked PRs, then kept up to date with one sync/restack command.
 
+Picked the wrong trunk branch? Run `st init` to reconfigure it interactively, or `st init --trunk <branch>` to set it directly.
+
 Next steps:
 - [Getting Started: Quick Start](docs/getting-started/quick-start.md)
 - [Workflow: Merge and Cascade](docs/workflows/merge-and-cascade.md)

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -13,6 +13,7 @@
 | `st rs --restack` | Sync and rebase full stack |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st cascade` | Restack, push, and create/update PRs |
+| `st init` | Initialize stax or reconfigure the repo trunk |
 | `st standup` | Summarize recent engineering activity |
 | `st changelog` | Generate changelog between refs |
 | `st open` | Open repository in browser |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -89,6 +89,8 @@
 | `st config` | Show current configuration |
 | `st config --reset-ai` | Clear saved AI defaults, then re-prompt interactively |
 | `st config --reset-ai --no-prompt` | Clear saved AI defaults without reopening the picker |
+| `st init` | Initialize stax or reconfigure the repo trunk interactively |
+| `st init --trunk <branch>` | Set the repo trunk directly |
 | `st doctor` | Check repo health |
 | `st continue` | Continue after conflicts |
 | `st pr` | Open current branch PR |
@@ -188,6 +190,7 @@
 - `st standup --summary --jit`
 - `st auth --from-gh`
 - `st auth --token <token>`
+- `st init --trunk main`
 - `st undo --yes --no-push`
 - `st undo --quiet`
 - `st redo --yes --no-push --quiet`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -363,6 +363,13 @@ enum Commands {
         yes: bool,
     },
 
+    /// Initialize stax or reconfigure the repo trunk branch
+    Init {
+        /// Set the trunk branch directly instead of prompting
+        #[arg(long)]
+        trunk: Option<String>,
+    },
+
     /// Show diffs for each branch vs parent plus an aggregate stack diff
     Diff {
         /// Show only the stack for this branch
@@ -1060,6 +1067,12 @@ pub fn run() -> Result<()> {
             update::check_in_background();
             return result;
         }
+        Commands::Init { trunk } => {
+            let result = commands::init::run(trunk.clone());
+            update::show_update_notification();
+            update::check_in_background();
+            return result;
+        }
         Commands::Doctor => {
             let result = commands::doctor::run();
             update::show_update_notification();
@@ -1223,6 +1236,7 @@ pub fn run() -> Result<()> {
         Commands::Modify { message, quiet } => commands::modify::run(message, quiet),
         Commands::Auth { .. } => unreachable!(), // Handled above
         Commands::Config { .. } => unreachable!(), // Handled above
+        Commands::Init { .. } => unreachable!(), // Handled above
         Commands::Diff { stack, all } => commands::diff::run(stack, all),
         Commands::RangeDiff { stack, all } => commands::range_diff::run(stack, all),
         Commands::Doctor => unreachable!(), // Handled above

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -20,7 +20,36 @@ pub fn ensure_initialized() -> Result<bool> {
         return auto_init(&repo);
     }
 
-    run_init(&repo)
+    run_interactive(&repo, false)?;
+    Ok(true)
+}
+
+/// Initialize or reconfigure stax in the current repo.
+pub fn run(trunk: Option<String>) -> Result<()> {
+    let repo = GitRepo::open()?;
+
+    if let Some(trunk) = trunk {
+        set_trunk(repo, &trunk)?;
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        if repo.is_initialized() {
+            anyhow::bail!(
+                "Repository already initialized. Use `stax init --trunk <branch>` to change trunk non-interactively."
+            );
+        }
+
+        if auto_init(&repo)? {
+            return Ok(());
+        }
+
+        anyhow::bail!(
+            "Could not detect a trunk branch automatically. Use `stax init --trunk <branch>`."
+        );
+    }
+
+    run_interactive(&repo, repo.is_initialized())
 }
 
 /// Auto-initialize without prompts (for non-interactive use)
@@ -32,75 +61,130 @@ fn auto_init(repo: &GitRepo) -> Result<bool> {
     Ok(false)
 }
 
-/// Run the interactive initialization
-fn run_init(repo: &GitRepo) -> Result<bool> {
-    println!(
-        "{}",
-        "stax has not been initialized, setting up now...".dimmed()
-    );
-    println!();
-    println!("{}", "Welcome to stax!".green().bold());
-    println!();
-
-    // Detect and confirm trunk branch
-    let detected_trunk = repo.detect_trunk().ok();
+fn set_trunk(repo: GitRepo, trunk: &str) -> Result<()> {
     let branches = repo.list_branches()?;
 
-    // Handle empty repo (no branches yet)
     if branches.is_empty() {
-        if let Some(detected) = detected_trunk {
-            // Use detected trunk even if no branches exist yet
-            repo.set_trunk(&detected)?;
-            println!("Trunk set to {}", detected.cyan());
-            println!();
-            println!(
-                "{}",
-                "Ready to go! Try `stax bc <name>` to create your first branch.".green()
-            );
-            return Ok(true);
-        } else {
-            // No branches and can't detect trunk - need at least one commit
-            anyhow::bail!(
-                "No branches found. Please make an initial commit first:\n  \
-                 git add . && git commit -m \"Initial commit\""
-            );
+        anyhow::bail!(
+            "No branches found. Please make an initial commit first:\n  \
+             git add . && git commit -m \"Initial commit\""
+        );
+    }
+
+    if !branches.iter().any(|branch| branch == trunk) {
+        anyhow::bail!(
+            "Branch '{}' does not exist. Available branches: {}",
+            trunk,
+            branches.join(", ")
+        );
+    }
+
+    let previous_trunk = if repo.is_initialized() {
+        repo.trunk_branch().ok()
+    } else {
+        None
+    };
+    repo.set_trunk(trunk)?;
+
+    match previous_trunk {
+        Some(previous) if previous == trunk => {
+            println!("Trunk unchanged: {}", trunk.cyan());
+        }
+        Some(previous) => {
+            println!("Trunk changed: {} -> {}", previous.cyan(), trunk.green());
+        }
+        None => {
+            println!("Trunk set to {}", trunk.cyan());
         }
     }
 
-    let trunk = if let Some(detected) = &detected_trunk {
-        // Show selection with detected as default
-        let prompt = format!(
-            "Select trunk branch (PRs target this) - detected {}",
-            detected.cyan()
-        );
+    Ok(())
+}
 
-        let default_idx = branches.iter().position(|b| b == detected).unwrap_or(0);
-
-        let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
-            .with_prompt(&prompt)
-            .items(&branches)
-            .default(default_idx)
-            .interact()?;
-
-        branches[selection].clone()
+/// Run interactive initialization or trunk reconfiguration.
+fn run_interactive(repo: &GitRepo, reconfigure: bool) -> Result<()> {
+    if reconfigure {
+        if let Ok(current) = repo.trunk_branch() {
+            println!("Current trunk: {}", current.cyan());
+            println!();
+        }
     } else {
-        // No auto-detection, must select
-        let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
-            .with_prompt("Select trunk branch (PRs target this)")
-            .items(&branches)
-            .interact()?;
+        println!(
+            "{}",
+            "stax has not been initialized, setting up now...".dimmed()
+        );
+        println!();
+        println!("{}", "Welcome to stax!".green().bold());
+        println!();
+    }
 
-        branches[selection].clone()
+    let branches = repo.list_branches()?;
+    let detected_trunk = repo
+        .trunk_branch()
+        .ok()
+        .or_else(|| repo.detect_trunk().ok());
+
+    if branches.is_empty() {
+        if let Some(detected) = detected_trunk {
+            repo.set_trunk(&detected)?;
+            println!("Trunk set to {}", detected.cyan());
+            if !reconfigure {
+                println!();
+                println!(
+                    "{}",
+                    "Ready to go! Try `stax bc <name>` to create your first branch.".green()
+                );
+            }
+            return Ok(());
+        }
+
+        anyhow::bail!(
+            "No branches found. Please make an initial commit first:\n  \
+             git add . && git commit -m \"Initial commit\""
+        );
+    }
+
+    let prompt = if reconfigure {
+        "Select trunk branch"
+    } else {
+        "Select trunk branch (PRs target this)"
     };
 
-    // Save trunk setting
+    let selection = if let Some(detected) = &detected_trunk {
+        let default_idx = branches.iter().position(|b| b == detected).unwrap_or(0);
+        FuzzySelect::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!("{} - detected {}", prompt, detected.cyan()))
+            .items(&branches)
+            .default(default_idx)
+            .interact()?
+    } else {
+        FuzzySelect::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
+            .items(&branches)
+            .interact()?
+    };
+
+    let trunk = branches[selection].clone();
+    let previous_trunk = if repo.is_initialized() {
+        repo.trunk_branch().ok()
+    } else {
+        None
+    };
     repo.set_trunk(&trunk)?;
-    println!("Trunk set to {}", trunk.cyan());
+
+    match previous_trunk {
+        Some(previous) if previous == trunk => println!("Trunk unchanged: {}", trunk.cyan()),
+        Some(previous) => println!("Trunk changed: {} -> {}", previous.cyan(), trunk.green()),
+        None => println!("Trunk set to {}", trunk.cyan()),
+    }
+
+    if reconfigure {
+        return Ok(());
+    }
+
     println!();
 
-    // Offer to track existing branches
     let other_branches: Vec<_> = branches.iter().filter(|b| *b != &trunk).collect();
-
     if !other_branches.is_empty() {
         let track = Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt("Would you like to track existing branches?")
@@ -121,5 +205,5 @@ fn run_init(repo: &GitRepo) -> Result<bool> {
         "Ready to go! Try `stax bc <name>` to create your first branch.".green()
     );
 
-    Ok(true)
+    Ok(())
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -240,6 +240,15 @@ fn test_config_reset_ai_no_prompt_clears_saved_defaults() {
 }
 
 #[test]
+fn test_init_help_includes_trunk_flag() {
+    let output = stax(&["init", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Initialize stax"));
+    assert!(stdout.contains("--trunk"));
+}
+
+#[test]
 fn test_status_help_flags() {
     let output = stax(&["status", "--help"]);
     assert!(output.status.success());

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -103,6 +103,28 @@ fn test_sync_alias_rs_help() {
     output.assert_success();
 }
 
+#[test]
+fn test_init_command_sets_trunk_branch() {
+    let repo = TestRepo::new();
+
+    let git_output = repo.git(&["branch", "master"]);
+    assert!(
+        git_output.status.success(),
+        "{}",
+        TestRepo::stderr(&git_output)
+    );
+
+    let output = repo.run_stax(&["init", "--trunk", "master"]);
+    output.assert_success();
+
+    let json = repo.get_status_json();
+    assert_eq!(json["trunk"], "master");
+
+    let trunk_output = repo.run_stax(&["trunk"]);
+    trunk_output.assert_success();
+    assert_eq!(repo.current_branch(), "master");
+}
+
 // =============================================================================
 // Restack Command Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- expose `st init` as an explicit command so trunk can be reconfigured after first run
- add `st init --trunk <branch>` for non-interactive trunk changes
- document the new command and add regression coverage for trunk updates

## Testing
- `cargo fmt --all`
- `cargo check --tests` *(blocked locally by the unmet Xcode license on this machine before linking proc-macro dylibs)*

Fixes #86.