### PR TITLE
[codex] Fix st lane picker under shell integration

### DIFF
--- a/src/commands/worktree/ai.rs
+++ b/src/commands/worktree/ai.rs
@@ -279,8 +279,17 @@ fn prepare_ai_launch_with_tmux_probe(
     Ok(PreparedAiLaunch { launch, messages })
 }
 
+fn has_lane_picker_terminal(stdin_is_terminal: bool, stderr_is_terminal: bool) -> bool {
+    stdin_is_terminal && stderr_is_terminal
+}
+
 fn pick_lane_interactively(repo: &GitRepo) -> Result<LaneSelection> {
-    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+    // dialoguer renders lane picker prompts on stderr, so shell-output wrappers
+    // can still host the interactive flow even when stdout is captured.
+    if !has_lane_picker_terminal(
+        std::io::stdin().is_terminal(),
+        std::io::stderr().is_terminal(),
+    ) {
         bail!("`st lane` with no name requires an interactive terminal");
     }
 
@@ -420,10 +429,18 @@ fn normalize_prompt(prompt: Option<String>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{prepare_ai_launch_with_tmux_probe, AiLaneRequest};
+    use super::{has_lane_picker_terminal, prepare_ai_launch_with_tmux_probe, AiLaneRequest};
     use crate::commands::worktree::shared::LaunchSpec;
     use crate::config::Config;
     use anyhow::anyhow;
+
+    #[test]
+    fn lane_picker_requires_stdin_and_stderr_terminals() {
+        assert!(has_lane_picker_terminal(true, true));
+        assert!(!has_lane_picker_terminal(true, false));
+        assert!(!has_lane_picker_terminal(false, true));
+        assert!(!has_lane_picker_terminal(false, false));
+    }
 
     #[test]
     fn prepare_ai_launch_ignores_configured_model_for_ai_lanes() {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,7 +1,7 @@
 # Lessons
 
 - When changing the `stax co` UI, match the `stax ls` visual language (colors, tree/indentation) and confirm it visually. Do not ship a redesign without verifying the output looks like the `ls` tree and that selection emphasis is obvious.
-- Interactive prompts rendered on `stderr` must style item text against `stderr` too; stdout-based color detection breaks when shell integration captures stdout for `--shell-output`.
+- Interactive prompts rendered on `stderr` must style item text against `stderr` and gate interactivity on `stdin` + `stderr`; shell integration can capture stdout for `--shell-output` while dialoguer prompts still run on stderr.
 - TUI changes must be checked at standard terminal widths (around 80 columns); keep one-line summaries and footers compact, and prefer a single contextual action over listing every shortcut.
 - If interactive lists scroll the terminal on navigation, clear and position the cursor before invoking the dialog to avoid rendering into the lower viewport.
 - Bare commands that default to a TUI/dashboard must gate on both `stdin` and `stdout` being terminals and otherwise fall back to help or a non-interactive view; never assume `st`/`st wt` is launched from a full TTY.
@@ -14,7 +14,7 @@
 - Shared bash/zsh shell snippets must use shell-specific command lookup (`whence -p` in zsh, `type -P` in bash) when they need the real binary path; bash-only flags in shared wrappers can break every `st`/`stax` invocation on zsh.
 - Shared bash/zsh shell snippets must not use zsh-special parameter names like `path` for local scratch variables inside wrappers; localizing `path` in zsh also localizes `PATH` and breaks nested command lookup.
 - `shell-setup --install` must replace legacy inline/eval shell integration blocks instead of appending a new source line, and later runs should refresh existing generated shell-setup files after upgrades; stale pasted wrappers or stale generated snippets both leave users with duplicate or broken shell behavior.
-- Shell integration should special-case only commands that require shell-side directory changes (`wt go/create` and removing the current worktree); route all other commands straight to the binary without injecting `--shell-output`.
+- Shell integration should special-case only commands that require shell-side directory changes (`wt go/create`, `lane`, and removing the current worktree); route all other commands straight to the binary without injecting `--shell-output`.
 - Commands intended for first-run/setup flows (for example `shell-setup`) must bypass repo initialization in `src/cli.rs`; otherwise running them outside a configured repo can accidentally trigger `init` and break shell startup or onboarding.
 - Agent-launching commands must not blindly inherit the global `ai.model` setting across different CLIs; only an explicit per-command `--model` should override the selected agent's own default.
 - When sync reparents children off merged branches, never clear `parent_branch_revision`; preserve the old-base boundary (or merged parent tip) so restack can run `git rebase --onto <new> <old>` and avoid replaying already-integrated commits.


### PR DESCRIPTION
## Summary
- fix `st lane` interactive terminal detection to use `stdin` plus `stderr`, which matches how `dialoguer` renders prompts
- preserve shell integration's `--shell-output` lane path so named lanes still move the parent shell into the selected worktree
- update durable repo lessons to document the stderr-based prompt contract and the fact that `lane` is a shell-integration special case

## Root cause
`st lane` with no explicit lane name was checking `stdin` plus `stdout` before launching the interactive picker. Under shell integration, lane commands intentionally capture `stdout` for `--shell-output`, while `dialoguer` renders the picker on `stderr`. That made bare `st lane` incorrectly fail with "requires an interactive terminal" instead of opening the picker.

## Impact
- bare `st lane` works again when launched through shell integration
- explicit `st lane <name>` behavior is unchanged, including parent-shell handoff into the lane
- future contributors have clearer guidance for stderr-rendered prompts and shell-integration routing

## Validation
- `cargo test lane_picker_requires_stdin_and_stderr_terminals -- --nocapture`
- `cargo test posix_shell_snippet_wraps_lane_commands_in_zsh -- --nocapture`

## Notes
- full suite not run