### PR TITLE
ci: run Windows tests only on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Install cargo-nextest
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        uses: taiki-e/install-action@nextest
+
+      - name: Run Windows tests
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: cargo nextest run --lib --bins
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -11,12 +11,8 @@ concurrency:
 
 jobs:
   unit-tests:
-    name: Unit Tests (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: Unit Tests
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -27,7 +23,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.os }}
+          key: ubuntu-latest
       - name: Run unit tests
         run: cargo nextest run --lib --bins
 


### PR DESCRIPTION
## Summary

- run unit tests on Ubuntu only in the regular Rust test workflow
- run the Windows unit test job only from the release workflow before building the Windows artifact
- keep integration tests on their existing PR and main triggers
