### PR TITLE
Faster repo sync

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,7 +249,7 @@ enum Commands {
         /// Also restack branches after syncing
         #[arg(short, long)]
         restack: bool,
-        /// Prune stale remote-tracking refs during fetch
+        /// No-op: sync always prunes stale remote-tracking refs during fetch
         #[arg(long)]
         prune: bool,
         /// Don't delete merged branches
@@ -1127,11 +1127,14 @@ pub fn run() -> Result<()> {
     let _ = Config::ensure_exists();
 
     let cli = Cli::parse();
+    let stdin_is_terminal = std::io::stdin().is_terminal();
+    let stdout_is_terminal = std::io::stdout().is_terminal();
 
-    // No command = launch TUI
+    // Bare `st`/`stax` should only enter the TUI when both sides are interactive.
+    // In shells or wrappers without a usable TTY, fall back to the regular status view.
     let command = match cli.command {
         Some(cmd) => cmd,
-        None => {
+        None if should_launch_default_tui(stdin_is_terminal, stdout_is_terminal) => {
             // TUI requires initialized repo
             commands::init::ensure_initialized()?;
             let result = tui::run();
@@ -1139,6 +1142,13 @@ pub fn run() -> Result<()> {
             update::check_in_background();
             return result;
         }
+        None => Commands::Status {
+            json: false,
+            stack: None,
+            current: false,
+            compact: false,
+            quiet: false,
+        },
     };
 
     // Commands that don't need repo initialization
@@ -1657,7 +1667,15 @@ pub fn run() -> Result<()> {
     result
 }
 
+fn should_launch_default_tui(stdin_is_terminal: bool, stdout_is_terminal: bool) -> bool {
+    has_interactive_terminal(stdin_is_terminal, stdout_is_terminal)
+}
+
 fn should_launch_worktree_dashboard(stdin_is_terminal: bool, stdout_is_terminal: bool) -> bool {
+    has_interactive_terminal(stdin_is_terminal, stdout_is_terminal)
+}
+
+fn has_interactive_terminal(stdin_is_terminal: bool, stdout_is_terminal: bool) -> bool {
     stdin_is_terminal && stdout_is_terminal
 }
 
@@ -1674,7 +1692,10 @@ fn print_worktree_help() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_launch_worktree_dashboard, Cli, Commands, RestackSubmitAfter};
+    use super::{
+        has_interactive_terminal, should_launch_default_tui, should_launch_worktree_dashboard, Cli,
+        Commands, RestackSubmitAfter,
+    };
     use clap::Parser;
 
     #[test]
@@ -1682,6 +1703,22 @@ mod tests {
         assert!(should_launch_worktree_dashboard(true, true));
         assert!(!should_launch_worktree_dashboard(true, false));
         assert!(!should_launch_worktree_dashboard(false, true));
+    }
+
+    #[test]
+    fn default_tui_requires_interactive_terminal() {
+        assert!(should_launch_default_tui(true, true));
+        assert!(!should_launch_default_tui(true, false));
+        assert!(!should_launch_default_tui(false, true));
+        assert!(!should_launch_default_tui(false, false));
+    }
+
+    #[test]
+    fn interactive_terminal_requires_both_stdio_streams() {
+        assert!(has_interactive_terminal(true, true));
+        assert!(!has_interactive_terminal(true, false));
+        assert!(!has_interactive_terminal(false, true));
+        assert!(!has_interactive_terminal(false, false));
     }
 
     #[test]

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -12,6 +12,7 @@ use crate::remote::RemoteInfo;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::collections::HashMap;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -19,7 +20,7 @@ use std::time::{Duration, Instant};
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     restack: bool,
-    prune: bool,
+    #[allow(unused_variables)] prune: bool,
     delete_merged: bool,
     delete_upstream_gone: bool,
     force: bool,
@@ -85,11 +86,9 @@ pub fn run(
     let fetch_timer = LiveTimer::maybe_new(!quiet, &format!("Fetch {}", remote_name));
 
     let fetch_started_at = Instant::now();
-    let fetch_args: Vec<&str> = if prune {
-        vec!["fetch", "--prune", "--no-tags", &remote_name]
-    } else {
-        vec!["fetch", "--no-tags", &remote_name]
-    };
+    // Always prune so remote-tracking refs match GitHub after branch deletion (enables
+    // merged-branch detection). The CLI `--prune` flag is kept for compatibility.
+    let fetch_args: Vec<&str> = vec!["fetch", "--prune", "--no-tags", &remote_name];
     let output = Command::new("git")
         .args(&fetch_args)
         .current_dir(&workdir)
@@ -1127,10 +1126,11 @@ fn find_merged_branches(
             continue;
         }
 
-        // Check if PR state is "merged" (case-insensitive)
+        // PR merged or closed without merge (cancelled) — both warrant cleanup offer.
         if matches!(
             info.pr_state.as_deref(),
-            Some(state) if state.eq_ignore_ascii_case("merged")
+            Some(state)
+                if state.eq_ignore_ascii_case("merged") || state.eq_ignore_ascii_case("closed")
         ) {
             merged.push(branch.clone());
         }
@@ -1198,15 +1198,88 @@ fn find_merged_branches(
     // when trunk has advanced past the merge point (where a simple tree diff
     // would show false negatives). Run this last so cheaper signals resolve
     // most cases before the provenance path touches more refs.
+    let trunk = stack.trunk.as_str();
+    let mut need_patch_id: Vec<(String, String)> = Vec::new();
+
     for branch in stack.branches.keys() {
         if branch == &stack.trunk || merged.contains(branch) {
             continue;
         }
-        if repo
-            .is_branch_merged_equivalent_to_trunk(branch)
-            .unwrap_or(false)
-        {
-            merged.push(branch.clone());
+        // Remote still exists -> not merged via squash-delete; skip expensive check.
+        if remote_branches.contains(branch.as_str()) {
+            continue;
+        }
+        match repo.is_branch_merged_cheap(branch) {
+            Ok(Some(())) => merged.push(branch.clone()),
+            Ok(None) => {
+                if let Ok(mb) = repo.merge_base(trunk, branch) {
+                    need_patch_id.push((branch.clone(), mb));
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    if !need_patch_id.is_empty() {
+        let mut by_merge_base: HashMap<String, Vec<String>> = HashMap::new();
+        for (branch, mb) in need_patch_id {
+            by_merge_base.entry(mb).or_default().push(branch);
+        }
+
+        for (merge_base, branches) in by_merge_base {
+            let trunk_range = format!("{}..{}", merge_base, trunk);
+            let trunk_count = match repo.rev_list_count(workdir, &trunk_range) {
+                Ok(c) => c,
+                Err(_) => {
+                    for branch in branches {
+                        if repo
+                            .is_branch_merged_equivalent_to_trunk(&branch)
+                            .unwrap_or(false)
+                        {
+                            merged.push(branch);
+                        }
+                    }
+                    continue;
+                }
+            };
+
+            if trunk_count > GitRepo::PATCH_ID_TRUNK_COMMIT_CAP {
+                for branch in branches {
+                    if repo
+                        .is_branch_merged_equivalent_to_trunk(&branch)
+                        .unwrap_or(false)
+                    {
+                        merged.push(branch);
+                    }
+                }
+                continue;
+            }
+
+            let trunk_patch_ids = match repo.patch_ids_for_range(workdir, &trunk_range) {
+                Ok(ids) => ids,
+                Err(_) => {
+                    for branch in branches {
+                        if repo
+                            .is_branch_merged_equivalent_to_trunk(&branch)
+                            .unwrap_or(false)
+                        {
+                            merged.push(branch);
+                        }
+                    }
+                    continue;
+                }
+            };
+
+            for branch in branches {
+                let branch_range = format!("{}..{}", merge_base, branch);
+                let branch_patch_ids = match repo.patch_ids_for_range(workdir, &branch_range) {
+                    Ok(ids) => ids,
+                    Err(_) => continue,
+                };
+                if branch_patch_ids.is_empty() || branch_patch_ids.is_subset(&trunk_patch_ids) {
+                    merged.push(branch);
+                }
+            }
         }
     }
 

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -595,11 +595,7 @@ impl GitRepo {
         // First check if trunk is stored
         if let Some(trunk) = super::refs::read_trunk(&self.repo)? {
             // Validate the stored trunk branch actually exists locally
-            if self
-                .repo
-                .find_branch(&trunk, BranchType::Local)
-                .is_ok()
-            {
+            if self.repo.find_branch(&trunk, BranchType::Local).is_ok() {
                 return Ok(trunk);
             }
             // Stored trunk doesn't exist, fall through to auto-detection
@@ -782,7 +778,23 @@ impl GitRepo {
             .collect())
     }
 
-    fn patch_ids_for_range(&self, cwd: &Path, range: &str) -> Result<HashSet<String>> {
+    /// Max commits in `merge_base..trunk` for patch-id provenance; beyond this we skip the
+    /// expensive `git log -p` path (see sync merged-branch detection).
+    pub(crate) const PATCH_ID_TRUNK_COMMIT_CAP: usize = 200;
+
+    pub(crate) fn rev_list_count(&self, cwd: &Path, range: &str) -> Result<usize> {
+        let output = self.run_git(cwd, &["rev-list", "--count", range])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!("git rev-list --count {} failed: {}", range, stderr);
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse()
+            .unwrap_or(0))
+    }
+
+    pub(crate) fn patch_ids_for_range(&self, cwd: &Path, range: &str) -> Result<HashSet<String>> {
         let output = self.run_git(cwd, &["log", "--format=%H", "-p", "--no-merges", range])?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -1282,6 +1294,24 @@ Use --auto-stash-pop or stash/commit changes first.",
             == branch_commit.id())
     }
 
+    /// Cheap merge-equivalence checks only (ancestor + identical tree). Returns `Some(())` if
+    /// merged by those signals, `None` if patch-id provenance may still be needed.
+    pub fn is_branch_merged_cheap(&self, branch: &str) -> Result<Option<()>> {
+        if self.is_branch_merged(branch).unwrap_or(false) {
+            return Ok(Some(()));
+        }
+
+        let trunk = self.trunk_branch()?;
+
+        // Tree-level diff: if the trees are identical the branch is fully merged,
+        // regardless of how many commits were squashed.
+        if self.refs_have_no_diff(&trunk, branch)? {
+            return Ok(Some(()));
+        }
+
+        Ok(None)
+    }
+
     /// Return true when two refs have no content diff.
     /// Check whether a branch is merged-equivalent to trunk.
     ///
@@ -1292,17 +1322,11 @@ Use --auto-stash-pop or stash/commit changes first.",
     /// 3. Patch-id provenance — catches single-commit squash/cherry-pick merges even
     ///    after trunk has advanced with unrelated commits
     pub fn is_branch_merged_equivalent_to_trunk(&self, branch: &str) -> Result<bool> {
-        if self.is_branch_merged(branch).unwrap_or(false) {
+        if self.is_branch_merged_cheap(branch)?.is_some() {
             return Ok(true);
         }
 
         let trunk = self.trunk_branch()?;
-
-        // Tree-level diff: if the trees are identical the branch is fully merged,
-        // regardless of how many commits were squashed.
-        if self.refs_have_no_diff(&trunk, branch)? {
-            return Ok(true);
-        }
 
         // Patch-id provenance: handles the case where trunk has advanced past the
         // merge point with unrelated commits (tree diff would show false negatives).
@@ -1311,14 +1335,20 @@ Use --auto-stash-pop or stash/commit changes first.",
             Err(_) => return Ok(false),
         };
 
+        let cwd = self.workdir()?;
         let branch_range = format!("{}..{}", merge_base, branch);
-        let branch_patch_ids = self.patch_ids_for_range(self.workdir()?, &branch_range)?;
+        let branch_patch_ids = self.patch_ids_for_range(cwd, &branch_range)?;
         if branch_patch_ids.is_empty() {
             return Ok(true);
         }
 
         let trunk_range = format!("{}..{}", merge_base, trunk);
-        let trunk_patch_ids = self.patch_ids_for_range(self.workdir()?, &trunk_range)?;
+        let trunk_count = self.rev_list_count(cwd, &trunk_range)?;
+        if trunk_count > Self::PATCH_ID_TRUNK_COMMIT_CAP {
+            return Ok(false);
+        }
+
+        let trunk_patch_ids = self.patch_ids_for_range(cwd, &trunk_range)?;
         if trunk_patch_ids.is_empty() {
             return Ok(false);
         }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2,6 +2,7 @@
 
 - When changing the `stax co` UI, match the `stax ls` visual language (colors, tree/indentation) and confirm it visually. Do not ship a redesign without verifying the output looks like the `ls` tree and that selection emphasis is obvious.
 - If interactive lists scroll the terminal on navigation, clear and position the cursor before invoking the dialog to avoid rendering into the lower viewport.
+- Bare commands that default to a TUI/dashboard must gate on both `stdin` and `stdout` being terminals and otherwise fall back to help or a non-interactive view; never assume `st`/`st wt` is launched from a full TTY.
 - When adding or changing CLI commands/flags, update both `README.md` and `docs/` command references in the same change and verify parity against `stax --help` before marking docs complete.
 - Shell integration snippets that define common command names (`stax`, `st`, `sw`) must clear conflicting aliases first; zsh expands aliases while parsing function definitions and can abort shell startup otherwise.
 - Commands intended for first-run/setup flows (for example `shell-setup`) must bypass repo initialization in `src/cli.rs`; otherwise running them outside a configured repo can accidentally trigger `init` and break shell startup or onboarding.

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -723,6 +723,16 @@ fn test_status_shows_branch_info() {
     output.assert_stdout_contains("feature");
 }
 
+#[test]
+fn test_bare_command_falls_back_to_status_noninteractive() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+
+    let output = repo.run_stax(&[]);
+    output.assert_success();
+    output.assert_stdout_contains("feature");
+}
+
 // =============================================================================
 // Merge Command Tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Improve `sync` performance and reliability by always pruning remote refs, making merged-branch detection cheaper before falling back to patch-id provenance, and preventing bare `st` from trying to launch the TUI in non-interactive environments.

## Key changes

### Faster and more accurate `sync` cleanup detection

`sync` now always fetches with `--prune`, regardless of the `--prune` flag, so stale remote-tracking refs are removed consistently after PR branch deletion. This makes merged/upstream-gone detection more reliable and keeps the existing flag as a compatibility no-op.

Merged-branch detection was also reworked to prefer cheap signals first and only use patch-id provenance when necessary. Branches are grouped by merge base so trunk patch IDs are computed once per group, and the expensive provenance path is skipped entirely when the trunk range is too large. Cleanup eligibility also now includes PRs that were closed without merge.

### Safer non-interactive CLI behavior

Bare `st`/`stax` now launches the TUI only when both `stdin` and `stdout` are attached to terminals. In non-interactive shells, wrappers, or scripted environments, it falls back to the normal `status` view instead of attempting to start the TUI.

This same “both streams must be terminals” rule is now shared across the default TUI and worktree dashboard gating logic, with unit and command coverage tests added for the fallback behavior.

## How it works

- **Behavior**: `st sync` prunes stale remote refs on every fetch, detects merged branches more efficiently, and offers cleanup for both merged and closed PR branches. Bare `st` behaves safely in non-interactive contexts by showing status instead of opening the TUI.
- **Implementation**: Added shared terminal-interactivity helpers in the CLI, introduced `GitRepo::is_branch_merged_cheap`, `rev_list_count`, and a patch-id commit cap, and restructured sync’s merged-branch scan to batch work by merge base before falling back to the expensive equivalence check.
- **Tradeoffs**: The `--prune` flag remains exposed but is now informational for backward compatibility. Patch-id provenance is intentionally skipped for very large trunk ranges, so some edge cases fall back to conservative “not merged” behavior instead of paying a large sync-time cost.

## Configuration changes

- [x] No config changes
- [ ] Config changes included (describe below)

```toml
# No configuration changes.
```

## Testing

- [ ] `make test` (or `just test`) for full-suite validation
- [ ] `cargo check`
- [ ] `cargo clippy -- -D warnings`
- [ ] `cargo fmt -- --check`
- [ ] Manual verification (if applicable)

Commands/output (if relevant):

```bash
# Added automated coverage for:
# - bare command non-interactive fallback to status
# - terminal interactivity gating helpers
```