### PR TITLE
route checkout through shell integration for worktree cd

### DIFF
--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -158,6 +158,15 @@ __stax_remove_current_worktree() {
 
 __stax_dispatch() {
   case "$1" in
+    checkout|co|bco)
+      __stax_run_worktree_shell "$@" ;;
+    branch|b)
+      case "$2" in
+        checkout|co)
+          __stax_run_worktree_shell "$@" ;;
+        *)
+          __stax_exec "$@" ;;
+      esac ;;
     wtgo)
       __stax_run_worktree_shell worktree go "${@:2}" ;;
     wtc)
@@ -301,6 +310,15 @@ end
 
 function __stax_dispatch
     switch "$argv[1]"
+        case checkout co bco
+            __stax_run_worktree_shell $argv
+        case branch b
+            switch "$argv[2]"
+                case checkout co
+                    __stax_run_worktree_shell $argv
+                case '*'
+                    __stax_exec $argv
+            end
         case wtgo
             __stax_run_worktree_shell worktree go $argv[2..-1]
         case wtc
@@ -904,7 +922,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn posix_shell_snippet_does_not_wrap_checkout_commands_in_zsh() {
+    fn posix_shell_snippet_wraps_checkout_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
         if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
@@ -953,17 +971,12 @@ mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             stdout.contains(&format!("resolved:{}", fake_stax.display())),
-            "expected zsh wrapper to resolve fake stax binary for passthrough checkout commands, got:\n{}",
+            "expected zsh wrapper to resolve fake stax binary for checkout commands, got:\n{}",
             stdout
         );
         assert!(
-            stdout.contains("args:bco feature"),
-            "expected checkout command to pass through unchanged, got:\n{}",
-            stdout
-        );
-        assert!(
-            !stdout.contains("--shell-output"),
-            "expected checkout command to avoid shell-output injection, got:\n{}",
+            stdout.contains("args:bco feature --shell-output"),
+            "expected checkout command to be wrapped with --shell-output, got:\n{}",
             stdout
         );
     }


### PR DESCRIPTION
## Summary

- When `stax checkout` routes to a worktree, the shell couldn't `cd` automatically because `checkout`/`co`/`bco` weren't intercepted by the shell wrapper
- Added checkout commands to `__stax_dispatch` in both POSIX and Fish snippets so `--shell-output` is injected and `builtin cd` works
- Also handles `branch checkout`/`branch co` and their aliases (`b checkout`, `b co`)

**Before:** "Current shell did not move automatically. cd /path/to/worktree"
**After:** Shell automatically moves to the worktree directory

## Test plan

- [x] All 14 `shell_setup` tests pass (including updated `posix_shell_snippet_wraps_checkout_commands_in_zsh`)
- [ ] Manual: `stax checkout` a branch in a worktree → shell should cd automatically
- [ ] Manual: `stax co --parent` / `stax co --trunk` still work normally when no worktree involved
- [ ] Verify `stax shell-setup --refresh` updates the installed snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)