### PR TITLE
fix(merge): retarget dependent PRs before parent merge

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -213,6 +213,7 @@ pub fn run(
     for (idx, branch_info) in scope.to_merge.iter().enumerate() {
         let pr_number = branch_info.pr_number.unwrap();
         let position = idx + 1;
+        let next_branch = scope.to_merge.get(idx + 1);
 
         if !quiet {
             println!();
@@ -263,6 +264,32 @@ pub fn run(
                 }
             }
 
+            if let Some(next_branch) = next_branch {
+                let next_pr = next_branch.pr_number.unwrap();
+                let update_base_timer = LiveTimer::maybe_new(
+                    !quiet,
+                    &format!(
+                        "Retargeting #{} to {} before merge...",
+                        next_pr, scope.trunk
+                    ),
+                );
+
+                match rt.block_on(async { client.update_pr_base(next_pr, &scope.trunk).await }) {
+                    Ok(()) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "done");
+                    }
+                    Err(e) => {
+                        LiveTimer::maybe_finish_err(update_base_timer, "failed");
+                        failed_pr = Some((
+                            branch_info.branch.clone(),
+                            pr_number,
+                            format!("Failed to retarget dependent PR #{}: {}", next_pr, e),
+                        ));
+                        break;
+                    }
+                }
+            }
+
             // Merge the PR
             let merge_timer =
                 LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
@@ -283,9 +310,8 @@ pub fn run(
             }
         }
 
-        // If there are more PRs, rebase and update the next one
-        if idx + 1 < total {
-            let next_branch = &scope.to_merge[idx + 1];
+        // If there are more PRs, rebase the next one onto trunk.
+        if let Some(next_branch) = next_branch {
             let next_pr = next_branch.pr_number.unwrap();
 
             // Fetch latest from remote
@@ -329,19 +355,6 @@ pub fn run(
                         "Rebase conflict".to_string(),
                     ));
                     break;
-                }
-            }
-
-            // Update PR base to trunk
-            let update_base_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Updating PR base to {}...", scope.trunk));
-
-            match rt.block_on(async { client.update_pr_base(next_pr, &scope.trunk).await }) {
-                Ok(()) => {
-                    LiveTimer::maybe_finish_ok(update_base_timer, "done");
-                }
-                Err(e) => {
-                    LiveTimer::maybe_finish_warn(update_base_timer, &format!("warning: {}", e));
                 }
             }
 

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -253,6 +253,7 @@ pub fn run(
     for idx in 0..total {
         let pr_number = branches[idx].pr_number;
         let branch_name = branches[idx].branch.clone();
+        let next_branch = branches.get(idx + 1).cloned();
 
         if !quiet {
             println!();
@@ -295,6 +296,36 @@ pub fn run(
                 }
             }
 
+            if let Some(next_branch) = &next_branch {
+                let update_base_timer = LiveTimer::maybe_new(
+                    !quiet,
+                    &format!(
+                        "Retargeting #{} to {} before merge...",
+                        next_branch.pr_number, scope.trunk
+                    ),
+                );
+
+                match rt.block_on(async {
+                    client
+                        .update_pr_base(next_branch.pr_number, &scope.trunk)
+                        .await
+                }) {
+                    Ok(()) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "done");
+                    }
+                    Err(e) => {
+                        LiveTimer::maybe_finish_err(update_base_timer, "failed");
+                        let reason = format!(
+                            "Failed to retarget dependent PR #{}: {}",
+                            next_branch.pr_number, e
+                        );
+                        branches[idx].status = LandStatus::Failed(reason.clone());
+                        failed_pr = Some((branch_name, pr_number, reason));
+                        break;
+                    }
+                }
+            }
+
             // Merge the PR
             branches[idx].status = LandStatus::Merging;
             let merge_timer =
@@ -319,10 +350,10 @@ pub fn run(
             }
         }
 
-        // If there are more PRs, rebase and update the next one
-        if idx + 1 < total {
-            let next_branch = branches[idx + 1].branch.clone();
-            let next_pr = branches[idx + 1].pr_number;
+        // If there are more PRs, rebase the next one onto trunk.
+        if let Some(next_branch) = next_branch {
+            let next_branch_name = next_branch.branch.clone();
+            let next_pr = next_branch.pr_number;
 
             // Fetch latest from remote
             let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching latest...");
@@ -336,13 +367,13 @@ pub fn run(
             // Rebase next branch onto trunk
             let rebase_timer = LiveTimer::maybe_new(
                 !quiet,
-                &format!("Rebasing {} onto {}...", next_branch, scope.trunk),
+                &format!("Rebasing {} onto {}...", next_branch_name, scope.trunk),
             );
 
-            repo.checkout(&next_branch)?;
+            repo.checkout(&next_branch_name)?;
             let rebase_result = rebase_descendant_onto_remote_trunk_with_provenance(
                 &repo,
-                &next_branch,
+                &next_branch_name,
                 &scope.trunk,
                 &remote_info.name,
             )?;
@@ -360,29 +391,16 @@ pub fn run(
                     LiveTimer::maybe_finish_err(rebase_timer, "conflict");
                     let reason = "Rebase conflict".to_string();
                     branches[idx + 1].status = LandStatus::Failed(reason.clone());
-                    failed_pr = Some((next_branch, next_pr, reason));
+                    failed_pr = Some((next_branch_name, next_pr, reason));
                     break;
                 }
             }
 
-            // Update PR base to trunk
-            let update_base_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Updating PR base to {}...", scope.trunk));
-
-            match rt.block_on(async { client.update_pr_base(next_pr, &scope.trunk).await }) {
-                Ok(()) => {
-                    LiveTimer::maybe_finish_ok(update_base_timer, "done");
-                }
-                Err(e) => {
-                    LiveTimer::maybe_finish_warn(update_base_timer, &format!("warning: {}", e));
-                }
-            }
-
-            // Force push the rebased branch
-            let push_timer = LiveTimer::maybe_new(!quiet, &format!("Pushing {}...", next_branch));
+            let push_timer =
+                LiveTimer::maybe_new(!quiet, &format!("Pushing {}...", next_branch_name));
 
             let push_status = Command::new("git")
-                .args(["push", "-f", &remote_info.name, &next_branch])
+                .args(["push", "-f", &remote_info.name, &next_branch_name])
                 .current_dir(repo.workdir()?)
                 .output()
                 .context("Failed to push")?;
@@ -391,7 +409,7 @@ pub fn run(
                 LiveTimer::maybe_finish_err(push_timer, "failed");
                 let reason = "Failed to push rebased branch".to_string();
                 branches[idx + 1].status = LandStatus::Failed(reason.clone());
-                failed_pr = Some((next_branch, next_pr, reason));
+                failed_pr = Some((next_branch_name, next_pr, reason));
                 break;
             }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4469,6 +4469,19 @@ mod github_mock_tests {
         remote_root
     }
 
+    fn find_request_index(
+        requests: &[wiremock::Request],
+        method_name: &str,
+        path_name: &str,
+    ) -> usize {
+        requests
+            .iter()
+            .position(|request| {
+                request.method.as_str() == method_name && request.url.path() == path_name
+            })
+            .unwrap_or_else(|| panic!("Did not find request {} {}", method_name, path_name))
+    }
+
     fn squash_merge_branch_on_fake_remote(remote_root: &TempDir, branch: &str) {
         let remote_repo = remote_root.path().join("test").join("repo.git");
         let clone_dir = super::test_tempdir();
@@ -4884,6 +4897,152 @@ mod github_mock_tests {
     }
 
     #[tokio::test]
+    async fn test_merge_retargets_next_pr_before_merging_parent_pr() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/101",
+                    "id": 101,
+                    "number": 101,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": "merge-a", "sha": "sha-a", "label": "test:merge-a" },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/102",
+                    "id": 102,
+                    "number": 102,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": "merge-b", "sha": "sha-b", "label": "test:merge-b" },
+                    "base": { "ref": "merge-a", "sha": "sha-a" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/101",
+                "id": 101,
+                "number": 101,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": "merge-a", "sha": "sha-a", "label": "test:merge-a" },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/102",
+                "id": 102,
+                "number": 102,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": "merge-b", "sha": "sha-b", "label": "test:merge-b" },
+                "base": { "ref": "merge-a", "sha": "sha-a" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/102",
+                "id": 102,
+                "number": 102,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": "merge-b", "sha": "sha-b", "label": "test:merge-b" },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/101/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/102/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/102");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/101/merge");
+        assert!(
+            patch_idx < merge_idx,
+            "Expected dependent PR retarget before parent merge, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
     async fn test_merge_when_ready_already_merged_pr_still_rebases_next_branch_and_reparents_metadata(
     ) {
         let mock_server = MockServer::start().await;
@@ -5080,6 +5239,162 @@ mod github_mock_tests {
             TestRepo::stdout(&unique_count).trim(),
             "1",
             "Expected descendant branch to keep only novel commits after squash-merge restack"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_when_ready_retargets_next_pr_before_merging_parent_pr() {
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mwr-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mwr-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/201",
+                    "id": 201,
+                    "number": 201,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_a, "sha": "sha-a", "label": "test:mwr-a" },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/202",
+                    "id": 202,
+                    "number": 202,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_b, "sha": "sha-b", "label": "test:mwr-b" },
+                    "base": { "ref": branch_a, "sha": "sha-a" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/201"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/201",
+                "id": 201,
+                "number": 201,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": branch_a, "sha": "sha-a", "label": "test:mwr-a" },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/202"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/202",
+                "id": 202,
+                "number": 202,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": branch_b, "sha": "sha-b", "label": "test:mwr-b" },
+                "base": { "ref": branch_a, "sha": "sha-a" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/202"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/202",
+                "id": 202,
+                "number": 202,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": "mwr-b", "sha": "sha-b", "label": "test:mwr-b" },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/201/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/202/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &[
+                "merge",
+                "--when-ready",
+                "--yes",
+                "--no-delete",
+                "--timeout",
+                "1",
+                "--interval",
+                "1",
+                "--no-sync",
+            ],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge-when-ready failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/202");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/201/merge");
+        assert!(
+            patch_idx < merge_idx,
+            "Expected dependent PR retarget before parent merge, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
## Summary
- retarget the dependent PR to trunk before merging its parent PR in both `st merge` and `st merge --when-ready`
- keep the existing provenance-aware rebase and push flow after the merge
- add request-order regression tests to prove the retarget happens before the parent merge request is sent

## Fix Plan
1. Move the child-PR base update ahead of the parent merge call so GitHub does not get a chance to auto-close the child PR when the parent branch is merged/deleted.
2. Fail fast if that pre-retarget step cannot be completed, instead of merging the parent PR and leaving the stack in a worse state.
3. Preserve the existing post-merge rebase/push flow so descendant branches still land on trunk with correct provenance.
4. Cover both `st merge --no-wait` and `st merge --when-ready` with request-order regression tests.

## Testing
- `cargo fmt --all`
- `git diff --check`
- `cargo check --tests` *(blocked locally by the unmet Xcode license on this machine before linking proc-macro dylibs)*

Fixes #66.