### PR TITLE
feat: add --no-verify flag to stax modify

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -377,6 +377,9 @@ enum Commands {
         /// Suppress extra output
         #[arg(long)]
         quiet: bool,
+        /// Skip pre-commit and commit-msg hooks
+        #[arg(long = "no-verify", short = 'n')]
+        no_verify: bool,
     },
 
     /// Authenticate with GitHub
@@ -1431,7 +1434,8 @@ pub fn run() -> Result<()> {
             message,
             all,
             quiet,
-        } => commands::modify::run(message, all, quiet),
+            no_verify,
+        } => commands::modify::run(message, all, quiet, no_verify),
         Commands::Auth { .. } => unreachable!(), // Handled above
         Commands::Config { .. } => unreachable!(), // Handled above
         Commands::Init { .. } => unreachable!(), // Handled above

--- a/src/commands/modify.rs
+++ b/src/commands/modify.rs
@@ -16,7 +16,7 @@ enum ModifyTarget {
 /// When files are already staged, only those files are committed.
 /// When nothing is staged, prompts to stage all (or use `-a`).
 /// On a fresh tracked branch, `-m` creates the first branch-local commit safely.
-pub fn run(message: Option<String>, all: bool, quiet: bool) -> Result<()> {
+pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let workdir = repo.workdir()?;
     let current = repo.current_branch()?;
@@ -32,14 +32,15 @@ pub fn run(message: Option<String>, all: bool, quiet: bool) -> Result<()> {
     let target = modify_target(&repo, &current)?;
 
     if all {
-        // Explicit --all: stage everything (old behavior)
+        // Explicit --all: force-stage everything, even when some files are
+        // already selectively staged.
         stage_all(workdir)?;
     } else {
         // Check whether anything is already staged
         let has_staged = !is_staging_area_empty(workdir)?;
 
         if !has_staged {
-            // Nothing staged — prompt in interactive mode, bail otherwise
+            // Nothing staged — prompt interactively, bail otherwise
             if Term::stderr().is_term() {
                 let change_count = count_uncommitted_changes(workdir);
                 let prompt = if change_count > 0 {
@@ -78,6 +79,10 @@ pub fn run(message: Option<String>, all: bool, quiet: bool) -> Result<()> {
     match target {
         ModifyTarget::Amend => {
             let mut amend_args = vec!["commit", "--amend"];
+
+            if no_verify {
+                amend_args.push("--no-verify");
+            }
 
             if let Some(ref msg) = message {
                 amend_args.push("-m");
@@ -121,8 +126,13 @@ pub fn run(message: Option<String>, all: bool, quiet: bool) -> Result<()> {
                 )
             })?;
 
+            let mut commit_args = vec!["commit", "-m", commit_message];
+            if no_verify {
+                commit_args.push("--no-verify");
+            }
+
             let commit_status = Command::new("git")
-                .args(["commit", "-m", commit_message])
+                .args(&commit_args)
                 .current_dir(workdir)
                 .status()
                 .context("Failed to create commit")?;
@@ -163,6 +173,7 @@ fn is_staging_area_empty(workdir: &Path) -> Result<bool> {
         .context("Failed to check staged changes")?;
     Ok(status.success())
 }
+
 
 /// Count files with uncommitted changes (staged + unstaged + untracked).
 fn count_uncommitted_changes(workdir: &Path) -> usize {


### PR DESCRIPTION
## Summary
- Adds `--no-verify` / `-n` flag to `stax modify` that passes `--no-verify` to the underlying `git commit` call
- Works for both the amend path (`git commit --amend --no-verify`) and the create-first-commit path (`git commit -m ... --no-verify`)
- Matches Graphite's `gt modify --no-verify` behavior and standard git semantics
- Existing staging behavior is unchanged: prompts when nothing is staged, respects selective staging

Closes #194

## Test plan
- [ ] `stax modify --no-verify` — amends without running pre-commit hooks
- [ ] `stax modify -n -m "wip"` — short flag works
- [ ] `stax modify` (without flag) — hooks still run as before
- [ ] Selective staging still respected (only staged files committed when some are staged)
- [ ] Nothing staged still prompts interactively
- [ ] `stax modify --help` shows the new flag
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)