### PR TITLE
fix: prevent stax ls stack overflow

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -503,46 +503,179 @@ fn collect_display_branches_with_nesting(
     max_column: &mut usize,
     allowed: Option<&HashSet<String>>,
 ) {
-    collect_recursive(stack, branch, base_column, result, max_column, allowed);
-}
-
-fn collect_recursive(
-    stack: &Stack,
-    branch: &str,
-    column: usize,
-    result: &mut Vec<DisplayBranch>,
-    max_column: &mut usize,
-    allowed: Option<&HashSet<String>>,
-) {
-    if allowed.is_some_and(|set| !set.contains(branch)) {
-        return;
+    #[derive(Clone)]
+    struct Frame {
+        branch: String,
+        column: usize,
+        expanded: bool,
     }
 
-    *max_column = (*max_column).max(column);
+    let mut stack_frames = vec![Frame {
+        branch: branch.to_string(),
+        column: base_column,
+        expanded: false,
+    }];
+    let mut visiting = HashSet::new();
+    let mut emitted = HashSet::new();
 
-    if let Some(info) = stack.branches.get(branch) {
-        let mut children: Vec<&String> = info
-            .children
-            .iter()
-            .filter(|c| allowed.is_none_or(|set| set.contains(*c)))
-            .collect();
+    while let Some(frame) = stack_frames.pop() {
+        if allowed.is_some_and(|set| !set.contains(&frame.branch)) {
+            continue;
+        }
 
-        if !children.is_empty() {
-            // Sort children alphabetically (like fp)
+        if frame.expanded {
+            visiting.remove(&frame.branch);
+            if emitted.insert(frame.branch.clone()) {
+                result.push(DisplayBranch {
+                    name: frame.branch,
+                    column: frame.column,
+                });
+            }
+            continue;
+        }
+
+        if emitted.contains(&frame.branch) || !visiting.insert(frame.branch.clone()) {
+            continue;
+        }
+
+        *max_column = (*max_column).max(frame.column);
+        stack_frames.push(Frame {
+            branch: frame.branch.clone(),
+            column: frame.column,
+            expanded: true,
+        });
+
+        if let Some(info) = stack.branches.get(&frame.branch) {
+            let mut children: Vec<&String> = info
+                .children
+                .iter()
+                .filter(|child| allowed.is_none_or(|set| set.contains(*child)))
+                .collect();
+
             children.sort();
 
-            // Each child gets column + index: first child at same column, second at +1, etc.
-            for (i, child) in children.iter().enumerate() {
-                collect_recursive(stack, child, column + i, result, max_column, allowed);
+            for (i, child) in children.into_iter().enumerate().rev() {
+                if emitted.contains(child) || visiting.contains(child) {
+                    continue;
+                }
+
+                stack_frames.push(Frame {
+                    branch: child.clone(),
+                    column: frame.column + i,
+                    expanded: false,
+                });
             }
         }
     }
+}
 
-    // Add current branch after all children are processed (post-order)
-    result.push(DisplayBranch {
-        name: branch.to_string(),
-        column,
-    });
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::stack::StackBranch;
+
+    fn branch(parent: Option<&str>, children: Vec<String>) -> StackBranch {
+        StackBranch {
+            name: String::new(),
+            parent: parent.map(str::to_string),
+            children,
+            needs_restack: false,
+            pr_number: None,
+            pr_state: None,
+            pr_is_draft: None,
+        }
+    }
+
+    #[test]
+    fn collect_display_branches_handles_deep_chains_without_recursion() {
+        let depth = 20_000;
+        let mut branches = HashMap::new();
+        let trunk = "main".to_string();
+        branches.insert(
+            trunk.clone(),
+            StackBranch {
+                name: trunk.clone(),
+                parent: None,
+                children: vec!["branch-0".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+
+        for i in 0..depth {
+            let name = format!("branch-{i}");
+            let child = (i + 1 < depth).then(|| format!("branch-{}", i + 1));
+            branches.insert(
+                name.clone(),
+                StackBranch {
+                    name,
+                    parent: Some(if i == 0 {
+                        trunk.clone()
+                    } else {
+                        format!("branch-{}", i - 1)
+                    }),
+                    children: child.into_iter().collect(),
+                    needs_restack: false,
+                    pr_number: None,
+                    pr_state: None,
+                    pr_is_draft: None,
+                },
+            );
+        }
+
+        let stack = Stack { branches, trunk };
+        let mut result = Vec::new();
+        let mut max_column = 0;
+        collect_display_branches_with_nesting(
+            &stack,
+            "branch-0",
+            0,
+            &mut result,
+            &mut max_column,
+            None,
+        );
+
+        assert_eq!(result.len(), depth);
+        assert_eq!(
+            result.first().map(|b| b.name.as_str()),
+            Some("branch-19999")
+        );
+        assert_eq!(result.last().map(|b| b.name.as_str()), Some("branch-0"));
+        assert_eq!(max_column, 0);
+    }
+
+    #[test]
+    fn collect_display_branches_skips_cycles() {
+        let mut branches = HashMap::new();
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                children: vec!["a".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert("a".to_string(), branch(Some("main"), vec!["b".to_string()]));
+        branches.insert("b".to_string(), branch(Some("a"), vec!["a".to_string()]));
+
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+        let mut result = Vec::new();
+        let mut max_column = 0;
+        collect_display_branches_with_nesting(&stack, "a", 0, &mut result, &mut max_column, None);
+
+        let names: Vec<&str> = result.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(names, vec!["b", "a"]);
+        assert_eq!(max_column, 0);
+    }
 }
 
 /// Get line additions and deletions between parent and branch

--- a/src/engine/stack.rs
+++ b/src/engine/stack.rs
@@ -2,7 +2,7 @@ use crate::engine::BranchMetadata;
 use crate::git::{refs, GitRepo};
 use anyhow::Result;
 use git2::BranchType;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Represents a branch in the stack
 #[derive(Debug, Clone)]
@@ -108,9 +108,13 @@ impl Stack {
     pub fn ancestors(&self, branch: &str) -> Vec<String> {
         let mut result = Vec::new();
         let mut current = branch.to_string();
+        let mut visited = HashSet::from([current.clone()]);
 
         while let Some(b) = self.branches.get(&current) {
             if let Some(parent) = &b.parent {
+                if !visited.insert(parent.clone()) {
+                    break;
+                }
                 result.push(parent.clone());
                 current = parent.clone();
             } else {
@@ -125,10 +129,14 @@ impl Stack {
     pub fn descendants(&self, branch: &str) -> Vec<String> {
         let mut result = Vec::new();
         let mut to_visit = vec![branch.to_string()];
+        let mut visited = HashSet::from([branch.to_string()]);
 
         while let Some(current) = to_visit.pop() {
             if let Some(b) = self.branches.get(&current) {
                 for child in &b.children {
+                    if !visited.insert(child.clone()) {
+                        continue;
+                    }
                     result.push(child.clone());
                     to_visit.push(child.clone());
                 }
@@ -140,11 +148,28 @@ impl Stack {
 
     /// Get the current stack (ancestors + current + descendants)
     pub fn current_stack(&self, branch: &str) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut result = Vec::new();
         let mut ancestors = self.ancestors(branch);
         ancestors.reverse();
-        ancestors.push(branch.to_string());
-        ancestors.extend(self.descendants(branch));
-        ancestors
+
+        for name in ancestors {
+            if seen.insert(name.clone()) {
+                result.push(name);
+            }
+        }
+
+        if seen.insert(branch.to_string()) {
+            result.push(branch.to_string());
+        }
+
+        for name in self.descendants(branch) {
+            if seen.insert(name.clone()) {
+                result.push(name);
+            }
+        }
+
+        result
     }
 
     /// Get branches that need restacking
@@ -368,6 +393,103 @@ mod tests {
         let stack = create_test_stack();
         let current = stack.current_stack("feature-b");
         assert_eq!(current, vec!["main", "feature-b"]);
+    }
+
+    #[test]
+    fn test_ancestors_breaks_parent_cycles() {
+        let mut branches = HashMap::new();
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                children: vec![],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "a".to_string(),
+            StackBranch {
+                name: "a".to_string(),
+                parent: Some("b".to_string()),
+                children: vec!["b".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "b".to_string(),
+            StackBranch {
+                name: "b".to_string(),
+                parent: Some("a".to_string()),
+                children: vec!["a".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+
+        assert_eq!(stack.ancestors("a"), vec!["b"]);
+        assert_eq!(stack.current_stack("a"), vec!["b", "a"]);
+    }
+
+    #[test]
+    fn test_descendants_breaks_child_cycles() {
+        let mut branches = HashMap::new();
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                children: vec!["a".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "a".to_string(),
+            StackBranch {
+                name: "a".to_string(),
+                parent: Some("main".to_string()),
+                children: vec!["b".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "b".to_string(),
+            StackBranch {
+                name: "b".to_string(),
+                parent: Some("a".to_string()),
+                children: vec!["a".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+
+        assert_eq!(stack.descendants("a"), vec!["b"]);
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -8,6 +8,7 @@
 - Integration tests that shell out to the compiled `stax` binary must resolve a path that exists at runtime; prefer helper logic that falls back from `CARGO_BIN_EXE_stax` to the sibling `target/.../stax` binary so `nextest` and Docker runs stay stable.
 - Tests that must run outside any Git repository must not use temp dirs rooted under `STAX_TEST_TMPDIR`/`TMPDIR` inside the workspace; `git discover` walks parent directories, so those fixtures can accidentally execute inside the repo during `make test-native`.
 - For full-suite test runs, use `make test` or `just test` (never `cargo test`); on macOS the default should use Docker for performance and consistency.
+- Stack/branch graph traversal in user-facing commands must be iterative and cycle-safe; do not recurse over metadata graphs that can be deep or corrupted by local refs.
 - For stack-merge flows that delete merged branches, always rebase and retarget descendant branches/PR bases before cleanup; deleting a base branch first can auto-close descendant PRs on GitHub.
 - Any descendant-rebase path (`merge`, `merge --when-ready`, `restack`, `upstack restack`, `sync --restack`) must preserve provenance boundaries (`parent_branch_revision` / old parent tip) and use provenance-aware rebase logic; plain `git rebase <trunk>` will replay already-integrated parent history after squash merges.
 - Configure explicit connect/read/write timeouts for GitHub API clients (and other network clients); never rely on library defaults for long-running CLI flows where silent waits look like hangs.


### PR DESCRIPTION
## Summary

- prevent `stax ls` from overflowing the Rust call stack on deep or corrupt stack graphs
- make stack ancestor/descendant traversal cycle-safe so `stax ls --current` also fails safely
- add regression tests for deep chains and cyclic metadata

Fixes #101
