### PR TITLE
feat(forge): make standup remote activity forge-aware

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -110,7 +110,7 @@
 | `st comments` | Show PR comments |
 | `st copy` | Copy branch name |
 | `st copy --pr` | Copy PR URL |
-| `st standup` | Show recent activity |
+| `st standup` | Show recent activity (GitHub, GitLab, Gitea) |
 | `st standup --summary` | AI-generated spoken standup update |
 | `st standup --summary --jit` | Include Jira `jit` context for in-flight and next-up work ([jit repo](https://github.com/cesarferreira/jit)) |
 | `st changelog [from] [to]` | Generate changelog (auto-resolves last tag if `from` omitted) |

--- a/docs/workflows/reporting.md
+++ b/docs/workflows/reporting.md
@@ -12,6 +12,11 @@ st standup --json            # Raw activity data as JSON
 ![Standup summary](../assets/standup.png)
 
 Shows merged PRs, opened PRs, recent pushes, and items that need attention.
+Works with GitHub, GitLab, and Gitea repositories.
+
+> **Note:** "Reviews given" data is not yet available on any forge. Efficiently
+> querying reviews authored by a user requires GraphQL (GitHub) or iterating
+> every open PR (GitLab/Gitea), which is too slow for large repositories.
 
 ## AI standup summary
 

--- a/src/commands/standup.rs
+++ b/src/commands/standup.rs
@@ -2,7 +2,7 @@ use crate::commands::generate;
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::git::GitRepo;
-use crate::github::{GitHubClient, PrActivity, ReviewActivity};
+use crate::forge::{ForgeClient, PrActivity, ReviewActivity};
 use crate::progress::LiveTimer;
 use crate::remote::RemoteInfo;
 use anyhow::{bail, Context, Result};
@@ -115,7 +115,7 @@ fn collect_standup_data(all: bool, hours: i64) -> Result<StandupData> {
     };
 
     let (merged_prs, opened_prs, reviews_received, reviews_given) =
-        fetch_github_activity(&remote_info, hours);
+        fetch_forge_activity(&remote_info, hours);
 
     let recent_pushes = get_recent_pushes(&repo, &branches_to_show, hours);
     let needs_attention =
@@ -956,7 +956,7 @@ fn print_jit_section(jit: &JitSummary) {
     println!();
 }
 
-fn fetch_github_activity(
+fn fetch_forge_activity(
     remote_info: &Option<RemoteInfo>,
     hours: i64,
 ) -> (
@@ -969,7 +969,7 @@ fn fetch_github_activity(
         return (vec![], vec![], vec![], vec![]);
     };
 
-    if Config::github_token().is_none() {
+    if crate::forge::forge_token(remote.forge).is_none() {
         return (vec![], vec![], vec![], vec![]);
     }
 
@@ -978,9 +978,7 @@ fn fetch_github_activity(
         Err(_) => return (vec![], vec![], vec![], vec![]),
     };
 
-    let client = match rt.block_on(async {
-        GitHubClient::new(remote.owner(), &remote.repo, remote.api_base_url.clone())
-    }) {
+    let client = match rt.block_on(async { ForgeClient::new(remote) }) {
         Ok(client) => client,
         Err(_) => return (vec![], vec![], vec![], vec![]),
     };
@@ -994,7 +992,6 @@ fn fetch_github_activity(
         return (vec![], vec![], vec![], vec![]);
     }
 
-    // Fetch all activity - using search API filtered by user (fast)
     let merged_prs = rt
         .block_on(async { client.get_recent_merged_prs(hours, &username).await })
         .unwrap_or_default();

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use super::{
     aggregate_ci_overall, build_http_client, ci_status_from_string, delete_empty, get_json,
     make_issue_comment, mergeable_bool, patch_json, post_json, stack_comment_body, AuthStyle,
-    RepoIssueListItem, RepoPrListItem, STACK_COMMENT_MARKER,
+    PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity, STACK_COMMENT_MARKER,
 };
 use crate::ci::CheckRunInfo;
 use crate::github::client::OpenPrInfo;
@@ -37,6 +37,7 @@ struct GiteaPull {
     user: Option<GiteaUser>,
     html_url: Option<String>,
     created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,6 +83,13 @@ struct GiteaIssue {
 #[derive(Debug, Deserialize)]
 struct GiteaLabel {
     name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaReview {
+    user: Option<GiteaUser>,
+    state: Option<String>,
+    submitted_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize)]
@@ -487,6 +495,105 @@ impl GiteaClient {
             })
             .collect())
     }
+
+    pub async fn get_recent_merged_prs(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<PrActivity>> {
+        let since = Utc::now() - chrono::Duration::hours(hours);
+        let url = format!("{}?state=closed&sort=recentupdate&limit=30", self.repo_url("/pulls"));
+        let prs: Vec<GiteaPull> = get_json(&self.client, &url).await?;
+        Ok(prs
+            .into_iter()
+            .filter(|pr| {
+                pr.merged == Some(true)
+                    && pr.user.as_ref().is_some_and(|u| u.login == username)
+                    && pr.updated_at.is_some_and(|t| t >= since)
+            })
+            .map(|pr| PrActivity {
+                number: pr.number,
+                title: pr.title,
+                timestamp: pr.updated_at.unwrap_or_default(),
+                url: pr.html_url.unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    pub async fn get_recent_opened_prs(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<PrActivity>> {
+        let since = Utc::now() - chrono::Duration::hours(hours);
+        let url = format!("{}?state=open&sort=newest&limit=30", self.repo_url("/pulls"));
+        let prs: Vec<GiteaPull> = get_json(&self.client, &url).await?;
+        Ok(prs
+            .into_iter()
+            .filter(|pr| {
+                pr.user.as_ref().is_some_and(|u| u.login == username)
+                    && pr.created_at.is_some_and(|t| t >= since)
+            })
+            .map(|pr| PrActivity {
+                number: pr.number,
+                title: pr.title,
+                timestamp: pr.created_at.unwrap_or_default(),
+                url: pr.html_url.unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    pub async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        let since = Utc::now() - chrono::Duration::hours(hours);
+        // Get user's open PRs, then fetch reviews on each
+        let prs_url = format!("{}?state=open&limit=20", self.repo_url("/pulls"));
+        let prs: Vec<GiteaPull> = get_json(&self.client, &prs_url).await?;
+
+        let mut reviews = Vec::new();
+        for pr in prs {
+            if pr.user.as_ref().is_none_or(|u| u.login != username) {
+                continue;
+            }
+            let reviews_url = self.repo_url(&format!("/pulls/{}/reviews", pr.number));
+            let pr_reviews: Vec<GiteaReview> = match get_json(&self.client, &reviews_url).await {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            for review in pr_reviews {
+                let reviewer = match &review.user {
+                    Some(u) if u.login != username => u.login.clone(),
+                    _ => continue,
+                };
+                if let Some(ts) = review.submitted_at {
+                    if ts >= since {
+                        reviews.push(ReviewActivity {
+                            pr_number: pr.number,
+                            pr_title: pr.title.clone(),
+                            reviewer,
+                            state: review.state.unwrap_or_else(|| "COMMENTED".to_string()),
+                            timestamp: ts,
+                            is_received: true,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(reviews)
+    }
+
+    pub async fn get_reviews_given(
+        &self,
+        _hours: i64,
+        _username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        // Not implemented: Gitea has no efficient way to query "reviews given by user".
+        // Would require iterating all open PRs and checking reviews on each.
+        Ok(vec![])
+    }
 }
 
 fn normalize_gitea_state_str(state: &str, merged: Option<bool>) -> String {
@@ -748,5 +855,141 @@ mod tests {
         assert_eq!(prs.len(), 1);
         assert_eq!(prs[0].number, 1);
         assert_eq!(prs[0].head_branch, "carol-feature");
+    }
+
+    #[tokio::test]
+    async fn test_get_recent_merged_prs() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("Authorization", "token test-token"))
+            .and(path("/repos/org/repo/pulls"))
+            .and(query_param("state", "closed"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 10,
+                    "state": "closed",
+                    "title": "Merged PR",
+                    "merged": true,
+                    "head": { "ref": "feat-a", "sha": "aaa" },
+                    "base": { "ref": "main", "sha": "bbb" },
+                    "user": { "login": "carol" },
+                    "html_url": "https://gitea.example.com/org/repo/pulls/10",
+                    "updated_at": "2099-01-01T12:00:00Z"
+                },
+                {
+                    "number": 11,
+                    "state": "closed",
+                    "title": "Closed not merged",
+                    "merged": false,
+                    "head": { "ref": "feat-b", "sha": "ccc" },
+                    "base": { "ref": "main", "sha": "ddd" },
+                    "user": { "login": "carol" },
+                    "updated_at": "2099-01-01T12:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GiteaClient::new(&remote_info(&server)).unwrap();
+        let prs = client.get_recent_merged_prs(9999, "carol").await.unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 10);
+        assert_eq!(prs[0].title, "Merged PR");
+    }
+
+    #[tokio::test]
+    async fn test_get_recent_opened_prs() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("Authorization", "token test-token"))
+            .and(path("/repos/org/repo/pulls"))
+            .and(query_param("state", "open"))
+            .and(query_param("sort", "newest"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 20,
+                    "state": "open",
+                    "title": "New PR",
+                    "merged": false,
+                    "head": { "ref": "feat-new", "sha": "eee" },
+                    "base": { "ref": "main", "sha": "fff" },
+                    "user": { "login": "carol" },
+                    "created_at": "2099-01-01T10:00:00Z"
+                },
+                {
+                    "number": 21,
+                    "state": "open",
+                    "title": "Other user PR",
+                    "merged": false,
+                    "head": { "ref": "other", "sha": "ggg" },
+                    "base": { "ref": "main", "sha": "hhh" },
+                    "user": { "login": "dave" },
+                    "created_at": "2099-01-01T10:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GiteaClient::new(&remote_info(&server)).unwrap();
+        let prs = client.get_recent_opened_prs(9999, "carol").await.unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 20);
+        assert_eq!(prs[0].title, "New PR");
+    }
+
+    #[tokio::test]
+    async fn test_get_reviews_received() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+
+        // Mock: user's open PRs
+        Mock::given(method("GET"))
+            .and(header("Authorization", "token test-token"))
+            .and(path("/repos/org/repo/pulls"))
+            .and(query_param("state", "open"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 30,
+                    "state": "open",
+                    "title": "Carol's PR",
+                    "merged": false,
+                    "head": { "ref": "feat", "sha": "aaa" },
+                    "base": { "ref": "main", "sha": "bbb" },
+                    "user": { "login": "carol" }
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        // Mock: reviews on PR 30
+        Mock::given(method("GET"))
+            .and(header("Authorization", "token test-token"))
+            .and(path("/repos/org/repo/pulls/30/reviews"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "user": { "login": "dave" },
+                    "state": "APPROVED",
+                    "submitted_at": "2099-01-01T09:00:00Z"
+                },
+                {
+                    "user": { "login": "carol" },
+                    "state": "COMMENTED",
+                    "submitted_at": "2099-01-01T09:30:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GiteaClient::new(&remote_info(&server)).unwrap();
+        let reviews = client.get_reviews_received(9999, "carol").await.unwrap();
+        // carol's self-review should be excluded
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].reviewer, "dave");
+        assert_eq!(reviews[0].state, "APPROVED");
+        assert!(reviews[0].is_received);
     }
 }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use super::{
     aggregate_ci_overall, build_http_client, ci_status_from_string, delete_empty, get_json,
     make_issue_comment, mergeable_bool, post_json, put_json, stack_comment_body, AuthStyle,
-    RepoIssueListItem, RepoPrListItem, STACK_COMMENT_MARKER,
+    PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity, STACK_COMMENT_MARKER,
 };
 use crate::ci::CheckRunInfo;
 use crate::github::client::OpenPrInfo;
@@ -37,6 +37,8 @@ struct GitLabMr {
     sha: Option<String>,
     author: Option<GitLabUser>,
     created_at: Option<DateTime<Utc>>,
+    merged_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -74,6 +76,17 @@ struct GitLabIssue {
     author: Option<GitLabUser>,
     labels: Vec<String>,
     updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabApproval {
+    user: GitLabUser,
+    created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabApprovals {
+    approved_by: Vec<GitLabApproval>,
 }
 
 #[derive(Serialize)]
@@ -492,6 +505,120 @@ impl GitLabClient {
             })
             .collect())
     }
+
+    pub async fn get_recent_merged_prs(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<PrActivity>> {
+        let since = Utc::now() - chrono::Duration::hours(hours);
+        let url = format!(
+            "{}?state=merged&author_username={}&updated_after={}&per_page=30&order_by=updated_at&sort=desc",
+            self.project_url("/merge_requests"),
+            encode_query_value(username),
+            since.to_rfc3339()
+        );
+        let mrs: Vec<GitLabMr> = get_json(&self.client, &url).await?;
+        Ok(mrs
+            .into_iter()
+            .filter_map(|mr| {
+                let ts = mr.merged_at.or(mr.updated_at)?;
+                if ts < since {
+                    return None;
+                }
+                Some(PrActivity {
+                    number: mr.iid,
+                    title: mr.title,
+                    timestamp: ts,
+                    url: mr.web_url.unwrap_or_default(),
+                })
+            })
+            .collect())
+    }
+
+    pub async fn get_recent_opened_prs(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<PrActivity>> {
+        let since = Utc::now() - chrono::Duration::hours(hours);
+        let url = format!(
+            "{}?author_username={}&created_after={}&per_page=30&order_by=created_at&sort=desc",
+            self.project_url("/merge_requests"),
+            encode_query_value(username),
+            since.to_rfc3339()
+        );
+        let mrs: Vec<GitLabMr> = get_json(&self.client, &url).await?;
+        Ok(mrs
+            .into_iter()
+            .filter_map(|mr| {
+                let ts = mr.created_at?;
+                if ts < since {
+                    return None;
+                }
+                Some(PrActivity {
+                    number: mr.iid,
+                    title: mr.title,
+                    timestamp: ts,
+                    url: mr.web_url.unwrap_or_default(),
+                })
+            })
+            .collect())
+    }
+
+    pub async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        let since = Utc::now() - chrono::Duration::hours(hours);
+        let url = format!(
+            "{}?state=opened&author_username={}&per_page=20",
+            self.project_url("/merge_requests"),
+            encode_query_value(username)
+        );
+        let mrs: Vec<GitLabMr> = get_json(&self.client, &url).await?;
+
+        let mut reviews = Vec::new();
+        for mr in mrs {
+            let approvals_url =
+                self.project_url(&format!("/merge_requests/{}/approvals", mr.iid));
+            let approvals: GitLabApprovals =
+                match get_json(&self.client, &approvals_url).await {
+                    Ok(a) => a,
+                    Err(_) => continue,
+                };
+            for approval in approvals.approved_by {
+                if approval.user.username == username {
+                    continue; // skip self-approvals
+                }
+                let Some(ts) = approval.created_at else {
+                    continue;
+                };
+                if ts >= since {
+                    reviews.push(ReviewActivity {
+                        pr_number: mr.iid,
+                        pr_title: mr.title.clone(),
+                        reviewer: approval.user.username,
+                        state: "APPROVED".to_string(),
+                        timestamp: ts,
+                        is_received: true,
+                    });
+                }
+            }
+        }
+        Ok(reviews)
+    }
+
+    pub async fn get_reviews_given(
+        &self,
+        _hours: i64,
+        _username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        // Not implemented: GitLab has no efficient way to query "reviews given by user"
+        // across all MRs. Would require iterating all open MRs and checking approvals.
+        Ok(vec![])
+    }
 }
 
 /// Percent-encode a value for use in a URL query parameter.
@@ -768,5 +895,119 @@ mod tests {
         assert_eq!(prs[0].head_branch, "feature-y");
         assert_eq!(prs[0].base_branch, "main");
         assert_eq!(prs[0].state, "OPEN");
+    }
+
+    #[tokio::test]
+    async fn test_get_recent_merged_prs() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/merge_requests"))
+            .and(query_param("state", "merged"))
+            .and(query_param("author_username", "alice"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "iid": 20,
+                    "title": "Merged MR",
+                    "state": "merged",
+                    "draft": false,
+                    "source_branch": "feat-z",
+                    "target_branch": "main",
+                    "web_url": "https://gitlab.example.com/g/s/r/-/merge_requests/20",
+                    "merged_at": "2099-01-01T12:00:00Z",
+                    "updated_at": "2099-01-01T12:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GitLabClient::new(&remote_info(&server)).unwrap();
+        let prs = client.get_recent_merged_prs(9999, "alice").await.unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 20);
+        assert_eq!(prs[0].title, "Merged MR");
+    }
+
+    #[tokio::test]
+    async fn test_get_recent_opened_prs() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+
+        Mock::given(method("GET"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/merge_requests"))
+            .and(query_param("author_username", "alice"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "iid": 21,
+                    "title": "New MR",
+                    "state": "opened",
+                    "draft": false,
+                    "source_branch": "feat-new",
+                    "target_branch": "main",
+                    "web_url": "https://gitlab.example.com/g/s/r/-/merge_requests/21",
+                    "created_at": "2099-01-01T10:00:00Z"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = GitLabClient::new(&remote_info(&server)).unwrap();
+        let prs = client.get_recent_opened_prs(9999, "alice").await.unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 21);
+        assert_eq!(prs[0].title, "New MR");
+    }
+
+    #[tokio::test]
+    async fn test_get_reviews_received() {
+        let server = MockServer::start().await;
+        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+
+        // Mock: user's open MRs
+        Mock::given(method("GET"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/merge_requests"))
+            .and(query_param("state", "opened"))
+            .and(query_param("author_username", "alice"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "iid": 30,
+                    "title": "My MR",
+                    "state": "opened",
+                    "draft": false,
+                    "source_branch": "feat",
+                    "target_branch": "main"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        // Mock: approvals on MR 30
+        Mock::given(method("GET"))
+            .and(header("PRIVATE-TOKEN", "test-token"))
+            .and(path(
+                "/projects/group%2Fsubgroup%2Frepo/merge_requests/30/approvals",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "approved_by": [
+                    {
+                        "user": { "username": "bob" },
+                        "created_at": "2099-01-01T09:00:00Z"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitLabClient::new(&remote_info(&server)).unwrap();
+        let reviews = client.get_reviews_received(9999, "alice").await.unwrap();
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].reviewer, "bob");
+        assert_eq!(reviews[0].state, "APPROVED");
+        assert_eq!(reviews[0].pr_number, 30);
+        assert!(reviews[0].is_received);
     }
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -16,6 +16,26 @@ use crate::github::pr::{
 };
 use crate::remote::{ForgeType, RemoteInfo};
 
+/// PR activity for standup reports.
+#[derive(Debug, Clone, Serialize)]
+pub struct PrActivity {
+    pub number: u64,
+    pub title: String,
+    pub timestamp: DateTime<Utc>,
+    pub url: String,
+}
+
+/// Review activity for standup reports.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewActivity {
+    pub pr_number: u64,
+    pub pr_title: String,
+    pub reviewer: String,
+    pub state: String,
+    pub timestamp: DateTime<Utc>,
+    pub is_received: bool,
+}
+
 /// Open pull request info for repo-level listing commands.
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoPrListItem {
@@ -284,6 +304,38 @@ impl ForgeClient {
 
     pub async fn get_user_open_prs(&self, username: &str) -> Result<Vec<OpenPrInfo>> {
         dispatch!(self, get_user_open_prs(username))
+    }
+
+    pub async fn get_recent_merged_prs(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<PrActivity>> {
+        dispatch!(self, get_recent_merged_prs(hours, username))
+    }
+
+    pub async fn get_recent_opened_prs(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<PrActivity>> {
+        dispatch!(self, get_recent_opened_prs(hours, username))
+    }
+
+    pub async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        dispatch!(self, get_reviews_received(hours, username))
+    }
+
+    pub async fn get_reviews_given(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        dispatch!(self, get_reviews_given(hours, username))
     }
 }
 

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -3,14 +3,14 @@ use chrono::{DateTime, Utc};
 use octocrab::params::repos::Reference;
 use octocrab::service::middleware::retry::RetryConfig;
 use octocrab::Octocrab;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::config::Config;
-use crate::forge::{RepoIssueListItem, RepoPrListItem};
+use crate::forge::{PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity};
 
 const GITHUB_API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const GITHUB_API_READ_TIMEOUT: Duration = Duration::from_secs(30);
@@ -89,26 +89,6 @@ struct CheckRun {
     name: String,
     status: String,
     conclusion: Option<String>,
-}
-
-/// PR activity for standup reports
-#[derive(Debug, Clone, Serialize)]
-pub struct PrActivity {
-    pub number: u64,
-    pub title: String,
-    pub timestamp: DateTime<Utc>,
-    pub url: String,
-}
-
-/// Review activity for standup reports
-#[derive(Debug, Clone, Serialize)]
-pub struct ReviewActivity {
-    pub pr_number: u64,
-    pub pr_title: String,
-    pub reviewer: String,
-    pub state: String,
-    pub timestamp: DateTime<Utc>,
-    pub is_received: bool, // true = received on your PR, false = given by you
 }
 
 /// Open PR info for tracking command

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -2,4 +2,4 @@ pub mod client;
 pub mod pr;
 pub mod pr_template;
 
-pub use client::{GitHubClient, PrActivity, ReviewActivity};
+pub use client::GitHubClient;


### PR DESCRIPTION
## Summary
- Route `st standup` remote PR/review activity through `ForgeClient` instead of directly instantiating `GitHubClient`
- Move `PrActivity` and `ReviewActivity` to `forge/mod.rs` as shared types
- Implement `get_recent_merged_prs()`, `get_recent_opened_prs()`, `get_reviews_received()` for GitLabClient and GiteaClient
- `get_reviews_given()` returns empty on all three forges (too expensive without GraphQL — same limitation as the existing GitHub implementation)

### Forge support details

| Operation | GitHub | GitLab | Gitea |
|-----------|--------|--------|-------|
| Merged PRs | Search API | `state=merged&author_username=&updated_after=` | Client-side author+time filter on closed PRs |
| Opened PRs | Search API | `created_after=&author_username=` | Client-side author+time filter |
| Reviews received | Per-PR `/reviews` | `/approvals` endpoint | Per-PR `/reviews` |
| Reviews given | Empty (needs GraphQL) | Empty (needs iteration) | Empty (needs iteration) |

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all tests pass
- [x] Existing forge unit tests (23) all pass

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)