### PR TITLE
feat(merge): add --remote for API-only stack merge on GitHub

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -8,7 +8,7 @@
 | `st ll` | | Show stack with PR URLs and full details |
 | `st log` | `l` | Show stack with commits and PR info |
 | `st submit` | `ss` | Submit full current stack |
-| `st merge` | | Merge PRs bottom -> current with provenance-aware descendant rebases, then sync local repo (`--no-sync` to skip) |
+| `st merge` | | Merge PRs bottom -> current with provenance-aware descendant rebases, then sync local repo (`--no-sync` to skip); `st merge --remote` merges via GitHub API only (no local git; GitHub-only) |
 | `st merge-when-ready` | `mwr` | Backward-compatible alias for `st merge --when-ready` |
 | `st sync` | `rs` | Pull trunk from remote, detect and delete merged branches (incl. squash merges), reparent their children — **no rebasing** |
 | `st sync --restack` | `rs --restack` | Everything `sync` does, **then** rebase the current stack onto updated parents |
@@ -166,6 +166,8 @@ Worktree launch examples:
 - `st merge --dry-run`
 - `st merge --when-ready`
 - `st merge --when-ready --interval 10`
+- `st merge --remote`
+- `st merge --remote --all --method squash --yes`
 - `st merge --no-wait`
 - `st merge --no-sync`
 - `st merge --timeout 60 --no-delete --quiet`

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -25,6 +25,8 @@ st merge --method merge
 st merge --method rebase
 st merge --when-ready
 st merge --when-ready --interval 10
+st merge --remote
+st merge --remote --all
 st merge --no-wait
 st merge --no-delete
 st merge --no-sync
@@ -32,7 +34,23 @@ st merge --timeout 60
 st merge --yes
 ```
 
-`--when-ready` cannot be combined with `--dry-run` or `--no-wait`.
+`--when-ready` cannot be combined with `--dry-run`, `--no-wait`, or `--remote`.
+
+### `--remote` mode (GitHub only)
+
+`st merge --remote` merges the stack entirely via the GitHub API. No local git operations are performed (no checkout, rebase, or push) — you can keep working on other branches while it runs. Dependent PR head branches are updated on GitHub using the same mechanism as the **Update branch** button (REST `PUT .../pulls/{pull}/update-branch`).
+
+```bash
+st merge --remote
+st merge --remote --all
+st merge --remote --method squash
+st merge --remote --timeout 60
+st merge --remote --interval 10
+```
+
+After a successful run, run `st rs` to sync your local repository (delete merged local branches, reparent children, etc.). `--remote` uses `--interval` for CI polling, same as `--when-ready`.
+
+`--remote` cannot be combined with `--dry-run`, `--when-ready`, or `--no-wait`. Only **GitHub** is supported (not GitLab/Gitea).
 
 ### Partial stack merge
 

--- a/skills.md
+++ b/skills.md
@@ -169,7 +169,9 @@ stax merge --all                   # Merge whole stack
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
 stax merge --when-ready            # Wait for CI + approval before each merge
-stax merge --interval 30           # Poll interval in seconds for --when-ready
+stax merge --remote                # Merge via GitHub API only — no local checkout/rebase/push
+stax merge --remote --all          # Include full stack (GitHub only)
+stax merge --interval 30           # Poll interval in seconds for --when-ready / --remote
 stax merge --no-wait               # Fail fast if CI is pending
 stax merge --timeout 60            # Max wait minutes per PR
 stax merge --no-delete             # Keep branches after merge

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,10 +198,13 @@ enum Commands {
         #[arg(long, default_value = "30")]
         timeout: u64,
         /// Wait for each PR to be ready (CI + approval) before merging
-        #[arg(long, conflicts_with_all = ["dry_run", "no_wait"])]
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "remote"])]
         when_ready: bool,
-        /// Polling interval in seconds for --when-ready mode
-        #[arg(long, default_value = "15", requires = "when_ready")]
+        /// Merge via GitHub API only (no local checkout/rebase/push); GitHub updates branches remotely
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready"])]
+        remote: bool,
+        /// Polling interval in seconds for --when-ready and --remote
+        #[arg(long, default_value = "15")]
         interval: u64,
         /// Skip post-merge sync (`stax rs`)
         #[arg(long)]
@@ -1254,13 +1257,25 @@ pub fn run() -> Result<()> {
             no_wait,
             timeout,
             when_ready,
+            remote,
             interval,
             no_sync,
             yes,
             quiet,
         } => {
             let merge_method = method.parse().unwrap_or_default();
-            if when_ready {
+            if remote {
+                commands::merge_remote::run(
+                    all,
+                    merge_method,
+                    timeout,
+                    interval,
+                    no_delete,
+                    no_sync,
+                    yes,
+                    quiet,
+                )
+            } else if when_ready {
                 commands::merge_when_ready::run(
                     all,
                     merge_method,

--- a/src/commands/merge_remote.rs
+++ b/src/commands/merge_remote.rs
@@ -1,0 +1,690 @@
+//! Merge a stack using only the GitHub API — no local checkout, rebase, or push.
+//!
+//! Dependent PR branches are updated via GitHub's "Update branch" endpoint (`PUT .../update-branch`).
+
+use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
+use crate::config::Config;
+use crate::engine::Stack;
+use crate::forge::ForgeClient;
+use crate::git::GitRepo;
+use crate::github::pr::{MergeMethod, PrMergeStatus};
+use crate::progress::LiveTimer;
+use crate::remote::{ForgeType, RemoteInfo};
+use anyhow::{Context, Result};
+use colored::Colorize;
+use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::io::Write;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+struct LandBranchInfo {
+    branch: String,
+    pr_number: u64,
+}
+
+#[derive(Debug, Clone)]
+struct RemainingBranchInfo {
+    branch: String,
+    pr_number: Option<u64>,
+}
+
+struct MergeRemoteScope {
+    to_merge: Vec<String>,
+    remaining: Vec<String>,
+    trunk: String,
+}
+
+enum WaitResult {
+    Ready,
+    Failed(String),
+    Timeout,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    all: bool,
+    method: MergeMethod,
+    timeout_mins: u64,
+    interval_secs: u64,
+    no_delete: bool,
+    no_sync: bool,
+    yes: bool,
+    quiet: bool,
+) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let current = repo.current_branch()?;
+    let stack = Stack::load(&repo)?;
+    let config = Config::load()?;
+
+    if current == stack.trunk {
+        if !quiet {
+            println!(
+                "{}",
+                "You are on trunk. Checkout a branch in a stack to merge.".yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    if !stack.branches.contains_key(&current) {
+        if !quiet {
+            println!(
+                "{}",
+                format!(
+                    "Branch '{}' is not tracked. Run 'stax branch track' first.",
+                    current
+                )
+                .yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    let scope = calculate_merge_scope(&stack, &current, all);
+
+    let mut branches: Vec<LandBranchInfo> = Vec::new();
+
+    let remote_info = RemoteInfo::from_repo(&repo, &config);
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+    let probe_client = remote_info
+        .as_ref()
+        .ok()
+        .and_then(|info| ForgeClient::new(info).ok());
+
+    let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching PR info...");
+
+    for branch_name in &scope.to_merge {
+        let branch_info = stack.branches.get(branch_name);
+        let mut pr_number = branch_info.and_then(|b| b.pr_number);
+
+        if pr_number.is_none() {
+            if let Some(ref client) = probe_client {
+                if let Ok(Some(pr_info)) = rt.block_on(async { client.find_pr(branch_name).await })
+                {
+                    pr_number = Some(pr_info.number);
+                }
+            }
+        }
+
+        match pr_number {
+            Some(num) => branches.push(LandBranchInfo {
+                branch: branch_name.clone(),
+                pr_number: num,
+            }),
+            None => {
+                LiveTimer::maybe_finish_err(fetch_timer, "missing PR");
+                anyhow::bail!(
+                    "Branch '{}' has no PR. Run 'stax submit' first to create PRs.",
+                    branch_name
+                );
+            }
+        }
+    }
+
+    let mut remaining_branches: Vec<RemainingBranchInfo> = Vec::new();
+    for branch_name in &scope.remaining {
+        let branch_info = stack.branches.get(branch_name);
+        let mut pr_number = branch_info.and_then(|b| b.pr_number);
+
+        if pr_number.is_none() {
+            if let Some(ref client) = probe_client {
+                if let Ok(Some(pr_info)) = rt.block_on(async { client.find_pr(branch_name).await })
+                {
+                    pr_number = Some(pr_info.number);
+                }
+            }
+        }
+
+        remaining_branches.push(RemainingBranchInfo {
+            branch: branch_name.clone(),
+            pr_number,
+        });
+    }
+
+    LiveTimer::maybe_finish_ok(fetch_timer, "done");
+
+    if branches.is_empty() {
+        if !quiet {
+            println!("{}", "No branches to merge.".yellow());
+        }
+        return Ok(());
+    }
+
+    let remote_info = remote_info.context("Failed to read git remote configuration")?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax merge --remote` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+
+    let client = ForgeClient::new(&remote_info).context(
+        "Failed to connect to the configured forge. Check your token and remote configuration.",
+    )?;
+
+    if !quiet {
+        println!();
+        print_remote_preview(&branches, &scope.trunk, &method);
+    }
+
+    if !yes {
+        let confirm = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Proceed with merge --remote?")
+            .default(false)
+            .interact()?;
+
+        if !confirm {
+            println!("{}", "Aborted.".dimmed());
+            return Ok(());
+        }
+    }
+
+    if !quiet {
+        println!();
+        print_header("Merge Remote");
+    }
+
+    let timeout = Duration::from_secs(timeout_mins * 60);
+    let poll_interval = Duration::from_secs(interval_secs);
+    let total = branches.len();
+    let mut merged_prs: Vec<(String, u64)> = Vec::new();
+    let mut failed_pr: Option<(String, u64, String)> = None;
+
+    for idx in 0..total {
+        let pr_number = branches[idx].pr_number;
+        let branch_name = branches[idx].branch.clone();
+        let next_branch = branches.get(idx + 1).cloned();
+
+        if !quiet {
+            println!();
+            println!(
+                "[{}/{}] {} (#{})",
+                (idx + 1).to_string().cyan(),
+                total,
+                branch_name.bold(),
+                pr_number
+            );
+        }
+
+        let is_merged = rt.block_on(async { client.is_pr_merged(pr_number).await })?;
+        if is_merged {
+            if !quiet {
+                println!("      {} Already merged", "✓".green());
+            }
+            merged_prs.push((branch_name.clone(), pr_number));
+
+            if let Some(ref next_branch) = next_branch {
+                let update_base_timer = LiveTimer::maybe_new(
+                    !quiet,
+                    &format!(
+                        "Retargeting #{} to {}...",
+                        next_branch.pr_number, scope.trunk
+                    ),
+                );
+
+                match rt.block_on(async {
+                    client
+                        .update_pr_base(next_branch.pr_number, &scope.trunk)
+                        .await
+                }) {
+                    Ok(()) => LiveTimer::maybe_finish_ok(update_base_timer, "done"),
+                    Err(e) => {
+                        LiveTimer::maybe_finish_err(update_base_timer, "failed");
+                        failed_pr = Some((
+                            branch_name,
+                            pr_number,
+                            format!(
+                                "Failed to retarget dependent PR #{}: {}",
+                                next_branch.pr_number, e
+                            ),
+                        ));
+                        break;
+                    }
+                }
+            }
+        } else {
+            match wait_for_pr_ready(&rt, &client, pr_number, timeout, poll_interval, quiet)? {
+                WaitResult::Ready => {}
+                WaitResult::Failed(reason) => {
+                    failed_pr = Some((branch_name, pr_number, reason));
+                    break;
+                }
+                WaitResult::Timeout => {
+                    failed_pr =
+                        Some((branch_name, pr_number, "Timeout waiting for CI".to_string()));
+                    break;
+                }
+            }
+
+            if let Some(ref next_branch) = next_branch {
+                let update_base_timer = LiveTimer::maybe_new(
+                    !quiet,
+                    &format!(
+                        "Retargeting #{} to {} before merge...",
+                        next_branch.pr_number, scope.trunk
+                    ),
+                );
+
+                match rt.block_on(async {
+                    client
+                        .update_pr_base(next_branch.pr_number, &scope.trunk)
+                        .await
+                }) {
+                    Ok(()) => LiveTimer::maybe_finish_ok(update_base_timer, "done"),
+                    Err(e) => {
+                        LiveTimer::maybe_finish_err(update_base_timer, "failed");
+                        failed_pr = Some((
+                            branch_name,
+                            pr_number,
+                            format!(
+                                "Failed to retarget dependent PR #{}: {}",
+                                next_branch.pr_number, e
+                            ),
+                        ));
+                        break;
+                    }
+                }
+            }
+
+            let merge_timer =
+                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
+
+            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
+                Ok(()) => {
+                    LiveTimer::maybe_finish_ok(merge_timer, "done");
+                    merged_prs.push((branch_name.clone(), pr_number));
+                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_name);
+                }
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(merge_timer, "failed");
+                    failed_pr = Some((branch_name, pr_number, e.to_string()));
+                    break;
+                }
+            }
+        }
+
+        if let Some(next_branch) = next_branch {
+            let update_timer = LiveTimer::maybe_new(
+                !quiet,
+                &format!(
+                    "Updating branch for #{} on GitHub (merge {} → head)...",
+                    next_branch.pr_number, scope.trunk
+                ),
+            );
+
+            match rt.block_on(async { client.update_pr_branch(next_branch.pr_number).await }) {
+                Ok(()) => LiveTimer::maybe_finish_ok(update_timer, "done"),
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(update_timer, "failed");
+                    failed_pr = Some((
+                        next_branch.branch.clone(),
+                        next_branch.pr_number,
+                        format!(
+                            "Failed to update branch for PR #{}: {}",
+                            next_branch.pr_number, e
+                        ),
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    if !merged_prs.is_empty() && !remaining_branches.is_empty() && failed_pr.is_none() {
+        if !quiet {
+            println!();
+            println!(
+                "{}",
+                "Updating remaining stack branches on GitHub...".dimmed()
+            );
+        }
+
+        for remaining in &remaining_branches {
+            let Some(pr_num) = remaining.pr_number else {
+                continue;
+            };
+
+            let base_timer = LiveTimer::maybe_new(
+                !quiet,
+                &format!("Retargeting #{} to {}...", pr_num, scope.trunk),
+            );
+            match rt.block_on(async { client.update_pr_base(pr_num, &scope.trunk).await }) {
+                Ok(()) => LiveTimer::maybe_finish_ok(base_timer, "done"),
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(base_timer, "failed");
+                    failed_pr = Some((
+                        remaining.branch.clone(),
+                        pr_num,
+                        format!("Failed to retarget PR #{}: {}", pr_num, e),
+                    ));
+                    break;
+                }
+            }
+
+            let update_timer = LiveTimer::maybe_new(
+                !quiet,
+                &format!("Updating branch for #{} on GitHub...", pr_num),
+            );
+            match rt.block_on(async { client.update_pr_branch(pr_num).await }) {
+                Ok(()) => LiveTimer::maybe_finish_ok(update_timer, "done"),
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(update_timer, "failed");
+                    failed_pr = Some((
+                        remaining.branch.clone(),
+                        pr_num,
+                        format!("Failed to update branch for PR #{}: {}", pr_num, e),
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    if !no_delete && !merged_prs.is_empty() {
+        if !quiet {
+            println!();
+            println!(
+                "{}",
+                "Cleaning up stax metadata for merged branches...".dimmed()
+            );
+        }
+
+        for (branch, _) in &merged_prs {
+            let _ = crate::git::refs::delete_metadata(repo.inner(), branch);
+            if !quiet {
+                println!("  {} metadata cleared for {}", "✓".green(), branch.dimmed());
+            }
+        }
+    }
+
+    println!();
+
+    if let Some((branch, pr, reason)) = &failed_pr {
+        print_header_error("Merge Remote Stopped");
+        println!();
+        println!("Progress:");
+        for (merged_branch, merged_pr) in &merged_prs {
+            println!(
+                "  {} #{} {} → merged",
+                "✓".green(),
+                merged_pr,
+                merged_branch
+            );
+        }
+        println!("  {} #{} {} → {}", "✗".red(), pr, branch, reason);
+        println!();
+        println!("{}", "Already merged PRs remain merged.".dimmed());
+        println!(
+            "{}",
+            "Fix the issue and run 'stax merge --remote' to continue.".dimmed()
+        );
+    } else {
+        print_header_success("Stack Merged (remote)");
+        println!();
+        println!(
+            "Merged {} {} into {} via GitHub API:",
+            merged_prs.len(),
+            if merged_prs.len() == 1 { "PR" } else { "PRs" },
+            scope.trunk.cyan()
+        );
+        for (branch, pr) in &merged_prs {
+            println!("  {} #{} {}", "✓".green(), pr, branch);
+        }
+
+        if !remaining_branches.is_empty() {
+            println!();
+            println!("Remaining in stack (branches updated on GitHub):");
+            for remaining in &remaining_branches {
+                if let Some(pr) = remaining.pr_number {
+                    println!("  {} #{} {}", "○".dimmed(), pr, remaining.branch);
+                } else {
+                    println!("  {} {}", "○".dimmed(), remaining.branch);
+                }
+            }
+        }
+
+        send_notification(
+            "stax merge --remote",
+            &format!(
+                "Merged {} {} into {}",
+                merged_prs.len(),
+                if merged_prs.len() == 1 { "PR" } else { "PRs" },
+                scope.trunk
+            ),
+        );
+    }
+
+    if failed_pr.is_none() && !merged_prs.is_empty() && !no_sync && !quiet {
+        println!();
+        println!(
+            "{}",
+            "Run `stax rs` to sync your local repository (delete merged branches, reparent children)."
+                .dimmed()
+        );
+    }
+
+    Ok(())
+}
+
+fn calculate_merge_scope(stack: &Stack, current: &str, all: bool) -> MergeRemoteScope {
+    let mut to_merge = stack.ancestors(current);
+    to_merge.reverse();
+    to_merge.retain(|b| b != &stack.trunk);
+    to_merge.push(current.to_string());
+
+    let mut remaining = stack.descendants(current);
+
+    if all && !remaining.is_empty() {
+        to_merge.extend(remaining);
+        remaining = Vec::new();
+    }
+
+    MergeRemoteScope {
+        to_merge,
+        remaining,
+        trunk: stack.trunk.clone(),
+    }
+}
+
+fn print_remote_preview(branches: &[LandBranchInfo], trunk: &str, method: &MergeMethod) {
+    print_header("Merge Remote");
+    println!();
+
+    let pr_word = if branches.len() == 1 { "PR" } else { "PRs" };
+    println!(
+        "Will merge {} {} bottom-up into {} (GitHub API only — no local git):",
+        branches.len().to_string().bold(),
+        pr_word,
+        trunk.cyan()
+    );
+    println!();
+
+    for (idx, branch) in branches.iter().enumerate() {
+        println!(
+            "  {}. {} (#{})",
+            (idx + 1).to_string().bold(),
+            branch.branch.bold(),
+            branch.pr_number,
+        );
+    }
+
+    println!();
+    println!(
+        "Merge method: {} {}",
+        method.as_str().cyan(),
+        "(change with --method)".dimmed()
+    );
+    println!(
+        "{}",
+        "Each PR is polled for CI + approval; dependent branches use GitHub \"Update branch\"."
+            .dimmed()
+    );
+}
+
+fn wait_for_pr_ready(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    pr_number: u64,
+    timeout: Duration,
+    poll_interval: Duration,
+    quiet: bool,
+) -> Result<WaitResult> {
+    let start = Instant::now();
+    let mut last_status: Option<String> = None;
+
+    loop {
+        let status: PrMergeStatus =
+            rt.block_on(async { client.get_pr_merge_status(pr_number).await })?;
+
+        if status.is_ready() {
+            if !quiet && last_status.is_some() {
+                println!();
+            }
+            return Ok(WaitResult::Ready);
+        }
+
+        if status.is_blocked() {
+            if !quiet && last_status.is_some() {
+                println!();
+            }
+            return Ok(WaitResult::Failed(status.status_text().to_string()));
+        }
+
+        if start.elapsed() > timeout {
+            if !quiet && last_status.is_some() {
+                println!();
+            }
+            return Ok(WaitResult::Timeout);
+        }
+
+        if !quiet {
+            let elapsed = start.elapsed().as_secs();
+            let status_text = format!(
+                "      {} Waiting for {}... ({}s)",
+                "⏳".yellow(),
+                status.status_text().to_lowercase(),
+                elapsed
+            );
+
+            if last_status.is_some() {
+                print!("\r{}\r", " ".repeat(80));
+            }
+            print!("{}", status_text);
+            std::io::stdout().flush().ok();
+            last_status = Some(status_text);
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+}
+
+fn record_ci_history_for_branch(
+    repo: &GitRepo,
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    stack: &Stack,
+    branch: &str,
+) {
+    if repo.branch_commit(branch).is_err() {
+        return;
+    }
+
+    let branches = vec![branch.to_string()];
+    if let Ok(statuses) = fetch_ci_statuses(repo, rt, client, stack, &branches) {
+        record_ci_history(repo, &statuses);
+    }
+}
+
+fn send_notification(title: &str, message: &str) {
+    if cfg!(target_os = "macos") {
+        let script = format!(
+            r#"display notification "{}" with title "{}""#,
+            message.replace('"', "\\\""),
+            title.replace('"', "\\\""),
+        );
+        let _ = Command::new("osascript").args(["-e", &script]).output();
+    }
+}
+
+fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut in_escape = false;
+
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+            continue;
+        }
+        if in_escape {
+            if c == 'm' {
+                in_escape = false;
+            }
+            continue;
+        }
+        result.push(c);
+    }
+
+    result
+}
+
+fn display_width(s: &str) -> usize {
+    let stripped = strip_ansi(s);
+    stripped
+        .chars()
+        .map(|c| match c {
+            '\x00'..='\x1f' | '\x7f' => 0,
+            '\x20'..='\x7e' => 1,
+            '─' | '│' | '┌' | '┐' | '└' | '┘' | '├' | '┤' | '┬' | '┴' | '┼' | '╭' | '╮' | '╯'
+            | '╰' | '║' | '═' => 1,
+            '←' | '→' | '↑' | '↓' => 1,
+            '✓' | '✗' | '✔' | '✘' => 1,
+            _ => 2,
+        })
+        .sum()
+}
+
+fn print_header(title: &str) {
+    let width: usize = 56;
+    let title_width = display_width(title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        title.bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}
+
+fn print_header_success(title: &str) {
+    let width: usize = 56;
+    let full_title = format!("✓ {}", title);
+    let title_width = display_width(&full_title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        full_title.green().bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}
+
+fn print_header_error(title: &str) {
+    let width: usize = 56;
+    let full_title = format!("✗ {}", title);
+    let title_width = display_width(&full_title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        full_title.red().bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod issue;
 pub mod log;
 pub mod merge;
 pub(crate) mod merge_rebase;
+pub mod merge_remote;
 pub mod merge_when_ready;
 pub mod modify;
 pub mod navigate;

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -116,6 +116,16 @@ impl ForgeClient {
         dispatch!(self, update_pr_base(number, new_base))
     }
 
+    /// GitHub only: merge the PR base into the head branch remotely ("Update branch").
+    pub async fn update_pr_branch(&self, number: u64) -> Result<()> {
+        match self {
+            Self::GitHub(client) => client.update_pr_branch(number).await,
+            Self::GitLab(_) | Self::Gitea(_) => {
+                bail!("`stax merge --remote` is currently only supported for GitHub")
+            }
+        }
+    }
+
     pub async fn update_pr_body(&self, number: u64, body: &str) -> Result<()> {
         dispatch!(self, update_pr_body(number, body))
     }

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -506,6 +506,36 @@ impl GitHubClient {
         Ok(())
     }
 
+    /// Merge the pull request base branch into the head branch (GitHub "Update branch" button).
+    ///
+    /// See <https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch>.
+    pub async fn update_pr_branch(&self, pr_number: u64) -> Result<()> {
+        self.record_api_call("pulls.update-branch");
+        let route = format!(
+            "/repos/{}/{}/pulls/{}/update-branch",
+            self.owner, self.repo, pr_number
+        );
+        let result = self
+            .octocrab
+            .put::<serde_json::Value, _, serde_json::Value>(&route, Some(&serde_json::json!({})))
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                // 422 when head already includes base (nothing to merge)
+                if msg.contains("Update is not required")
+                    || msg.contains("There are no new commits")
+                {
+                    Ok(())
+                } else {
+                    Err(e).context("Failed to update PR branch")
+                }
+            }
+        }
+    }
+
     /// Update PR body text
     pub async fn update_pr_body(&self, pr_number: u64, body: &str) -> Result<()> {
         self.record_api_call("pulls.update.body");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -96,6 +96,7 @@ fn test_merge_help_flags_include_when_ready_mode() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--when-ready"));
+    assert!(stdout.contains("--remote"));
     assert!(stdout.contains("--interval"));
     assert!(stdout.contains("--no-sync"));
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4944,6 +4944,100 @@ fn test_merge_help() {
     );
     assert!(stdout.contains("--yes"), "Expected --yes flag in help");
     assert!(stdout.contains("--quiet"), "Expected --quiet flag in help");
+    assert!(
+        stdout.contains("--remote"),
+        "Expected --remote flag in help"
+    );
+}
+
+#[test]
+fn test_merge_remote_on_trunk_shows_error() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["status"]);
+    assert!(output.status.success());
+    assert_eq!(repo.current_branch(), "main");
+
+    let output = repo.run_stax(&["merge", "--remote"]);
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    let combined = format!("{}{}", stdout, stderr);
+    assert!(
+        combined.contains("trunk") || combined.contains("Checkout"),
+        "Expected message about being on trunk, got: {}",
+        combined
+    );
+}
+
+#[test]
+fn test_merge_remote_on_untracked_branch_shows_error() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["status"]);
+    repo.git(&["checkout", "-b", "untracked-remote"]);
+    repo.create_file("test.txt", "content");
+    repo.commit("Untracked commit");
+
+    let output = repo.run_stax(&["merge", "--remote"]);
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    let combined = format!("{}{}", stdout, stderr);
+    assert!(
+        combined.contains("not tracked") || combined.contains("track"),
+        "Expected message about untracked branch, got: {}",
+        combined
+    );
+}
+
+#[test]
+fn test_merge_remote_without_pr_shows_error() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-remote-no-pr"]);
+    repo.create_file("feature.txt", "content");
+    repo.commit("Feature commit");
+
+    let output = repo.run_stax(&["merge", "--remote", "--yes"]);
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    let combined = format!("{}{}", stdout, stderr);
+    assert!(
+        combined.contains("PR") || combined.contains("submit"),
+        "Expected message about missing PR, got: {}",
+        combined
+    );
+}
+
+#[test]
+fn test_merge_remote_conflicts_with_when_ready() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["merge", "--remote", "--when-ready"]);
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        !output.status.success(),
+        "Expected non-success for conflicting flags"
+    );
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
+        "Expected clap conflict error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_merge_remote_conflicts_with_dry_run() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["merge", "--remote", "--dry-run"]);
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        !output.status.success(),
+        "Expected non-success for conflicting flags"
+    );
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
+        "Expected clap conflict error, got: {}",
+        stderr
+    );
 }
 
 #[test]
@@ -6941,6 +7035,181 @@ mod forge_mock_tests {
                 .iter()
                 .map(|request| format!("{} {}", request.method, request.url.path()))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_remote_retargets_and_updates_branch_before_merging() {
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mremote-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mremote-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/301",
+                    "id": 301,
+                    "number": 301,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_a, "sha": "sha-a", "label": "test:mremote-a" },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/302",
+                    "id": 302,
+                    "number": 302,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_b, "sha": "sha-b", "label": "test:mremote-b" },
+                    "base": { "ref": branch_a, "sha": "sha-a" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/301"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/301",
+                "id": 301,
+                "number": 301,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "title": "p",
+                "head": { "ref": branch_a, "sha": "sha-a", "label": "test:mremote-a" },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/302"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/302",
+                "id": 302,
+                "number": 302,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "title": "c",
+                "head": { "ref": branch_b, "sha": "sha-b", "label": "test:mremote-b" },
+                "base": { "ref": branch_a, "sha": "sha-a" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/302"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/302",
+                "id": 302,
+                "number": 302,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": branch_b, "sha": "sha-b", "label": "test:mremote-b" },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/301/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/302/update-branch"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "message": "Updating pull request branch.",
+                "url": "https://api.github.com/repos/test/repo/pulls/302"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/302/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &[
+                "merge",
+                "--remote",
+                "--yes",
+                "--no-delete",
+                "--timeout",
+                "1",
+                "--interval",
+                "1",
+                "--no-sync",
+            ],
+        );
+        assert!(
+            merge_output.status.success(),
+            "merge --remote failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/302");
+        let merge1_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/301/merge");
+        let update_idx =
+            find_request_index(&requests, "PUT", "/repos/test/repo/pulls/302/update-branch");
+        let merge2_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/302/merge");
+
+        assert!(
+            patch_idx < merge1_idx,
+            "Expected dependent PR retarget before parent merge"
+        );
+        assert!(
+            update_idx > merge1_idx,
+            "Expected update-branch after parent merge"
+        );
+        assert!(
+            update_idx < merge2_idx,
+            "Expected update-branch before child merge"
         );
     }
 


### PR DESCRIPTION
## Summary

- feat(merge): add --remote for API-only stack merge on GitHub