### PR TITLE
fix(split): scrolling + patch application in hunk split TUI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -570,6 +570,10 @@ enum Commands {
         /// Split by selecting individual hunks instead of by commit
         #[arg(long)]
         hunk: bool,
+
+        /// Skip pre-commit hooks when committing split branches
+        #[arg(long)]
+        no_verify: bool,
     },
 
     /// Copy branch name or PR URL to clipboard
@@ -1525,7 +1529,7 @@ pub fn run() -> Result<()> {
             interval,
             verbose,
         } => commands::ci::run(all, stack, json, refresh, watch, interval, verbose),
-        Commands::Split { hunk } => commands::split::run(hunk),
+        Commands::Split { hunk, no_verify } => commands::split::run(hunk, no_verify),
         Commands::Copy { pr } => {
             let target = if pr {
                 commands::copy::CopyTarget::Pr

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use colored::Colorize;
 use std::io::IsTerminal;
 
-pub fn run(hunk_mode: bool) -> Result<()> {
+pub fn run(hunk_mode: bool, no_verify: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let stack = Stack::load(&repo)?;
     let current = repo.current_branch()?;
@@ -58,7 +58,7 @@ pub fn run(hunk_mode: bool) -> Result<()> {
 
     if hunk_mode {
         drop(repo);
-        return tui::split_hunk::run();
+        return tui::split_hunk::run(no_verify);
     }
 
     tui::split::run()

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -406,14 +406,19 @@ impl HunkSplitApp {
         let patch = reconstruct_full_patch(&self.files, &selections);
 
         let debug = std::env::var("STAX_SPLIT_DEBUG").is_ok();
+        let debug_log_path = std::env::temp_dir().join("stax-split-debug.log");
         if debug {
-            let log_path = self.workdir.join(".stax-split-debug.log");
-            let mut log = format!(
+            let mut log = if self.round == 1 {
+                String::new()
+            } else {
+                std::fs::read_to_string(&debug_log_path).unwrap_or_default()
+            };
+            log.push_str(&format!(
                 "=== Round {} commit ===\nBranch: {}\nSelected: {}/{}\nSelections: {:?}\n",
                 self.round, branch_name, selected_count, total_count, selections,
-            );
+            ));
             log.push_str(&format!("--- patch ---\n{}\n--- end patch ---\n", patch));
-            let _ = std::fs::write(&log_path, &log);
+            let _ = std::fs::write(&debug_log_path, &log);
         }
 
         git(&self.workdir, &["reset"])?;
@@ -437,8 +442,7 @@ impl HunkSplitApp {
         let has_remaining = !files.is_empty();
 
         if debug {
-            let log_path = self.workdir.join(".stax-split-debug.log");
-            let mut log = std::fs::read_to_string(&log_path).unwrap_or_default();
+            let mut log = std::fs::read_to_string(&debug_log_path).unwrap_or_default();
             log.push_str(&format!(
                 "--- post-commit diff ({} files remaining) ---\n{}\n--- end diff ---\n",
                 files.len(),
@@ -451,7 +455,7 @@ impl HunkSplitApp {
             if selected_count < total_count && !has_remaining {
                 log.push_str("!!! BUG: partial selection but no remaining hunks !!!\n");
             }
-            let _ = std::fs::write(&log_path, &log);
+            let _ = std::fs::write(&debug_log_path, &log);
         }
 
         if has_remaining {

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -50,6 +50,9 @@ pub struct HunkSplitApp {
     pub flat_items: Vec<FlatItem>,
     pub cursor: usize,
     pub list_state: ListState,
+    pub diff_scroll: u16,
+    pub diff_line_count: u16,
+    pub diff_viewport_height: u16,
     pub mode: HunkSplitMode,
     pub round: usize,
     created_branches: Vec<String>,
@@ -161,6 +164,9 @@ impl HunkSplitApp {
             flat_items,
             cursor: 0,
             list_state: ListState::default(),
+            diff_scroll: 0,
+            diff_line_count: 0,
+            diff_viewport_height: 0,
             mode: HunkSplitMode::List,
             round: 1,
             created_branches: Vec::new(),
@@ -185,6 +191,7 @@ impl HunkSplitApp {
         if self.cursor > 0 {
             self.cursor -= 1;
         }
+        self.diff_scroll = 0;
     }
 
     /// Move cursor down one item
@@ -192,6 +199,7 @@ impl HunkSplitApp {
         if self.cursor < self.flat_items.len().saturating_sub(1) {
             self.cursor += 1;
         }
+        self.diff_scroll = 0;
     }
 
     /// Toggle selection of the hunk at cursor
@@ -248,6 +256,21 @@ impl HunkSplitApp {
         }
     }
 
+    pub fn scroll_diff_down(&mut self) {
+        let max = self
+            .diff_line_count
+            .saturating_sub(self.diff_viewport_height);
+        if self.diff_scroll < max {
+            self.diff_scroll += 1;
+        }
+    }
+
+    pub fn scroll_diff_up(&mut self) {
+        if self.diff_scroll > 0 {
+            self.diff_scroll -= 1;
+        }
+    }
+
     /// Select the current hunk and advance to the next (sequential mode)
     pub fn accept_and_advance(&mut self) {
         if let Some(FlatItem::Hunk { file_idx, hunk_idx }) = self.current_item().copied() {
@@ -261,6 +284,7 @@ impl HunkSplitApp {
             }
         }
         self.advance_to_next_hunk();
+        self.diff_scroll = 0;
     }
 
     /// Skip the current hunk and advance to the next (sequential mode)
@@ -276,6 +300,7 @@ impl HunkSplitApp {
             }
         }
         self.advance_to_next_hunk();
+        self.diff_scroll = 0;
     }
 
     fn advance_to_next_hunk(&mut self) {

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -383,6 +383,9 @@ impl HunkSplitApp {
     /// Stage and commit the selected hunks for this round.
     /// Returns `Ok(true)` if there are remaining hunks for another round.
     pub fn commit_round(&mut self, branch_name: &str) -> Result<bool> {
+        let selected_count = self.selected_count();
+        let total_count = self.total_hunk_count();
+
         let mut selections: Vec<(usize, Vec<usize>)> = Vec::new();
         for (fi, file_sel) in self.selected.iter().enumerate() {
             let hunks: Vec<usize> = file_sel
@@ -401,6 +404,17 @@ impl HunkSplitApp {
         }
 
         let patch = reconstruct_full_patch(&self.files, &selections);
+
+        let debug = std::env::var("STAX_SPLIT_DEBUG").is_ok();
+        if debug {
+            let log_path = self.workdir.join(".stax-split-debug.log");
+            let mut log = format!(
+                "=== Round {} commit ===\nBranch: {}\nSelected: {}/{}\nSelections: {:?}\n",
+                self.round, branch_name, selected_count, total_count, selections,
+            );
+            log.push_str(&format!("--- patch ---\n{}\n--- end patch ---\n", patch));
+            let _ = std::fs::write(&log_path, &log);
+        }
 
         git(&self.workdir, &["reset"])?;
 
@@ -421,6 +435,24 @@ impl HunkSplitApp {
         let diff_output = git(&self.workdir, &["diff"])?;
         let files = parse_diff(&diff_output);
         let has_remaining = !files.is_empty();
+
+        if debug {
+            let log_path = self.workdir.join(".stax-split-debug.log");
+            let mut log = std::fs::read_to_string(&log_path).unwrap_or_default();
+            log.push_str(&format!(
+                "--- post-commit diff ({} files remaining) ---\n{}\n--- end diff ---\n",
+                files.len(),
+                if diff_output.is_empty() {
+                    "(empty)".to_string()
+                } else {
+                    diff_output.clone()
+                },
+            ));
+            if selected_count < total_count && !has_remaining {
+                log.push_str("!!! BUG: partial selection but no remaining hunks !!!\n");
+            }
+            let _ = std::fs::write(&log_path, &log);
+        }
 
         if has_remaining {
             self.selected = files.iter().map(|f| vec![false; f.hunks.len()]).collect();

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -417,6 +417,7 @@ impl HunkSplitApp {
             self.existing_branches.push(branch_name.to_string());
         }
 
+        git(&self.workdir, &["add", "-N", "."])?;
         let diff_output = git(&self.workdir, &["diff"])?;
         let files = parse_diff(&diff_output);
         let has_remaining = !files.is_empty();

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -64,6 +64,7 @@ pub struct HunkSplitApp {
     pub round_complete: bool,
     pub all_done: bool,
     existing_branches: Vec<String>,
+    no_verify: bool,
 }
 
 fn git(workdir: &Path, args: &[&str]) -> Result<String> {
@@ -90,7 +91,7 @@ fn git_ok(workdir: &Path, args: &[&str]) -> bool {
 
 impl HunkSplitApp {
     /// Initialize the hunk split: validate state, flatten branch, parse diff.
-    pub fn new() -> Result<Self> {
+    pub fn new(no_verify: bool) -> Result<Self> {
         let repo = GitRepo::open()?;
         let stack = Stack::load(&repo)?;
         let current = repo.current_branch()?;
@@ -122,10 +123,11 @@ impl HunkSplitApp {
         let stashed = repo.is_dirty()?;
         if stashed {
             git(&workdir, &["add", "-A"])?;
-            git(
-                &workdir,
-                &["commit", "-m", "WIP: uncommitted changes for split"],
-            )?;
+            let mut commit_args = vec!["commit", "-m", "WIP: uncommitted changes for split"];
+            if no_verify {
+                commit_args.push("--no-verify");
+            }
+            git(&workdir, &commit_args)?;
         }
 
         let parent_sha = repo.merge_base(&parent, &current)?;
@@ -178,6 +180,7 @@ impl HunkSplitApp {
             round_complete: false,
             all_done: false,
             existing_branches,
+            no_verify,
         })
     }
 
@@ -429,7 +432,11 @@ impl HunkSplitApp {
 
         let patch_str = patch_path.to_string_lossy().to_string();
         git(&self.workdir, &["apply", "--cached", &patch_str])?;
-        git(&self.workdir, &["commit", "-m", branch_name])?;
+        let mut commit_args = vec!["commit", "-m", branch_name];
+        if self.no_verify {
+            commit_args.push("--no-verify");
+        }
+        git(&self.workdir, &commit_args)?;
 
         self.created_branches.push(branch_name.to_string());
         if branch_name != self.original_branch {

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -4,6 +4,7 @@ use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::tui::split_hunk::diff_parser::{parse_diff, reconstruct_full_patch, DiffFile};
 use anyhow::{bail, Context, Result};
+use ratatui::widgets::ListState;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -48,6 +49,7 @@ pub struct HunkSplitApp {
     pub selected: Vec<Vec<bool>>,
     pub flat_items: Vec<FlatItem>,
     pub cursor: usize,
+    pub list_state: ListState,
     pub mode: HunkSplitMode,
     pub round: usize,
     created_branches: Vec<String>,
@@ -158,6 +160,7 @@ impl HunkSplitApp {
             selected,
             flat_items,
             cursor: 0,
+            list_state: ListState::default(),
             mode: HunkSplitMode::List,
             round: 1,
             created_branches: Vec::new(),

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -417,15 +417,20 @@ impl HunkSplitApp {
             self.existing_branches.push(branch_name.to_string());
         }
 
-        remove_committed_hunks(&mut self.files, &mut self.selected, &selections);
-
-        let has_remaining = self.files.iter().any(|f| !f.hunks.is_empty());
+        let diff_output = git(&self.workdir, &["diff"])?;
+        let files = parse_diff(&diff_output);
+        let has_remaining = !files.is_empty();
 
         if has_remaining {
+            self.selected = files.iter().map(|f| vec![false; f.hunks.len()]).collect();
+            self.files = files;
             self.flat_items = build_flat_items(&self.files);
             self.cursor = 0;
+            self.diff_scroll = 0;
             self.undo_stack.clear();
             self.round += 1;
+        } else {
+            self.files = files;
         }
 
         Ok(has_remaining)
@@ -548,28 +553,6 @@ fn build_flat_items(files: &[DiffFile]) -> Vec<FlatItem> {
     items
 }
 
-fn remove_committed_hunks(
-    files: &mut Vec<DiffFile>,
-    selected: &mut Vec<Vec<bool>>,
-    selections: &[(usize, Vec<usize>)],
-) {
-    for (fi, hunk_indices) in selections.iter().rev() {
-        for hi in hunk_indices.iter().rev() {
-            files[*fi].hunks.remove(*hi);
-            selected[*fi].remove(*hi);
-        }
-    }
-
-    let mut i = files.len();
-    while i > 0 {
-        i -= 1;
-        if files[i].hunks.is_empty() {
-            files.remove(i);
-            selected.remove(i);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -631,44 +614,5 @@ mod tests {
     fn test_build_flat_items_empty() {
         let items = build_flat_items(&[]);
         assert!(items.is_empty());
-    }
-
-    #[test]
-    fn test_remove_committed_hunks_partial() {
-        let mut files = vec![make_file("a.rs", 3), make_file("b.rs", 2)];
-        let mut selected = vec![vec![true, false, true], vec![false, true]];
-
-        let selections = vec![(0, vec![0, 2])];
-        remove_committed_hunks(&mut files, &mut selected, &selections);
-
-        assert_eq!(files.len(), 2);
-        assert_eq!(files[0].hunks.len(), 1);
-        assert_eq!(files[0].hunks[0].new_start, 11);
-        assert_eq!(selected[0], vec![false]);
-    }
-
-    #[test]
-    fn test_remove_committed_hunks_removes_empty_file() {
-        let mut files = vec![make_file("a.rs", 1), make_file("b.rs", 1)];
-        let mut selected = vec![vec![true], vec![false]];
-
-        let selections = vec![(0, vec![0])];
-        remove_committed_hunks(&mut files, &mut selected, &selections);
-
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "b.rs");
-        assert_eq!(selected.len(), 1);
-    }
-
-    #[test]
-    fn test_remove_committed_hunks_all() {
-        let mut files = vec![make_file("a.rs", 2)];
-        let mut selected = vec![vec![true, true]];
-
-        let selections = vec![(0, vec![0, 1])];
-        remove_committed_hunks(&mut files, &mut selected, &selections);
-
-        assert!(files.is_empty());
-        assert!(selected.is_empty());
     }
 }

--- a/src/tui/split_hunk/mod.rs
+++ b/src/tui/split_hunk/mod.rs
@@ -129,6 +129,8 @@ fn handle_list_key(app: &mut HunkSplitApp, code: KeyCode) {
             app.status_message = Some("Sequential mode: y/n to accept/skip hunks".to_string());
         }
         KeyCode::Enter => try_finish_round(app),
+        KeyCode::Char('J') => app.scroll_diff_down(),
+        KeyCode::Char('K') => app.scroll_diff_up(),
         KeyCode::Char('q') | KeyCode::Esc => app.mode = HunkSplitMode::ConfirmAbort,
         KeyCode::Char('?') => app.mode = HunkSplitMode::Help,
         _ => {}
@@ -149,6 +151,8 @@ fn handle_sequential_key(app: &mut HunkSplitApp, code: KeyCode) {
             app.status_message = Some("List mode".to_string());
         }
         KeyCode::Enter => try_finish_round(app),
+        KeyCode::Char('J') => app.scroll_diff_down(),
+        KeyCode::Char('K') => app.scroll_diff_up(),
         KeyCode::Char('q') | KeyCode::Esc => app.mode = HunkSplitMode::ConfirmAbort,
         KeyCode::Char('?') => app.mode = HunkSplitMode::Help,
         _ => {}

--- a/src/tui/split_hunk/mod.rs
+++ b/src/tui/split_hunk/mod.rs
@@ -14,8 +14,8 @@ use std::io;
 use std::time::Duration;
 
 /// Run the hunk-based split TUI
-pub fn run() -> Result<()> {
-    let mut app = HunkSplitApp::new()?;
+pub fn run(no_verify: bool) -> Result<()> {
+    let mut app = HunkSplitApp::new(no_verify)?;
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();

--- a/src/tui/split_hunk/mod.rs
+++ b/src/tui/split_hunk/mod.rs
@@ -68,9 +68,11 @@ fn run_app(
                     return Ok(false);
                 }
 
+                let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+
                 match &app.mode {
-                    HunkSplitMode::List => handle_list_key(app, key.code),
-                    HunkSplitMode::Sequential => handle_sequential_key(app, key.code),
+                    HunkSplitMode::List => handle_list_key(app, key.code, shift),
+                    HunkSplitMode::Sequential => handle_sequential_key(app, key.code, shift),
                     HunkSplitMode::Naming => handle_naming_key(app, key.code),
                     HunkSplitMode::ConfirmAbort => handle_confirm_abort_key(app, key.code),
                     HunkSplitMode::Help => handle_help_key(app, key.code),
@@ -117,10 +119,14 @@ fn try_finish_round(app: &mut HunkSplitApp) {
     }
 }
 
-fn handle_list_key(app: &mut HunkSplitApp, code: KeyCode) {
+fn handle_list_key(app: &mut HunkSplitApp, code: KeyCode, shift: bool) {
     match code {
+        KeyCode::Down | KeyCode::Char('j' | 'J') if shift => app.scroll_diff_down(),
+        KeyCode::Up | KeyCode::Char('k' | 'K') if shift => app.scroll_diff_up(),
         KeyCode::Down | KeyCode::Char('j') => app.move_cursor_down(),
         KeyCode::Up | KeyCode::Char('k') => app.move_cursor_up(),
+        KeyCode::PageDown => app.scroll_diff_down(),
+        KeyCode::PageUp => app.scroll_diff_up(),
         KeyCode::Char(' ') => app.toggle_current(),
         KeyCode::Char('a') => app.toggle_file(),
         KeyCode::Char('u') => app.undo(),
@@ -129,16 +135,18 @@ fn handle_list_key(app: &mut HunkSplitApp, code: KeyCode) {
             app.status_message = Some("Sequential mode: y/n to accept/skip hunks".to_string());
         }
         KeyCode::Enter => try_finish_round(app),
-        KeyCode::Char('J') => app.scroll_diff_down(),
-        KeyCode::Char('K') => app.scroll_diff_up(),
         KeyCode::Char('q') | KeyCode::Esc => app.mode = HunkSplitMode::ConfirmAbort,
         KeyCode::Char('?') => app.mode = HunkSplitMode::Help,
         _ => {}
     }
 }
 
-fn handle_sequential_key(app: &mut HunkSplitApp, code: KeyCode) {
+fn handle_sequential_key(app: &mut HunkSplitApp, code: KeyCode, shift: bool) {
     match code {
+        KeyCode::Down | KeyCode::Char('j' | 'J') if shift => app.scroll_diff_down(),
+        KeyCode::Up | KeyCode::Char('k' | 'K') if shift => app.scroll_diff_up(),
+        KeyCode::PageDown => app.scroll_diff_down(),
+        KeyCode::PageUp => app.scroll_diff_up(),
         KeyCode::Char('y') => app.accept_and_advance(),
         KeyCode::Char('n') => app.skip_and_advance(),
         KeyCode::Char('a') => {
@@ -151,8 +159,6 @@ fn handle_sequential_key(app: &mut HunkSplitApp, code: KeyCode) {
             app.status_message = Some("List mode".to_string());
         }
         KeyCode::Enter => try_finish_round(app),
-        KeyCode::Char('J') => app.scroll_diff_down(),
-        KeyCode::Char('K') => app.scroll_diff_up(),
         KeyCode::Char('q') | KeyCode::Esc => app.mode = HunkSplitMode::ConfirmAbort,
         KeyCode::Char('?') => app.mode = HunkSplitMode::Help,
         _ => {}

--- a/src/tui/split_hunk/ui.rs
+++ b/src/tui/split_hunk/ui.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
 
@@ -149,7 +149,7 @@ fn render_file_list(f: &mut Frame, app: &mut HunkSplitApp, area: Rect) {
     f.render_stateful_widget(list, area, &mut app.list_state);
 }
 
-fn render_diff_preview(f: &mut Frame, app: &HunkSplitApp, area: Rect) {
+fn render_diff_preview(f: &mut Frame, app: &mut HunkSplitApp, area: Rect) {
     let block = Block::default()
         .title(" Diff Preview ")
         .borders(Borders::ALL)
@@ -230,17 +230,19 @@ fn render_diff_preview(f: &mut Frame, app: &HunkSplitApp, area: Rect) {
         ))],
     };
 
-    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+    app.diff_line_count = lines.len() as u16;
+    app.diff_viewport_height = inner.height;
+    let paragraph = Paragraph::new(lines).scroll((app.diff_scroll, 0));
     f.render_widget(paragraph, inner);
 }
 
 fn render_status_bar(f: &mut Frame, app: &HunkSplitApp, area: Rect) {
     let help_line = match app.mode {
         HunkSplitMode::List => {
-            "j/k:nav  Space:toggle  a:file  Tab:sequential  Enter:commit  u:undo  ?:help  q:quit"
+            "j/k:nav  J/K:scroll diff  Space:toggle  a:file  Tab:sequential  Enter:commit  u:undo  ?:help  q:quit"
         }
         HunkSplitMode::Sequential => {
-            "y:accept  n:skip  a:toggle file  Tab:list  Enter:commit  u:undo  ?:help  q:quit"
+            "y:accept  n:skip  a:toggle file  J/K:scroll diff  Tab:list  Enter:commit  u:undo  ?:help  q:quit"
         }
         HunkSplitMode::Naming => "Enter:confirm  Esc:cancel",
         HunkSplitMode::ConfirmAbort => "y:quit  n:cancel",
@@ -374,6 +376,7 @@ fn render_help_dialog(f: &mut Frame) {
             "General",
             Style::default().add_modifier(Modifier::BOLD),
         )),
+        Line::from("  J/K        Scroll diff preview"),
         Line::from("  ?          Toggle help"),
         Line::from("  q/Esc      Quit (abort split)"),
         Line::from("  Ctrl-C     Force quit"),

--- a/src/tui/split_hunk/ui.rs
+++ b/src/tui/split_hunk/ui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Frame,
 };
 
-pub fn render(f: &mut Frame, app: &HunkSplitApp) {
+pub fn render(f: &mut Frame, app: &mut HunkSplitApp) {
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(3), Constraint::Length(2)])
@@ -30,7 +30,7 @@ pub fn render(f: &mut Frame, app: &HunkSplitApp) {
     }
 }
 
-fn render_file_list(f: &mut Frame, app: &HunkSplitApp, area: Rect) {
+fn render_file_list(f: &mut Frame, app: &mut HunkSplitApp, area: Rect) {
     let mut items: Vec<ListItem> = Vec::new();
 
     for (i, flat_item) in app.flat_items.iter().enumerate() {
@@ -145,7 +145,8 @@ fn render_file_list(f: &mut Frame, app: &HunkSplitApp, area: Rect) {
         .border_style(Style::default().fg(Color::Blue));
 
     let list = List::new(items).block(block);
-    f.render_widget(list, area);
+    app.list_state.select(Some(app.cursor));
+    f.render_stateful_widget(list, area, &mut app.list_state);
 }
 
 fn render_diff_preview(f: &mut Frame, app: &HunkSplitApp, area: Rect) {

--- a/src/tui/split_hunk/ui.rs
+++ b/src/tui/split_hunk/ui.rs
@@ -239,10 +239,10 @@ fn render_diff_preview(f: &mut Frame, app: &mut HunkSplitApp, area: Rect) {
 fn render_status_bar(f: &mut Frame, app: &HunkSplitApp, area: Rect) {
     let help_line = match app.mode {
         HunkSplitMode::List => {
-            "j/k:nav  J/K:scroll diff  Space:toggle  a:file  Tab:sequential  Enter:commit  u:undo  ?:help  q:quit"
+            "j/k:nav  Shift+j/k:scroll diff  Space:toggle  a:file  Tab:sequential  Enter:commit  u:undo  ?:help  q:quit"
         }
         HunkSplitMode::Sequential => {
-            "y:accept  n:skip  a:toggle file  J/K:scroll diff  Tab:list  Enter:commit  u:undo  ?:help  q:quit"
+            "y:accept  n:skip  a:toggle file  Shift+j/k:scroll diff  Tab:list  Enter:commit  u:undo  ?:help  q:quit"
         }
         HunkSplitMode::Naming => "Enter:confirm  Esc:cancel",
         HunkSplitMode::ConfirmAbort => "y:quit  n:cancel",
@@ -376,7 +376,8 @@ fn render_help_dialog(f: &mut Frame) {
             "General",
             Style::default().add_modifier(Modifier::BOLD),
         )),
-        Line::from("  J/K        Scroll diff preview"),
+        Line::from("  Shift+j/k  Scroll diff preview"),
+        Line::from("  PgUp/PgDn  Scroll diff preview"),
         Line::from("  ?          Toggle help"),
         Line::from("  q/Esc      Quit (abort split)"),
         Line::from("  Ctrl-C     Force quit"),

--- a/src/tui/split_hunk/ui.rs
+++ b/src/tui/split_hunk/ui.rs
@@ -270,8 +270,13 @@ fn render_naming_dialog(f: &mut Frame, app: &HunkSplitApp) {
     let area = centered_rect(50, 20, f.area());
     f.render_widget(Clear, area);
 
+    let title = format!(
+        " Enter branch name ({}/{} hunks) ",
+        app.selected_count(),
+        app.total_hunk_count()
+    );
     let block = Block::default()
-        .title(" Enter branch name ")
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow));
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -76,6 +76,15 @@ fn sh_quote(value: &str) -> String {
 
 #[allow(dead_code)]
 pub fn run_stax_in_script(cwd: &Path, args: &[&str], input_script: &str) -> Output {
+    run_stax_in_script_with_env(cwd, args, input_script, &[])
+}
+
+pub fn run_stax_in_script_with_env(
+    cwd: &Path,
+    args: &[&str],
+    input_script: &str,
+    env: &[(&str, &str)],
+) -> Output {
     let stax_bin = stax_bin();
     let command = std::iter::once(stax_bin.to_string_lossy().into_owned())
         .chain(args.iter().map(|arg| (*arg).to_string()))
@@ -95,6 +104,9 @@ pub fn run_stax_in_script(cwd: &Path, args: &[&str], input_script: &str) -> Outp
     let mut cmd = Command::new("sh");
     cmd.args(["-c", &shell_script]).current_dir(cwd);
     apply_sanitized_test_env(&mut cmd);
+    for (key, val) in env {
+        cmd.env(key, val);
+    }
     cmd.output().expect("Failed to run stax inside script")
 }
 

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -445,3 +445,221 @@ fn test_split_hunk_same_file_three_hunks() {
     assert!(final_content.contains("line 20 MODIFIED"));
     assert!(final_content.contains("line 37 MODIFIED"));
 }
+
+#[test]
+fn test_split_hunk_line_additions_partial_select() {
+    let repo = TestRepo::new();
+
+    // Create base file with enough lines for 4 hunks (lines 8 apart minimum)
+    let base: String = (1..=60).map(|i| format!("line {}\n", i)).collect();
+    repo.create_file("main.txt", &base);
+    repo.commit("add base file");
+
+    let output = repo.run_stax(&["bc", "add-lines-split"]);
+    assert!(
+        output.status.success(),
+        "bc failed: {}",
+        TestRepo::stderr(&output)
+    );
+    let original = repo.current_branch();
+
+    // ADD new lines (not modify) at 4 locations — this shifts offsets between hunks
+    let modified: String = (1..=60)
+        .flat_map(|i| {
+            let mut lines = vec![format!("line {}\n", i)];
+            match i {
+                5 => {
+                    lines.push("ADDED AFTER 5a\n".to_string());
+                    lines.push("ADDED AFTER 5b\n".to_string());
+                }
+                18 => {
+                    lines.push("ADDED AFTER 18a\n".to_string());
+                    lines.push("ADDED AFTER 18b\n".to_string());
+                    lines.push("ADDED AFTER 18c\n".to_string());
+                }
+                35 => {
+                    lines.push("ADDED AFTER 35a\n".to_string());
+                }
+                50 => {
+                    lines.push("ADDED AFTER 50a\n".to_string());
+                    lines.push("ADDED AFTER 50b\n".to_string());
+                }
+                _ => {}
+            }
+            lines
+        })
+        .collect();
+    repo.create_file("main.txt", &modified);
+    repo.commit("add lines at 4 locations");
+
+    // Flat list:
+    //   [0] FileHeader(main.txt)
+    //   [1] Hunk 0 (adds 2 lines after line 5)
+    //   [2] Hunk 1 (adds 3 lines after line 18)
+    //   [3] Hunk 2 (adds 1 line after line 35)
+    //   [4] Hunk 3 (adds 2 lines after line 50)
+    //
+    // Round 1: select hunk 0 only (j, space, Enter, Enter)
+    // Round 2: select hunk 1 only (j, space, Enter, Enter)
+    // Round 3: select hunks 2 and 3 (j, space, j, space, Enter, Enter)
+
+    let script = [
+        "sleep 1",
+        "printf 'j \\r\\r'",
+        "sleep 3",
+        "printf 'j \\r\\r'",
+        "sleep 3",
+        "printf 'j j \\r\\r'",
+        "sleep 2",
+    ]
+    .join("; ");
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
+    assert!(
+        output.status.success(),
+        "Split TUI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let split_1 = format!("{}_split_1", original);
+    let split_2 = format!("{}_split_2", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&split_2),
+        "Missing {split_2}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    // Verify split_1 only has hunk 0
+    let s1 = file_content(&repo, &split_1, "main.txt");
+    assert!(s1.contains("ADDED AFTER 5a"), "split_1 should have hunk 0");
+    assert!(
+        !s1.contains("ADDED AFTER 18a"),
+        "split_1 should NOT have hunk 1"
+    );
+
+    // Verify split_2 has hunks 0+1
+    let s2 = file_content(&repo, &split_2, "main.txt");
+    assert!(s2.contains("ADDED AFTER 5a"));
+    assert!(s2.contains("ADDED AFTER 18a"));
+    assert!(!s2.contains("ADDED AFTER 35a"));
+
+    // Final branch has everything
+    let fin = file_content(&repo, &original, "main.txt");
+    assert!(fin.contains("ADDED AFTER 5a"));
+    assert!(fin.contains("ADDED AFTER 18a"));
+    assert!(fin.contains("ADDED AFTER 35a"));
+    assert!(fin.contains("ADDED AFTER 50a"));
+}
+
+#[test]
+fn test_split_hunk_partial_file_selection_gets_second_round() {
+    let repo = TestRepo::new();
+
+    // Create a base file on main with enough lines for 4 well-separated hunks
+    let base_a: String = (1..=50).map(|i| format!("a line {}\n", i)).collect();
+    repo.create_file("file_a.txt", &base_a);
+    let base_b: String = (1..=20).map(|i| format!("b line {}\n", i)).collect();
+    repo.create_file("file_b.txt", &base_b);
+    repo.commit("add base files");
+
+    let output = repo.run_stax(&["bc", "partial-select"]);
+    assert!(
+        output.status.success(),
+        "bc failed: {}",
+        TestRepo::stderr(&output)
+    );
+    let original = repo.current_branch();
+
+    // Modify file_a in 4 well-separated locations (4 hunks)
+    let mod_a: String = (1..=50)
+        .map(|i| match i {
+            3 => "a line 3 MODIFIED\n".to_string(),
+            15 => "a line 15 MODIFIED\n".to_string(),
+            30 => "a line 30 MODIFIED\n".to_string(),
+            45 => "a line 45 MODIFIED\n".to_string(),
+            _ => format!("a line {}\n", i),
+        })
+        .collect();
+    repo.create_file("file_a.txt", &mod_a);
+
+    // Modify file_b in 2 well-separated locations (2 hunks)
+    let mod_b: String = (1..=20)
+        .map(|i| match i {
+            3 => "b line 3 MODIFIED\n".to_string(),
+            15 => "b line 15 MODIFIED\n".to_string(),
+            _ => format!("b line {}\n", i),
+        })
+        .collect();
+    repo.create_file("file_b.txt", &mod_b);
+    repo.commit("modify both files");
+
+    // Flat list:
+    //   [0] FileHeader(file_a.txt)
+    //   [1] Hunk(A, 0) - line 3
+    //   [2] Hunk(A, 1) - line 15
+    //   [3] Hunk(A, 2) - line 30
+    //   [4] Hunk(A, 3) - line 45
+    //   [5] FileHeader(file_b.txt)
+    //   [6] Hunk(B, 0) - line 3
+    //   [7] Hunk(B, 1) - line 15
+    //
+    // Round 1: select A:0, A:1, and all of B (skip A:2, A:3)
+    //   j=A:0, space=select, j=A:1, space=select, j=A:2, j=A:3, j=FileHeader(B), a=select-all-B
+    //   Enter=commit, Enter=accept name
+    //
+    // Round 2: should have A:2, A:3 remaining
+    //   j=A:2(now idx 0), space=select, j=A:3(now idx 1), space=select
+    //   Enter=commit, Enter=accept name
+
+    let script = "sleep 1; printf 'j j jjja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
+    assert!(
+        output.status.success(),
+        "Split hunk TUI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    // split_1 should have A:0, A:1 + all of B
+    let s1_a = file_content(&repo, &split_1, "file_a.txt");
+    assert!(s1_a.contains("a line 3 MODIFIED"));
+    assert!(s1_a.contains("a line 15 MODIFIED"));
+    assert!(
+        !s1_a.contains("a line 30 MODIFIED"),
+        "split_1 should NOT have A hunk 2"
+    );
+    assert!(
+        !s1_a.contains("a line 45 MODIFIED"),
+        "split_1 should NOT have A hunk 3"
+    );
+
+    // original should have all modifications
+    let final_a = file_content(&repo, &original, "file_a.txt");
+    assert!(final_a.contains("a line 3 MODIFIED"));
+    assert!(final_a.contains("a line 15 MODIFIED"));
+    assert!(
+        final_a.contains("a line 30 MODIFIED"),
+        "final branch should have A hunk 2"
+    );
+    assert!(
+        final_a.contains("a line 45 MODIFIED"),
+        "final branch should have A hunk 3"
+    );
+}

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -137,6 +137,11 @@ fn run_split_hunk(repo: &TestRepo, rounds: usize) {
     );
 }
 
+fn file_content(repo: &TestRepo, branch: &str, path: &str) -> String {
+    let output = repo.git(&["show", &format!("{}:{}", branch, path)]);
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
 #[test]
 fn test_split_hunk_two_files_into_two_branches() {
     let repo = TestRepo::new();
@@ -296,4 +301,147 @@ fn test_split_hunk_abort_with_dirty_workdir_preserves_changes() {
     );
     let content = std::fs::read_to_string(&dirty_path).unwrap();
     assert_eq!(content, "dirty content\n");
+}
+
+// =============================================================================
+// Regression tests: same-file multi-hunk splits (stale offset bug)
+// =============================================================================
+
+#[test]
+fn test_split_hunk_same_file_two_hunks() {
+    let repo = TestRepo::new();
+
+    let base_content: String = (1..=30).map(|i| format!("line {}\n", i)).collect();
+    repo.create_file("shared.txt", &base_content);
+    repo.commit("add shared file");
+
+    let output = repo.run_stax(&["bc", "same-file-split"]);
+    assert!(
+        output.status.success(),
+        "bc failed: {}",
+        TestRepo::stderr(&output)
+    );
+    let original = repo.current_branch();
+
+    let modified: String = (1..=30)
+        .map(|i| match i {
+            3 => "line 3 MODIFIED\n".to_string(),
+            25 => "line 25 MODIFIED\n".to_string(),
+            _ => format!("line {}\n", i),
+        })
+        .collect();
+    repo.create_file("shared.txt", &modified);
+    repo.commit("modify shared file in two places");
+
+    run_split_hunk(&repo, 2);
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    let parents = parent_map(&repo);
+    assert_eq!(parents.get(&split_1).map(String::as_str), Some("main"));
+    assert_eq!(
+        parents.get(&original).map(String::as_str),
+        Some(split_1.as_str())
+    );
+
+    let s1_content = file_content(&repo, &split_1, "shared.txt");
+    assert!(
+        s1_content.contains("line 3 MODIFIED"),
+        "split_1 should have line 3 modification"
+    );
+    assert!(
+        !s1_content.contains("line 25 MODIFIED"),
+        "split_1 should NOT have line 25 modification"
+    );
+
+    let final_content = file_content(&repo, &original, "shared.txt");
+    assert!(
+        final_content.contains("line 3 MODIFIED"),
+        "final branch should have line 3 modification"
+    );
+    assert!(
+        final_content.contains("line 25 MODIFIED"),
+        "final branch should have line 25 modification"
+    );
+}
+
+#[test]
+fn test_split_hunk_same_file_three_hunks() {
+    let repo = TestRepo::new();
+
+    let base_content: String = (1..=40).map(|i| format!("line {}\n", i)).collect();
+    repo.create_file("shared.txt", &base_content);
+    repo.commit("add shared file");
+
+    let output = repo.run_stax(&["bc", "three-way-split"]);
+    assert!(
+        output.status.success(),
+        "bc failed: {}",
+        TestRepo::stderr(&output)
+    );
+    let original = repo.current_branch();
+
+    let modified: String = (1..=40)
+        .map(|i| match i {
+            3 => "line 3 MODIFIED\n".to_string(),
+            20 => "line 20 MODIFIED\n".to_string(),
+            37 => "line 37 MODIFIED\n".to_string(),
+            _ => format!("line {}\n", i),
+        })
+        .collect();
+    repo.create_file("shared.txt", &modified);
+    repo.commit("modify shared file in three places");
+
+    run_split_hunk(&repo, 3);
+
+    let split_1 = format!("{}_split_1", original);
+    let split_2 = format!("{}_split_2", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&split_2),
+        "Missing {split_2}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    let parents = parent_map(&repo);
+    assert_eq!(parents.get(&split_1).map(String::as_str), Some("main"));
+    assert_eq!(
+        parents.get(&split_2).map(String::as_str),
+        Some(split_1.as_str())
+    );
+    assert_eq!(
+        parents.get(&original).map(String::as_str),
+        Some(split_2.as_str())
+    );
+
+    let s1_content = file_content(&repo, &split_1, "shared.txt");
+    assert!(s1_content.contains("line 3 MODIFIED"));
+    assert!(!s1_content.contains("line 20 MODIFIED"));
+    assert!(!s1_content.contains("line 37 MODIFIED"));
+
+    let s2_content = file_content(&repo, &split_2, "shared.txt");
+    assert!(s2_content.contains("line 3 MODIFIED"));
+    assert!(s2_content.contains("line 20 MODIFIED"));
+    assert!(!s2_content.contains("line 37 MODIFIED"));
+
+    let final_content = file_content(&repo, &original, "shared.txt");
+    assert!(final_content.contains("line 3 MODIFIED"));
+    assert!(final_content.contains("line 20 MODIFIED"));
+    assert!(final_content.contains("line 37 MODIFIED"));
 }

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -663,3 +663,291 @@ fn test_split_hunk_partial_file_selection_gets_second_round() {
         "final branch should have A hunk 3"
     );
 }
+
+// =============================================================================
+// Interaction pattern tests: different ways to select the same hunks
+// =============================================================================
+
+/// Set up a repo with file_a (4 hunks) and file_b (2 hunks) on a stax branch.
+/// Returns (repo, original_branch_name).
+fn setup_two_file_four_two_hunks() -> (TestRepo, String) {
+    let repo = TestRepo::new();
+
+    let base_a: String = (1..=50).map(|i| format!("a line {}\n", i)).collect();
+    repo.create_file("file_a.txt", &base_a);
+    let base_b: String = (1..=20).map(|i| format!("b line {}\n", i)).collect();
+    repo.create_file("file_b.txt", &base_b);
+    repo.commit("add base files");
+
+    let output = repo.run_stax(&["bc", "interaction-test"]);
+    assert!(
+        output.status.success(),
+        "bc failed: {}",
+        TestRepo::stderr(&output)
+    );
+    let original = repo.current_branch();
+
+    let mod_a: String = (1..=50)
+        .map(|i| match i {
+            3 => "a line 3 MODIFIED\n".to_string(),
+            15 => "a line 15 MODIFIED\n".to_string(),
+            30 => "a line 30 MODIFIED\n".to_string(),
+            45 => "a line 45 MODIFIED\n".to_string(),
+            _ => format!("a line {}\n", i),
+        })
+        .collect();
+    repo.create_file("file_a.txt", &mod_a);
+
+    let mod_b: String = (1..=20)
+        .map(|i| match i {
+            3 => "b line 3 MODIFIED\n".to_string(),
+            15 => "b line 15 MODIFIED\n".to_string(),
+            _ => format!("b line {}\n", i),
+        })
+        .collect();
+    repo.create_file("file_b.txt", &mod_b);
+    repo.commit("modify both files");
+
+    (repo, original)
+}
+
+/// Flat list layout for 4+2 hunk setup:
+///   [0] FileHeader(file_a.txt)
+///   [1] Hunk(A, 0) - line 3
+///   [2] Hunk(A, 1) - line 15
+///   [3] Hunk(A, 2) - line 30
+///   [4] Hunk(A, 3) - line 45
+///   [5] FileHeader(file_b.txt)
+///   [6] Hunk(B, 0) - line 3
+///   [7] Hunk(B, 1) - line 15
+fn assert_split_1_has_a01_and_all_b(repo: &TestRepo, split_1: &str, original: &str) {
+    let s1_a = file_content(repo, split_1, "file_a.txt");
+    assert!(
+        s1_a.contains("a line 3 MODIFIED"),
+        "split_1 should have A:0"
+    );
+    assert!(
+        s1_a.contains("a line 15 MODIFIED"),
+        "split_1 should have A:1"
+    );
+    assert!(
+        !s1_a.contains("a line 30 MODIFIED"),
+        "split_1 should NOT have A:2"
+    );
+    assert!(
+        !s1_a.contains("a line 45 MODIFIED"),
+        "split_1 should NOT have A:3"
+    );
+
+    let s1_b = file_content(repo, split_1, "file_b.txt");
+    assert!(
+        s1_b.contains("b line 3 MODIFIED"),
+        "split_1 should have B:0"
+    );
+    assert!(
+        s1_b.contains("b line 15 MODIFIED"),
+        "split_1 should have B:1"
+    );
+
+    let final_a = file_content(repo, original, "file_a.txt");
+    assert!(final_a.contains("a line 3 MODIFIED"));
+    assert!(final_a.contains("a line 15 MODIFIED"));
+    assert!(
+        final_a.contains("a line 30 MODIFIED"),
+        "final should have A:2"
+    );
+    assert!(
+        final_a.contains("a line 45 MODIFIED"),
+        "final should have A:3"
+    );
+}
+
+#[test]
+fn test_split_hunk_toggle_file_then_deselect() {
+    let (repo, original) = setup_two_file_four_two_hunks();
+
+    // Round 1: 'a' on file_a header selects all A, then deselect A:2 and A:3,
+    //          then 'a' on file_b header selects all B.
+    //
+    // [0] FileHeader(A) ← cursor starts here
+    //   a → select all A (A:0..A:3 = true)
+    //   j → [1] A:0
+    //   j → [2] A:1
+    //   j → [3] A:2
+    //   space → deselect A:2
+    //   j → [4] A:3
+    //   space → deselect A:3
+    //   j → [5] FileHeader(B)
+    //   a → select all B
+    //   Enter → commit (4/6 selected: A:0,A:1,B:0,B:1)
+    //   Enter → accept name
+    //
+    // Round 2 (list mode): file_a with 2 remaining hunks
+    //   j → first hunk, space, j → second hunk, space, Enter, Enter
+
+    let script = "sleep 1; printf 'ajjj j ja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    assert!(
+        output.status.success(),
+        "Split failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    assert_split_1_has_a01_and_all_b(&repo, &split_1, &original);
+}
+
+#[test]
+fn test_split_hunk_select_later_hunks_first() {
+    let (repo, original) = setup_two_file_four_two_hunks();
+
+    // Round 1: skip A:0 and A:1, select A:2 and A:3, then 'a' on file_b.
+    //
+    // [0] FileHeader(A) ← start
+    //   j → [1] A:0 (skip)
+    //   j → [2] A:1 (skip)
+    //   j → [3] A:2
+    //   space → select A:2
+    //   j → [4] A:3
+    //   space → select A:3
+    //   j → [5] FileHeader(B)
+    //   a → select all B
+    //   Enter → commit (4/6 selected: A:2,A:3,B:0,B:1)
+    //   Enter → accept name
+    //
+    // Round 2: file_a with A:0 and A:1 remaining
+    //   j → first hunk, space, j → second hunk, space, Enter, Enter
+
+    let script = "sleep 1; printf 'jjj j ja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    assert!(
+        output.status.success(),
+        "Split failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    // split_1 should have A:2, A:3 + all B (inverted from the other tests)
+    let s1_a = file_content(&repo, &split_1, "file_a.txt");
+    assert!(!s1_a.contains("a line 3 MODIFIED"), "split_1 should NOT have A:0");
+    assert!(!s1_a.contains("a line 15 MODIFIED"), "split_1 should NOT have A:1");
+    assert!(s1_a.contains("a line 30 MODIFIED"), "split_1 should have A:2");
+    assert!(s1_a.contains("a line 45 MODIFIED"), "split_1 should have A:3");
+
+    // original should have everything
+    let final_a = file_content(&repo, &original, "file_a.txt");
+    assert!(final_a.contains("a line 3 MODIFIED"));
+    assert!(final_a.contains("a line 15 MODIFIED"));
+    assert!(final_a.contains("a line 30 MODIFIED"));
+    assert!(final_a.contains("a line 45 MODIFIED"));
+}
+
+#[test]
+fn test_split_hunk_sequential_mode_partial() {
+    let (repo, original) = setup_two_file_four_two_hunks();
+
+    // Round 1 via sequential mode:
+    //   Tab → enter sequential mode (cursor at [0] FileHeader A)
+    //   y → no-op on header, advance to [1] A:0
+    //   y → accept A:0, advance to [2] A:1
+    //   y → accept A:1, advance to [3] A:2
+    //   n → skip A:2, advance to [4] A:3
+    //   n → skip A:3, advance to [6] B:0 (skips FileHeader)
+    //   a → toggle file B (selects all B) + advance past B → auto-enters Naming
+    //   Enter → accept name
+    //
+    // Round 2 (list mode): remaining A:2, A:3
+    //   j, space, j, space, Enter, Enter
+
+    let script =
+        "sleep 1; printf '\\tyyynnna\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    assert!(
+        output.status.success(),
+        "Split failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let split_1 = format!("{}_split_1", original);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&split_1),
+        "Missing {split_1}, got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&original),
+        "Missing {original}, got: {branches:?}"
+    );
+
+    assert_split_1_has_a01_and_all_b(&repo, &split_1, &original);
+}
+
+#[test]
+fn test_split_hunk_debug_log_captures_selections() {
+    let (repo, original) = setup_two_file_four_two_hunks();
+
+    // Same as partial-select: select A:0, A:1 + all B, expect round 2 with A:2, A:3
+    let script = "sleep 1; printf 'j j jjja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let output = common::run_stax_in_script_with_env(
+        &repo.path(),
+        &["split", "--hunk"],
+        script,
+        &[("STAX_SPLIT_DEBUG", "1")],
+    );
+    assert!(
+        output.status.success(),
+        "Split failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify the debug log was written and contains expected data
+    let log_path = std::env::temp_dir().join("stax-split-debug.log");
+    assert!(log_path.exists(), "Debug log should exist");
+
+    let log = std::fs::read_to_string(&log_path).unwrap();
+
+    // Round 1 should show 4/6 selected (A:0,A:1,B:0,B:1)
+    assert!(
+        log.contains("Selected: 4/6"),
+        "Debug log should show 4/6 selected in round 1, got:\n{}",
+        log
+    );
+
+    // Round 2 should show 2/2 selected (remaining A:2,A:3)
+    assert!(
+        log.contains("Selected: 2/2"),
+        "Debug log should show 2/2 selected in round 2, got:\n{}",
+        log
+    );
+
+    // Should NOT contain the bug marker
+    assert!(
+        !log.contains("!!! BUG"),
+        "Debug log should not contain bug marker, got:\n{}",
+        log
+    );
+
+    // Verify branches were created correctly
+    let split_1 = format!("{}_split_1", original);
+    assert_split_1_has_a01_and_all_b(&repo, &split_1, &original);
+}


### PR DESCRIPTION
## Summary

Fixes #233

Three improvements to `stax split --hunk`:

### 1. TUI scrolling for large PRs
In large PRs, the file list and diff preview panes didn't scroll. The file list now uses `ListState` + `render_stateful_widget` for auto-scroll. The diff preview supports `Shift+j/k`, `Shift+Arrow`, and `PageUp/PageDown` for manual scrolling.

### 2. "patch does not apply" on later rounds
When splitting multiple hunks from the same file across rounds, later rounds failed because hunk headers retained stale `@@` line offsets after HEAD moved forward. Fixed by re-running `git diff` after each round instead of mutating stale in-memory data. Also adds `git add -N .` before re-diffing to preserve intent-to-add status for new files.

### 3. `--no-verify` flag
Added `stax split --hunk --no-verify` to skip pre-commit hooks during the split workflow. Useful when hooks are slow or not relevant to the split operation.

### Diagnostics
- Naming dialog now shows selected/total hunk count (e.g. "3/6 hunks")
- Set `STAX_SPLIT_DEBUG=1` to write detailed selection state and patch content to a log file for debugging

## Test plan

- [x] `cargo test --test split_hunk_tests` — all 21 tests pass (13 existing + 8 new)
- [x] New tests cover: line additions with offset changes, toggle-file interactions, later-hunk selection, sequential mode partial selection, debug log verification
- [x] `cargo build` — clean, no new warnings
- [x] `cargo clippy` — no new warnings
- [x] Manual: `stax split --hunk` on a branch with a large diff — verify file list and diff pane scroll
- [x] Manual: split multiple hunks from the same file across rounds — verify no "patch does not apply"
- [x] Manual: `stax split --hunk --no-verify` — verify hooks are skipped