### PR TITLE
fix: doctor checks correct forge token instead of always GitHub

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::engine::Stack;
+use crate::forge;
 use crate::git::GitRepo;
 use crate::remote::{self, RemoteInfo};
 use anyhow::Result;
@@ -53,12 +54,18 @@ pub fn run() -> Result<()> {
         }
     }
 
-    let forge_label = match RemoteInfo::from_repo(&repo, &config) {
-        Ok(info) => info.forge.to_string(),
-        Err(_) => "Forge".to_string(),
-    };
+    let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
+    let forge_label = remote_info
+        .as_ref()
+        .map(|info| info.forge.to_string())
+        .unwrap_or_else(|| "Forge".to_string());
 
-    if Config::github_token().is_some() {
+    let has_token = remote_info
+        .as_ref()
+        .map(|info| forge::forge_token(info.forge).is_some())
+        .unwrap_or_else(|| Config::github_token().is_some());
+
+    if has_token {
         println!(
             "{} {}",
             "✓".green(),


### PR DESCRIPTION
## Summary
- `stax doctor` unconditionally called `Config::github_token()` to check for API token availability, causing false "token missing" warnings for GitLab/Gitea remotes even when the correct token (e.g. `STAX_GITLAB_TOKEN`) was set
- Now uses `forge::forge_token(forge_type)` which dispatches to the correct token lookup based on the detected forge type
- Falls back to `Config::github_token()` only when the remote info cannot be determined

Fixes #192

## Test plan
- [ ] Configure a remote with `forge = "gitlab"` and set `STAX_GITLAB_TOKEN` → `stax doctor` should show ✓ for token
- [ ] Same for Gitea with `STAX_GITEA_TOKEN`
- [ ] GitHub remotes continue to work as before
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)