### PR TITLE
fix(split-hunk): e2e tests, docs, and bug fixes for hunk splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Next steps:
 | `st rs --restack` | Sync trunk, clean merged branches, then rebase stack |
 | `st restack` | Rebase current stack onto parents locally (`--stop-here` skips descendants) |
 | `st cascade` | Restack, push, and create/update PRs |
+| `st split` | Split branch into stacked branches (by commit or `--hunk`) |
 | `st undo` / `st redo` | Recover or re-apply risky operations |
 | `st resolve` | Resolve an in-progress rebase conflict with AI and continue automatically |
 | `st standup` | Summarize recent engineering activity |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -54,10 +54,11 @@
 
 ## Interactive
 
-| Command | Description |
-|---|---|
-| `st` | Launch TUI |
-| `st split` | Split branch into stacked branches |
+| Command | Alias | Description |
+|---|---|---|
+| `st` | | Launch TUI |
+| `st split` | | Split branch into stacked branches (commit-based; needs 2+ commits) |
+| `st split --hunk` | | Split a single commit into stacked branches by selecting individual diff hunks |
 
 ## Recovery
 

--- a/docs/interface/tui.md
+++ b/docs/interface/tui.md
@@ -79,3 +79,51 @@ st split
 | `q`/`Esc` | Cancel |
 
 Split operations are transactional and recoverable with `st undo`.
+
+## Hunk Split Mode
+
+Split a branch by selecting individual diff hunks rather than whole commits. Useful when a branch has a single commit that should be broken into smaller stacked branches.
+
+```bash
+st split --hunk
+```
+
+The hunk picker shows a two-pane layout: file/hunk list on the left, diff preview on the right. Splitting happens in rounds — select hunks, name the new branch, repeat until all hunks are assigned.
+
+### List mode (default)
+
+| Key | Action |
+|---|---|
+| `j/k` or `↑/↓` | Navigate files and hunks |
+| `Space` | Toggle hunk selection |
+| `a` | Toggle all hunks in current file |
+| `u` | Undo last selection change |
+| `Tab` | Switch to sequential mode |
+| `Enter` | Finish round (proceed to naming) |
+| `?` | Show help |
+| `q`/`Esc` | Abort split |
+
+### Sequential mode
+
+Step through hunks one by one with yes/no prompts. Press `Tab` to return to list mode.
+
+| Key | Action |
+|---|---|
+| `y` | Accept hunk and advance |
+| `n` | Skip hunk and advance |
+| `a` | Toggle file and jump to next file |
+| `u` | Undo |
+| `Enter` | Finish round |
+
+### Naming
+
+After finishing a round, enter a branch name for the selected hunks. The default suggestion is `<original>_split_N` for intermediate rounds and the original branch name for the final round.
+
+### Workflow
+
+1. Select hunks for the first new branch
+2. Press `Enter`, confirm the branch name
+3. Repeat for remaining hunks
+4. After the last round, stax creates the branch chain and updates stack metadata
+
+Hunk split operations are transactional and recoverable with `st undo`.

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -128,15 +128,22 @@ impl HunkSplitApp {
 
         let tip = git(&workdir, &["rev-parse", "HEAD"])?;
         git(&workdir, &["switch", "-d", &tip])?;
-        git(&workdir, &["reset", "-Nq", &parent_sha])?;
 
-        let diff_output = git(&workdir, &["diff"])?;
-        let files = parse_diff(&diff_output);
-
-        if files.is_empty() {
-            git(&workdir, &["checkout", "-f", &current])?;
-            bail!("No diff hunks found between parent and branch tip.");
-        }
+        let files = match (|| -> Result<Vec<DiffFile>> {
+            git(&workdir, &["reset", "-Nq", &parent_sha])?;
+            let diff_output = git(&workdir, &["diff"])?;
+            let files = parse_diff(&diff_output);
+            if files.is_empty() {
+                bail!("No diff hunks found between parent and branch tip.");
+            }
+            Ok(files)
+        })() {
+            Ok(files) => files,
+            Err(e) => {
+                let _ = git(&workdir, &["checkout", "-f", &current]);
+                return Err(e);
+            }
+        };
 
         let selected: Vec<Vec<bool>> = files.iter().map(|f| vec![false; f.hunks.len()]).collect();
         let flat_items = build_flat_items(&files);
@@ -419,11 +426,10 @@ impl HunkSplitApp {
         };
         tx::print_plan(tx.kind(), &summary, false);
         tx.set_plan_summary(summary);
-        tx.snapshot()?;
 
         let num_branches = self.created_branches.len();
         for (i, name) in self.created_branches.iter().enumerate() {
-            let offset = num_branches - i;
+            let offset = num_branches - 1 - i;
             let rev = format!("{}~{}", split_tip, offset);
             if name == &self.original_branch {
                 git(&self.workdir, &["branch", "-f", name, &rev])?;
@@ -466,6 +472,7 @@ impl HunkSplitApp {
             .clone();
         git(&self.workdir, &["checkout", &checkout_target])?;
 
+        tx.snapshot()?;
         tx.finish_ok()?;
 
         Ok(())

--- a/src/tui/split_hunk/mod.rs
+++ b/src/tui/split_hunk/mod.rs
@@ -30,12 +30,17 @@ pub fn run() -> Result<()> {
     terminal.show_cursor()?;
 
     match result {
-        Ok(true) => {
-            app.finalize()?;
-            println!("Split complete! Created {} branches.", app.round);
-            println!("Use `stax ls` to see the new stack structure.");
-            Ok(())
-        }
+        Ok(true) => match app.finalize() {
+            Ok(()) => {
+                println!("Split complete! Created {} branches.", app.round);
+                println!("Use `stax ls` to see the new stack structure.");
+                Ok(())
+            }
+            Err(e) => {
+                app.rollback();
+                Err(e)
+            }
+        },
         Ok(false) => {
             app.rollback();
             println!("Split aborted.");

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::{OutputAssertions, TestRepo};
+use std::collections::{HashMap, HashSet};
 
 #[test]
 fn test_split_hunk_help() {
@@ -15,6 +16,10 @@ fn test_split_hunk_help() {
         stdout
     );
 }
+
+// =============================================================================
+// Error Case Tests (validation before TUI)
+// =============================================================================
 
 #[test]
 fn test_split_hunk_on_trunk_fails() {
@@ -80,4 +85,189 @@ fn test_split_hunk_requires_terminal() {
         "Expected terminal requirement error, got: {}",
         stderr
     );
+}
+
+// =============================================================================
+// End-to-end success tests (scripted TUI via pseudo-terminal)
+// =============================================================================
+
+/// Each round: j(down to hunk), Space(select), Enter(finish round), Enter(accept name).
+fn split_hunk_script(rounds: usize) -> String {
+    let mut parts = vec!["sleep 1".to_string()];
+    for _ in 0..rounds {
+        parts.push("printf 'j \\r\\r'".to_string());
+        parts.push("sleep 2".to_string());
+    }
+    parts.join("; ")
+}
+
+fn parent_map(repo: &TestRepo) -> HashMap<String, String> {
+    let json = repo.get_status_json();
+    json["branches"]
+        .as_array()
+        .map(|branches| {
+            branches
+                .iter()
+                .filter_map(|b| {
+                    let name = b["name"].as_str()?;
+                    let parent = b["parent"].as_str()?;
+                    Some((name.to_string(), parent.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn introduced_files(repo: &TestRepo, base: &str, branch: &str) -> HashSet<String> {
+    let output = repo.git(&["diff", "--name-only", base, branch]);
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+fn run_split_hunk(repo: &TestRepo, rounds: usize) {
+    let script = split_hunk_script(rounds);
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
+    assert!(
+        output.status.success(),
+        "Split hunk TUI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_split_hunk_two_files_into_two_branches() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature-a"]);
+    let original = repo.current_branch();
+    repo.create_file("extra.txt", "extra content\n");
+    repo.commit("add extra file");
+
+    run_split_hunk(&repo, 2);
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(branches.contains(&split_1), "Missing {split_1}, got: {branches:?}");
+    assert!(branches.contains(&original), "Missing {original}, got: {branches:?}");
+
+    let parents = parent_map(&repo);
+    assert_eq!(parents.get(&split_1).map(String::as_str), Some("main"));
+    assert_eq!(parents.get(&original).map(String::as_str), Some(split_1.as_str()));
+
+    // Each branch should introduce exactly one of the two files
+    let s1_files = introduced_files(&repo, "main", &split_1);
+    let orig_files = introduced_files(&repo, &split_1, &original);
+    assert!(
+        (s1_files.contains("extra.txt") && orig_files.contains("feature-a.txt"))
+            || (s1_files.contains("feature-a.txt") && orig_files.contains("extra.txt")),
+        "Each branch should introduce one file. split_1: {:?}, original: {:?}",
+        s1_files, orig_files
+    );
+}
+
+#[test]
+fn test_split_hunk_three_files_three_branches() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["multi-split"]);
+    let original = repo.current_branch();
+    repo.create_file("file_b.txt", "content b\n");
+    repo.commit("add file b");
+    repo.create_file("file_c.txt", "content c\n");
+    repo.commit("add file c");
+
+    run_split_hunk(&repo, 3);
+
+    let split_1 = format!("{}_split_1", original);
+    let split_2 = format!("{}_split_2", original);
+    let branches = repo.list_branches();
+    assert!(branches.contains(&split_1), "Missing {split_1}, got: {branches:?}");
+    assert!(branches.contains(&split_2), "Missing {split_2}, got: {branches:?}");
+    assert!(branches.contains(&original), "Missing {original}, got: {branches:?}");
+
+    let parents = parent_map(&repo);
+    assert_eq!(parents.get(&split_1).map(String::as_str), Some("main"));
+    assert_eq!(parents.get(&split_2).map(String::as_str), Some(split_1.as_str()));
+    assert_eq!(parents.get(&original).map(String::as_str), Some(split_2.as_str()));
+}
+
+#[test]
+fn test_split_hunk_children_reparented() {
+    let repo = TestRepo::new();
+    let stack = repo.create_stack(&["parent-branch", "child-branch"]);
+    let child = stack[1].clone();
+
+    repo.run_stax(&["checkout", &stack[0]]).assert_success();
+    let parent_name = repo.current_branch();
+    repo.create_file("second.txt", "second content\n");
+    repo.commit("add second file");
+
+    run_split_hunk(&repo, 2);
+
+    let parents = parent_map(&repo);
+    assert_eq!(
+        parents.get(&child).map(String::as_str),
+        Some(parent_name.as_str()),
+        "child's parent should be the last split branch (original name)"
+    );
+}
+
+#[test]
+fn test_split_hunk_with_new_file() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["new-file-test"]);
+    let original = repo.current_branch();
+    repo.create_file("brand_new.txt", "brand new content\n");
+    repo.commit("add brand new file");
+
+    run_split_hunk(&repo, 2);
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(branches.contains(&split_1));
+    assert!(branches.contains(&original));
+
+    let s1_files = introduced_files(&repo, "main", &split_1);
+    let orig_files = introduced_files(&repo, &split_1, &original);
+    assert!(
+        s1_files.contains("brand_new.txt") ^ orig_files.contains("brand_new.txt"),
+        "brand_new.txt should be introduced by exactly one branch: split_1={:?}, original={:?}",
+        s1_files, orig_files
+    );
+}
+
+#[test]
+fn test_split_hunk_abort_with_dirty_workdir_preserves_changes() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["dirty-test"]);
+    let original = repo.current_branch();
+
+    repo.create_file("tracked.txt", "tracked content\n");
+    repo.commit("add tracked file");
+
+    // Create uncommitted changes (dirty workdir)
+    repo.create_file("dirty.txt", "dirty content\n");
+
+    // Abort immediately: q(quit) y(confirm)
+    let script = "sleep 1; printf 'qy'; sleep 2";
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+
+    assert!(
+        output.status.success(),
+        "Split hunk abort failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Should be back on the original branch
+    assert_eq!(repo.current_branch(), original);
+
+    // Dirty file should still exist in the working directory
+    let dirty_path = repo.path().join("dirty.txt");
+    assert!(
+        dirty_path.exists(),
+        "dirty.txt should be restored after abort"
+    );
+    let content = std::fs::read_to_string(&dirty_path).unwrap();
+    assert_eq!(content, "dirty content\n");
 }


### PR DESCRIPTION
## Summary

- Add 5 end-to-end integration tests for `st split --hunk` that exercise successful flows against real repos and verify branch topology, metadata, and file distribution
- Document `st split --hunk` in README, command reference, and TUI docs
- Fix 4 bugs discovered by the new e2e tests

## Bugs found and fixed

The e2e tests uncovered four bugs in the `split --hunk` implementation shipped in #165:

1. **Off-by-one in `finalize()` branch ref creation** (`app.rs:426`): `num_branches - i` should be `num_branches - 1 - i`. Each branch pointed one commit behind where it should, causing the first split branch to contain no changes and the last to miss its own.

2. **`finalize()` failure left partial state without rollback** (`mod.rs:34`): if `finalize()` errored, the `?` propagated without cleaning up partially-created branches and metadata.

3. **Transaction snapshot taken before mutations** (`app.rs:422`): `tx.snapshot()` was called before `git branch` commands, so `st undo` captured pre-mutation state. Moved to after all mutations complete.

4. **Init cleanup missing after detach** (`app.rs:130`): if git commands failed after `git switch -d`, the user was left in detached HEAD with no recovery. Added cleanup that restores the original branch on any error after detaching.

## Test plan

- [x] `cargo test --test split_hunk_tests` — 13 passed (5 new e2e + 5 existing validation + 3 common)
- [x] `cargo test --test split_tests` — 11 passed (no regressions)
- [x] `cargo test --test tui_commands_tests` — 17 passed (no regressions)
- [x] `cargo test --lib split_hunk` — 15 unit tests passed

Closes #167, closes #168.