### PR TITLE
ci(release): Linux arm64 prebuilt binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
             os: macos-15
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 
@@ -101,6 +103,7 @@ jobs:
           echo "ARM_SHA=$(sha256sum stax-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)" >> $GITHUB_ENV
           echo "INTEL_SHA=$(sha256sum stax-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)" >> $GITHUB_ENV
           echo "LINUX_SHA=$(sha256sum stax-x86_64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)" >> $GITHUB_ENV
+          echo "LINUX_ARM_SHA=$(sha256sum stax-aarch64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Checkout Homebrew tap
         uses: actions/checkout@v6
@@ -122,6 +125,7 @@ jobs:
           
           sed -i "0,/PLACEHOLDER/s/PLACEHOLDER/$ARM_SHA/" $FORMULA
           sed -i "0,/PLACEHOLDER/s/PLACEHOLDER/$INTEL_SHA/" $FORMULA
+          sed -i "0,/PLACEHOLDER/s/PLACEHOLDER/$LINUX_ARM_SHA/" $FORMULA
           sed -i "0,/PLACEHOLDER/s/PLACEHOLDER/$LINUX_SHA/" $FORMULA
 
       - name: Commit and push tap


### PR DESCRIPTION
Closes #137

Publishes `stax-aarch64-unknown-linux-gnu.tar.gz` from `ubuntu-24.04-arm`.

**Homebrew:** merge companion tap PR first so the formula has four `sha256` slots (mac ARM, mac Intel, Linux ARM, Linux x86): https://github.com/cesarferreira/homebrew-tap/pull/1

Made with [Cursor](https://cursor.com)