### PR TITLE
fix: enable vendored-openssl for CI cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: cargo nextest run --lib --bins
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
 
       - name: Package (Unix)
         if: matrix.target != 'x86_64-pc-windows-msvc'


### PR DESCRIPTION
## Summary
Fixes the x86_64-apple-darwin build failure in GitHub Actions CI.

## Problem
The release workflow was failing when building the x86_64-apple-darwin target with:
```
error: failed to run custom build command for `openssl-sys v0.9.112`
Could not find directory of OpenSSL installation
pkg-config has not been configured to support cross-compilation
```

## Root Cause
- Commit addc189 ("Removed openssl") removed the explicit `openssl` dependency with `vendored` feature
- A `vendored-openssl` feature was added to `Cargo.toml` but not enabled in the CI build
- When cross-compiling x86_64 on ARM macOS runners, pkg-config cannot find OpenSSL for the target architecture

## Solution
Enable the `vendored-openssl` feature in the CI build command. This ensures git2 uses vendored OpenSSL for all cross-compilation scenarios without affecting local development builds.

## Test Plan
- [x] Verified the build command works locally: `cargo build --release --features vendored-openssl`
- [ ] CI will validate all platform builds pass with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)