### PR TITLE
feat(cli): add stack command group with sr and ss aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ brew install cesarferreira/tap/stax
 cargo binstall stax
 ```
 
-### Prebuilt binaries (no package manager needed)
+<details>
+<summary>Other installation methods (Linux, Windows, prebuilt binaries, build from source)</summary>
+
+### Prebuilt binaries
 
 Download the latest binary from [GitHub Releases](https://github.com/cesarferreira/stax/releases):
 
@@ -68,12 +71,6 @@ mv stax st ~/.local/bin/
 ```
 
 **Windows (x86_64):** download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases), extract both `stax.exe` and `st.exe`, and place them in a directory on your `PATH`. See [Windows notes](#windows-notes) for shell and worktree limitations.
-
-Verify install:
-
-```bash
-st --version
-```
 
 ### Building from Source
 
@@ -99,6 +96,14 @@ Alternatively, you can build without system OpenSSL dependencies using the vendo
 
 ```bash
 cargo install --path . --locked --features vendored-openssl
+```
+
+</details>
+
+Verify install:
+
+```bash
+st --version
 ```
 
 <a id="quick-start"></a>

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -6,7 +6,8 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 
 | freephite | graphite | stax |
 |-----------|----------|------|
-| `fp ss` | `gt submit` | `st submit` / `st ss` |
+| `fp ss` | `gt submit` | `st stack submit` / `st ss` / `st s s` |
+| `fp sr` | — | `st stack restack` / `st sr` / `st s r` |
 | `fp bs` | `gt branch submit` | `st branch submit` / `st bs` |
 | `fp us submit` | `gt upstack submit` | `st upstack submit` |
 | `fp ds submit` | `gt downstack submit` | `st downstack submit` |
@@ -17,7 +18,7 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 | `fp bd` | `gt down` | `st down` / `st bd` |
 | `fp ls` | `gt log` | `st status` / `st ls` |
 | — | `gt modify` | `st modify` / `st m` |
-| `fp restack` | `gt restack` | `st restack` |
+| `fp restack` | `gt restack` | `st restack` / `st sr` |
 | — | `gt restack --upstack` | `st upstack restack` |
 | — | `gt merge` | `st merge` |
 | — | — | `st cascade` |
@@ -28,10 +29,13 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 stax also installs as `st` — a shorter alias for the same binary:
 
 ```bash
-st ss       # same as st submit
+st ss       # same as st stack submit (or st s s)
+st sr       # same as st stack restack (or st s r)
 st rs       # same as st sync
 st ls       # same as st status
 ```
+
+> **Note:** `st s` opens the `stack` subcommand group. Use `st ls` or `st status` for the status view.
 
 ## Migration is instant
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,7 +127,7 @@ struct AiLaneArgs {
 #[derive(Subcommand)]
 enum Commands {
     /// Show all stacks (simple tree view)
-    #[command(visible_aliases = ["s", "ls"])]
+    #[command(visible_alias = "ls")]
     Status {
         /// Output JSON for scripting
         #[arg(long)]
@@ -187,7 +187,7 @@ enum Commands {
     },
 
     /// Submit stack - push branches and create/update PRs
-    #[command(visible_alias = "ss")]
+    #[command(visible_alias = "ss", hide = true)]
     Submit {
         #[command(flatten)]
         submit: SubmitOptions,
@@ -301,6 +301,7 @@ enum Commands {
     },
 
     /// Restack (rebase) the current branch onto its parent
+    #[command(hide = true)]
     Restack {
         /// Restack all branches in the stack
         #[arg(short, long)]
@@ -498,6 +499,10 @@ enum Commands {
     /// Downstack commands (operate on ancestors)
     #[command(subcommand, visible_alias = "ds")]
     Downstack(DownstackCommands),
+
+    /// Stack commands (submit, restack)
+    #[command(subcommand, visible_alias = "s")]
+    Stack(StackCommands),
 
     /// Create a new branch stacked on current
     #[command(visible_alias = "c")]
@@ -881,12 +886,70 @@ enum Commands {
     },
     #[command(hide = true)]
     Wtrs,
+    #[command(hide = true)]
+    Sr {
+        #[arg(short, long)]
+        all: bool,
+        #[arg(long, conflicts_with = "all")]
+        stop_here: bool,
+        #[arg(long)]
+        r#continue: bool,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(short, long)]
+        yes: bool,
+        #[arg(long)]
+        quiet: bool,
+        #[arg(long)]
+        auto_stash_pop: bool,
+        #[arg(long, value_enum, default_value_t = RestackSubmitAfter::No)]
+        submit_after: RestackSubmitAfter,
+    },
 }
 
 #[derive(Subcommand, Clone)]
 enum AuthSubcommand {
     /// Show which auth source is currently active
     Status,
+}
+
+#[derive(Subcommand)]
+enum StackCommands {
+    /// Submit stack - push branches and create/update PRs
+    #[command(visible_alias = "s")]
+    Submit {
+        #[command(flatten)]
+        submit: SubmitOptions,
+    },
+
+    /// Restack (rebase) the current branch onto its parent
+    #[command(visible_alias = "r")]
+    Restack {
+        /// Restack all branches in the stack
+        #[arg(short, long)]
+        all: bool,
+        /// Restack ancestors + current only (skip descendants)
+        #[arg(long, conflicts_with = "all")]
+        stop_here: bool,
+        /// Continue after resolving conflicts
+        #[arg(long)]
+        r#continue: bool,
+        /// Preview predicted conflicts without rebasing
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip conflict confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+        /// Suppress extra output
+        #[arg(long)]
+        quiet: bool,
+        /// Auto-stash and auto-pop dirty target worktrees during restack operations
+        #[arg(long)]
+        auto_stash_pop: bool,
+        /// After restack, submit stack updates (`ask`, `yes`, `no`)
+        #[arg(long, value_enum, default_value_t = RestackSubmitAfter::No)]
+        submit_after: RestackSubmitAfter,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1665,6 +1728,30 @@ pub fn run() -> Result<()> {
                 run_submit(submit, commands::submit::SubmitScope::Downstack)
             }
         },
+        Commands::Stack(cmd) => match cmd {
+            StackCommands::Submit { submit } => {
+                run_submit(submit, commands::submit::SubmitScope::Stack)
+            }
+            StackCommands::Restack {
+                all,
+                stop_here,
+                r#continue,
+                dry_run,
+                yes,
+                quiet,
+                auto_stash_pop,
+                submit_after,
+            } => commands::restack::run(
+                all,
+                stop_here,
+                r#continue,
+                dry_run,
+                yes,
+                quiet,
+                auto_stash_pop,
+                submit_after.into(),
+            ),
+        },
         // Hidden shortcuts
         Commands::Bc {
             name,
@@ -1676,6 +1763,25 @@ pub fn run() -> Result<()> {
         Commands::Bu { count } => commands::navigate::up(count),
         Commands::Bd { count } => commands::navigate::down(count),
         Commands::Bs { submit } => run_submit(submit, commands::submit::SubmitScope::Branch),
+        Commands::Sr {
+            all,
+            stop_here,
+            r#continue,
+            dry_run,
+            yes,
+            quiet,
+            auto_stash_pop,
+            submit_after,
+        } => commands::restack::run(
+            all,
+            stop_here,
+            r#continue,
+            dry_run,
+            yes,
+            quiet,
+            auto_stash_pop,
+            submit_after.into(),
+        ),
         Commands::Worktree { command } => match command {
             None => {
                 let interactive_terminal =
@@ -1919,7 +2025,8 @@ fn print_worktree_help() -> Result<()> {
 mod tests {
     use super::{
         check_interactive_terminal_with_probe, detect_interactive_stdio, has_interactive_terminal,
-        Cli, Commands, InteractiveTerminalCheck, RestackSubmitAfter, WorktreeCommands,
+        Cli, Commands, InteractiveTerminalCheck, RestackSubmitAfter, StackCommands,
+        WorktreeCommands,
     };
     use clap::Parser;
     use std::cell::Cell;
@@ -2112,5 +2219,68 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn stack_restack_via_two_tokens() {
+        let cli = parse_cli(&["stax", "s", "r"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Stack(StackCommands::Restack {
+                submit_after: RestackSubmitAfter::No,
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn stack_restack_via_single_token_sr() {
+        let cli = parse_cli(&["stax", "sr"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Sr {
+                submit_after: RestackSubmitAfter::No,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn stack_submit_via_two_tokens() {
+        let cli = parse_cli(&["stax", "s", "s"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Stack(StackCommands::Submit { .. }))
+        ));
+    }
+
+    #[test]
+    fn ss_still_parses_as_top_level_submit() {
+        let cli = parse_cli(&["stax", "ss"]);
+        assert!(matches!(cli.command, Some(Commands::Submit { .. })));
+    }
+
+    #[test]
+    fn ls_parses_as_status() {
+        let cli = parse_cli(&["stax", "ls"]);
+        assert!(matches!(cli.command, Some(Commands::Status { .. })));
+    }
+
+    #[test]
+    fn submit_backward_compat() {
+        let cli = parse_cli(&["stax", "submit"]);
+        assert!(matches!(cli.command, Some(Commands::Submit { .. })));
+    }
+
+    #[test]
+    fn restack_backward_compat() {
+        let cli = parse_cli(&["stax", "restack"]);
+        assert!(matches!(cli.command, Some(Commands::Restack { .. })));
+    }
+
+    #[test]
+    fn s_alone_shows_stack_group() {
+        let result = try_parse_cli(&["stax", "s"]);
+        assert!(result.is_err(), "bare `s` should require a subcommand");
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -38,12 +38,19 @@ fn test_help() {
 }
 
 #[test]
-fn test_status_alias_s() {
-    // Both aliases should work
+fn test_status_alias_ls() {
     let output1 = stax(&["status", "--help"]);
-    let output2 = stax(&["s", "--help"]);
+    let output2 = stax(&["ls", "--help"]);
     assert!(output1.status.success());
     assert!(output2.status.success());
+}
+
+#[test]
+fn test_stack_alias_s() {
+    let output = stax(&["s", "--help"]);
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("submit") || String::from_utf8_lossy(&output.stdout).contains("submit"));
 }
 
 #[test]

--- a/tests/comprehensive_coverage_tests.rs
+++ b/tests/comprehensive_coverage_tests.rs
@@ -52,11 +52,11 @@ fn test_navigation_bottom_from_top() {
 // =============================================================================
 
 #[test]
-fn test_status_alias_s() {
+fn test_stack_alias_s() {
     let repo = TestRepo::new();
     repo.create_stack(&["feature"]);
 
-    let output = repo.run_stax(&["s"]);
+    let output = repo.run_stax(&["s", "s", "--help"]);
     output.assert_success();
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -840,14 +840,28 @@ fn test_status_compact_output() {
 }
 
 #[test]
-fn test_status_alias_s() {
+fn test_status_alias_ls() {
     let repo = TestRepo::new();
 
     let output1 = repo.run_stax(&["status"]);
-    let output2 = repo.run_stax(&["s"]);
+    let output2 = repo.run_stax(&["ls"]);
 
     assert!(output1.status.success());
     assert!(output2.status.success());
+}
+
+#[test]
+fn test_stack_alias_s() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["s", "--help"]);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("submit"));
+    assert!(combined.contains("restack"));
 }
 
 #[test]


### PR DESCRIPTION
Introduces a `stack` command group (alias `s`) containing `submit` and `restack`, giving `st sr` and `st ss` structural meaning.

- `st s r` / `st sr` — stack restack
- `st s s` / `st ss` — stack submit
- `st ls` / `st status` — status (previously `st s`)
- Backward compat: `st submit`, `st restack`, `st ss` all still work

Made with [Cursor](https://cursor.com)