### PR TITLE
docs: expand the st lane guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ Read more: [docs/workflows/multi-worktree.md](docs/workflows/multi-worktree.md)
 
 Run 2, 3, or 8 AI coding sessions in parallel without sharing one working directory.
 
-Each lane is an isolated Git worktree with a real branch behind it. When stax creates the branch for a lane, it also writes normal stax metadata, so that lane shows up in `st ls`, participates in restack/sync/undo, and can be reopened instantly with `st wt go`.
+Each lane is an isolated Git worktree with a real branch behind it. When stax creates the branch for a lane, it also writes normal stax metadata, so that lane shows up in `st ls`, participates in restack/sync/undo, and can be reopened instantly with `st wt go` or `st lane`.
+
+`st lane` is the fast AI path: it creates or reuses the lane, launches your configured agent, prefers tmux when available, reattaches to existing sessions, and opens a fresh tmux window when you pass a new prompt into an already-running lane.
 
 ```bash
 # Spin up three lanes in parallel

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -1,73 +1,139 @@
 # AI Worktree Lanes
 
-`st wt` lets you run multiple AI coding sessions in parallel while keeping them inside stax's normal branch model.
+`st lane` is the high-level shortcut for running parallel AI coding sessions on top of `st wt`.
 
-This page focuses on the AI workflow. For the full `st worktree` / `st wt` command reference, dashboard behavior, cleanup semantics, shell integration, and configuration, see [Worktrees](../worktrees/index.md).
+Each lane is a real Git worktree backed by a real branch, so the work stays visible to stax instead of disappearing into a pile of ad-hoc terminals.
 
-## Why Use AI Lanes
+This page is the dedicated guide for the AI workflow. For the full `st worktree` / `st wt` command surface, cleanup semantics, shell integration, dashboard controls, and config, see [Worktrees](../worktrees/index.md).
 
-Worktree lanes solve a specific problem: you want several active coding sessions at once without making them invisible to the rest of your stack.
+## What `st lane` Actually Does
 
-With stax lanes you can:
+`st lane <name> [prompt]` is the fast path for:
 
-- isolate each agent session to its own worktree and branch
-- keep those branches visible in `st ls`
-- restack them safely when trunk or a parent moves
-- jump back into them with `st wt go`
-- inspect them with `st wt ll`
-- clean them up with normal stax worktree commands
+1. finding or creating a named worktree lane
+2. resolving the branch that lane should use
+3. launching your configured AI agent inside it
+4. preferring tmux when available so you can resume the lane later
 
-That is the difference between "a pile of terminals" and "several active branches that stax still understands."
+That gives you isolated working directories **without** giving up normal stax behavior.
 
-## Example Workflow
+A lane created by stax is still a normal tracked branch, so it can participate in:
+
+- `st ls`
+- `st restack`
+- `st sync --restack`
+- `st wt rs`
+- undo / redo flows
+- normal worktree cleanup
+
+## Why This Is Better Than "Just Open Another Terminal"
+
+AI lanes are useful when you want multiple active coding threads at once, but still want the repo to stay understandable.
+
+With `st lane`, each task gets:
+
+- its own worktree
+- its own branch
+- optional tmux session reuse
+- visibility in the rest of stax
+- a clean path back into the lane later
+
+That means you can do things like:
+
+- fix flaky tests in one lane
+- address PR comments in another
+- poke at a risky refactor in a third
+- restack them all after trunk moves
+- remove the finished ones cleanly
+
+## The Main Flows
+
+### 1. Start a new lane fast
 
 ```bash
-# Start three parallel lanes
-st lane auth-refresh "fix token refresh edge cases"
 st lane flaky-tests "stabilize the flaky test suite"
-st wt c ui-polish --run "cursor ."
-st lane review-pass "address the open PR comments"
-
-# They are normal stax branches
-st ls
-
-# Jump back into any lane later
-st lane flaky-tests
-st lane
-
-# Trunk moved while those sessions were in flight
-st wt rs
-
-# See which lanes are dirty / rebasing / managed
-st wt ll
-
-# Remove finished work
-st wt rm auth-refresh --delete-branch
 ```
 
-## Primary Commands
+If the lane does not exist yet, stax will:
+
+- create a worktree for it
+- create a branch when needed
+- write normal stax metadata for new managed branches
+- launch your configured AI agent in that lane
+
+### 2. Re-enter an existing lane
 
 ```bash
-st lane api-tests "write the missing integration tests"
-st lane api-tests --agent gemini
-st lane api-tests --agent opencode --model opencode/gpt-5.1-codex
-st lane review-pass "address the open PR comments"
+st lane flaky-tests
+```
+
+If the lane already exists, stax reuses it instead of creating a duplicate.
+
+### 3. Browse lanes interactively
+
+```bash
 st lane
 ```
 
-`st lane <name> [prompt]` is the canonical explicit form:
+With no lane name, stax opens an interactive picker of **stax-managed** lanes.
 
-- create or reuse the named lane
-- default to your configured AI agent
-- default to tmux when available
-- use `--no-tmux` when you want a direct terminal launch instead
+From there you can:
 
-`st lane` also supports the interactive path:
+- jump into an existing lane
+- create a new lane
+- filter the list fuzzily
+- see which lane is current
+- see concise tmux and status columns before entering
 
-- `st lane` opens an interactive picker of stax-managed lanes
-- `st lane <name> [prompt]` is the short explicit form
-- if a lane already has a tmux session, stax reattaches to it
-- if you pass a new prompt to an existing tmux-backed lane, stax opens a fresh tmux window in that session
+If there are no managed lanes yet, stax falls back to prompting for a new one.
+
+## Tmux Behavior
+
+The tmux behavior is one of the most useful parts of `st lane`, and it is worth being explicit about.
+
+When tmux is available, `st lane <name> [prompt]` defaults to tmux-backed launches.
+
+### Existing tmux session + no prompt
+
+```bash
+st lane review-pass
+```
+
+If the lane already has a tmux session and you do **not** pass a new prompt, stax reattaches / switches to that existing session.
+
+This is the "resume exactly where I left off" path.
+
+### Existing tmux session + new prompt
+
+```bash
+st lane review-pass "address the latest review comments"
+```
+
+If the lane already has a tmux session **and** you pass a new prompt, stax opens a **new tmux window** in that same session and starts the agent there.
+
+This is the "same lane, fresh subtask" path.
+
+### No tmux available
+
+If tmux is unavailable, stax falls back to launching directly in the lane and tells you it is doing that.
+
+### Force direct terminal mode
+
+```bash
+st lane review-pass --no-tmux
+```
+
+Use `--no-tmux` when you want the agent to launch directly in the terminal even if tmux is installed.
+
+### Override the derived tmux session name
+
+```bash
+st lane review-pass --tmux-session pr-review
+```
+
+`--tmux-session` only works with an explicit lane name.
+
+## Agent Selection
 
 Supported `--agent` values are:
 
@@ -76,13 +142,119 @@ Supported `--agent` values are:
 - `gemini`
 - `opencode`
 
-Use `--model` with `--agent` when you want an explicit model override.
+Examples:
 
-Use `--no-tmux` when you want each AI lane to launch directly in the terminal instead of tmux.
+```bash
+st lane api-tests --agent gemini
+st lane api-tests --agent opencode --model opencode/gpt-5.1-codex
+st lane review-pass --agent codex "address the open PR comments"
+```
 
-## Advanced Patterns
+Notes:
 
-The older worktree launch flags still exist for lower-level or non-AI use cases:
+- `--model` requires `--agent`
+- if you omit `--agent`, stax uses your configured default agent
+- the optional `[prompt]` is passed through to the launched agent
+
+## A Realistic Daily Workflow
+
+```bash
+# Start a few parallel lanes
+st lane auth-refresh "fix token refresh edge cases"
+st lane flaky-tests "stabilize the flaky test suite"
+st wt c ui-polish --run "cursor ."
+st lane review-pass "address the open PR comments"
+
+# They are still visible as branches
+st ls
+
+# Jump back into one lane later
+st lane flaky-tests
+
+# Or browse first
+st lane
+
+# Trunk moved while those sessions were in flight
+st wt rs
+
+# Check operational state
+st wt ll
+
+# Clean up after merge
+st wt cleanup --dry-run
+st wt rm auth-refresh --delete-branch
+```
+
+## Managed vs Unmanaged Matters
+
+The docs around lanes are much easier to understand once you separate **worktree existence** from **stax management**.
+
+### Managed lanes
+
+A lane is stax-managed when its branch has stax metadata.
+
+Common cases:
+
+- a new lane created by stax is managed
+- an already tracked stax branch stays managed when opened as a lane
+
+Managed lanes are the ones that fully participate in stack-aware flows like:
+
+- `st ls`
+- `st restack`
+- `st sync --restack`
+- `st wt rs`
+- cleanup of merged managed lanes
+
+### Unmanaged worktrees
+
+If you open an existing plain Git branch as a worktree, stax can still navigate to it and list it as a worktree, but it stays unmanaged until you explicitly track it.
+
+So the practical rule is:
+
+- **all lanes are worktrees**
+- **only managed lanes are first-class stax stack entries**
+
+If you need the lower-level tracking details, see [Worktrees](../worktrees/index.md).
+
+## The Interactive Picker
+
+Bare `st lane` is not just a shortcut to a list. It is a specific lane-oriented entry flow.
+
+The picker shows stax-managed lanes with columns for:
+
+- lane name
+- branch
+- tmux state
+- status summary
+
+The tmux column uses concise labels:
+
+- `attached`: session exists and has attached clients
+- `ready`: session exists and can be resumed
+- `new`: tmux is available but no session exists yet
+- `off`: tmux is unavailable
+
+The status column compresses lane state into a small summary such as:
+
+- `clean`
+- `dirty`
+- `rebasing`
+- conflict-related states
+
+And because this flow is interactive, it requires a real terminal when you run `st lane` with no name.
+
+## When To Use `st lane` vs `st wt`
+
+Use `st lane` when the thing you want is:
+
+- "make or resume an AI lane"
+- "launch my configured agent there"
+- "reuse tmux if possible"
+
+Use lower-level `st wt` commands when you want more manual control or a non-AI launcher.
+
+Examples:
 
 ```bash
 st wt c ui-polish --run "cursor ."
@@ -90,52 +262,23 @@ st wt c review-pass --agent codex --tmux -- "address the open PR comments"
 st wt go review-pass --agent codex --tmux
 ```
 
-Use `--run` when you want a non-agent launcher such as an editor.
+That split is useful:
 
-## Why The Lanes Stay First-Class
-
-When stax creates a new branch for the lane, it writes normal stax metadata. That is why the lane participates in normal stax flows:
-
-- `st ls` shows the branch in the stack
-- `st restack`, `st sync --restack`, and `st wt rs` can reason about it
-- undo/redo still operate on the branch history
-- the stack TUI and the worktree dashboard both understand the lane
-
-Tracking nuance:
-
-- a new lane created by `st wt c foo` is stax-managed
-- an already tracked branch stays managed when you open a worktree for it
-- an existing plain Git branch gets a worktree, but it stays unmanaged until `st branch track`
-
-## Recommended Loop
-
-```bash
-# Start a scratch lane fast
-st lane flaky-tests "fix flaky tests"
-
-# Re-enter it later
-st lane flaky-tests
-
-# Or browse your active lanes first
-st lane
-
-# Trunk moved while the lane was in flight
-st wt rs
-
-# Inspect operational state
-st wt ll
-
-# Clean up after merge
-st wt cleanup --dry-run
-st wt rm flaky-tests --delete-branch
-```
+- `st lane` = opinionated AI shortcut
+- `st wt` = general worktree control plane
 
 ## Setup Once
 
-Install shell integration if you want `create` and `go` to move the parent shell automatically:
+Install shell integration if you want lane creation and navigation to move the parent shell automatically:
 
 ```bash
 st shell-setup --install
 ```
+
+After shell integration is installed:
+
+- `st wt c ...` can move the parent shell into the new lane
+- `st wt go ...` can move the parent shell into the selected lane
+- `st lane ...` can move the parent shell into the selected lane
 
 For shell integration details, cleanup semantics, hooks, dashboard behavior, and Windows limitations, use the canonical [Worktrees](../worktrees/index.md) page.


### PR DESCRIPTION
## Summary
- rewrite the dedicated AI worktree lanes doc around the actual `st lane` behavior
- document tmux attach vs new-window semantics, picker behavior, and managed vs unmanaged lanes
- tighten the README lane section so the top-level docs better reflect what the command actually does

## Testing
- git diff --check