### PR TITLE
feat(merge): add --queue flag for GitHub merge queue and GitLab merge train support

### DIFF
--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -52,9 +52,9 @@ After a successful run, run `st rs` to sync your local repository (delete merged
 
 `--remote` cannot be combined with `--dry-run`, `--when-ready`, or `--no-wait`. Only **GitHub** is supported (not GitLab/Gitea).
 
-### `--queue` mode (GitHub only)
+### `--queue` mode (GitHub & GitLab)
 
-`st merge --queue` enqueues your stack PRs into [GitHub's merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue). Instead of merging PRs one-by-one (each waiting for CI), the merge queue batches them so CI runs once on the combined result. This is significantly faster for stacks with slow CI pipelines.
+`st merge --queue` enqueues your stack PRs into the forge's merge queue instead of merging them one-by-one. The merge queue batches CI so it runs once on the combined result, which is significantly faster for stacks with slow CI pipelines.
 
 ```bash
 st merge --queue
@@ -64,18 +64,25 @@ st merge --queue --yes
 
 **What happens:**
 
-1. All stack PRs are retargeted to trunk
-2. Each PR is enqueued into the merge queue via the GitHub GraphQL API
-3. GitHub handles CI validation and merging automatically
+1. All stack PRs/MRs are retargeted to trunk
+2. Each PR/MR is enqueued into the merge queue via the forge API
+3. The forge handles CI validation and merging automatically
 
-Once GitHub finishes merging, `st rs` (sync) will automatically detect the merged branches and clean up — just like any other merge path. No extra steps required beyond your normal workflow.
+Once the forge finishes merging, `st rs` (sync) will automatically detect the merged branches and clean up — just like any other merge path. No extra steps required beyond your normal workflow.
 
-> **Note:** GitHub merge queues require the repository to have merge queue enabled
-> in its branch protection rules. This feature is available on **GitHub Team and
-> Enterprise Cloud** plans, or on **public repositories** on any plan.
-> See [GitHub's merge queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) for setup instructions.
+#### GitHub
 
-`--queue` cannot be combined with `--dry-run`, `--when-ready`, `--remote`, or `--no-wait`. Only **GitHub** is supported (not GitLab/Gitea).
+Uses the `enqueuePullRequest` GraphQL mutation. Requires merge queue enabled in branch protection rules. Available on **GitHub Team and Enterprise Cloud** plans, or on **public repositories** on any plan. See [GitHub's merge queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) for setup instructions.
+
+#### GitLab
+
+Uses the [merge trains REST API](https://docs.gitlab.com/api/merge_trains/). Requires **GitLab Premium or Ultimate** and [merge request pipelines](https://docs.gitlab.com/ci/pipelines/merge_request_pipelines/) configured in `.gitlab-ci.yml`. MRs are added with `auto_merge` so they enter the train once their pipeline succeeds.
+
+#### Gitea / Forgejo
+
+**Not supported.** Gitea does not have a merge queue or merge train feature. Use `st merge` or `st merge --when-ready` instead.
+
+`--queue` cannot be combined with `--dry-run`, `--when-ready`, `--remote`, or `--no-wait`.
 
 ### Partial stack merge
 

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -52,6 +52,31 @@ After a successful run, run `st rs` to sync your local repository (delete merged
 
 `--remote` cannot be combined with `--dry-run`, `--when-ready`, or `--no-wait`. Only **GitHub** is supported (not GitLab/Gitea).
 
+### `--queue` mode (GitHub only)
+
+`st merge --queue` enqueues your stack PRs into [GitHub's merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue). Instead of merging PRs one-by-one (each waiting for CI), the merge queue batches them so CI runs once on the combined result. This is significantly faster for stacks with slow CI pipelines.
+
+```bash
+st merge --queue
+st merge --queue --all
+st merge --queue --yes
+```
+
+**What happens:**
+
+1. All stack PRs are retargeted to trunk
+2. Each PR is enqueued into the merge queue via the GitHub GraphQL API
+3. GitHub handles CI validation and merging automatically
+
+Once GitHub finishes merging, `st rs` (sync) will automatically detect the merged branches and clean up — just like any other merge path. No extra steps required beyond your normal workflow.
+
+> **Note:** GitHub merge queues require the repository to have merge queue enabled
+> in its branch protection rules. This feature is available on **GitHub Team and
+> Enterprise Cloud** plans, or on **public repositories** on any plan.
+> See [GitHub's merge queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) for setup instructions.
+
+`--queue` cannot be combined with `--dry-run`, `--when-ready`, `--remote`, or `--no-wait`. Only **GitHub** is supported (not GitLab/Gitea).
+
 ### Partial stack merge
 
 ```bash

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -66,9 +66,11 @@ st merge --queue --yes
 
 1. All stack PRs/MRs are retargeted to trunk
 2. Each PR/MR is enqueued into the merge queue via the forge API
-3. The forge handles CI validation and merging automatically
+3. stax polls until all PRs are merged (respects `--timeout` and `--interval`)
+4. Automatically runs `st rs` to clean up merged branches (unless `--no-sync`)
+5. Sends a desktop notification when complete
 
-Once the forge finishes merging, `st rs` (sync) will automatically detect the merged branches and clean up — just like any other merge path. No extra steps required beyond your normal workflow.
+This gives a "land and walk away" experience — enqueue, wait for CI, auto-cleanup — similar to Graphite's merge flow.
 
 #### GitHub
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -223,7 +223,7 @@ enum Commands {
         /// Supported on GitHub (merge queue) and GitLab (merge trains). Not available on Gitea.
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote"])]
         queue: bool,
-        /// Polling interval in seconds for --when-ready and --remote
+        /// Polling interval in seconds for --when-ready, --remote, and --queue
         #[arg(long, default_value = "15")]
         interval: u64,
         /// Skip post-merge sync (`stax rs`)
@@ -1360,7 +1360,7 @@ pub fn run() -> Result<()> {
         } => {
             let merge_method = method.parse().unwrap_or_default();
             if queue {
-                commands::merge_queue::run(all, yes, quiet)
+                commands::merge_queue::run(all, timeout, interval, no_sync, yes, quiet)
             } else if remote {
                 commands::merge_remote::run(
                     all,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -219,8 +219,8 @@ enum Commands {
         /// Merge via GitHub API only (no local checkout/rebase/push); GitHub updates branches remotely
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "queue"])]
         remote: bool,
-        /// Enqueue PRs into GitHub's merge queue instead of merging one-by-one.
-        /// Requires merge queue enabled in branch protection rules (GitHub Team/Enterprise, or public repos).
+        /// Enqueue PRs into the forge's merge queue instead of merging one-by-one.
+        /// Supported on GitHub (merge queue) and GitLab (merge trains). Not available on Gitea.
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote"])]
         queue: bool,
         /// Polling interval in seconds for --when-ready and --remote

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -214,11 +214,15 @@ enum Commands {
         #[arg(long, default_value = "30")]
         timeout: u64,
         /// Wait for each PR to be ready (CI + approval) before merging
-        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "remote"])]
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "remote", "queue"])]
         when_ready: bool,
         /// Merge via GitHub API only (no local checkout/rebase/push); GitHub updates branches remotely
-        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready"])]
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "queue"])]
         remote: bool,
+        /// Enqueue PRs into GitHub's merge queue instead of merging one-by-one.
+        /// Requires merge queue enabled in branch protection rules (GitHub Team/Enterprise, or public repos).
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote"])]
+        queue: bool,
         /// Polling interval in seconds for --when-ready and --remote
         #[arg(long, default_value = "15")]
         interval: u64,
@@ -1348,13 +1352,16 @@ pub fn run() -> Result<()> {
             timeout,
             when_ready,
             remote,
+            queue,
             interval,
             no_sync,
             yes,
             quiet,
         } => {
             let merge_method = method.parse().unwrap_or_default();
-            if remote {
+            if queue {
+                commands::merge_queue::run(all, yes, quiet)
+            } else if remote {
                 commands::merge_remote::run(
                     all,
                     merge_method,

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -1,8 +1,9 @@
-//! Enqueue a stack into the forge's merge queue — no polling, no local git.
+//! Enqueue a stack into the forge's merge queue, wait for completion, and sync.
 //!
-//! Retargets all stack PRs to trunk, then enqueues them via the forge's
-//! merge queue API (GitHub GraphQL `enqueuePullRequest`, GitLab merge
-//! trains REST API).  The forge handles CI and merging.
+//! Retargets all stack PRs to trunk, enqueues them via the forge's merge
+//! queue API (GitHub `enqueuePullRequest`, GitLab merge trains), then
+//! polls until all PRs are merged.  Finishes with auto-sync and a desktop
+//! notification — the same "land and walk away" experience as Graphite.
 
 use crate::config::Config;
 use crate::engine::Stack;
@@ -13,6 +14,8 @@ use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::process::Command;
+use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 struct QueueBranchInfo {
@@ -20,7 +23,7 @@ struct QueueBranchInfo {
     pr_number: u64,
 }
 
-pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
+pub fn run(all: bool, timeout: u64, interval: u64, no_sync: bool, yes: bool, quiet: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let current = repo.current_branch()?;
     let stack = Stack::load(&repo)?;
@@ -266,37 +269,170 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
             "{}",
             "Fix the issue and run 'stax merge --queue' to continue.".dimmed()
         );
-    } else if enqueued.is_empty() {
+        return Ok(());
+    }
+
+    if enqueued.is_empty() {
         if !quiet {
             println!("{}", "All PRs were already merged.".dimmed());
         }
-    } else {
-        print_header_success("Stack Enqueued");
-        println!();
-        println!(
-            "Enqueued {} {} into {}'s {}:",
-            enqueued.len(),
-            if enqueued.len() == 1 { "PR" } else { "PRs" },
-            trunk.cyan(),
-            queue_term,
-        );
-        for (branch, pr, position) in &enqueued {
-            let pos_str = match position {
-                Some(pos) => format!(" (position {})", pos),
-                None => String::new(),
-            };
-            println!("  {} #{} {}{}", "✓".green(), pr, branch, pos_str.dimmed());
-        }
+        return Ok(());
+    }
 
-        println!();
+    // --- Wait for the merge queue/train to process ---
+
+    if !quiet {
         println!(
             "{}",
             format!(
-                "{} will run CI and merge automatically. Run `stax rs` to sync once merged.",
-                forge_name
+                "Enqueued {} {}. Waiting for {} to merge...",
+                enqueued.len(),
+                if enqueued.len() == 1 { "PR" } else { "PRs" },
+                queue_term,
             )
             .dimmed()
         );
+        println!();
+    }
+
+    let timeout_duration = Duration::from_secs(timeout * 60);
+    let poll_interval = Duration::from_secs(interval);
+    let start = Instant::now();
+    let mut pending: Vec<(String, u64)> = enqueued
+        .iter()
+        .map(|(b, pr, _)| (b.clone(), *pr))
+        .collect();
+    let mut timed_out = false;
+
+    while !pending.is_empty() {
+        std::thread::sleep(poll_interval);
+
+        let elapsed = start.elapsed();
+        if elapsed > timeout_duration {
+            timed_out = true;
+            break;
+        }
+
+        let mut still_pending = Vec::new();
+        for (branch, pr) in &pending {
+            match rt.block_on(async { client.is_pr_merged(*pr).await }) {
+                Ok(true) => {
+                    if !quiet {
+                        println!(
+                            "  {} #{} {} merged  {}",
+                            "✓".green(),
+                            pr,
+                            branch,
+                            format!("({}s)", elapsed.as_secs()).dimmed()
+                        );
+                    }
+                }
+                Ok(false) => still_pending.push((branch.clone(), *pr)),
+                Err(_) => still_pending.push((branch.clone(), *pr)),
+            }
+        }
+        pending = still_pending;
+
+        if !pending.is_empty() && !quiet {
+            let names: Vec<String> = pending.iter().map(|(_, pr)| format!("#{}", pr)).collect();
+            print!(
+                "\r  {} {}  {}",
+                "⏳",
+                names.join(", "),
+                format!("({}s)", elapsed.as_secs()).dimmed()
+            );
+            // Flush without newline so the line updates in-place
+            use std::io::Write;
+            let _ = std::io::stdout().flush();
+        }
+    }
+
+    // Clear any in-place status line
+    if !quiet && !timed_out {
+        print!("\r{}\r", " ".repeat(72));
+    }
+    println!();
+
+    if timed_out {
+        if !quiet {
+            println!(
+                "{} {}",
+                "warning:".yellow().bold(),
+                format!(
+                    "Timed out after {} min waiting for {} to finish.",
+                    timeout, queue_term
+                )
+                .yellow()
+            );
+            println!(
+                "{}",
+                "Run `stax rs` manually to sync once merged.".dimmed()
+            );
+        }
+        return Ok(());
+    }
+
+    // --- All merged ---
+
+    print_header_success("Stack Merged");
+    println!();
+    println!(
+        "Merged {} {} into {} via {}:",
+        enqueued.len(),
+        if enqueued.len() == 1 { "PR" } else { "PRs" },
+        trunk.cyan(),
+        queue_term,
+    );
+    for (branch, pr, _) in &enqueued {
+        println!("  {} #{} {}", "✓".green(), pr, branch);
+    }
+
+    send_notification(
+        "stax merge --queue",
+        &format!(
+            "Merged {} {} into {}",
+            enqueued.len(),
+            if enqueued.len() == 1 { "PR" } else { "PRs" },
+            trunk
+        ),
+    );
+
+    if !no_sync {
+        if !quiet {
+            println!();
+            println!("{}", "Running post-merge sync...".dimmed());
+        }
+
+        // Release handles before sync opens a fresh repo view.
+        drop(rt);
+        drop(client);
+        drop(repo);
+
+        if let Err(err) = crate::commands::sync::run(
+            false, // restack
+            false, // prune
+            false, // full
+            true,  // delete merged branches
+            false, // delete upstream-gone
+            true,  // force
+            false, // safe
+            false, // continue
+            quiet, false, // verbose
+            false, // auto_stash_pop
+        ) {
+            if !quiet {
+                println!();
+                println!(
+                    "{} {}",
+                    "warning:".yellow().bold(),
+                    format!("post-merge sync failed: {}", err).yellow()
+                );
+                println!(
+                    "{}",
+                    "Run 'stax rs --force' manually to sync local state.".dimmed()
+                );
+            }
+        }
     }
 
     Ok(())
@@ -313,6 +449,17 @@ fn calculate_queue_scope(stack: &Stack, current: &str, all: bool) -> (Vec<String
     }
 
     (to_queue, stack.trunk.clone())
+}
+
+fn send_notification(title: &str, message: &str) {
+    if cfg!(target_os = "macos") {
+        let script = format!(
+            r#"display notification "{}" with title "{}""#,
+            message.replace('"', "\\\""),
+            title.replace('"', "\\\""),
+        );
+        let _ = Command::new("osascript").args(["-e", &script]).output();
+    }
 }
 
 fn capitalize(s: &str) -> String {

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -1,0 +1,381 @@
+//! Enqueue a stack into GitHub's merge queue — no polling, no local git.
+//!
+//! Retargets all stack PRs to trunk, then enqueues them via the
+//! `enqueuePullRequest` GraphQL mutation.  GitHub handles CI and merging.
+
+use crate::config::Config;
+use crate::engine::Stack;
+use crate::forge::ForgeClient;
+use crate::git::GitRepo;
+use crate::progress::LiveTimer;
+use crate::remote::{ForgeType, RemoteInfo};
+use anyhow::{Context, Result};
+use colored::Colorize;
+use dialoguer::{theme::ColorfulTheme, Confirm};
+
+#[derive(Debug)]
+struct QueueBranchInfo {
+    branch: String,
+    pr_number: u64,
+}
+
+pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let current = repo.current_branch()?;
+    let stack = Stack::load(&repo)?;
+    let config = Config::load()?;
+
+    if current == stack.trunk {
+        if !quiet {
+            println!(
+                "{}",
+                "You are on trunk. Checkout a branch in a stack to merge.".yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    if !stack.branches.contains_key(&current) {
+        if !quiet {
+            println!(
+                "{}",
+                format!(
+                    "Branch '{}' is not tracked. Run 'stax branch track' first.",
+                    current
+                )
+                .yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    let remote_info = RemoteInfo::from_repo(&repo, &config)
+        .context("Failed to read git remote configuration")?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax merge --queue` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+
+    let client = ForgeClient::new(&remote_info).context(
+        "Failed to connect to the configured forge. Check your token and remote configuration.",
+    )?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+
+    let (to_queue, trunk) = calculate_queue_scope(&stack, &current, all);
+
+    let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching PR info...");
+
+    let open_prs = rt
+        .block_on(async { client.list_open_prs_by_head().await })
+        .ok();
+
+    let mut branches: Vec<QueueBranchInfo> = Vec::new();
+    for branch_name in &to_queue {
+        let pr_number = stack
+            .branches
+            .get(branch_name)
+            .and_then(|b| b.pr_number)
+            .or_else(|| {
+                open_prs
+                    .as_ref()
+                    .and_then(|prs| prs.get(branch_name))
+                    .map(|pr| pr.info.number)
+            });
+
+        match pr_number {
+            Some(num) => branches.push(QueueBranchInfo {
+                branch: branch_name.clone(),
+                pr_number: num,
+            }),
+            None => {
+                LiveTimer::maybe_finish_err(fetch_timer, "missing PR");
+                anyhow::bail!(
+                    "Branch '{}' has no PR. Run 'stax submit' first to create PRs.",
+                    branch_name
+                );
+            }
+        }
+    }
+
+    LiveTimer::maybe_finish_ok(fetch_timer, "done");
+
+    if branches.is_empty() {
+        if !quiet {
+            println!("{}", "No branches to enqueue.".yellow());
+        }
+        return Ok(());
+    }
+
+    if !quiet {
+        println!();
+        print_header("Merge Queue");
+        println!();
+        let pr_word = if branches.len() == 1 { "PR" } else { "PRs" };
+        println!(
+            "Will retarget and enqueue {} {} into {}'s merge queue:",
+            branches.len().to_string().bold(),
+            pr_word,
+            trunk.cyan()
+        );
+        println!();
+        for (idx, branch) in branches.iter().enumerate() {
+            println!(
+                "  {}. {} (#{})",
+                (idx + 1).to_string().bold(),
+                branch.branch.bold(),
+                branch.pr_number,
+            );
+        }
+        println!();
+        println!(
+            "{}",
+            "GitHub will run CI on the combined changes and merge automatically.".dimmed()
+        );
+    }
+
+    if !yes {
+        let confirm = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Proceed with merge --queue?")
+            .default(false)
+            .interact()?;
+
+        if !confirm {
+            println!("{}", "Aborted.".dimmed());
+            return Ok(());
+        }
+    }
+
+    if !quiet {
+        println!();
+        print_header("Enqueuing");
+    }
+
+    let total = branches.len();
+    let mut enqueued: Vec<(String, u64, Option<u32>)> = Vec::new();
+    let mut failed: Option<(String, u64, String)> = None;
+
+    for (idx, branch) in branches.iter().enumerate() {
+        if !quiet {
+            println!(
+                "\n[{}/{}] {} (#{})",
+                (idx + 1).to_string().cyan(),
+                total,
+                branch.branch.bold(),
+                branch.pr_number
+            );
+        }
+
+        match rt.block_on(async { client.is_pr_merged(branch.pr_number).await }) {
+            Ok(true) => {
+                if !quiet {
+                    println!("      {} Already merged", "✓".green());
+                }
+                continue;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                failed = Some((
+                    branch.branch.clone(),
+                    branch.pr_number,
+                    format!("Failed to check merge status: {}", e),
+                ));
+                break;
+            }
+        }
+
+        let retarget_timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!("Retargeting #{} to {}...", branch.pr_number, trunk),
+        );
+
+        match rt.block_on(async { client.update_pr_base(branch.pr_number, &trunk).await }) {
+            Ok(()) => LiveTimer::maybe_finish_ok(retarget_timer, "done"),
+            Err(e) => {
+                LiveTimer::maybe_finish_err(retarget_timer, "failed");
+                failed = Some((
+                    branch.branch.clone(),
+                    branch.pr_number,
+                    format!("Failed to retarget PR: {}", e),
+                ));
+                break;
+            }
+        }
+
+        let enqueue_timer =
+            LiveTimer::maybe_new(!quiet, &format!("Enqueuing #{}...", branch.pr_number));
+
+        match rt.block_on(async { client.enqueue_pr(branch.pr_number).await }) {
+            Ok(result) => {
+                let position = result.merge_queue_entry.and_then(|e| e.position);
+                let msg = match position {
+                    Some(pos) => format!("queued at position {}", pos),
+                    None => "queued".to_string(),
+                };
+                LiveTimer::maybe_finish_ok(enqueue_timer, &msg);
+                enqueued.push((branch.branch.clone(), branch.pr_number, position));
+            }
+            Err(e) => {
+                LiveTimer::maybe_finish_err(enqueue_timer, "failed");
+                failed = Some((
+                    branch.branch.clone(),
+                    branch.pr_number,
+                    format!("Failed to enqueue: {}", e),
+                ));
+                break;
+            }
+        }
+    }
+
+    println!();
+
+    if let Some((branch, pr, reason)) = &failed {
+        print_header_error("Merge Queue Failed");
+        println!();
+        println!("Progress:");
+        for (queued_branch, queued_pr, _) in &enqueued {
+            println!(
+                "  {} #{} {} → enqueued",
+                "✓".green(),
+                queued_pr,
+                queued_branch
+            );
+        }
+        println!("  {} #{} {} → {}", "✗".red(), pr, branch, reason);
+        println!();
+        println!(
+            "{}",
+            "Already enqueued PRs remain in the merge queue.".dimmed()
+        );
+        println!(
+            "{}",
+            "Fix the issue and run 'stax merge --queue' to continue.".dimmed()
+        );
+    } else if enqueued.is_empty() {
+        if !quiet {
+            println!("{}", "All PRs were already merged.".dimmed());
+        }
+    } else {
+        print_header_success("Stack Enqueued");
+        println!();
+        println!(
+            "Enqueued {} {} into {}'s merge queue:",
+            enqueued.len(),
+            if enqueued.len() == 1 { "PR" } else { "PRs" },
+            trunk.cyan()
+        );
+        for (branch, pr, position) in &enqueued {
+            let pos_str = match position {
+                Some(pos) => format!(" (position {})", pos),
+                None => String::new(),
+            };
+            println!("  {} #{} {}{}", "✓".green(), pr, branch, pos_str.dimmed());
+        }
+
+        println!();
+        println!(
+            "{}",
+            "GitHub will run CI and merge automatically. Run `stax rs` to sync once merged."
+                .dimmed()
+        );
+    }
+
+    Ok(())
+}
+
+fn calculate_queue_scope(stack: &Stack, current: &str, all: bool) -> (Vec<String>, String) {
+    let mut to_queue = stack.ancestors(current);
+    to_queue.reverse();
+    to_queue.retain(|b| b != &stack.trunk);
+    to_queue.push(current.to_string());
+
+    if all {
+        to_queue.extend(stack.descendants(current));
+    }
+
+    (to_queue, stack.trunk.clone())
+}
+
+// --- Display helpers (same as merge_remote.rs) ---
+
+fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut in_escape = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+            continue;
+        }
+        if in_escape {
+            if c == 'm' {
+                in_escape = false;
+            }
+            continue;
+        }
+        result.push(c);
+    }
+    result
+}
+
+fn display_width(s: &str) -> usize {
+    let stripped = strip_ansi(s);
+    stripped
+        .chars()
+        .map(|c| match c {
+            '\x00'..='\x1f' | '\x7f' => 0,
+            '\x20'..='\x7e' => 1,
+            '─' | '│' | '┌' | '┐' | '└' | '┘' | '├' | '┤' | '┬' | '┴' | '┼' | '╭' | '╮'
+            | '╯' | '╰' | '║' | '═' => 1,
+            '←' | '→' | '↑' | '↓' => 1,
+            '✓' | '✗' | '✔' | '✘' => 1,
+            _ => 2,
+        })
+        .sum()
+}
+
+fn print_header(title: &str) {
+    let width: usize = 56;
+    let title_width = display_width(title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        title.bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}
+
+fn print_header_success(title: &str) {
+    let width: usize = 56;
+    let full_title = format!("✓ {}", title);
+    let title_width = display_width(&full_title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        full_title.green().bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}
+
+fn print_header_error(title: &str) {
+    let width: usize = 56;
+    let full_title = format!("✗ {}", title);
+    let title_width = display_width(&full_title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        full_title.red().bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -1,7 +1,8 @@
-//! Enqueue a stack into GitHub's merge queue — no polling, no local git.
+//! Enqueue a stack into the forge's merge queue — no polling, no local git.
 //!
-//! Retargets all stack PRs to trunk, then enqueues them via the
-//! `enqueuePullRequest` GraphQL mutation.  GitHub handles CI and merging.
+//! Retargets all stack PRs to trunk, then enqueues them via the forge's
+//! merge queue API (GitHub GraphQL `enqueuePullRequest`, GitLab merge
+//! trains REST API).  The forge handles CI and merging.
 
 use crate::config::Config;
 use crate::engine::Stack;
@@ -51,16 +52,18 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
 
     let remote_info = RemoteInfo::from_repo(&repo, &config)
         .context("Failed to read git remote configuration")?;
-    if remote_info.forge != ForgeType::GitHub {
+    if remote_info.forge == ForgeType::Gitea {
         anyhow::bail!(
-            "`stax merge --queue` is only supported for GitHub remotes (found {})",
-            remote_info.forge
+            "`stax merge --queue` is not supported for Gitea/Forgejo — \
+             Gitea does not have a merge queue feature.\n\
+             Tip: use `stax merge` or `stax merge --when-ready` instead."
         );
     }
 
     let client = ForgeClient::new(&remote_info).context(
         "Failed to connect to the configured forge. Check your token and remote configuration.",
     )?;
+    let forge_name = remote_info.forge.to_string();
 
     let rt = tokio::runtime::Runtime::new()?;
     let _enter = rt.enter();
@@ -133,7 +136,11 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
         println!();
         println!(
             "{}",
-            "GitHub will run CI on the combined changes and merge automatically.".dimmed()
+            format!(
+                "{} will run CI on the combined changes and merge automatically.",
+                forge_name
+            )
+            .dimmed()
         );
     }
 
@@ -278,8 +285,11 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
         println!();
         println!(
             "{}",
-            "GitHub will run CI and merge automatically. Run `stax rs` to sync once merged."
-                .dimmed()
+            format!(
+                "{} will run CI and merge automatically. Run `stax rs` to sync once merged.",
+                forge_name
+            )
+            .dimmed()
         );
     }
 

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -64,6 +64,10 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
         "Failed to connect to the configured forge. Check your token and remote configuration.",
     )?;
     let forge_name = remote_info.forge.to_string();
+    let queue_term = match remote_info.forge {
+        ForgeType::GitLab => "merge train",
+        _ => "merge queue",
+    };
 
     let rt = tokio::runtime::Runtime::new()?;
     let _enter = rt.enter();
@@ -115,14 +119,15 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
 
     if !quiet {
         println!();
-        print_header("Merge Queue");
+        print_header(&capitalize(queue_term));
         println!();
         let pr_word = if branches.len() == 1 { "PR" } else { "PRs" };
         println!(
-            "Will retarget and enqueue {} {} into {}'s merge queue:",
+            "Will retarget and enqueue {} {} into {}'s {}:",
             branches.len().to_string().bold(),
             pr_word,
-            trunk.cyan()
+            trunk.cyan(),
+            queue_term,
         );
         println!();
         for (idx, branch) in branches.iter().enumerate() {
@@ -240,7 +245,7 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
     println!();
 
     if let Some((branch, pr, reason)) = &failed {
-        print_header_error("Merge Queue Failed");
+        print_header_error(&format!("{} Failed", capitalize(queue_term)));
         println!();
         println!("Progress:");
         for (queued_branch, queued_pr, _) in &enqueued {
@@ -255,7 +260,7 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
         println!();
         println!(
             "{}",
-            "Already enqueued PRs remain in the merge queue.".dimmed()
+            format!("Already enqueued PRs remain in the {}.", queue_term).dimmed()
         );
         println!(
             "{}",
@@ -269,10 +274,11 @@ pub fn run(all: bool, yes: bool, quiet: bool) -> Result<()> {
         print_header_success("Stack Enqueued");
         println!();
         println!(
-            "Enqueued {} {} into {}'s merge queue:",
+            "Enqueued {} {} into {}'s {}:",
             enqueued.len(),
             if enqueued.len() == 1 { "PR" } else { "PRs" },
-            trunk.cyan()
+            trunk.cyan(),
+            queue_term,
         );
         for (branch, pr, position) in &enqueued {
             let pos_str = match position {
@@ -307,6 +313,14 @@ fn calculate_queue_scope(stack: &Stack, current: &str, all: bool) -> (Vec<String
     }
 
     (to_queue, stack.trunk.clone())
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+    }
 }
 
 // --- Display helpers (same as merge_remote.rs) ---

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod log;
 pub mod merge;
 pub(crate) mod merge_rebase;
 pub mod merge_remote;
+pub mod merge_queue;
 pub mod merge_when_ready;
 pub mod modify;
 pub mod navigate;

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -118,10 +118,7 @@ struct MergeMrRequest<'a> {
 
 #[derive(Serialize)]
 struct AddToMergeTrainRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    auto_merge: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    squash: Option<bool>,
+    auto_merge: bool,
 }
 
 #[derive(Serialize)]
@@ -339,8 +336,7 @@ impl GitLabClient {
         number: u64,
     ) -> Result<crate::github::pr::EnqueueResult> {
         let request = AddToMergeTrainRequest {
-            auto_merge: Some(true),
-            squash: None,
+            auto_merge: true,
         };
         let _: serde_json::Value = post_json(
             &self.client,

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -117,6 +117,14 @@ struct MergeMrRequest<'a> {
 }
 
 #[derive(Serialize)]
+struct AddToMergeTrainRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_merge: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    squash: Option<bool>,
+}
+
+#[derive(Serialize)]
 struct CreateNoteRequest<'a> {
     body: &'a str,
 }
@@ -319,6 +327,34 @@ impl GitLabClient {
             .collect::<Vec<_>>();
         comments.sort_by_key(|comment| comment.created_at());
         Ok(comments)
+    }
+
+    /// Add an MR to GitLab's merge train.
+    ///
+    /// Uses `auto_merge: true` so the MR is scheduled to enter the merge train
+    /// once its pipeline succeeds. Requires GitLab Premium/Ultimate and merge
+    /// trains enabled in the project CI/CD settings.
+    pub async fn add_to_merge_train(
+        &self,
+        number: u64,
+    ) -> Result<crate::github::pr::EnqueueResult> {
+        let request = AddToMergeTrainRequest {
+            auto_merge: Some(true),
+            squash: None,
+        };
+        let _: serde_json::Value = post_json(
+            &self.client,
+            &self.project_url(&format!("/merge_trains/merge_requests/{}", number)),
+            &request,
+        )
+        .await
+        .context(
+            "Failed to add MR to merge train. Ensure merge trains are enabled \
+             (GitLab Premium/Ultimate) and merge request pipelines are configured.",
+        )?;
+        Ok(crate::github::pr::EnqueueResult {
+            merge_queue_entry: Some(crate::github::pr::MergeQueueEntry { position: None }),
+        })
     }
 
     pub async fn merge_pr(

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -169,15 +169,20 @@ impl ForgeClient {
         dispatch!(self, update_pr_base(number, new_base))
     }
 
-    /// GitHub only: enqueue a PR into GitHub's merge queue.
+    /// Enqueue a PR into the forge's merge queue (GitHub) or merge train (GitLab).
+    /// Not supported on Gitea/Forgejo (no merge queue feature).
     pub async fn enqueue_pr(
         &self,
         number: u64,
     ) -> Result<crate::github::pr::EnqueueResult> {
         match self {
             Self::GitHub(client) => client.enqueue_pr(number).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                bail!("`stax merge --queue` is only supported for GitHub repos with merge queue enabled")
+            Self::GitLab(client) => client.add_to_merge_train(number).await,
+            Self::Gitea(_) => {
+                bail!(
+                    "`stax merge --queue` is not supported for Gitea/Forgejo — \
+                     Gitea does not have a merge queue feature"
+                )
             }
         }
     }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -169,6 +169,19 @@ impl ForgeClient {
         dispatch!(self, update_pr_base(number, new_base))
     }
 
+    /// GitHub only: enqueue a PR into GitHub's merge queue.
+    pub async fn enqueue_pr(
+        &self,
+        number: u64,
+    ) -> Result<crate::github::pr::EnqueueResult> {
+        match self {
+            Self::GitHub(client) => client.enqueue_pr(number).await,
+            Self::GitLab(_) | Self::Gitea(_) => {
+                bail!("`stax merge --queue` is only supported for GitHub repos with merge queue enabled")
+            }
+        }
+    }
+
     /// GitHub only: merge the PR base into the head branch remotely ("Update branch").
     pub async fn update_pr_branch(&self, number: u64) -> Result<()> {
         match self {

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -262,6 +262,41 @@ struct PrReviewData {
     repository: Option<RepositoryData>,
 }
 
+// --- Merge queue (enqueuePullRequest) GraphQL types ---
+
+#[derive(Debug, Deserialize)]
+struct PrNodeIdData {
+    repository: Option<PrNodeIdRepo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrNodeIdRepo {
+    #[serde(rename = "pullRequest")]
+    pull_request: Option<PrNodeId>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrNodeId {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnqueueData {
+    #[serde(rename = "enqueuePullRequest")]
+    enqueue_pull_request: Option<EnqueueResult>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EnqueueResult {
+    #[serde(rename = "mergeQueueEntry")]
+    pub merge_queue_entry: Option<MergeQueueEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MergeQueueEntry {
+    pub position: Option<u32>,
+}
+
 #[derive(Debug, Deserialize)]
 struct RepositoryData {
     #[serde(rename = "pullRequest")]
@@ -835,6 +870,83 @@ impl GitHubClient {
             .unwrap_or((None, 0, false));
 
         Ok((review_decision, approvals, changes_requested))
+    }
+
+    /// Get the GraphQL node ID for a PR (needed for mutations like enqueuePullRequest).
+    async fn get_pr_node_id(&self, pr_number: u64) -> Result<String> {
+        let query = format!(
+            r#"
+            query {{
+                repository(owner: "{}", name: "{}") {{
+                    pullRequest(number: {}) {{
+                        id
+                    }}
+                }}
+            }}
+            "#,
+            self.owner, self.repo, pr_number
+        );
+
+        let response: GraphQLResponse<PrNodeIdData> = self
+            .octocrab
+            .graphql(&serde_json::json!({ "query": query }))
+            .await
+            .context("Failed to query PR node ID")?;
+
+        if let Some(errors) = response.errors {
+            if !errors.is_empty() {
+                anyhow::bail!("GraphQL error: {}", errors[0].message);
+            }
+        }
+
+        response
+            .data
+            .and_then(|d| d.repository)
+            .and_then(|r| r.pull_request)
+            .map(|pr| pr.id)
+            .context("PR not found")
+    }
+
+    /// Enqueue a PR into GitHub's merge queue.
+    ///
+    /// Requires the repository to have merge queue enabled in branch protection rules.
+    /// Returns the queue entry with position information.
+    pub async fn enqueue_pr(&self, pr_number: u64) -> Result<EnqueueResult> {
+        let node_id = self.get_pr_node_id(pr_number).await?;
+
+        let mutation = format!(
+            r#"
+            mutation {{
+                enqueuePullRequest(input: {{ pullRequestId: "{}" }}) {{
+                    mergeQueueEntry {{
+                        position
+                    }}
+                }}
+            }}
+            "#,
+            node_id
+        );
+
+        let response: GraphQLResponse<EnqueueData> = self
+            .octocrab
+            .graphql(&serde_json::json!({ "query": mutation }))
+            .await
+            .context("Failed to enqueue PR into merge queue")?;
+
+        if let Some(errors) = response.errors {
+            if !errors.is_empty() {
+                anyhow::bail!(
+                    "Failed to enqueue PR #{} into merge queue: {}",
+                    pr_number,
+                    errors[0].message
+                );
+            }
+        }
+
+        response
+            .data
+            .and_then(|d| d.enqueue_pull_request)
+            .context("No enqueue result returned — is merge queue enabled on this repository?")
     }
 
     /// Check if a PR is already merged


### PR DESCRIPTION
## Summary

- Adds `st merge --queue` flag that enqueues stack PRs into the forge's merge queue, waits for completion, and auto-syncs
- **GitHub**: uses the `enqueuePullRequest` GraphQL mutation
- **GitLab**: uses the merge trains REST API (`POST /merge_trains/merge_requests/:iid`) with `auto_merge: true`
- **Gitea/Forgejo**: not supported — no merge queue feature; clear error suggests alternatives
- After enqueuing, polls until all PRs are merged, then auto-cleans up via `stax rs` and sends a desktop notification — a "land and walk away" experience similar to Graphite

Closes #138

## Changes

- **`src/commands/merge_queue.rs`** — command implementing enqueue → poll → sync → notify flow
- **`src/cli.rs`** — `--queue` flag with `--timeout`/`--interval`/`--no-sync` support
- **`src/github/pr.rs`** — `enqueue_pr` and `get_pr_node_id` methods using GitHub GraphQL API
- **`src/forge/gitlab.rs`** — `add_to_merge_train` method using GitLab merge trains REST API
- **`src/forge/mod.rs`** — `enqueue_pr` dispatches to GitHub/GitLab, bails on Gitea
- **`docs/workflows/merge-and-cascade.md`** — documents `--queue` mode with per-forge details

## What it looks like

```
╭────────────────────────────────────────────────────────╮
│                     Merge Queue                        │
╰────────────────────────────────────────────────────────╯

Will retarget and enqueue 2 PRs into main's merge queue:

  1. feature-a (#42)
  2. feature-b (#43)

GitHub will run CI on the combined changes and merge automatically.

╭────────────────────────────────────────────────────────╮
│                      Enqueuing                         │
╰────────────────────────────────────────────────────────╯

[1/2] feature-a (#42)
      Retargeting #42 to main... ✓ done
      Enqueuing #42... ✓ queued at position 1

[2/2] feature-b (#43)
      Retargeting #43 to main... ✓ done
      Enqueuing #43... ✓ queued at position 2

Enqueued 2 PRs. Waiting for merge queue to merge...

  ✓ #42 feature-a merged  (45s)
  ✓ #43 feature-b merged  (90s)

╭────────────────────────────────────────────────────────╮
│                   ✓ Stack Merged                       │
╰────────────────────────────────────────────────────────╯

Merged 2 PRs into main via merge queue:
  ✓ #42 feature-a
  ✓ #43 feature-b

Running post-merge sync...
```

## Forge support matrix

| Forge | Supported | Mechanism | Requirements |
|-------|-----------|-----------|-------------|
| GitHub | Yes | `enqueuePullRequest` GraphQL mutation | Merge queue in branch protection (Team/Enterprise/public) |
| GitLab | Yes | `POST /projects/:id/merge_trains/merge_requests/:iid` | Premium/Ultimate + MR pipelines in CI config |
| Gitea/Forgejo | No | N/A | No merge queue feature exists |

## Test plan

- [ ] Build passes (`cargo build`)
- [ ] Test with a GitHub repo that has merge queue enabled
- [ ] Test with a GitLab Premium repo that has merge trains enabled
- [ ] Verify polling shows live status and completes when PRs merge
- [ ] Verify auto-sync runs after all PRs merge
- [ ] Verify macOS notification fires on completion
- [ ] Verify `--timeout` causes graceful exit with helpful message
- [ ] Verify `--no-sync` skips post-merge cleanup
- [ ] Verify `--queue` conflicts correctly with `--dry-run`, `--no-wait`, `--when-ready`, `--remote`
- [ ] Verify clear error when used on Gitea remotes
- [ ] Verify `--queue` uses correct terminology ("merge train" for GitLab, "merge queue" for GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)