### PR TITLE
feat(forge): make pr list and issue list forge-aware

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -96,8 +96,8 @@
 | `st continue` | Continue after conflicts |
 | `st pr` | Open current branch PR |
 | `st pr open` | Explicit form of `st pr` |
-| `st pr list` | List open pull requests in the current repo |
-| `st issue list` | List open issues in the current repo |
+| `st pr list` | List open pull requests in the current repo (GitHub, GitLab, Gitea) |
+| `st issue list` | List open issues in the current repo (GitHub, GitLab, Gitea) |
 | `st open` | Open repository in browser |
 | `st ci` | Show CI status for current branch (full per-check table with ETA) |
 | `st ci --stack` | Show CI status for all branches in current stack |

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -3,8 +3,8 @@ use crate::commands::github_list::{
     TableColumn, TruncationMode,
 };
 use crate::config::Config;
+use crate::forge::{ForgeClient, RepoIssueListItem};
 use crate::git::GitRepo;
-use crate::github::{GitHubClient, RepoIssueListItem};
 use crate::remote::RemoteInfo;
 use anyhow::Result;
 
@@ -19,14 +19,10 @@ pub fn run_list(limit: u8, json: bool) -> Result<()> {
     let repo_label = format!("{}/{}", remote_info.namespace, remote_info.repo);
 
     let rt = tokio::runtime::Runtime::new()?;
-    let client = rt.block_on(async {
-        GitHubClient::new(
-            remote_info.owner(),
-            &remote_info.repo,
-            remote_info.api_base_url.clone(),
-        )
+    let issues = rt.block_on(async {
+        let client = ForgeClient::new(&remote_info)?;
+        client.list_open_issues(limit).await
     })?;
-    let issues = rt.block_on(async { client.list_open_issues(limit).await })?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&issues)?);

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -5,8 +5,8 @@ use crate::commands::github_list::{
 use crate::commands::open::open_url_in_browser;
 use crate::config::Config;
 use crate::engine::Stack;
+use crate::forge::{ForgeClient, RepoPrListItem};
 use crate::git::GitRepo;
-use crate::github::{GitHubClient, RepoPrListItem};
 use crate::remote::RemoteInfo;
 use anyhow::Result;
 use colored::Colorize;
@@ -61,14 +61,10 @@ pub fn run_list(limit: u8, json: bool) -> Result<()> {
     let repo_label = format!("{}/{}", remote_info.namespace, remote_info.repo);
 
     let rt = tokio::runtime::Runtime::new()?;
-    let client = rt.block_on(async {
-        GitHubClient::new(
-            remote_info.owner(),
-            &remote_info.repo,
-            remote_info.api_base_url.clone(),
-        )
+    let prs = rt.block_on(async {
+        let client = ForgeClient::new(&remote_info)?;
+        client.list_open_pull_requests(limit).await
     })?;
-    let prs = rt.block_on(async { client.list_open_pull_requests(limit).await })?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&prs)?);

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use super::{
     aggregate_ci_overall, build_http_client, ci_status_from_string, delete_empty, get_json,
     make_issue_comment, mergeable_bool, patch_json, post_json, stack_comment_body, AuthStyle,
-    STACK_COMMENT_MARKER,
+    RepoIssueListItem, RepoPrListItem, STACK_COMMENT_MARKER,
 };
 use crate::ci::CheckRunInfo;
 use crate::github::pr::{MergeMethod, PrComment, PrInfo, PrInfoWithHead, PrMergeStatus};
@@ -33,6 +33,9 @@ struct GiteaPull {
     merged: Option<bool>,
     head: GiteaBranchRef,
     base: GiteaBranchRef,
+    user: Option<GiteaUser>,
+    html_url: Option<String>,
+    created_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -63,6 +66,21 @@ struct GiteaCommitStatus {
     target_url: Option<String>,
     created_at: Option<String>,
     updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaIssue {
+    number: u64,
+    title: String,
+    html_url: Option<String>,
+    user: Option<GiteaUser>,
+    labels: Vec<GiteaLabel>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaLabel {
+    name: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -384,6 +402,69 @@ impl GiteaClient {
 
         Ok((overall, checks))
     }
+
+    pub async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        let limit = limit.clamp(1, 50);
+        let url = format!(
+            "{}?state=open&sort=newest&limit={}",
+            self.repo_url("/pulls"),
+            limit
+        );
+        let prs: Vec<GiteaPull> = get_json(&self.client, &url).await?;
+        Ok(prs
+            .into_iter()
+            .map(|pr| RepoPrListItem {
+                number: pr.number,
+                title: pr.title,
+                url: pr.html_url.unwrap_or_default(),
+                author: pr
+                    .user
+                    .map(|u| u.login)
+                    .unwrap_or_else(|| "unknown".to_string()),
+                head_branch: pr.head.ref_name,
+                base_branch: pr.base.ref_name,
+                state: normalize_gitea_state_str(&pr.state, pr.merged),
+                is_draft: pr.draft.unwrap_or(false),
+                created_at: pr.created_at.unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    pub async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        let limit = limit.clamp(1, 50);
+        let url = format!(
+            "{}?state=open&type=issues&sort=updated&limit={}",
+            self.repo_url("/issues"),
+            limit
+        );
+        let issues: Vec<GiteaIssue> = get_json(&self.client, &url).await?;
+        Ok(issues
+            .into_iter()
+            .map(|issue| RepoIssueListItem {
+                number: issue.number,
+                title: issue.title,
+                url: issue.html_url.unwrap_or_default(),
+                author: issue
+                    .user
+                    .map(|u| u.login)
+                    .unwrap_or_else(|| "unknown".to_string()),
+                labels: issue
+                    .labels
+                    .into_iter()
+                    .filter_map(|l| l.name)
+                    .collect(),
+                updated_at: issue.updated_at,
+            })
+            .collect())
+    }
+}
+
+fn normalize_gitea_state_str(state: &str, merged: Option<bool>) -> String {
+    if merged.unwrap_or(false) {
+        "MERGED".to_string()
+    } else {
+        state.to_uppercase()
+    }
 }
 
 fn normalize_gitea_status(status: Option<&str>) -> String {
@@ -402,11 +483,7 @@ fn normalize_gitea_conclusion(status: &str) -> String {
 }
 
 fn normalize_gitea_state(pr: &GiteaPull) -> String {
-    if pr.merged.unwrap_or(false) {
-        "MERGED".to_string()
-    } else {
-        pr.state.to_uppercase()
-    }
+    normalize_gitea_state_str(&pr.state, pr.merged)
 }
 
 fn pr_to_info(pr: &GiteaPull) -> PrInfo {
@@ -509,5 +586,76 @@ mod tests {
         assert_eq!(overall.as_deref(), Some("pending"));
         assert_eq!(checks.len(), 2);
         assert_eq!(checks[0].status, "in_progress");
+    }
+
+    #[tokio::test]
+    async fn test_list_open_pull_requests() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("Authorization", "token test-token"))
+            .and(path("/repos/org/repo/pulls"))
+            .and(query_param("state", "open"))
+            .and(query_param("sort", "newest"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 5,
+                    "state": "open",
+                    "title": "Add widget",
+                    "body": "description",
+                    "draft": false,
+                    "mergeable": true,
+                    "merged": false,
+                    "head": { "ref": "add-widget", "sha": "aaa111" },
+                    "base": { "ref": "main", "sha": "bbb222" },
+                    "user": { "login": "carol" },
+                    "html_url": "https://gitea.example.com/org/repo/pulls/5",
+                    "created_at": "2024-07-01T10:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GiteaClient::new(&remote_info(&server)).unwrap();
+        let prs = client.list_open_pull_requests(30).await.unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 5);
+        assert_eq!(prs[0].title, "Add widget");
+        assert_eq!(prs[0].author, "carol");
+        assert_eq!(prs[0].head_branch, "add-widget");
+        assert_eq!(prs[0].base_branch, "main");
+    }
+
+    #[tokio::test]
+    async fn test_list_open_issues() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("Authorization", "token test-token"))
+            .and(path("/repos/org/repo/issues"))
+            .and(query_param("state", "open"))
+            .and(query_param("type", "issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 12,
+                    "title": "Fix timeout",
+                    "html_url": "https://gitea.example.com/org/repo/issues/12",
+                    "user": { "login": "dave" },
+                    "labels": [{ "name": "bug" }],
+                    "updated_at": "2024-07-10T14:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GiteaClient::new(&remote_info(&server)).unwrap();
+        let issues = client.list_open_issues(30).await.unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].number, 12);
+        assert_eq!(issues[0].title, "Fix timeout");
+        assert_eq!(issues[0].author, "dave");
+        assert_eq!(issues[0].labels, vec!["bug"]);
     }
 }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use super::{
     aggregate_ci_overall, build_http_client, ci_status_from_string, delete_empty, get_json,
     make_issue_comment, mergeable_bool, post_json, put_json, stack_comment_body, AuthStyle,
-    STACK_COMMENT_MARKER,
+    RepoIssueListItem, RepoPrListItem, STACK_COMMENT_MARKER,
 };
 use crate::ci::CheckRunInfo;
 use crate::github::pr::{MergeMethod, PrComment, PrInfo, PrInfoWithHead, PrMergeStatus};
@@ -34,6 +34,8 @@ struct GitLabMr {
     web_url: Option<String>,
     head_pipeline: Option<GitLabPipeline>,
     sha: Option<String>,
+    author: Option<GitLabUser>,
+    created_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,6 +63,16 @@ struct GitLabCommitStatus {
     target_url: Option<String>,
     started_at: Option<String>,
     finished_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabIssue {
+    iid: u64,
+    title: String,
+    web_url: Option<String>,
+    author: Option<GitLabUser>,
+    labels: Vec<String>,
+    updated_at: DateTime<Utc>,
 }
 
 #[derive(Serialize)]
@@ -403,6 +415,57 @@ impl GitLabClient {
 
         Ok((overall, checks))
     }
+
+    pub async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        let per_page = limit.clamp(1, 100);
+        let url = format!(
+            "{}?state=opened&per_page={}&order_by=created_at&sort=desc",
+            self.project_url("/merge_requests"),
+            per_page
+        );
+        let mrs: Vec<GitLabMr> = get_json(&self.client, &url).await?;
+        Ok(mrs
+            .into_iter()
+            .map(|mr| RepoPrListItem {
+                number: mr.iid,
+                title: mr.title,
+                url: mr.web_url.unwrap_or_default(),
+                author: mr
+                    .author
+                    .map(|a| a.username)
+                    .unwrap_or_else(|| "unknown".to_string()),
+                head_branch: mr.source_branch,
+                base_branch: mr.target_branch,
+                state: normalize_gitlab_state(&mr.state),
+                is_draft: mr.draft,
+                created_at: mr.created_at.unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    pub async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        let per_page = limit.clamp(1, 100);
+        let url = format!(
+            "{}?state=opened&per_page={}&order_by=updated_at&sort=desc",
+            self.project_url("/issues"),
+            per_page
+        );
+        let issues: Vec<GitLabIssue> = get_json(&self.client, &url).await?;
+        Ok(issues
+            .into_iter()
+            .map(|issue| RepoIssueListItem {
+                number: issue.iid,
+                title: issue.title,
+                url: issue.web_url.unwrap_or_default(),
+                author: issue
+                    .author
+                    .map(|a| a.username)
+                    .unwrap_or_else(|| "unknown".to_string()),
+                labels: issue.labels,
+                updated_at: issue.updated_at,
+            })
+            .collect())
+    }
 }
 
 /// Percent-encode a value for use in a URL query parameter.
@@ -553,5 +616,78 @@ mod tests {
         assert_eq!(overall.as_deref(), Some("pending"));
         assert_eq!(checks.len(), 2);
         assert_eq!(checks[0].status, "in_progress");
+    }
+
+    #[tokio::test]
+    async fn test_list_open_pull_requests() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/merge_requests"))
+            .and(query_param("state", "opened"))
+            .and(query_param("order_by", "created_at"))
+            .and(query_param("sort", "desc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "iid": 10,
+                    "title": "Add feature X",
+                    "state": "opened",
+                    "draft": true,
+                    "source_branch": "feature-x",
+                    "target_branch": "main",
+                    "description": "body",
+                    "web_url": "https://gitlab.example.com/group/subgroup/repo/-/merge_requests/10",
+                    "author": { "username": "alice" },
+                    "created_at": "2024-06-01T12:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GitLabClient::new(&remote_info(&server)).unwrap();
+        let prs = client.list_open_pull_requests(30).await.unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 10);
+        assert_eq!(prs[0].title, "Add feature X");
+        assert_eq!(prs[0].author, "alice");
+        assert_eq!(prs[0].head_branch, "feature-x");
+        assert_eq!(prs[0].base_branch, "main");
+        assert!(prs[0].is_draft);
+        assert_eq!(prs[0].state, "OPEN");
+    }
+
+    #[tokio::test]
+    async fn test_list_open_issues() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/issues"))
+            .and(query_param("state", "opened"))
+            .and(query_param("order_by", "updated_at"))
+            .and(query_param("sort", "desc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "iid": 42,
+                    "title": "Bug in login",
+                    "web_url": "https://gitlab.example.com/group/subgroup/repo/-/issues/42",
+                    "author": { "username": "bob" },
+                    "labels": ["bug", "urgent"],
+                    "updated_at": "2024-06-15T08:30:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GitLabClient::new(&remote_info(&server)).unwrap();
+        let issues = client.list_open_issues(30).await.unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].number, 42);
+        assert_eq!(issues[0].title, "Bug in login");
+        assert_eq!(issues[0].author, "bob");
+        assert_eq!(issues[0].labels, vec!["bug", "urgent"]);
     }
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -16,6 +16,31 @@ use crate::github::pr::{
 };
 use crate::remote::{ForgeType, RemoteInfo};
 
+/// Open pull request info for repo-level listing commands.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoPrListItem {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub author: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub state: String,
+    pub is_draft: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Open issue info for repo-level listing commands.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoIssueListItem {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub author: String,
+    pub labels: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
 mod gitea;
 mod gitlab;
 
@@ -91,6 +116,14 @@ impl ForgeClient {
 
     pub async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>> {
         dispatch!(self, list_open_prs_by_head())
+    }
+
+    pub async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        dispatch!(self, list_open_pull_requests(limit))
+    }
+
+    pub async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        dispatch!(self, list_open_issues(limit))
     }
 
     pub async fn create_pr(

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::config::Config;
+use crate::forge::{RepoIssueListItem, RepoPrListItem};
 
 const GITHUB_API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const GITHUB_API_READ_TIMEOUT: Duration = Duration::from_secs(30);
@@ -120,30 +121,6 @@ pub struct OpenPrInfo {
     pub is_draft: bool,
 }
 
-/// Open pull request info for repo-level listing commands
-#[derive(Debug, Clone, Serialize)]
-pub struct RepoPrListItem {
-    pub number: u64,
-    pub title: String,
-    pub url: String,
-    pub author: String,
-    pub head_branch: String,
-    pub base_branch: String,
-    pub state: String,
-    pub is_draft: bool,
-    pub created_at: DateTime<Utc>,
-}
-
-/// Open issue info for repo-level listing commands
-#[derive(Debug, Clone, Serialize)]
-pub struct RepoIssueListItem {
-    pub number: u64,
-    pub title: String,
-    pub url: String,
-    pub author: String,
-    pub labels: Vec<String>,
-    pub updated_at: DateTime<Utc>,
-}
 
 #[derive(Debug, Deserialize)]
 struct ReviewUser {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -2,4 +2,4 @@ pub mod client;
 pub mod pr;
 pub mod pr_template;
 
-pub use client::{GitHubClient, PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity};
+pub use client::{GitHubClient, PrActivity, ReviewActivity};


### PR DESCRIPTION
## Summary
- Route `st pr list` and `st issue list` through `ForgeClient` instead of directly instantiating `GitHubClient`, enabling them to work with GitHub, GitLab, and Gitea repositories
- Move `RepoPrListItem` and `RepoIssueListItem` to `forge/mod.rs` as shared types
- Implement `list_open_pull_requests()` and `list_open_issues()` for `GitLabClient` and `GiteaClient`
- Add wiremock tests for all new endpoints

Both GitLab and Gitea APIs fully support PR and issue listing, so this is a complete multi-forge implementation — no limitations or fallbacks needed.

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all tests pass (3 pre-existing worktree test failures unrelated to this change)
- [x] New wiremock tests for GitLab `list_open_pull_requests`, `list_open_issues`
- [x] New wiremock tests for Gitea `list_open_pull_requests`, `list_open_issues`

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)