### PR TITLE
feat(modify): add `--restack` flag to auto-restack after modify

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -35,7 +35,7 @@
 | Command | Alias | Description |
 |---|---|---|
 | `st create <name>` | `c`, `bc` | Create stacked branch |
-| `st modify` | `m` | Amend staged changes into current commit; prompts when nothing is staged (`-a` to stage all); on a fresh tracked branch, `-m` creates the first commit safely |
+| `st modify` | `m` | Amend staged changes into current commit; prompts when nothing is staged (`-a` to stage all); on a fresh tracked branch, `-m` creates the first commit safely; `-r` restacks the stack afterwards |
 | `st rename` | | Rename current branch |
 | `st branch track` | | Track existing branch |
 | `st branch track --all-prs` | | Track all open PRs (GitHub, GitLab, Gitea) |
@@ -146,6 +146,8 @@ Worktree launch examples:
 
 - `st modify -a` (stage all and amend, old default behavior)
 - `st modify -am "msg"` (stage all and amend with new message)
+- `st modify -r` (amend and restack the stack)
+- `st modify -ar` (stage all, amend, and restack)
 - `st create -am "msg"`
 - `st branch create --message "msg" --prefix feature/`
 - `st branch reparent --branch feature-a --parent main`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -396,6 +396,9 @@ enum Commands {
         /// Skip pre-commit and commit-msg hooks
         #[arg(long = "no-verify", short = 'n')]
         no_verify: bool,
+        /// Restack the stack after modifying
+        #[arg(short, long)]
+        restack: bool,
     },
 
     /// Authenticate with GitHub
@@ -1480,7 +1483,8 @@ pub fn run() -> Result<()> {
             all,
             quiet,
             no_verify,
-        } => commands::modify::run(message, all, quiet, no_verify),
+            restack,
+        } => commands::modify::run(message, all, quiet, no_verify, restack),
         Commands::Auth { .. } => unreachable!(), // Handled above
         Commands::Config { .. } => unreachable!(), // Handled above
         Commands::Init { .. } => unreachable!(), // Handled above

--- a/src/commands/modify.rs
+++ b/src/commands/modify.rs
@@ -16,7 +16,7 @@ enum ModifyTarget {
 /// When files are already staged, only those files are committed.
 /// When nothing is staged, prompts to stage all (or use `-a`).
 /// On a fresh tracked branch, `-m` creates the first branch-local commit safely.
-pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool) -> Result<()> {
+pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool, restack: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let workdir = repo.workdir()?;
     let current = repo.current_branch()?;
@@ -145,6 +145,22 @@ pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool) -> 
                 println!("{} {}", "Committed".green(), current.cyan());
             }
         }
+    }
+
+    if restack {
+        if !quiet {
+            println!();
+        }
+        super::restack::run(
+            false,  // all
+            false,  // stop_here
+            false,  // continue
+            false,  // dry_run
+            true,   // yes (skip confirmation)
+            quiet,
+            false,  // auto_stash_pop
+            super::restack::SubmitAfterRestack::No,
+        )?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Adds a `-r`/`--restack` flag to `stax modify` (`stax m`) that automatically restacks the current stack after amending or creating the first branch-local commit
- Addresses the workflow gap described in #235 — users coming from Graphite/Charcoal expect modify to restack automatically
- The flag is opt-in, so existing behavior is unchanged

## Usage

```sh
# Modify and restack in one step
stax m -r

# With other flags
stax m -a -r -m "update feature"
```

## Test plan

- [ ] Verify `stax m` still works without `--restack` (no behavior change)
- [ ] Verify `stax m -r` amends and then restacks the current stack
- [ ] Verify `stax m -r --quiet` suppresses output from both modify and restack
- [ ] Verify `stax m -r -m "msg"` works for first-commit-on-branch case followed by restack
- [ ] Verify restack conflicts are surfaced correctly when triggered via `--restack`

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)