### PR TITLE
docs: document Linux arm64 prebuilt binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-a
 curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-x86_64-apple-darwin.tar.gz | tar xz
 # Linux (x86_64)
 curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-x86_64-unknown-linux-gnu.tar.gz | tar xz
+# Linux (arm64 / aarch64, e.g. Raspberry Pi)
+curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-aarch64-unknown-linux-gnu.tar.gz | tar xz
 
 # Move both binaries to ~/.local/bin
 mkdir -p ~/.local/bin

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -10,6 +10,22 @@ cargo binstall stax
 
 Both `stax` and `st` (short alias) are installed automatically.
 
+### Manual install from GitHub Releases
+
+```bash
+# macOS (Apple Silicon)
+curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-aarch64-apple-darwin.tar.gz | tar xz
+# macOS (Intel)
+curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-x86_64-apple-darwin.tar.gz | tar xz
+# Linux (x86_64)
+curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-x86_64-unknown-linux-gnu.tar.gz | tar xz
+# Linux (arm64 / aarch64, e.g. Raspberry Pi)
+curl -fsSL https://github.com/cesarferreira/stax/releases/latest/download/stax-aarch64-unknown-linux-gnu.tar.gz | tar xz
+
+mkdir -p ~/.local/bin
+mv stax st ~/.local/bin/
+```
+
 ### Windows
 
 Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract both `stax.exe` and `st.exe`, and place them in a directory on your `PATH`.


### PR DESCRIPTION
## Summary
- document the Linux arm64/aarch64 prebuilt release artifact in the README manual install section
- add a matching manual install section to the getting started install docs
- mention Raspberry Pi explicitly so ARM Linux users can find the right asset quickly

Closes #213
