### PR TITLE
fix: resume the rest of the stack from stax continue

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1323,7 +1323,7 @@ pub fn run() -> Result<()> {
             parent,
             child,
         } => commands::checkout::run(branch, trunk, parent, child),
-        Commands::Continue => commands::continue_cmd::run(),
+        Commands::Continue => commands::continue_cmd::run_and_resume_restack(),
         Commands::Resolve {
             agent,
             model,

--- a/src/commands/continue_cmd.rs
+++ b/src/commands/continue_cmd.rs
@@ -1,6 +1,8 @@
+use crate::commands::restack;
 use crate::config::Config;
 use crate::engine::BranchMetadata;
 use crate::git::{GitRepo, RebaseResult};
+use crate::ops::receipt::{OpKind, OpReceipt, OpStatus};
 use anyhow::Result;
 use colored::Colorize;
 
@@ -23,9 +25,24 @@ pub(crate) fn continue_rebase_and_update_metadata(repo: &GitRepo) -> Result<Reba
     }
 }
 
-pub fn run() -> Result<()> {
-    let repo = GitRepo::open()?;
+fn latest_failed_restack(repo: &GitRepo) -> Result<Option<OpReceipt>> {
+    let git_dir = repo.git_dir()?;
+    let current = repo.current_branch()?;
+    let workdir = repo.workdir()?.to_string_lossy().to_string();
 
+    Ok(OpReceipt::load_latest(git_dir)?.filter(|receipt| {
+        receipt.kind == OpKind::Restack
+            && receipt.status == OpStatus::Failed
+            && receipt.repo_workdir == workdir
+            && receipt
+                .error
+                .as_ref()
+                .and_then(|error| error.failed_branch.as_deref())
+                == Some(current.as_str())
+    }))
+}
+
+fn continue_impl(repo: &GitRepo, resume_restack: bool) -> Result<()> {
     if !repo.rebase_in_progress()? {
         println!("{}", "No rebase in progress.".yellow());
         return Ok(());
@@ -33,9 +50,22 @@ pub fn run() -> Result<()> {
 
     println!("Continuing rebase...");
 
-    match continue_rebase_and_update_metadata(&repo)? {
+    match continue_rebase_and_update_metadata(repo)? {
         RebaseResult::Success => {
             println!("{}", "✓ Rebase completed successfully!".green());
+
+            if resume_restack {
+                if let Some(receipt) = latest_failed_restack(repo)? {
+                    println!();
+                    println!("{}", "Continuing restack...".bold());
+                    restack::resume_after_rebase(
+                        receipt.auto_stash_pop,
+                        Some(receipt.head_branch_before.clone()),
+                    )?;
+                    return Ok(());
+                }
+            }
+
             let config = Config::load().unwrap_or_default();
             if config.ui.tips {
                 println!();
@@ -59,4 +89,14 @@ pub fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn run() -> Result<()> {
+    let repo = GitRepo::open()?;
+    continue_impl(&repo, false)
+}
+
+pub fn run_and_resume_restack() -> Result<()> {
+    let repo = GitRepo::open()?;
+    continue_impl(&repo, true)
 }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -29,8 +29,6 @@ pub fn run(
     submit_after: SubmitAfterRestack,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
-    let current = repo.current_branch()?;
-    let mut stack = Stack::load(&repo)?;
 
     if r#continue {
         crate::commands::continue_cmd::run()?;
@@ -38,6 +36,52 @@ pub fn run(
             return Ok(());
         }
     }
+
+    run_impl(
+        &repo,
+        all,
+        dry_run,
+        yes,
+        quiet,
+        auto_stash_pop,
+        submit_after,
+        r#continue,
+        None,
+    )
+}
+
+pub(crate) fn resume_after_rebase(
+    auto_stash_pop: bool,
+    restore_branch: Option<String>,
+) -> Result<()> {
+    let repo = GitRepo::open()?;
+    run_impl(
+        &repo,
+        false,
+        false,
+        true,
+        false,
+        auto_stash_pop,
+        SubmitAfterRestack::No,
+        true,
+        restore_branch,
+    )
+}
+
+fn run_impl(
+    repo: &GitRepo,
+    all: bool,
+    dry_run: bool,
+    yes: bool,
+    quiet: bool,
+    auto_stash_pop: bool,
+    submit_after: SubmitAfterRestack,
+    skip_prediction: bool,
+    restore_branch: Option<String>,
+) -> Result<()> {
+    let current = repo.current_branch()?;
+    let restore_branch = restore_branch.unwrap_or_else(|| current.clone());
+    let mut stack = Stack::load(repo)?;
 
     let mut stashed = false;
     if repo.is_dirty()? {
@@ -92,9 +136,9 @@ pub fn run(
         });
     }
 
-    let normalized = normalize_scope_parents_for_restack(&repo, &scope_branches, quiet)?;
+    let normalized = normalize_scope_parents_for_restack(repo, &scope_branches, quiet)?;
     if normalized > 0 {
-        stack = Stack::load(&repo)?;
+        stack = Stack::load(repo)?;
     }
 
     let branches_to_restack = branches_needing_restack(&stack, &scope_branches);
@@ -110,7 +154,7 @@ pub fn run(
     }
 
     // Predict conflicts before proceeding
-    if !r#continue {
+    if !skip_prediction {
         let timer = LiveTimer::maybe_new(!quiet, "Checking for conflicts...");
         let branch_parent_pairs: Vec<(String, String)> = branches_to_restack
             .iter()
@@ -180,8 +224,8 @@ pub fn run(
     }
 
     // Begin transaction
-    let mut tx = Transaction::begin(OpKind::Restack, &repo, quiet)?;
-    tx.plan_branches(&repo, &scope_branches)?;
+    let mut tx = Transaction::begin(OpKind::Restack, repo, quiet)?;
+    tx.plan_branches(repo, &scope_branches)?;
     let summary = PlanSummary {
         branches_to_rebase: scope_branches.len(),
         branches_to_push: 0,
@@ -193,12 +237,13 @@ pub fn run(
     };
     tx::print_plan(tx.kind(), &summary, quiet);
     tx.set_plan_summary(summary);
+    tx.set_auto_stash_pop(auto_stash_pop);
     tx.snapshot()?;
 
     let mut summary: Vec<(String, String)> = Vec::new();
 
     for (index, branch) in scope_branches.iter().enumerate() {
-        let live_stack = Stack::load(&repo)?;
+        let live_stack = Stack::load(repo)?;
         let needs_restack = live_stack
             .branches
             .get(branch)
@@ -237,7 +282,7 @@ pub fn run(
                 updated_meta.write(repo.inner(), branch)?;
 
                 // Record the after-OID for this branch
-                tx.record_after(&repo, branch)?;
+                tx.record_after(repo, branch)?;
 
                 LiveTimer::maybe_finish_ok(restack_timer, "done");
                 summary.push((branch.clone(), "ok".to_string()));
@@ -250,7 +295,7 @@ pub fn run(
                     .map(|(name, _)| name.clone())
                     .collect();
                 print_restack_conflict(
-                    &repo,
+                    repo,
                     &RestackConflictContext {
                         branch,
                         parent_branch: &meta.parent_branch_name,
@@ -277,7 +322,7 @@ pub fn run(
     }
 
     // Return to original branch
-    repo.checkout(&current)?;
+    repo.checkout(&restore_branch)?;
 
     // Finish transaction successfully
     tx.finish_ok()?;
@@ -297,7 +342,7 @@ pub fn run(
     }
 
     // Check for merged branches and offer to delete them
-    cleanup_merged_branches(&repo, quiet, yes)?;
+    cleanup_merged_branches(repo, quiet, yes)?;
 
     if stashed {
         repo.stash_pop()?;
@@ -307,9 +352,6 @@ pub fn run(
     }
 
     let should_submit = should_submit_after_restack(&summary, quiet, submit_after)?;
-
-    // Release libgit2 handles from restack before opening a fresh repo in submit.
-    drop(repo);
 
     if should_submit {
         submit_after_restack(quiet)?;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -920,6 +920,7 @@ pub fn run(
             };
             tx::print_plan(tx.kind(), &summary, quiet);
             tx.set_plan_summary(summary);
+            tx.set_auto_stash_pop(auto_stash_pop);
             tx.snapshot()?;
 
             let mut summary: Vec<(String, String)> = Vec::new();

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -75,6 +75,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
     };
     tx::print_plan(tx.kind(), &summary, false);
     tx.set_plan_summary(summary);
+    tx.set_auto_stash_pop(auto_stash_pop);
     tx.snapshot()?;
 
     let mut completed_branches = Vec::new();

--- a/src/ops/receipt.rs
+++ b/src/ops/receipt.rs
@@ -112,6 +112,8 @@ pub struct OpReceipt {
     pub repo_workdir: String,
     /// Trunk branch name
     pub trunk: String,
+    /// Whether the operation auto-stashed dirty target worktrees
+    pub auto_stash_pop: bool,
     /// Branch that was checked out when operation started
     pub head_branch_before: String,
     /// Local refs that were/will be modified
@@ -143,6 +145,7 @@ impl OpReceipt {
             status: OpStatus::InProgress,
             repo_workdir,
             trunk,
+            auto_stash_pop: false,
             head_branch_before,
             local_refs: Vec::new(),
             remote_refs: Vec::new(),
@@ -350,6 +353,7 @@ mod tests {
         assert!(matches!(receipt.kind, OpKind::Submit));
         assert!(matches!(receipt.status, OpStatus::InProgress));
         assert!(receipt.finished_at.is_none());
+        assert!(!receipt.auto_stash_pop);
         assert!(receipt.local_refs.is_empty());
         assert!(receipt.remote_refs.is_empty());
         assert!(receipt.error.is_none());

--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -95,6 +95,11 @@ impl Transaction {
         self.receipt.plan_summary = summary;
     }
 
+    /// Record whether the operation should auto-stash dirty target worktrees.
+    pub fn set_auto_stash_pop(&mut self, auto_stash_pop: bool) {
+        self.receipt.auto_stash_pop = auto_stash_pop;
+    }
+
     /// Create backup refs and write the in-progress receipt
     pub fn snapshot(&mut self) -> Result<()> {
         if self.snapshotted {

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -5,6 +5,16 @@
 mod common;
 
 use common::{OutputAssertions, TestRepo};
+use serde_json::Value;
+
+fn branch_needs_restack(status: &Value, branch: &str) -> Option<bool> {
+    status["branches"].as_array().and_then(|branches| {
+        branches
+            .iter()
+            .find(|b| b["name"].as_str() == Some(branch))
+            .and_then(|b| b["needs_restack"].as_bool())
+    })
+}
 
 // =============================================================================
 // No Rebase In Progress Tests
@@ -180,6 +190,66 @@ fn test_continue_after_restack_creates_conflict_marker() {
         // Abort the rebase for cleanup
         repo.abort_rebase();
     }
+}
+
+#[test]
+fn test_continue_resumes_remaining_restack_after_conflict() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["bc", "resume-parent"]);
+    let parent = repo.current_branch();
+    repo.create_file("parent.txt", "parent content\n");
+    repo.commit("Parent commit");
+
+    repo.run_stax(&["bc", "resume-child"]);
+    let child = repo.current_branch();
+    repo.create_file("conflict.txt", "child content\n");
+    repo.commit("Child commit");
+
+    repo.run_stax(&["bc", "resume-grandchild"]);
+    let grandchild = repo.current_branch();
+    repo.create_file("grandchild.txt", "grandchild content\n");
+    repo.commit("Grandchild commit");
+
+    repo.run_stax(&["t"]);
+    repo.create_file("conflict.txt", "main content\n");
+    repo.commit("Main conflict commit");
+
+    repo.run_stax(&["checkout", &grandchild]);
+
+    let output = repo.run_stax(&["restack", "--quiet"]);
+    assert!(
+        output.status.success(),
+        "Restack should stop on conflict without failing\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected a rebase in progress after the conflict"
+    );
+
+    repo.resolve_conflicts_ours();
+
+    let output = repo.run_stax(&["continue"]);
+    output.assert_success();
+
+    let status = repo.get_status_json();
+    assert_eq!(
+        branch_needs_restack(&status, &grandchild),
+        Some(false),
+        "Grandchild should be fully restacked after continue"
+    );
+    assert_eq!(
+        branch_needs_restack(&status, &child),
+        Some(false),
+        "Child should remain restacked after continue"
+    );
+    assert_eq!(
+        branch_needs_restack(&status, &parent),
+        Some(false),
+        "Parent should remain restacked after continue"
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- make `stax continue` resume the remaining restack after resolving a conflict
- persist the original `auto_stash_pop` setting in the restack receipt so resume behavior matches the original command
- add coverage for continuing through the rest of the stack

## Stack Note
This branch is stacked on top of #122.
GitHub shows cumulative commits here because the base repo is `cesarferreira/stax` and the base branch has to stay `main`.
Incremental compare for this PR:
https://github.com/KacperKazan/stax/compare/fix/restack-exit-cleanly...fix/restack-continue-stack

## Testing
- cargo test --test continue_tests test_continue_resumes_remaining_restack_after_conflict -- --nocapture
- cargo test --test continue_tests test_restack_continue_flag -- --nocapture
- cargo test --test continue_tests test_continue_no_rebase_in_progress -- --nocapture
