### PR TITLE
[codex] limit shell integration to worktree flows

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -3,25 +3,40 @@ use crate::config::Config;
 use crate::engine::Stack;
 use crate::git::{checkout_branch_in, refs, GitRepo};
 use anyhow::Result;
-use colored::{Color, Colorize};
-use console::truncate_str;
+use colored::Colorize;
+use console::{truncate_str, Color, Style};
 use crossterm::terminal;
 use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 use std::collections::HashSet;
+use std::fmt::Display;
 use std::path::Path;
 
 // Colors for different columns (matching status.rs)
-const COLUMN_COLORS: &[Color] = &[
-    Color::Cyan,
-    Color::Green,
-    Color::Magenta,
-    Color::Blue,
-    Color::BrightCyan,
-    Color::BrightGreen,
-    Color::BrightMagenta,
-    Color::BrightBlue,
+const COLUMN_COLORS: &[CheckoutColor] = &[
+    CheckoutColor::new(Color::Cyan, false),
+    CheckoutColor::new(Color::Green, false),
+    CheckoutColor::new(Color::Magenta, false),
+    CheckoutColor::new(Color::Blue, false),
+    CheckoutColor::new(Color::Cyan, true),
+    CheckoutColor::new(Color::Green, true),
+    CheckoutColor::new(Color::Magenta, true),
+    CheckoutColor::new(Color::Blue, true),
 ];
 const LINKED_WORKTREE_GLYPH: &str = "↳";
+const BRIGHT_BLUE: CheckoutColor = CheckoutColor::new(Color::Blue, true);
+const BRIGHT_CYAN: CheckoutColor = CheckoutColor::new(Color::Cyan, true);
+
+#[derive(Clone, Copy)]
+struct CheckoutColor {
+    color: Color,
+    bright: bool,
+}
+
+impl CheckoutColor {
+    const fn new(color: Color, bright: bool) -> Self {
+        Self { color, bright }
+    }
+}
 
 /// Represents a branch in the display with its column position
 struct DisplayBranch {
@@ -32,6 +47,19 @@ struct DisplayBranch {
 struct CheckoutRow {
     branch: String,
     display: String,
+}
+
+fn checkout_style(spec: CheckoutColor) -> Style {
+    let style = Style::new().for_stderr().fg(spec.color);
+    if spec.bright {
+        style.bright()
+    } else {
+        style
+    }
+}
+
+fn render_stderr<T: Display>(value: T, style: Style) -> String {
+    format!("{}", style.apply_to(value))
 }
 
 pub fn run(
@@ -283,14 +311,15 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
             let col_color = COLUMN_COLORS[col % COLUMN_COLORS.len()];
             if col == db.column {
                 let circle = if is_current { "◉" } else { "○" };
-                tree.push_str(&format!("{}", circle.color(col_color)));
+                tree.push_str(&render_stderr(circle, checkout_style(col_color)));
                 visual_width += 1;
                 if needs_corner {
-                    tree.push_str(&format!("{}", "─┘".color(col_color)));
+                    tree.push_str(&render_stderr("─┘", checkout_style(col_color)));
                     visual_width += 2;
                 }
             } else {
-                tree.push_str(&format!("{} ", "│".color(col_color)));
+                tree.push_str(&render_stderr("│", checkout_style(col_color)));
+                tree.push(' ');
                 visual_width += 2;
             }
         }
@@ -305,9 +334,9 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
 
         let branch_color = COLUMN_COLORS[db.column % COLUMN_COLORS.len()];
         if is_current {
-            info_str.push_str(&format!("{}", branch.color(branch_color).bold()));
+            info_str.push_str(&render_stderr(branch, checkout_style(branch_color).bold()));
         } else {
-            info_str.push_str(&format!("{}", branch.color(branch_color)));
+            info_str.push_str(&render_stderr(branch, checkout_style(branch_color)));
         }
 
         if ahead > 0 || behind > 0 {
@@ -341,16 +370,16 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
     let mut trunk_visual_width = 0;
     let trunk_circle = if is_trunk_current { "◉" } else { "○" };
     let trunk_color = COLUMN_COLORS[0];
-    trunk_tree.push_str(&format!("{}", trunk_circle.color(trunk_color)));
+    trunk_tree.push_str(&render_stderr(trunk_circle, checkout_style(trunk_color)));
     trunk_visual_width += 1;
 
     if trunk_child_max_col >= 1 {
         for col in 1..=trunk_child_max_col {
             let col_color = COLUMN_COLORS[col % COLUMN_COLORS.len()];
             if col < trunk_child_max_col {
-                trunk_tree.push_str(&format!("{}", "─┴".color(col_color)));
+                trunk_tree.push_str(&render_stderr("─┴", checkout_style(col_color)));
             } else {
-                trunk_tree.push_str(&format!("{}", "─┘".color(col_color)));
+                trunk_tree.push_str(&render_stderr("─┘", checkout_style(col_color)));
             }
             trunk_visual_width += 2;
         }
@@ -367,9 +396,12 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
         linked_worktrees_by_branch.contains(&stack.trunk),
     );
     if is_trunk_current {
-        trunk_info.push_str(&format!("{}", stack.trunk.color(trunk_color).bold()));
+        trunk_info.push_str(&render_stderr(
+            &stack.trunk,
+            checkout_style(trunk_color).bold(),
+        ));
     } else {
-        trunk_info.push_str(&format!("{}", stack.trunk.color(trunk_color)));
+        trunk_info.push_str(&render_stderr(&stack.trunk, checkout_style(trunk_color)));
     }
 
     let (ahead, behind) = repo
@@ -404,14 +436,19 @@ fn render_presence_markers(
     let mut info_str = String::new();
     info_str.push(' ');
     if has_remote {
-        info_str.push_str(&format!("{} ", "☁️".bright_blue()));
+        info_str.push_str(&render_stderr("☁️", checkout_style(BRIGHT_BLUE)));
+        info_str.push(' ');
     } else {
         info_str.push_str("   ");
     }
 
     if show_worktree_column {
         if has_linked_worktree {
-            info_str.push_str(&format!("{} ", LINKED_WORKTREE_GLYPH.bright_cyan()));
+            info_str.push_str(&render_stderr(
+                LINKED_WORKTREE_GLYPH,
+                checkout_style(BRIGHT_CYAN),
+            ));
+            info_str.push(' ');
         } else {
             info_str.push_str("  ");
         }
@@ -634,6 +671,17 @@ mod tests {
             .expect("valid ANSI regex")
             .replace_all(s, "")
             .into_owned()
+    }
+
+    #[test]
+    fn test_checkout_style_uses_stderr_color_channel() {
+        let previous = console::colors_enabled_stderr();
+        console::set_colors_enabled_stderr(true);
+
+        let styled = render_stderr("branch", checkout_style(COLUMN_COLORS[0]).bold());
+
+        console::set_colors_enabled_stderr(previous);
+        assert!(styled.contains("\x1b["));
     }
 
     #[test]

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -16,9 +16,9 @@ enum ShellKind {
 }
 
 /// The shell function block that users source in their shell config.
-/// It intercepts worktree create/go flows for both `st` and `stax`, performs
-/// the actual `cd` in the calling shell process, and can safely relocate the
-/// shell before removing the current worktree.
+/// It intercepts worktree commands that need shell-side directory changes,
+/// performs the actual `cd` in the calling shell process, and can safely
+/// relocate the shell before removing the current worktree.
 fn shell_snippet(shell_kind: ShellKind) -> &'static str {
     match shell_kind {
         ShellKind::Posix => posix_shell_snippet(),
@@ -162,21 +162,12 @@ __stax_dispatch() {
       __stax_run_worktree_shell worktree go "${@:2}" ;;
     wtc)
       __stax_run_worktree_shell worktree create "${@:2}" ;;
-    checkout|co|bco)
-      __stax_run_worktree_shell "$@" ;;
     wtrm)
       if [[ -z "$2" || "$2" == -* ]]; then
         __stax_remove_current_worktree worktree remove "${@:2}"
       else
         __stax_exec "$@"
       fi ;;
-    branch|b)
-      case "$2" in
-        checkout|co)
-          __stax_run_worktree_shell "$@" ;;
-        *)
-          __stax_exec "$@" ;;
-      esac ;;
     worktree|wt)
       case "$2" in
         go|create|c)
@@ -314,20 +305,11 @@ function __stax_dispatch
             __stax_run_worktree_shell worktree go $argv[2..-1]
         case wtc
             __stax_run_worktree_shell worktree create $argv[2..-1]
-        case checkout co bco
-            __stax_run_worktree_shell $argv
         case wtrm
             if test (count $argv) -lt 2; or string match -qr '^-' -- "$argv[2]"
                 __stax_remove_current_worktree worktree remove $argv[2..-1]
             else
                 __stax_exec $argv
-            end
-        case branch b
-            switch "$argv[2]"
-                case checkout co
-                    __stax_run_worktree_shell $argv
-                case '*'
-                    __stax_exec $argv
             end
         case worktree wt
             switch "$argv[2]"
@@ -861,7 +843,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn posix_shell_snippet_keeps_path_for_shell_wrapped_commands_in_zsh() {
+    fn posix_shell_snippet_keeps_path_for_worktree_shell_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
         if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
@@ -892,7 +874,7 @@ mod tests {
 
         let original_path = std::env::var("PATH").unwrap_or_default();
         let path_env = format!("{}:{original_path}", bin_dir.display());
-        let command = format!("source \"{}\"; st bco", snippet_path.display());
+        let command = format!("source \"{}\"; st wtgo demo-lane", snippet_path.display());
         let output = Command::new("zsh")
             .arg("-lc")
             .arg(&command)
@@ -910,12 +892,78 @@ mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             stdout.contains(&format!("resolved:{}", fake_stax.display())),
-            "expected zsh wrapper to resolve fake stax binary for shell-wrapped commands, got:\n{}",
+            "expected zsh wrapper to resolve fake stax binary for worktree shell commands, got:\n{}",
             stdout
         );
         assert!(
-            stdout.contains("args:bco --shell-output"),
-            "expected shell-wrapped command to preserve PATH and inject --shell-output, got:\n{}",
+            stdout.contains("args:worktree go demo-lane --shell-output"),
+            "expected worktree shell command to preserve PATH and inject --shell-output, got:\n{}",
+            stdout
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn posix_shell_snippet_does_not_wrap_checkout_commands_in_zsh() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+            if err.kind() == ErrorKind::NotFound {
+                return;
+            }
+            panic!("failed to probe zsh: {err}");
+        }
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+
+        let fake_stax = bin_dir.join("stax");
+        fs::write(
+            &fake_stax,
+            "#!/bin/sh\nprintf 'resolved:%s\\n' \"$0\"\nprintf 'args:%s\\n' \"$*\"\n",
+        )
+        .expect("write fake stax");
+        let mut perms = fs::metadata(&fake_stax)
+            .expect("fake stax metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_stax, perms).expect("chmod fake stax");
+
+        let snippet_path = dir.path().join("shell-setup.sh");
+        fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
+
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        let path_env = format!("{}:{original_path}", bin_dir.display());
+        let command = format!("source \"{}\"; st bco feature", snippet_path.display());
+        let output = Command::new("zsh")
+            .arg("-lc")
+            .arg(&command)
+            .env("PATH", path_env)
+            .output()
+            .expect("run zsh shell snippet");
+
+        assert!(
+            output.status.success(),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(&format!("resolved:{}", fake_stax.display())),
+            "expected zsh wrapper to resolve fake stax binary for passthrough checkout commands, got:\n{}",
+            stdout
+        );
+        assert!(
+            stdout.contains("args:bco feature"),
+            "expected checkout command to pass through unchanged, got:\n{}",
+            stdout
+        );
+        assert!(
+            !stdout.contains("--shell-output"),
+            "expected checkout command to avoid shell-output injection, got:\n{}",
             stdout
         );
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,6 +1,7 @@
 # Lessons
 
 - When changing the `stax co` UI, match the `stax ls` visual language (colors, tree/indentation) and confirm it visually. Do not ship a redesign without verifying the output looks like the `ls` tree and that selection emphasis is obvious.
+- Interactive prompts rendered on `stderr` must style item text against `stderr` too; stdout-based color detection breaks when shell integration captures stdout for `--shell-output`.
 - TUI changes must be checked at standard terminal widths (around 80 columns); keep one-line summaries and footers compact, and prefer a single contextual action over listing every shortcut.
 - If interactive lists scroll the terminal on navigation, clear and position the cursor before invoking the dialog to avoid rendering into the lower viewport.
 - Bare commands that default to a TUI/dashboard must gate on both `stdin` and `stdout` being terminals and otherwise fall back to help or a non-interactive view; never assume `st`/`st wt` is launched from a full TTY.
@@ -12,6 +13,7 @@
 - Shared bash/zsh shell snippets must use shell-specific command lookup (`whence -p` in zsh, `type -P` in bash) when they need the real binary path; bash-only flags in shared wrappers can break every `st`/`stax` invocation on zsh.
 - Shared bash/zsh shell snippets must not use zsh-special parameter names like `path` for local scratch variables inside wrappers; localizing `path` in zsh also localizes `PATH` and breaks nested command lookup.
 - `shell-setup --install` must replace legacy inline/eval shell integration blocks instead of appending a new source line, and later runs should refresh existing generated shell-setup files after upgrades; stale pasted wrappers or stale generated snippets both leave users with duplicate or broken shell behavior.
+- Shell integration should special-case only commands that require shell-side directory changes (`wt go/create` and removing the current worktree); route all other commands straight to the binary without injecting `--shell-output`.
 - Commands intended for first-run/setup flows (for example `shell-setup`) must bypass repo initialization in `src/cli.rs`; otherwise running them outside a configured repo can accidentally trigger `init` and break shell startup or onboarding.
 - When sync reparents children off merged branches, never clear `parent_branch_revision`; preserve the old-base boundary (or merged parent tip) so restack can run `git rebase --onto <new> <old>` and avoid replaying already-integrated commits.
 - Integration tests that shell out to `git`/`stax` must be hermetic: strip GitHub token env, user-specific `stax` env such as `STAX_SHELL_INTEGRATION`, and force `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to null so contributor-specific git config and shell setup cannot change behavior or add large runtime overhead.


### PR DESCRIPTION
## What changed
- limited shell integration back to the commands that need shell-side directory changes: `wt go`, `wt create`, and removing the current worktree
- stopped wrapping checkout commands through the shell integration path, so `st co` and `st bco` now pass straight through to the binary again
- switched checkout selector row styling to stderr-aware console styles so colors still render when the interactive prompt is drawn on stderr
- added focused shell-setup and checkout tests, and recorded the repo-level lesson for shell integration scope

## Why
Shell integration had grown beyond its intended `worktree` use and started wrapping checkout commands as well. That widened the blast radius of the wrapper, introduced stdout capture into interactive checkout flows, and created user-visible regressions such as missing colors in `st co`.

## Impact
- shell integration now does only what the docs promise: transparent `cd` for worktree navigation and safe removal of the current worktree
- checkout commands are simpler again and no longer depend on shell-wrapper behavior
- interactive checkout colors are restored even when the prompt is rendered on stderr

## Root cause
The March 26 shell integration change added checkout commands to the shell wrapper so `st co` could route into another worktree. That meant interactive checkout rows were rendered through a path that captured stdout, while the prompt itself was rendered on stderr. The row styling still depended on stdout-based color detection, so the branch list went monochrome.

## Validation
- `cargo test checkout_style_uses_stderr_color_channel`
- `cargo test render_presence_markers_aligns_worktree_column`
- `cargo test posix_shell_snippet_keeps_path_for_worktree_shell_commands_in_zsh`
- `cargo test posix_shell_snippet_does_not_wrap_checkout_commands_in_zsh`
- `cargo test --test worktree_tests checkout_branch_checked_out_in_worktree_emits_shell_route_payload -- --exact`
