### PR TITLE
[codex] Fix binstall release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,14 @@ jobs:
         if: matrix.target != 'x86_64-pc-windows-msvc'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../stax-${{ matrix.target }}.tar.gz stax
+          tar czf ../../../stax-${{ matrix.target }}.tar.gz stax st
           cd ../../..
 
       - name: Package (Windows)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
         run: |
-          Compress-Archive -Path "target/${{ matrix.target }}/release/stax.exe" -DestinationPath "stax-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/stax.exe","target/${{ matrix.target }}/release/st.exe" -DestinationPath "stax-${{ matrix.target }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/README.md
+++ b/README.md
@@ -57,16 +57,15 @@ curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-x
 # Linux (x86_64)
 curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-x86_64-unknown-linux-gnu.tar.gz | tar xz
 
-# Move binary to ~/.local/bin and symlink `st` alias
+# Move both binaries to ~/.local/bin
 mkdir -p ~/.local/bin
-mv stax ~/.local/bin/
-ln -s ~/.local/bin/stax ~/.local/bin/st
+mv stax st ~/.local/bin/
 
 # If ~/.local/bin is not on your PATH, add it:
 # echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc  # or ~/.bashrc
 ```
 
-**Windows (x86_64):** download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases), extract `stax.exe`, and place it in a directory on your `PATH`. See [Windows notes](#windows-notes) for shell and worktree limitations.
+**Windows (x86_64):** download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases), extract both `stax.exe` and `st.exe`, and place them in a directory on your `PATH`. See [Windows notes](#windows-notes) for shell and worktree limitations.
 
 Verify install:
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -12,13 +12,7 @@ Both `stax` and `st` (short alias) are installed automatically.
 
 ### Windows
 
-Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract `stax.exe`, and place it in a directory on your `PATH`.
-
-To create the `st` short alias, copy or symlink the binary:
-
-```powershell
-Copy-Item stax.exe st.exe
-```
+Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract both `stax.exe` and `st.exe`, and place them in a directory on your `PATH`.
 
 See [Windows notes](../reference/windows.md) for shell and worktree limitations.
 

--- a/docs/reference/windows.md
+++ b/docs/reference/windows.md
@@ -4,13 +4,7 @@ stax ships pre-built Windows binaries (`x86_64-pc-windows-msvc`) starting from t
 
 ## Install
 
-Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract `stax.exe`, and place it in a directory on your `PATH`.
-
-To create the `st` short alias, copy the binary:
-
-```powershell
-Copy-Item stax.exe st.exe
-```
+Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract both `stax.exe` and `st.exe`, and place them in a directory on your `PATH`.
 
 ## What works
 


### PR DESCRIPTION
## What changed

- package both `stax` and `st` in release archives for Unix and Windows
- update install docs to reflect that release downloads now include both binaries directly

## Why

`cargo-binstall stax` reads the crate metadata and sees two non-optional binaries: `stax` and `st`.
The published GitHub release archives only contained `stax`, so `cargo-binstall` failed while resolving `st` and fell back to building from source.

## Impact

- `cargo binstall stax` should work with the prebuilt release artifacts after the next release
- manual GitHub release installs on macOS, Linux, and Windows now match the documented two-binary story

## Root cause

The crate manifest declares both binaries, but the release workflow only archived `stax` / `stax.exe`.
That left the release artifacts inconsistent with the crate metadata that `cargo-binstall` uses.

## Verification

- `cargo build --release --bins`
- `git diff --check -- .github/workflows/release.yml README.md docs/getting-started/install.md docs/reference/windows.md`
- built a local tarball from `target/release/stax` and `target/release/st`; archive contents were:
  - `stax`
  - `st`
