### PR TITLE
fix: make restack exit after success by default

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,7 +299,7 @@ enum Commands {
         #[arg(long)]
         auto_stash_pop: bool,
         /// After restack, submit stack updates (`ask`, `yes`, `no`)
-        #[arg(long, value_enum, default_value_t = RestackSubmitAfter::Ask)]
+        #[arg(long, value_enum, default_value_t = RestackSubmitAfter::No)]
         submit_after: RestackSubmitAfter,
     },
 
@@ -1653,7 +1653,7 @@ fn print_worktree_help() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_launch_worktree_dashboard, Cli, Commands};
+    use super::{should_launch_worktree_dashboard, Cli, Commands, RestackSubmitAfter};
     use clap::Parser;
 
     #[test]
@@ -1678,6 +1678,18 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::Worktree { command: Some(_) })
+        ));
+    }
+
+    #[test]
+    fn restack_defaults_to_not_submitting_after_success() {
+        let cli = Cli::try_parse_from(["stax", "restack"]).expect("parse restack");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Restack {
+                submit_after: RestackSubmitAfter::No,
+                ..
+            })
         ));
     }
 }


### PR DESCRIPTION
## Summary
- default `stax restack` to `--submit-after no`
- avoid pausing at the post-restack submit prompt after a successful restack
- add a parser regression test for the default

## Testing
- cargo test restack_defaults_to_not_submitting_after_success --lib
- cargo test --test command_coverage_tests test_restack_with_changes -- --nocapture
