### PR TITLE
fix(merge): retarget dependent PR after merge, not before

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -264,12 +264,32 @@ pub fn run(
                 }
             }
 
+            // Merge the PR
+            let merge_timer =
+                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
+
+            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
+                Ok(()) => {
+                    LiveTimer::maybe_finish_ok(merge_timer, "done");
+                    merged_prs.push((branch_info.branch.clone(), pr_number));
+
+                    // Record CI history for the merged branch
+                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_info.branch);
+                }
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(merge_timer, "failed");
+                    failed_pr = Some((branch_info.branch.clone(), pr_number, e.to_string()));
+                    break;
+                }
+            }
+
+            // Retarget next PR to trunk after successful merge
             if let Some(next_branch) = next_branch {
                 let next_pr = next_branch.pr_number.unwrap();
                 let update_base_timer = LiveTimer::maybe_new(
                     !quiet,
                     &format!(
-                        "Retargeting #{} to {} before merge...",
+                        "Retargeting #{} to {}...",
                         next_pr, scope.trunk
                     ),
                 );
@@ -287,25 +307,6 @@ pub fn run(
                         ));
                         break;
                     }
-                }
-            }
-
-            // Merge the PR
-            let merge_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
-
-            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
-                Ok(()) => {
-                    LiveTimer::maybe_finish_ok(merge_timer, "done");
-                    merged_prs.push((branch_info.branch.clone(), pr_number));
-
-                    // Record CI history for the merged branch
-                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_info.branch);
-                }
-                Err(e) => {
-                    LiveTimer::maybe_finish_err(merge_timer, "failed");
-                    failed_pr = Some((branch_info.branch.clone(), pr_number, e.to_string()));
-                    break;
                 }
             }
         }

--- a/src/commands/merge_remote.rs
+++ b/src/commands/merge_remote.rs
@@ -258,11 +258,28 @@ pub fn run(
                 }
             }
 
+            let merge_timer =
+                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
+
+            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
+                Ok(()) => {
+                    LiveTimer::maybe_finish_ok(merge_timer, "done");
+                    merged_prs.push((branch_name.clone(), pr_number));
+                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_name);
+                }
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(merge_timer, "failed");
+                    failed_pr = Some((branch_name, pr_number, e.to_string()));
+                    break;
+                }
+            }
+
+            // Retarget next PR to trunk after successful merge
             if let Some(ref next_branch) = next_branch {
                 let update_base_timer = LiveTimer::maybe_new(
                     !quiet,
                     &format!(
-                        "Retargeting #{} to {} before merge...",
+                        "Retargeting #{} to {}...",
                         next_branch.pr_number, scope.trunk
                     ),
                 );
@@ -285,22 +302,6 @@ pub fn run(
                         ));
                         break;
                     }
-                }
-            }
-
-            let merge_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
-
-            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
-                Ok(()) => {
-                    LiveTimer::maybe_finish_ok(merge_timer, "done");
-                    merged_prs.push((branch_name.clone(), pr_number));
-                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_name);
-                }
-                Err(e) => {
-                    LiveTimer::maybe_finish_err(merge_timer, "failed");
-                    failed_pr = Some((branch_name, pr_number, e.to_string()));
-                    break;
                 }
             }
         }

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -290,11 +290,35 @@ pub fn run(
                 }
             }
 
+            // Merge the PR
+            branches[idx].status = LandStatus::Merging;
+            let merge_timer =
+                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
+
+            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
+                Ok(()) => {
+                    LiveTimer::maybe_finish_ok(merge_timer, "done");
+                    branches[idx].status = LandStatus::Merged;
+                    merged_prs.push((branch_name.clone(), pr_number));
+
+                    // Record CI history
+                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_name);
+                }
+                Err(e) => {
+                    LiveTimer::maybe_finish_err(merge_timer, "failed");
+                    let reason = e.to_string();
+                    branches[idx].status = LandStatus::Failed(reason.clone());
+                    failed_pr = Some((branch_name, pr_number, reason));
+                    break;
+                }
+            }
+
+            // Retarget next PR to trunk after successful merge
             if let Some(next_branch) = &next_branch {
                 let update_base_timer = LiveTimer::maybe_new(
                     !quiet,
                     &format!(
-                        "Retargeting #{} to {} before merge...",
+                        "Retargeting #{} to {}...",
                         next_branch.pr_number, scope.trunk
                     ),
                 );
@@ -317,29 +341,6 @@ pub fn run(
                         failed_pr = Some((branch_name, pr_number, reason));
                         break;
                     }
-                }
-            }
-
-            // Merge the PR
-            branches[idx].status = LandStatus::Merging;
-            let merge_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Merging ({})...", method.as_str()));
-
-            match rt.block_on(async { client.merge_pr(pr_number, method, None, None).await }) {
-                Ok(()) => {
-                    LiveTimer::maybe_finish_ok(merge_timer, "done");
-                    branches[idx].status = LandStatus::Merged;
-                    merged_prs.push((branch_name.clone(), pr_number));
-
-                    // Record CI history
-                    record_ci_history_for_branch(&repo, &rt, &client, &stack, &branch_name);
-                }
-                Err(e) => {
-                    LiveTimer::maybe_finish_err(merge_timer, "failed");
-                    let reason = e.to_string();
-                    branches[idx].status = LandStatus::Failed(reason.clone());
-                    failed_pr = Some((branch_name, pr_number, reason));
-                    break;
                 }
             }
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6956,7 +6956,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_retargets_next_pr_before_merging_parent_pr() {
+    async fn test_merge_retargets_next_pr_after_merging_parent_pr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -7093,8 +7093,8 @@ mod forge_mock_tests {
         let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/102");
         let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/101/merge");
         assert!(
-            patch_idx < merge_idx,
-            "Expected dependent PR retarget before parent merge, requests were: {:?}",
+            patch_idx > merge_idx,
+            "Expected dependent PR retarget after parent merge, requests were: {:?}",
             requests
                 .iter()
                 .map(|request| format!("{} {}", request.method, request.url.path()))
@@ -7305,7 +7305,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_when_ready_retargets_next_pr_before_merging_parent_pr() {
+    async fn test_merge_when_ready_retargets_next_pr_after_merging_parent_pr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -7452,8 +7452,8 @@ mod forge_mock_tests {
         let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/202");
         let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/201/merge");
         assert!(
-            patch_idx < merge_idx,
-            "Expected dependent PR retarget before parent merge, requests were: {:?}",
+            patch_idx > merge_idx,
+            "Expected dependent PR retarget after parent merge, requests were: {:?}",
             requests
                 .iter()
                 .map(|request| format!("{} {}", request.method, request.url.path()))
@@ -7462,7 +7462,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_remote_retargets_and_updates_branch_before_merging() {
+    async fn test_merge_remote_retargets_and_updates_branch_after_merging() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -7624,8 +7624,8 @@ mod forge_mock_tests {
         let merge2_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/302/merge");
 
         assert!(
-            patch_idx < merge1_idx,
-            "Expected dependent PR retarget before parent merge"
+            patch_idx > merge1_idx,
+            "Expected dependent PR retarget after parent merge"
         );
         assert!(
             update_idx > merge1_idx,
@@ -8132,7 +8132,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_gitlab_retargets_next_mr_before_merging_parent_mr() {
+    async fn test_merge_gitlab_retargets_next_mr_after_merging_parent_mr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -8307,7 +8307,7 @@ mod forge_mock_tests {
             "PUT",
             "/projects/test%2Frepo/merge_requests/101/merge",
         );
-        assert!(retarget_idx < merge_idx);
+        assert!(retarget_idx > merge_idx);
         let retarget = requests
             .iter()
             .find(|request| {
@@ -8325,7 +8325,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_when_ready_gitlab_retargets_next_mr_before_merging_parent_mr() {
+    async fn test_merge_when_ready_gitlab_retargets_next_mr_after_merging_parent_mr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -8510,7 +8510,7 @@ mod forge_mock_tests {
             "PUT",
             "/projects/test%2Frepo/merge_requests/201/merge",
         );
-        assert!(retarget_idx < merge_idx);
+        assert!(retarget_idx > merge_idx);
     }
 
     #[tokio::test]
@@ -8945,7 +8945,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_gitea_retargets_next_pr_before_merging_parent_pr() {
+    async fn test_merge_gitea_retargets_next_pr_after_merging_parent_pr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -9103,7 +9103,7 @@ mod forge_mock_tests {
             .expect("request recording enabled");
         let retarget_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/102");
         let merge_idx = find_request_index(&requests, "POST", "/repos/test/repo/pulls/101/merge");
-        assert!(retarget_idx < merge_idx);
+        assert!(retarget_idx > merge_idx);
         let retarget = requests
             .iter()
             .find(|request| {
@@ -9121,7 +9121,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_when_ready_gitea_retargets_next_pr_before_merging_parent_pr() {
+    async fn test_merge_when_ready_gitea_retargets_next_pr_after_merging_parent_pr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -9289,6 +9289,6 @@ mod forge_mock_tests {
             .expect("request recording enabled");
         let retarget_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/202");
         let merge_idx = find_request_index(&requests, "POST", "/repos/test/repo/pulls/201/merge");
-        assert!(retarget_idx < merge_idx);
+        assert!(retarget_idx > merge_idx);
     }
 }


### PR DESCRIPTION
## Summary

Closes #231.

- Reorders the `update_pr_base` (retarget) call to happen **after** a successful `merge_pr` call in all three merge command files: `merge.rs`, `merge_remote.rs`, and `merge_when_ready.rs`.
- Previously, the dependent PR was retargeted to trunk **before** the parent merge. If the merge API call failed, the dependent PR was left pointing at trunk instead of its original parent branch — corrupting the stack.
- The "already merged" code paths (which retarget correctly) are unchanged.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib` passes (same pre-existing failures as `main`)
- [ ] Manual test: create a 3-branch stack, submit PRs, simulate a merge failure and verify the dependent PR base is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>