### PR TITLE
Improve restack conflict diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,7 +3094,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stax"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stax"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2021"
 default-run = "stax"
 description = "Fast stacked Git branches and PRs"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod redo;
 pub mod reorder;
 pub mod resolve;
 pub mod restack;
+pub(crate) mod restack_conflict;
 pub(crate) mod restack_parent;
 pub mod shell_setup;
 pub mod split;

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -1,3 +1,4 @@
+use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
 use crate::commands::restack_parent::normalize_scope_parents_for_restack;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::{GitRepo, RebaseResult};
@@ -194,7 +195,7 @@ pub fn run(
 
     let mut summary: Vec<(String, String)> = Vec::new();
 
-    for branch in &scope_branches {
+    for (index, branch) in scope_branches.iter().enumerate() {
         let live_stack = Stack::load(&repo)?;
         let needs_restack = live_stack
             .branches
@@ -241,14 +242,26 @@ pub fn run(
             }
             RebaseResult::Conflict => {
                 LiveTimer::maybe_finish_err(restack_timer, "conflict");
-                if !quiet {
-                    println!();
-                    println!("{}", "Resolve conflicts and run:".yellow());
-                    println!("  {}", "stax resolve".cyan());
-                    println!("  {}", "stax continue".cyan());
-                    println!("  {}", "stax restack --continue".cyan());
-                }
-                if stashed && !quiet {
+                let completed_branches: Vec<String> = summary
+                    .iter()
+                    .filter(|(_, status)| status == "ok")
+                    .map(|(name, _)| name.clone())
+                    .collect();
+                print_restack_conflict(
+                    &repo,
+                    &RestackConflictContext {
+                        branch,
+                        parent_branch: &meta.parent_branch_name,
+                        completed_branches: &completed_branches,
+                        remaining_branches: scope_branches.len().saturating_sub(index + 1),
+                        continue_commands: &[
+                            "stax resolve",
+                            "stax continue",
+                            "stax restack --continue",
+                        ],
+                    },
+                );
+                if stashed {
                     println!("{}", "Stash kept to avoid conflicts.".yellow());
                 }
                 summary.push((branch.clone(), "conflict".to_string()));

--- a/src/commands/restack_conflict.rs
+++ b/src/commands/restack_conflict.rs
@@ -1,0 +1,124 @@
+use crate::git::GitRepo;
+use colored::Colorize;
+
+pub(crate) struct RestackConflictContext<'a> {
+    pub branch: &'a str,
+    pub parent_branch: &'a str,
+    pub completed_branches: &'a [String],
+    pub remaining_branches: usize,
+    pub continue_commands: &'a [&'a str],
+}
+
+pub(crate) fn print_restack_conflict(repo: &GitRepo, context: &RestackConflictContext<'_>) {
+    let conflicted_files = repo.conflicted_files().unwrap_or_default();
+
+    println!();
+    println!("{}", "Restack stopped on conflict:".yellow());
+    for line in render_restack_conflict_details(context, &conflicted_files) {
+        println!("{}", line);
+    }
+    println!();
+    println!("{}", "Resolve conflicts and run:".yellow());
+    for command in context.continue_commands {
+        println!("  {}", command.cyan());
+    }
+}
+
+fn render_restack_conflict_details(
+    context: &RestackConflictContext<'_>,
+    conflicted_files: &[String],
+) -> Vec<String> {
+    let completed_count = context.completed_branches.len();
+
+    let mut lines = vec![
+        format!("  Stopped at: {}", context.branch),
+        format!("  Parent: {}", context.parent_branch),
+        format!(
+            "  Progress: {} rebased before conflict, {} remaining in stack",
+            branch_count_label(completed_count),
+            branch_count_label(context.remaining_branches)
+        ),
+    ];
+
+    if !context.completed_branches.is_empty() {
+        lines.push(format!(
+            "  Completed: {}",
+            context.completed_branches.join(", ")
+        ));
+    }
+
+    if conflicted_files.is_empty() {
+        lines.push("  Conflicted files: (not detected; run `git status`)".to_string());
+    } else {
+        lines.push("  Conflicted files:".to_string());
+        for path in conflicted_files {
+            lines.push(format!("    {}", path));
+        }
+    }
+
+    lines
+}
+
+fn branch_count_label(count: usize) -> String {
+    format!(
+        "{} {}",
+        count,
+        if count == 1 { "branch" } else { "branches" }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_restack_conflict_details, RestackConflictContext};
+
+    #[test]
+    fn renders_progress_completed_branches_and_conflicted_files() {
+        let completed = vec!["feature-a".to_string(), "feature-b".to_string()];
+        let conflicted_files = vec!["src/lib.rs".to_string(), "README.md".to_string()];
+        let context = RestackConflictContext {
+            branch: "feature-c",
+            parent_branch: "feature-b",
+            completed_branches: &completed,
+            remaining_branches: 1,
+            continue_commands: &["stax continue"],
+        };
+
+        let lines = render_restack_conflict_details(&context, &conflicted_files);
+
+        assert_eq!(lines[0], "  Stopped at: feature-c");
+        assert_eq!(lines[1], "  Parent: feature-b");
+        assert_eq!(
+            lines[2],
+            "  Progress: 2 branches rebased before conflict, 1 branch remaining in stack"
+        );
+        assert_eq!(lines[3], "  Completed: feature-a, feature-b");
+        assert_eq!(lines[4], "  Conflicted files:");
+        assert_eq!(lines[5], "    src/lib.rs");
+        assert_eq!(lines[6], "    README.md");
+    }
+
+    #[test]
+    fn renders_git_status_hint_when_conflicted_files_are_unknown() {
+        let completed = Vec::new();
+        let context = RestackConflictContext {
+            branch: "feature-a",
+            parent_branch: "main",
+            completed_branches: &completed,
+            remaining_branches: 0,
+            continue_commands: &["stax continue"],
+        };
+
+        let lines = render_restack_conflict_details(&context, &[]);
+
+        assert_eq!(lines[0], "  Stopped at: feature-a");
+        assert_eq!(lines[1], "  Parent: main");
+        assert_eq!(
+            lines[2],
+            "  Progress: 0 branches rebased before conflict, 0 branches remaining in stack"
+        );
+        assert_eq!(
+            lines[3],
+            "  Conflicted files: (not detected; run `git status`)"
+        );
+    }
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,4 +1,5 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
+use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::{GitRepo, RebaseResult};
@@ -917,7 +918,7 @@ pub fn run(
 
             let mut summary: Vec<(String, String)> = Vec::new();
 
-            for branch in &branches_to_restack {
+            for (index, branch) in branches_to_restack.iter().enumerate() {
                 let restack_timer = LiveTimer::maybe_new(!quiet, &format!("Restack {}", branch));
 
                 let meta = match BranchMetadata::read(repo.inner(), branch)? {
@@ -947,13 +948,28 @@ pub fn run(
                     }
                     RebaseResult::Conflict => {
                         LiveTimer::maybe_finish_warn(restack_timer, "conflict");
-                        if !quiet {
-                            println!("  {}", "Resolve conflicts and run:".yellow());
-                            println!("    {}", "stax resolve".cyan());
-                            println!("    {}", "stax continue".cyan());
-                            println!("    {}", "stax sync --continue".cyan());
-                        }
-                        if stashed && !quiet {
+                        let completed_branches: Vec<String> = summary
+                            .iter()
+                            .filter(|(_, status)| status == "ok")
+                            .map(|(name, _)| name.clone())
+                            .collect();
+                        print_restack_conflict(
+                            &repo,
+                            &RestackConflictContext {
+                                branch,
+                                parent_branch: &meta.parent_branch_name,
+                                completed_branches: &completed_branches,
+                                remaining_branches: branches_to_restack
+                                    .len()
+                                    .saturating_sub(index + 1),
+                                continue_commands: &[
+                                    "stax resolve",
+                                    "stax continue",
+                                    "stax sync --continue",
+                                ],
+                            },
+                        );
+                        if stashed {
                             println!("{}", "Stash kept to avoid conflicts.".yellow());
                         }
                         summary.push((branch.clone(), "conflict".to_string()));

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -1,3 +1,4 @@
+use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
 use crate::commands::restack_parent::normalize_scope_parents_for_restack;
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
@@ -76,6 +77,8 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
     tx.set_plan_summary(summary);
     tx.snapshot()?;
 
+    let mut completed_branches = Vec::new();
+
     for branch in &upstack {
         let live_stack = Stack::load(&repo)?;
         let needs_restack = live_stack
@@ -115,14 +118,25 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
                 // Record the after-OID for this branch
                 tx.record_after(&repo, branch)?;
 
+                completed_branches.push(branch.clone());
                 println!("    {}", "✓ done".green());
             }
             RebaseResult::Conflict => {
                 println!("    {}", "✗ conflict".red());
-                println!();
-                println!("{}", "Resolve conflicts and run:".yellow());
-                println!("  {}", "stax resolve".cyan());
-                println!("  {}", "stax continue".cyan());
+                print_restack_conflict(
+                    &repo,
+                    &RestackConflictContext {
+                        branch,
+                        parent_branch: &meta.parent_branch_name,
+                        completed_branches: &completed_branches,
+                        remaining_branches: upstack
+                            .iter()
+                            .position(|candidate| candidate == branch)
+                            .map(|index| upstack.len().saturating_sub(index + 1))
+                            .unwrap_or(0),
+                        continue_commands: &["stax resolve", "stax continue"],
+                    },
+                );
 
                 // Finish transaction with error
                 tx.finish_err("Rebase conflict", Some("rebase"), Some(branch))?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -378,6 +378,28 @@ impl TestRepo {
             .output()
             .expect("Failed to run git command")
     }
+
+    /// Create a two-branch stack where the parent restacks cleanly and the child conflicts.
+    fn create_restack_progress_conflict_scenario(&self) -> (String, String) {
+        self.run_stax(&["bc", "progress-parent"]);
+        let parent = self.current_branch();
+        self.create_file("parent.txt", "parent content\n");
+        self.commit("Parent commit");
+
+        self.run_stax(&["bc", "progress-child"]);
+        let child = self.current_branch();
+        self.create_file("conflict.txt", "child content\n");
+        self.commit("Child conflict commit");
+
+        self.run_stax(&["t"]);
+        self.create_file("main-update.txt", "main update\n");
+        self.create_file("conflict.txt", "main content\n");
+        self.commit("Main conflict commit");
+
+        self.run_stax(&["checkout", &child]);
+
+        (parent, child)
+    }
 }
 
 fn configure_submit_remote(repo: &TestRepo) {
@@ -1407,6 +1429,65 @@ fn test_restack_all_flag() {
     );
 }
 
+#[test]
+fn test_restack_conflict_reports_branch_progress_and_files() {
+    let repo = TestRepo::new();
+    let (parent, child) = repo.create_restack_progress_conflict_scenario();
+
+    let output = repo.run_stax(&["restack", "--yes"]);
+    assert!(
+        output.status.success(),
+        "restack failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Restack stopped on conflict:"),
+        "Expected conflict heading, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("Stopped at: {}", child)),
+        "Expected stopped-at branch, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("Parent: {}", parent)),
+        "Expected parent branch, got: {}",
+        stdout
+    );
+    assert!(
+        stdout
+            .contains("Progress: 1 branch rebased before conflict, 0 branches remaining in stack"),
+        "Expected progress summary, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("Completed: {}", parent)),
+        "Expected completed branch list, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Conflicted files:") && stdout.contains("conflict.txt"),
+        "Expected conflicted files in output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("stax restack --continue"),
+        "Expected continue guidance, got: {}",
+        stdout
+    );
+
+    let abort = repo.git(&["rebase", "--abort"]);
+    assert!(
+        abort.status.success(),
+        "Failed to abort rebase during cleanup: {}",
+        TestRepo::stderr(&abort)
+    );
+}
+
 // =============================================================================
 // Cascade Tests
 // =============================================================================
@@ -1511,6 +1592,49 @@ fn test_cascade_no_submit_from_middle_restacks_full_stack() {
             name
         );
     }
+}
+
+#[test]
+fn test_cascade_conflict_reports_restack_context() {
+    let repo = TestRepo::new();
+    let (_parent, child) = repo.create_restack_progress_conflict_scenario();
+
+    let output = repo.run_stax(&["cascade", "--no-submit"]);
+    assert!(
+        output.status.success(),
+        "cascade failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Cascading stack..."),
+        "Expected cascade banner, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Restack stopped on conflict:"),
+        "Expected restack conflict block, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("Stopped at: {}", child)),
+        "Expected stopped-at branch in cascade output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Conflicted files:") && stdout.contains("conflict.txt"),
+        "Expected conflicted files in cascade output, got: {}",
+        stdout
+    );
+
+    let abort = repo.git(&["rebase", "--abort"]);
+    assert!(
+        abort.status.success(),
+        "Failed to abort rebase during cleanup: {}",
+        TestRepo::stderr(&abort)
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- add a shared restack conflict formatter that shows the branch, parent, progress, and conflicted files
- surface that conflict block from restack, cascade, sync, and upstack restack, including quiet-mode cascade failures
- cover the new output with targeted integration tests for restack and cascade

## Samples
Illustrative examples of the new conflict block:

### Single-branch restack conflict
```text
Restack stopped on conflict:
  Stopped at: feature-a
  Parent: main
  Progress: 0 branches rebased before conflict, 0 branches remaining in stack
  Conflicted files:
    src/lib.rs

Resolve conflicts and run:
  stax resolve
  stax continue
  stax restack --continue
```

### Mid-stack conflict after one branch succeeded
```text
Restack stopped on conflict:
  Stopped at: feature-c
  Parent: feature-b
  Progress: 1 branch rebased before conflict, 0 branches remaining in stack
  Completed: feature-b
  Conflicted files:
    conflict.txt
    README.md

Resolve conflicts and run:
  stax resolve
  stax continue
  stax restack --continue
```

### Cascade hitting a restack conflict
```text
Cascading stack...
...
Restack stopped on conflict:
  Stopped at: feature-c
  Parent: feature-b
  Progress: 1 branch rebased before conflict, 0 branches remaining in stack
  Completed: feature-b
  Conflicted files:
    conflict.txt

Resolve conflicts and run:
  stax resolve
  stax continue
  stax restack --continue
```

## Testing
- cargo test renders_
- cargo test --test integration_tests conflict_reports
- cargo test --test command_coverage_tests test_upstack_restack
- cargo test --test continue_tests test_sync_continue_flag

Closes #99