### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,42 +1,8 @@
-## Summary
+## Motivation
 
-{{brief_summary_of_the_change}}
+<!-- What feature does this add / what does it fix? -->
 
-## Key changes
+## Description of changes / notes for reviewers
 
-### {{change_area_1}}
-
-{{what_changed_and_why}}
-
-### {{change_area_2}}
-
-{{what_changed_and_why}}
-
-## How it works
-
-- **Behavior**: {{runtime_or_user_facing_behavior}}
-- **Implementation**: {{technical_approach}}
-- **Tradeoffs**: {{limits_or_design_decisions}}
-
-## Configuration changes
-
-- [ ] No config changes
-- [ ] Config changes included (describe below)
-
-```toml
-# add or update config examples here when relevant
-```
-
-## Testing
-
-- [ ] `make test` (or `just test`) for full-suite validation
-- [ ] `cargo check`
-- [ ] `cargo clippy -- -D warnings`
-- [ ] `cargo fmt -- --check`
-- [ ] Manual verification (if applicable)
-
-Commands/output (if relevant):
-
-```bash
-# paste commands run and notable output
-```
+-
+-


### PR DESCRIPTION
## Motivation

Simplify the default PR body so authors can focus on why the change exists and what reviewers should know.

## Description of changes / notes for reviewers

- Replace the verbose multi-section template with a short two-section structure.
- Remove the default config/testing boilerplate from new PR descriptions.
