### PR TITLE
Fix worktree cleanup recovery flow

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -671,11 +671,14 @@ pub fn run(
                                 );
                                 if let Ok(Some(resolution)) = repo.branch_delete_resolution(branch)
                                 {
-                                    if let Some(remove_cmd) = resolution.remove_worktree_cmd() {
+                                    if let Some(remove_cmd) =
+                                        resolution.remove_worktree_and_branch_cmd()
+                                    {
                                         println!(
                                             "    {} {}",
                                             "↷".yellow(),
-                                            "Run to remove that worktree:".dimmed()
+                                            "Run to remove that worktree and delete the branch:"
+                                                .dimmed()
                                         );
                                         println!("      {}", remove_cmd.cyan());
                                     }
@@ -858,11 +861,11 @@ pub fn run(
                             "not deleted locally (checked out in another worktree)".yellow()
                         );
                         if let Ok(Some(resolution)) = repo.branch_delete_resolution(branch) {
-                            if let Some(remove_cmd) = resolution.remove_worktree_cmd() {
+                            if let Some(remove_cmd) = resolution.remove_worktree_and_branch_cmd() {
                                 println!(
                                     "    {} {}",
                                     "↷".yellow(),
-                                    "Run to remove that worktree:".dimmed()
+                                    "Run to remove that worktree and delete the branch:".dimmed()
                                 );
                                 println!("      {}", remove_cmd.cyan());
                             }

--- a/src/commands/worktree/remove.rs
+++ b/src/commands/worktree/remove.rs
@@ -53,10 +53,11 @@ pub fn run(name: Option<String>, force: bool, delete_branch: bool) -> Result<()>
 
     let branch = worktree.branch.clone();
     let path = worktree.path.clone();
-    let display_name = worktree.name.clone();
+    let display_name = branch.clone().unwrap_or_else(|| worktree.name.clone());
     repo.worktree_remove(&path, force)?;
 
     if delete_branch {
+        let repo = GitRepo::open_from_path(&main_workdir)?;
         if let Some(branch) = branch.as_deref() {
             match repo.delete_branch(branch, force) {
                 Ok(()) => {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -88,6 +88,11 @@ impl BranchDeleteResolution {
         }
     }
 
+    pub fn remove_worktree_and_branch_cmd(&self) -> Option<String> {
+        self.remove_worktree_cmd()
+            .map(|command| format!("{command} --delete-branch"))
+    }
+
     pub fn switch_branch_cmd(&self) -> String {
         match &self.switch_target {
             BranchDeleteSwitchTarget::Branch(target) => format!(

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -654,6 +654,38 @@ fn wt_remove_without_name_removes_current_worktree() {
 }
 
 #[test]
+fn wt_remove_delete_branch_from_current_worktree_removes_branch_too() {
+    let repo = TestRepo::new();
+    let home = clean_home(&repo);
+
+    repo.run_stax_with_env(&["wt", "c", "remove-branch"], &[("HOME", home.as_str())])
+        .assert_success();
+    let worktree_path = default_worktree_root(&repo, &home).join("remove-branch");
+
+    let out = repo.run_stax_in_with_env(
+        &worktree_path,
+        &["wt", "rm", "--delete-branch"],
+        &[("HOME", home.as_str())],
+    );
+    out.assert_success()
+        .assert_stdout_contains("Deleted branch 'remove-branch'")
+        .assert_stdout_contains("Removed  worktree 'remove-branch'");
+
+    assert!(
+        !worktree_path.exists(),
+        "expected current worktree directory to be removed"
+    );
+
+    let branch_ref = "refs/heads/remove-branch";
+    let show_ref = repo.git(&["show-ref", "--verify", "--quiet", branch_ref]);
+    assert!(
+        !show_ref.status.success(),
+        "expected branch '{}' to be deleted",
+        branch_ref
+    );
+}
+
+#[test]
 fn wt_restack_only_touches_stax_managed_worktrees() {
     let repo = TestRepo::new();
     let home = clean_home(&repo);

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -465,10 +465,10 @@ fn sync_reports_fix_commands_when_branch_delete_blocked_by_worktree() {
     output
         .assert_success()
         .assert_stdout_contains("not deleted locally (checked out in another worktree)")
-        .assert_stdout_contains("Run to remove that worktree:")
+        .assert_stdout_contains("Run to remove that worktree and delete the branch:")
         .assert_stdout_contains("wt-a")
         .assert_stdout_contains("Or keep the worktree and free the branch:")
-        .assert_stdout_contains(&format!("st wt rm {}", branch))
+        .assert_stdout_contains(&format!("st wt rm {} --delete-branch", branch))
         .assert_stdout_contains("switch --detach");
 }
 
@@ -507,13 +507,48 @@ fn sync_reports_unique_remove_command_when_worktree_basename_is_ambiguous() {
     let output = repo.run_stax(&["sync", "--force"]);
     output
         .assert_success()
-        .assert_stdout_contains("Run to remove that worktree:")
-        .assert_stdout_contains(&format!("st wt rm {}", branch));
+        .assert_stdout_contains("Run to remove that worktree and delete the branch:")
+        .assert_stdout_contains(&format!("st wt rm {} --delete-branch", branch));
 
     let stdout = TestRepo::stdout(&output);
     assert!(
-        !stdout.contains("st wt rm stax"),
+        !stdout.contains("st wt rm stax --delete-branch"),
         "expected sync hint to avoid ambiguous basename selector, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn wt_remove_reports_branch_name_when_worktree_basename_is_generic() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["create", "A"]).assert_success();
+    let branch = repo.current_branch();
+    repo.create_file("a.txt", "A\n");
+    repo.commit("A commit");
+    repo.run_stax(&["checkout", "main"]).assert_success();
+
+    let generic_parent = repo.path().join("codex-lane");
+    fs::create_dir_all(&generic_parent).expect("create generic worktree parent");
+
+    let generic_worktree = generic_parent.join("stax");
+    repo.git(&[
+        "worktree",
+        "add",
+        generic_worktree.to_str().unwrap(),
+        &branch,
+    ])
+    .assert_success();
+
+    let output = repo.run_stax(&["wt", "rm", &branch]);
+    output
+        .assert_success()
+        .assert_stdout_contains(&format!("worktree '{}'", branch));
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        !stdout.contains("worktree 'stax'"),
+        "expected remove output to use the branch name, got:\n{}",
         stdout
     );
 }


### PR DESCRIPTION
## Summary
- suggest `st wt rm <branch> --delete-branch` when sync finds a merged branch that is still checked out in another worktree
- make `st wt rm --delete-branch` reopen the main worktree before deleting the branch and report the branch name in its removal output
- add regression coverage for the sync hint and linked-worktree removal flows

## Testing
- cargo test --test worktree_tests sync_reports_fix_commands_when_branch_delete_blocked_by_worktree
- cargo test --test worktree_tests sync_reports_unique_remove_command_when_worktree_basename_is_ambiguous
- cargo test --test worktree_tests wt_remove_reports_branch_name_when_worktree_basename_is_generic
- cargo test --test worktree_tests branch_delete_checked_out_in_worktree_shows_fix_commands
- cargo test --test worktree_cli_tests wt_remove_without_name_removes_current_worktree
- cargo test --test worktree_cli_tests wt_remove_delete_branch_from_current_worktree_removes_branch_too