### PR TITLE
fix: hold auto-stashes until restack finishes

### DIFF
--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -8,8 +8,10 @@ use crate::progress::LiveTimer;
 use anyhow::Result;
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +32,7 @@ pub fn run(
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let current = repo.current_branch()?;
+    let current_workdir = canonical_workdir(&repo)?;
     let mut stack = Stack::load(&repo)?;
 
     if r#continue {
@@ -39,12 +42,17 @@ pub fn run(
         }
     }
 
-    let mut stashed = false;
+    let mut stashed_worktrees: Vec<PathBuf> = Vec::new();
+    let mut stashed_worktree_set: HashSet<PathBuf> = HashSet::new();
     if repo.is_dirty()? {
         if auto_stash_pop {
-            stashed = repo.stash_push()?;
+            let stashed = repo.stash_push()?;
             if stashed && !quiet {
                 println!("{}", "✓ Stashed working tree changes.".green());
+            }
+            if stashed {
+                stashed_worktree_set.insert(current_workdir.clone());
+                stashed_worktrees.push(current_workdir.clone());
             }
         } else if quiet {
             anyhow::bail!("Working tree is dirty. Please stash or commit changes first.");
@@ -55,8 +63,12 @@ pub fn run(
                 .interact()?;
 
             if stash {
-                stashed = repo.stash_push()?;
+                let stashed = repo.stash_push()?;
                 println!("{}", "✓ Stashed working tree changes.".green());
+                if stashed {
+                    stashed_worktree_set.insert(current_workdir.clone());
+                    stashed_worktrees.push(current_workdir.clone());
+                }
             } else {
                 println!("{}", "Aborted.".red());
                 return Ok(());
@@ -103,9 +115,7 @@ pub fn run(
         if !quiet {
             println!("{}", "✓ Stack is up to date, nothing to restack.".green());
         }
-        if stashed {
-            repo.stash_pop()?;
-        }
+        restore_stashed_worktrees(&repo, &stashed_worktrees, quiet)?;
         return Ok(());
     }
 
@@ -146,9 +156,7 @@ pub fn run(
         }
 
         if dry_run {
-            if stashed {
-                repo.stash_pop()?;
-            }
+            restore_stashed_worktrees(&repo, &stashed_worktrees, quiet)?;
             return Ok(());
         }
 
@@ -158,9 +166,7 @@ pub fn run(
                 .default(true)
                 .interact()?;
             if !confirm {
-                if stashed {
-                    repo.stash_pop()?;
-                }
+                restore_stashed_worktrees(&repo, &stashed_worktrees, quiet)?;
                 return Ok(());
             }
         }
@@ -219,6 +225,20 @@ pub fn run(
             &format!("{} onto {}", branch, meta.parent_branch_name),
         );
 
+        let target_workdir = repo.branch_rebase_target_workdir(branch)?;
+        if auto_stash_pop
+            && !stashed_worktree_set.contains(&target_workdir)
+            && repo.is_dirty_at(&target_workdir)?
+        {
+            if repo.stash_push_at(&target_workdir)? {
+                stashed_worktree_set.insert(target_workdir.clone());
+                stashed_worktrees.push(target_workdir.clone());
+                if !quiet {
+                    print_stash_message(&current_workdir, &target_workdir);
+                }
+            }
+        }
+
         // Rebase using provenance-aware upstream inference to avoid replaying
         // already-integrated commits after squash/cherry-pick merges.
         match repo.rebase_branch_onto_with_provenance(
@@ -263,8 +283,8 @@ pub fn run(
                         ],
                     },
                 );
-                if stashed {
-                    println!("{}", "Stash kept to avoid conflicts.".yellow());
+                if !stashed_worktrees.is_empty() {
+                    println!("{}", "Auto-stash kept to avoid conflicts.".yellow());
                 }
                 summary.push((branch.clone(), "conflict".to_string()));
 
@@ -299,12 +319,7 @@ pub fn run(
     // Check for merged branches and offer to delete them
     cleanup_merged_branches(&repo, quiet, yes)?;
 
-    if stashed {
-        repo.stash_pop()?;
-        if !quiet {
-            println!("{}", "✓ Restored stashed changes.".green());
-        }
-    }
+    restore_stashed_worktrees(&repo, &stashed_worktrees, quiet)?;
 
     let should_submit = should_submit_after_restack(&summary, quiet, submit_after)?;
 
@@ -315,6 +330,44 @@ pub fn run(
         submit_after_restack(quiet)?;
     }
 
+    Ok(())
+}
+
+fn canonical_workdir(repo: &GitRepo) -> Result<PathBuf> {
+    let workdir = repo.workdir()?.to_path_buf();
+    Ok(std::fs::canonicalize(&workdir).unwrap_or(workdir))
+}
+
+fn print_stash_message(current_workdir: &Path, target_workdir: &Path) {
+    if target_workdir == current_workdir {
+        println!("{}", "✓ Stashed working tree changes.".green());
+    } else {
+        println!(
+            "{}",
+            format!(
+                "✓ Stashed working tree changes in {}.",
+                target_workdir.display()
+            )
+            .green()
+        );
+    }
+}
+
+fn restore_stashed_worktrees(repo: &GitRepo, worktrees: &[PathBuf], quiet: bool) -> Result<()> {
+    let current_workdir = canonical_workdir(repo)?;
+    for worktree in worktrees.iter().rev() {
+        repo.stash_pop_at(worktree)?;
+        if !quiet {
+            if worktree == &current_workdir {
+                println!("{}", "✓ Restored stashed changes.".green());
+            } else {
+                println!(
+                    "{}",
+                    format!("✓ Restored stashed changes in {}.", worktree.display()).green()
+                );
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -620,18 +620,14 @@ impl GitRepo {
         self.rebase_with_args_in_path(cwd, &["rebase", "--onto", onto, upstream])
     }
 
-    fn prepare_branch_rebase_context(&self, branch: &str) -> Result<(PathBuf, PathBuf)> {
+    pub(crate) fn branch_rebase_target_workdir(&self, branch: &str) -> Result<PathBuf> {
         let current_workdir = Self::normalize_path(self.workdir()?);
         let target_workdir = self
             .branch_worktree_path(branch)?
             .unwrap_or_else(|| current_workdir.clone());
         let target_workdir = Self::normalize_path(&target_workdir);
 
-        if target_workdir == current_workdir {
-            if self.current_branch()? != branch {
-                self.checkout(branch)?;
-            }
-        } else {
+        if target_workdir != current_workdir {
             let current_in_target = self.current_branch_in_path(&target_workdir)?;
             if current_in_target != branch {
                 anyhow::bail!(
@@ -640,6 +636,19 @@ impl GitRepo {
                     target_workdir.display(),
                     current_in_target
                 );
+            }
+        }
+
+        Ok(target_workdir)
+    }
+
+    fn prepare_branch_rebase_context(&self, branch: &str) -> Result<(PathBuf, PathBuf)> {
+        let current_workdir = Self::normalize_path(self.workdir()?);
+        let target_workdir = self.branch_rebase_target_workdir(branch)?;
+
+        if target_workdir == current_workdir {
+            if self.current_branch()? != branch {
+                self.checkout(branch)?;
             }
         }
 

--- a/tests/additional_coverage_tests.rs
+++ b/tests/additional_coverage_tests.rs
@@ -220,6 +220,33 @@ fn test_restack_with_parent_changes() {
     output.assert_success();
 }
 
+#[test]
+fn test_restack_auto_stash_pop_restores_dirty_current_worktree() {
+    let repo = TestRepo::new();
+    let branches = repo.create_stack(&["a", "b", "c"]);
+
+    repo.run_stax(&["t"]);
+    repo.create_file("main-update.txt", "main update");
+    repo.commit("Main update");
+
+    repo.run_stax(&["checkout", &branches[2]]);
+    repo.create_file("dirty.txt", "committed content\n");
+    repo.commit("Add dirty file");
+    repo.create_file("dirty.txt", "committed content\nlocal change\n");
+
+    let output = repo.run_stax(&["restack", "--auto-stash-pop"]);
+    output.assert_success();
+
+    let status = repo.git(&["status", "--porcelain"]);
+    assert!(status.status.success(), "git status should succeed");
+    let stdout = TestRepo::stdout(&status);
+    assert!(
+        stdout.contains("dirty.txt"),
+        "Expected dirty current worktree changes to be restored, got:\n{}",
+        stdout
+    );
+}
+
 // =============================================================================
 // Status Command Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- keep restack auto-stashes in place until the full restack finishes
- pre-stash worktrees that will be reused during the restack before running branch rebases in them
- add coverage for a dirty current worktree being restored after a successful full-stack restack

## Testing
- cargo test --test worktree_tests restack_fails_on_dirty_target_worktree_without_flag -- --nocapture
- cargo test --test worktree_tests restack_auto_stash_pop_succeeds_and_restores_changes -- --nocapture
- cargo test --test additional_coverage_tests test_restack_auto_stash_pop_restores_dirty_current_worktree -- --nocapture
