### PR TITLE
Fix saved token reuse for GitLab and Gitea auth

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -103,11 +103,13 @@ When omitted, auto-detection is used: hostnames containing `gitlab` → GitLab, 
 
 ### Auth tokens by forge
 
-| Forge  | Environment variables (checked in order)                        |
-|--------|-----------------------------------------------------------------|
-| GitHub | `STAX_GITHUB_TOKEN`, credentials file, `gh` CLI, `GITHUB_TOKEN`|
-| GitLab | `STAX_GITLAB_TOKEN`, `GITLAB_TOKEN`, `STAX_FORGE_TOKEN`        |
-| Gitea  | `STAX_GITEA_TOKEN`, `GITEA_TOKEN`, `STAX_FORGE_TOKEN`          |
+| Forge  | Auth sources (checked in order)                                                    |
+|--------|-------------------------------------------------------------------------------------|
+| GitHub | `STAX_GITHUB_TOKEN`, credentials file, `gh` CLI, `GITHUB_TOKEN`                    |
+| GitLab | `STAX_GITLAB_TOKEN`, `GITLAB_TOKEN`, `STAX_FORGE_TOKEN`, credentials file          |
+| Gitea  | `STAX_GITEA_TOKEN`, `GITEA_TOKEN`, `STAX_FORGE_TOKEN`, credentials file            |
+
+`stax auth` writes the shared credentials file at `~/.config/stax/.credentials`. That saved token is reused for GitHub, GitLab, and Gitea when forge-specific environment variables are not set.
 
 ## GitHub auth resolution order
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -59,7 +59,8 @@ pub fn status() -> Result<()> {
     println!("{}", "Auth status".bold());
     println!(
         "{}",
-        "(One saved token is used for GitHub, GitLab, and Gitea API calls.)".dimmed()
+        "(The saved credentials-file token is reused for GitHub, GitLab, and Gitea API calls.)"
+            .dimmed()
     );
     if let Some(source) = status.active_source {
         println!(

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -263,8 +263,8 @@ pub fn run(
             "{} auth not configured.\n\
              Set the appropriate token for your forge:\n  \
              - GitHub: `stax auth`, `stax auth --from-gh`, or set `STAX_GITHUB_TOKEN`\n  \
-             - GitLab: set `STAX_GITLAB_TOKEN` or `GITLAB_TOKEN`\n  \
-             - Gitea:  set `STAX_GITEA_TOKEN` or `GITEA_TOKEN`",
+             - GitLab: `stax auth`, or set `STAX_GITLAB_TOKEN`, `GITLAB_TOKEN`, or `STAX_FORGE_TOKEN`\n  \
+             - Gitea:  `stax auth`, or set `STAX_GITEA_TOKEN`, `GITEA_TOKEN`, or `STAX_FORGE_TOKEN`",
             remote.forge
         );
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -337,6 +337,14 @@ impl Config {
         Self::resolve_github_auth_with_config(&auth_config).map(|(_, token)| token)
     }
 
+    /// Get the saved credentials-file token written by `stax auth`.
+    ///
+    /// This stored token is forge-agnostic and can be reused across GitHub,
+    /// GitLab, and Gitea when forge-specific env vars are not set.
+    pub fn saved_forge_token() -> Option<String> {
+        Self::token_from_credentials_file()
+    }
+
     pub fn github_auth_status() -> GitHubAuthStatus {
         let auth_config = Self::load().map(|c| c.auth).unwrap_or_default();
 
@@ -376,7 +384,7 @@ impl Config {
         }
     }
 
-    /// Set GitHub token (to credentials file)
+    /// Set the saved API token (to credentials file)
     pub fn set_github_token(token: &str) -> Result<()> {
         let path = Self::credentials_path()?;
         if let Some(parent) = path.parent() {

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -104,7 +104,7 @@ impl GiteaClient {
         }
 
         let token = super::forge_token(ForgeType::Gitea).context(
-            "Gitea auth not configured. Set `STAX_GITEA_TOKEN`, `GITEA_TOKEN`, or `STAX_FORGE_TOKEN`.",
+            "Gitea auth not configured. Use `stax auth` or set `STAX_GITEA_TOKEN`, `GITEA_TOKEN`, or `STAX_FORGE_TOKEN`.",
         )?;
 
         Ok(Self {

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -102,7 +102,7 @@ impl GitLabClient {
         }
 
         let token = super::forge_token(ForgeType::GitLab).context(
-            "GitLab auth not configured. Set `STAX_GITLAB_TOKEN`, `GITLAB_TOKEN`, or `STAX_FORGE_TOKEN`.",
+            "GitLab auth not configured. Use `stax auth` or set `STAX_GITLAB_TOKEN`, `GITLAB_TOKEN`, or `STAX_FORGE_TOKEN`.",
         )?;
 
         Ok(Self {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -269,10 +269,12 @@ pub fn forge_token(forge: ForgeType) -> Option<String> {
         ForgeType::GitHub => Config::github_token(),
         ForgeType::GitLab => read_env_token("STAX_GITLAB_TOKEN")
             .or_else(|| read_env_token("GITLAB_TOKEN"))
-            .or_else(|| read_env_token("STAX_FORGE_TOKEN")),
+            .or_else(|| read_env_token("STAX_FORGE_TOKEN"))
+            .or_else(Config::saved_forge_token),
         ForgeType::Gitea => read_env_token("STAX_GITEA_TOKEN")
             .or_else(|| read_env_token("GITEA_TOKEN"))
-            .or_else(|| read_env_token("STAX_FORGE_TOKEN")),
+            .or_else(|| read_env_token("STAX_FORGE_TOKEN"))
+            .or_else(Config::saved_forge_token),
     }
 }
 
@@ -421,6 +423,21 @@ fn make_issue_comment(id: u64, body: String, user: String, created_at: DateTime<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn restore_env(var: &str, value: Option<String>) {
+        match value {
+            Some(value) => env::set_var(var, value),
+            None => env::remove_var(var),
+        }
+    }
 
     fn is_failure(s: &str) -> bool {
         matches!(s, "failed" | "canceled" | "failure" | "error")
@@ -462,5 +479,75 @@ mod tests {
         let statuses: [&str; 0] = [];
         let result = aggregate_ci_overall(statuses.iter().copied(), is_failure, is_pending);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn gitlab_forge_token_falls_back_to_saved_credentials_token() {
+        let _guard = env_lock();
+
+        let orig_home = env::var("HOME").ok();
+        let orig_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+        let orig_stax_gitlab = env::var("STAX_GITLAB_TOKEN").ok();
+        let orig_gitlab = env::var("GITLAB_TOKEN").ok();
+        let orig_stax_forge = env::var("STAX_FORGE_TOKEN").ok();
+
+        let temp_dir =
+            env::temp_dir().join(format!("stax-forge-token-gitlab-{}", std::process::id()));
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        env::set_var("HOME", &temp_dir);
+        env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+        env::remove_var("STAX_GITLAB_TOKEN");
+        env::remove_var("GITLAB_TOKEN");
+        env::remove_var("STAX_FORGE_TOKEN");
+
+        Config::set_github_token("saved-token").unwrap();
+
+        assert_eq!(
+            forge_token(ForgeType::GitLab),
+            Some("saved-token".to_string())
+        );
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        restore_env("HOME", orig_home);
+        restore_env("STAX_CONFIG_DIR", orig_stax_config_dir);
+        restore_env("STAX_GITLAB_TOKEN", orig_stax_gitlab);
+        restore_env("GITLAB_TOKEN", orig_gitlab);
+        restore_env("STAX_FORGE_TOKEN", orig_stax_forge);
+    }
+
+    #[test]
+    fn gitea_forge_token_falls_back_to_saved_credentials_token() {
+        let _guard = env_lock();
+
+        let orig_home = env::var("HOME").ok();
+        let orig_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+        let orig_stax_gitea = env::var("STAX_GITEA_TOKEN").ok();
+        let orig_gitea = env::var("GITEA_TOKEN").ok();
+        let orig_stax_forge = env::var("STAX_FORGE_TOKEN").ok();
+
+        let temp_dir =
+            env::temp_dir().join(format!("stax-forge-token-gitea-{}", std::process::id()));
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        env::set_var("HOME", &temp_dir);
+        env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+        env::remove_var("STAX_GITEA_TOKEN");
+        env::remove_var("GITEA_TOKEN");
+        env::remove_var("STAX_FORGE_TOKEN");
+
+        Config::set_github_token("saved-token").unwrap();
+
+        assert_eq!(
+            forge_token(ForgeType::Gitea),
+            Some("saved-token".to_string())
+        );
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        restore_env("HOME", orig_home);
+        restore_env("STAX_CONFIG_DIR", orig_stax_config_dir);
+        restore_env("STAX_GITEA_TOKEN", orig_stax_gitea);
+        restore_env("GITEA_TOKEN", orig_gitea);
+        restore_env("STAX_FORGE_TOKEN", orig_stax_forge);
     }
 }


### PR DESCRIPTION
## Summary
- fall back to the shared credentials-file token for GitLab and Gitea after forge-specific env vars
- clarify auth messaging so `stax auth` is presented as a valid GitLab/Gitea setup path
- document the shared credentials-file reuse across supported forges

## Testing
- `cargo test --lib forge_token_falls_back_to_saved_credentials_token -- --test-threads=1`
- `cargo test --test auth_tests test_auth_status_command -- --test-threads=1`

Closes #172