### PR TITLE
fix(ci): don't block releases on Windows test failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,12 @@ jobs:
 
       - name: Run Windows tests (with nextest)
         if: matrix.target == 'x86_64-pc-windows-msvc' && steps.install-nextest.outcome == 'success'
+        continue-on-error: true
         run: cargo nextest run --lib --bins
 
       - name: Run Windows tests (fallback)
         if: matrix.target == 'x86_64-pc-windows-msvc' && steps.install-nextest.outcome != 'success'
+        continue-on-error: true
         run: cargo test --lib --bins
 
       - name: Build
@@ -83,6 +85,7 @@ jobs:
   release:
     name: Release
     needs: build
+    if: always() && needs.build.result != 'cancelled'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- stop tag releases from being blocked solely by the Windows test step failing
- keep Windows test coverage in the release workflow, but make those test steps non-blocking for packaging
- allow the release job to run after the build matrix completes so successfully built artifacts can still be published

## Evidence
- failed tagged run: https://github.com/cesarferreira/stax/actions/runs/23987630772
- `Build x86_64-pc-windows-msvc` failed specifically in `Run Windows tests (with nextest)`
- the other target builds succeeded, but the `Release` job was skipped because the matrix job failed overall

## Notes
- build/package steps remain blocking
- this only makes the Windows test steps non-blocking in the tag release workflow
- regular PR/main CI coverage still lives in `.github/workflows/rust-tests.yml`

Closes #212
