### PR TITLE
fix: don't treat closed unmerged PRs as merged during sync

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1277,7 +1277,10 @@ fn find_merged_branches(
         }
     }
 
-    // Method 2: Check PR state from metadata - if PR is merged, branch should be deleted
+    // Method 2: Check PR state from metadata.
+    // Only an explicitly merged PR is a strong enough signal for cleanup here.
+    // Closed-but-unmerged PRs must be preserved unless some other merge/deletion
+    // heuristic below proves the branch is safe to clean up.
     for (branch, info) in &stack.branches {
         // Skip trunk
         if branch == &stack.trunk {
@@ -1289,11 +1292,9 @@ fn find_merged_branches(
             continue;
         }
 
-        // PR merged or closed without merge (cancelled) — both warrant cleanup offer.
         if matches!(
             info.pr_state.as_deref(),
-            Some(state)
-                if state.eq_ignore_ascii_case("merged") || state.eq_ignore_ascii_case("closed")
+            Some(state) if state.eq_ignore_ascii_case("merged")
         ) {
             merged.push(branch.clone());
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4146,6 +4146,76 @@ fn test_sync_does_not_delete_untracked_upstream_gone_by_default() {
 }
 
 #[test]
+fn test_sync_does_not_treat_closed_unmerged_pr_as_merged() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-closed-pr"]);
+    let branch_name = repo.current_branch();
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", &branch_name]);
+
+    let main_sha = repo.get_commit_sha("main");
+    let metadata = serde_json::json!({
+        "parentBranchName": "main",
+        "parentBranchRevision": main_sha,
+        "prInfo": {
+            "number": 198,
+            "state": "CLOSED",
+            "isDraft": false
+        }
+    });
+    let metadata_json = metadata.to_string();
+
+    let mut hash_cmd = hermetic_git_command();
+    let metadata_oid_output = hash_cmd
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(metadata_json.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("Failed to write metadata blob");
+    assert!(
+        metadata_oid_output.status.success(),
+        "Failed to hash metadata: {}",
+        TestRepo::stderr(&metadata_oid_output)
+    );
+    let metadata_oid = TestRepo::stdout(&metadata_oid_output).trim().to_string();
+
+    let metadata_ref = format!("refs/branch-metadata/{}", branch_name);
+    let update_ref = repo.git(&["update-ref", &metadata_ref, &metadata_oid]);
+    assert!(
+        update_ref.status.success(),
+        "Failed to update metadata ref: {}",
+        TestRepo::stderr(&update_ref)
+    );
+
+    repo.run_stax(&["t"]);
+
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|b| b == &branch_name),
+        "Expected closed-but-unmerged PR branch to remain after sync"
+    );
+}
+
+#[test]
 fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
     let repo = TestRepo::new_with_remote();
 


### PR DESCRIPTION
## Summary
- stop treating `CLOSED` PR metadata as an automatic merged-branch cleanup signal in `stax sync`
- keep using stronger cleanup signals such as actual merge reachability, explicit `MERGED` PR state, or remote branch deletion
- add an integration regression test covering a tracked branch with a closed-but-unmerged PR

Closes #198

## Testing
- `cargo test test_sync_does_not_treat_closed_unmerged_pr_as_merged -- --nocapture` *(blocked in this environment: missing OpenSSL dev headers / `openssl.pc` for `openssl-sys`)*
- `cargo fmt -- src/commands/sync.rs tests/integration_tests.rs`