### PR TITLE
fix: handle squash-merged parents after trunk advances

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1042,15 +1042,36 @@ Use --auto-stash-pop or stash/commit changes first.",
         }
     }
 
-    /// Check whether a branch is merged-equivalent to trunk
-    /// (ancestor relationship or empty-diff equivalence).
+    /// Check whether a branch is merged-equivalent to trunk.
+    ///
+    /// Besides a direct ancestor relationship, this also detects squash/cherry-pick
+    /// merges by comparing patch-id provenance for the branch-only commits. Unlike a
+    /// full-tree diff, this remains true even when trunk has moved on with unrelated
+    /// commits after the branch was merged.
     pub fn is_branch_merged_equivalent_to_trunk(&self, branch: &str) -> Result<bool> {
         if self.is_branch_merged(branch).unwrap_or(false) {
             return Ok(true);
         }
 
         let trunk = self.trunk_branch()?;
-        self.refs_have_no_diff(&trunk, branch)
+        let merge_base = match self.merge_base(&trunk, branch) {
+            Ok(base) => base,
+            Err(_) => return Ok(false),
+        };
+
+        let branch_range = format!("{}..{}", merge_base, branch);
+        let branch_patch_ids = self.patch_ids_for_range(self.workdir()?, &branch_range)?;
+        if branch_patch_ids.is_empty() {
+            return Ok(true);
+        }
+
+        let trunk_range = format!("{}..{}", merge_base, trunk);
+        let trunk_patch_ids = self.patch_ids_for_range(self.workdir()?, &trunk_range)?;
+        if trunk_patch_ids.is_empty() {
+            return Ok(false);
+        }
+
+        Ok(branch_patch_ids.is_subset(&trunk_patch_ids))
     }
 
     /// Check if a branch has a remote tracking branch (origin/<branch>)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1293,6 +1293,67 @@ fn test_restack_auto_normalizes_squash_merged_parent() {
 }
 
 #[test]
+fn test_restack_auto_normalizes_squash_merged_parent_after_trunk_advances() {
+    let repo = TestRepo::new();
+
+    // Build stack: main -> parent -> child
+    repo.run_stax(&["bc", "restack-parent-advanced"]);
+    let parent = repo.current_branch();
+    repo.create_file("parent.txt", "parent 1\n");
+    repo.commit("Parent commit 1");
+
+    repo.run_stax(&["bc", "restack-child-advanced"]);
+    let child = repo.current_branch();
+    repo.create_file("child.txt", "child change\n");
+    repo.commit("Child commit");
+
+    // Squash-merge parent into main.
+    repo.run_stax(&["t"]);
+    let squash = repo.git(&["merge", "--squash", &parent]);
+    assert!(
+        squash.status.success(),
+        "Failed squash merge: {}",
+        TestRepo::stderr(&squash)
+    );
+    repo.commit("Squash merge parent");
+
+    // Advance trunk with unrelated work after the squash merge.
+    repo.create_file("main-later.txt", "later trunk work\n");
+    repo.commit("Later trunk commit");
+
+    repo.run_stax(&["checkout", &child]);
+    let output = repo.run_stax(&["restack", "--quiet"]);
+    assert!(
+        output.status.success(),
+        "restack failed after trunk advanced\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let metadata_ref = format!("refs/branch-metadata/{}", child);
+    let metadata_output = repo.git(&["show", &metadata_ref]);
+    assert!(
+        metadata_output.status.success(),
+        "Failed to read metadata: {}",
+        TestRepo::stderr(&metadata_output)
+    );
+    let metadata = TestRepo::stdout(&metadata_output);
+    assert!(
+        metadata.contains("\"parentBranchName\":\"main\""),
+        "Expected child to be reparented to trunk after squash merge, metadata was: {}",
+        metadata
+    );
+
+    let count_output = repo.git(&["rev-list", "--count", &format!("main..{}", child)]);
+    assert!(count_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&count_output.stdout).trim(),
+        "1",
+        "Expected child to retain only novel commits after restack even when trunk advanced"
+    );
+}
+
+#[test]
 fn test_restack_auto_normalizes_missing_parent() {
     let repo = TestRepo::new();
 


### PR DESCRIPTION
## Summary
- detect squash/cherry-pick merged branches by patch-id subset against trunk instead of full tree equality
- keep restack normalization working even after trunk gains unrelated commits post-merge
- add a regression test covering squash merge + later trunk commits + child restack

## Testing
- Not run locally in this environment (Rust toolchain unavailable on host)