### PR TITLE
fix(pr,comments,copy): fall back to forge lookup when PR metadata is missing

### DIFF
--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -35,6 +35,7 @@ pub fn run(plain: bool) -> Result<()> {
             "stax submit".cyan()
         );
     }
+
     let pr_number = pr_number.unwrap();
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
 

--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -25,8 +25,9 @@ pub fn run(plain: bool) -> Result<()> {
         );
     }
 
-    // Check if branch has a PR
-    let pr_number = branch_info.and_then(|b| b.pr_number);
+    // Resolve PR number (local metadata or forge fallback)
+    let pr_number =
+        super::resolve_pr::resolve_pr_number(&repo, &stack, &current, &config)?;
     if pr_number.is_none() {
         anyhow::bail!(
             "No PR found for branch '{}'. Use {} to create one.",
@@ -34,7 +35,6 @@ pub fn run(plain: bool) -> Result<()> {
             "stax submit".cyan()
         );
     }
-
     let pr_number = pr_number.unwrap();
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
 

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -37,8 +37,9 @@ pub fn run(target: CopyTarget) -> Result<()> {
                 );
             }
 
-            // Check if branch has a PR
-            let pr_number = branch_info.and_then(|b| b.pr_number);
+            // Resolve PR number (local metadata or forge fallback)
+            let pr_number =
+                super::resolve_pr::resolve_pr_number(&repo, &stack, &current, &config)?;
             if pr_number.is_none() {
                 anyhow::bail!(
                     "No PR found for branch '{}'. Use {} to create one.",
@@ -46,7 +47,6 @@ pub fn run(target: CopyTarget) -> Result<()> {
                     "stax submit".cyan()
                 );
             }
-
             let pr_number = pr_number.unwrap();
             let remote_info = RemoteInfo::from_repo(&repo, &config)?;
             remote_info.pr_url(pr_number)

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -47,6 +47,7 @@ pub fn run(target: CopyTarget) -> Result<()> {
                     "stax submit".cyan()
                 );
             }
+
             let pr_number = pr_number.unwrap();
             let remote_info = RemoteInfo::from_repo(&repo, &config)?;
             remote_info.pr_url(pr_number)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,7 +30,7 @@ pub mod range_diff;
 pub mod redo;
 pub mod reorder;
 pub mod resolve;
-pub mod resolve_pr;
+pub(crate) mod resolve_pr;
 pub mod restack;
 pub(crate) mod restack_conflict;
 pub(crate) mod restack_parent;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod range_diff;
 pub mod redo;
 pub mod reorder;
 pub mod resolve;
+pub mod resolve_pr;
 pub mod restack;
 pub(crate) mod restack_conflict;
 pub(crate) mod restack_parent;

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -36,7 +36,7 @@ pub fn run_open() -> Result<()> {
         );
     }
 
-    let pr_number = branch_info.and_then(|b| b.pr_number);
+    let pr_number = super::resolve_pr::resolve_pr_number(&repo, &stack, &current, &config)?;
     if pr_number.is_none() {
         anyhow::bail!(
             "No PR found for branch '{}'. Use {} to create one.",
@@ -44,9 +44,10 @@ pub fn run_open() -> Result<()> {
             "stax submit".cyan()
         );
     }
+    let pr_number = pr_number.unwrap();
 
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
-    let pr_url = remote_info.pr_url(pr_number.unwrap());
+    let pr_url = remote_info.pr_url(pr_number);
 
     println!("Opening {} in browser...", pr_url.cyan());
     open_url_in_browser(&pr_url);

--- a/src/commands/resolve_pr.rs
+++ b/src/commands/resolve_pr.rs
@@ -1,0 +1,63 @@
+use crate::config::Config;
+use crate::engine::metadata::BranchMetadata;
+use crate::engine::Stack;
+use crate::forge::ForgeClient;
+use crate::git::GitRepo;
+use crate::remote::RemoteInfo;
+use anyhow::Result;
+
+/// Resolve the PR number for a tracked branch.
+///
+/// 1. Returns the locally stored `pr_number` when available.
+/// 2. Falls back to a forge lookup (`find_pr`) when metadata is missing.
+/// 3. Persists the discovered PR number to branch metadata so future
+///    commands skip the network round-trip.
+///
+/// Returns `None` only when no PR exists either locally or remotely.
+pub fn resolve_pr_number(
+    repo: &GitRepo,
+    stack: &Stack,
+    branch: &str,
+    config: &Config,
+) -> Result<Option<u64>> {
+    // Check local metadata first
+    if let Some(branch_info) = stack.branches.get(branch) {
+        if let Some(pr_number) = branch_info.pr_number {
+            return Ok(Some(pr_number));
+        }
+    }
+
+    // Fall back to forge lookup (non-fatal on client creation failure)
+    let remote_info = match RemoteInfo::from_repo(repo, config) {
+        Ok(info) => info,
+        Err(_) => return Ok(None),
+    };
+    let rt = tokio::runtime::Runtime::new()?;
+    let client = match {
+        let _enter = rt.enter();
+        ForgeClient::new(&remote_info)
+    } {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+
+    let pr_number = rt
+        .block_on(async { client.find_pr(branch).await })?
+        .map(|pr_info| pr_info.number);
+
+    // Persist discovered PR number to metadata
+    if let Some(number) = pr_number {
+        if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch) {
+            if meta.pr_info.is_none() {
+                meta.pr_info = Some(crate::engine::metadata::PrInfo {
+                    number,
+                    state: "open".to_string(),
+                    is_draft: None,
+                });
+                let _ = meta.write(repo.inner(), branch);
+            }
+        }
+    }
+
+    Ok(pr_number)
+}

--- a/src/commands/resolve_pr.rs
+++ b/src/commands/resolve_pr.rs
@@ -13,7 +13,8 @@ use anyhow::Result;
 /// 3. Persists the discovered PR number to branch metadata so future
 ///    commands skip the network round-trip.
 ///
-/// Returns `None` only when no PR exists either locally or remotely.
+/// Returns `None` when no PR exists locally or remotely, or when the
+/// forge is unreachable (missing token, network error, etc.).
 pub fn resolve_pr_number(
     repo: &GitRepo,
     stack: &Stack,
@@ -27,37 +28,35 @@ pub fn resolve_pr_number(
         }
     }
 
-    // Fall back to forge lookup (non-fatal on client creation failure)
+    // Fall back to forge lookup — all failures are non-fatal so that
+    // missing tokens, network errors, etc. degrade gracefully.
     let remote_info = match RemoteInfo::from_repo(repo, config) {
         Ok(info) => info,
         Err(_) => return Ok(None),
     };
     let rt = tokio::runtime::Runtime::new()?;
-    let client = match {
-        let _enter = rt.enter();
-        ForgeClient::new(&remote_info)
-    } {
+    let _enter = rt.enter();
+    let client = match ForgeClient::new(&remote_info) {
         Ok(c) => c,
         Err(_) => return Ok(None),
     };
 
-    let pr_number = rt
-        .block_on(async { client.find_pr(branch).await })?
-        .map(|pr_info| pr_info.number);
+    let pr_number = match rt.block_on(async { client.find_pr(branch).await }) {
+        Ok(Some(pr_info)) => pr_info.number,
+        _ => return Ok(None),
+    };
 
     // Persist discovered PR number to metadata
-    if let Some(number) = pr_number {
-        if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch) {
-            if meta.pr_info.is_none() {
-                meta.pr_info = Some(crate::engine::metadata::PrInfo {
-                    number,
-                    state: "open".to_string(),
-                    is_draft: None,
-                });
-                let _ = meta.write(repo.inner(), branch);
-            }
+    if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch) {
+        if meta.pr_info.is_none() {
+            meta.pr_info = Some(crate::engine::metadata::PrInfo {
+                number: pr_number,
+                state: "open".to_string(),
+                is_draft: None,
+            });
+            let _ = meta.write(repo.inner(), branch);
         }
     }
 
-    Ok(pr_number)
+    Ok(Some(pr_number))
 }


### PR DESCRIPTION
## Summary

Closes #232.

- Adds a shared `resolve_pr_number()` helper in `src/commands/resolve_pr.rs` that centralizes the "resolve PR number for a branch" logic:
  1. Returns locally stored `pr_number` when available
  2. Falls back to `ForgeClient::find_pr()` when metadata is missing
  3. Persists the discovered PR number to branch metadata so future commands skip the network round-trip
  4. Handles forge client creation failures gracefully (returns `None`)
- Updates `stax pr`, `stax comments`, and `stax copy --pr` to use the shared helper instead of bailing immediately when `pr_number` is `None`.
- This makes these commands consistent with `stax merge`, which already had forge fallback logic.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib` passes (same pre-existing failures as `main`)
- [ ] Manual test: track a branch with an existing remote PR but no local PR metadata, verify `stax pr` / `stax comments` / `stax copy --pr` discover and open/display the PR
- [ ] Verify metadata is persisted after first lookup (subsequent runs should be instant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>