### PR TITLE
feat(absorb): add st absorb command for automatic change distribution

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -47,6 +47,7 @@
 | `st branch squash` | | Squash commits |
 | `st detach` | | Remove branch from stack, reparent children |
 | `st reorder` | | Interactively reorder branches in stack |
+| `st absorb` | | Distribute staged changes to the correct stack branches (file-level attribution) |
 | `st upstack restack` | | Restack current + descendants |
 | `st upstack submit` | | Submit current + descendants |
 | `st downstack get` | | Show branches below current |
@@ -214,4 +215,6 @@ Worktree launch examples:
 - `st init --trunk main`
 - `st undo --yes --no-push`
 - `st undo --quiet`
+- `st absorb --dry-run` (preview absorption plan without changes)
+- `st absorb -a` (stage all changes before absorbing)
 - `st redo --yes --no-push --quiet`

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -22,6 +22,7 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 | — | `gt restack --upstack` | `st upstack restack` |
 | — | `gt merge` | `st merge` |
 | — | — | `st cascade` |
+| — | `gt absorb` | `st absorb` |
 | — | — | `st undo` / `st redo` |
 
 ## Short alias: `st`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -588,6 +588,16 @@ enum Commands {
         no_verify: bool,
     },
 
+    /// Absorb staged changes into the correct stack branches
+    Absorb {
+        /// Show what would be absorbed without making changes
+        #[arg(long)]
+        dry_run: bool,
+        /// Stage all changes before absorbing (like -a)
+        #[arg(short, long)]
+        all: bool,
+    },
+
     /// Copy branch name or PR URL to clipboard
     Copy {
         /// Copy PR URL instead of branch name
@@ -1604,6 +1614,7 @@ pub fn run() -> Result<()> {
             verbose,
         } => commands::ci::run(all, stack, json, refresh, watch, interval, verbose),
         Commands::Split { hunk, no_verify } => commands::split::run(hunk, no_verify),
+        Commands::Absorb { dry_run, all } => commands::absorb::run(dry_run, all),
         Commands::Copy { pr } => {
             let target = if pr {
                 commands::copy::CopyTarget::Pr

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -1,8 +1,9 @@
-use crate::engine::{BranchMetadata, Stack};
+use crate::engine::Stack;
 use crate::git::GitRepo;
 use anyhow::{bail, Result};
 use colored::Colorize;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
@@ -60,27 +61,27 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Build the stack branch list (from trunk up to current, excluding trunk)
+    // Build (branch, parent) pairs from the Stack (no extra metadata reads needed)
     let ancestors = stack.ancestors(&current);
     let mut stack_branches: Vec<String> = ancestors.into_iter().rev().collect();
     stack_branches.push(current.clone());
-    // Remove trunk from the list
     stack_branches.retain(|b| *b != stack.trunk);
 
     if stack_branches.is_empty() {
         bail!("No stack branches found above trunk.");
     }
 
-    // For each branch, find its parent boundary for commit scoping
-    let mut branch_boundaries: Vec<(String, String)> = Vec::new();
-    for branch in &stack_branches {
-        let meta = BranchMetadata::read(repo.inner(), branch)?;
-        let parent = meta
-            .as_ref()
-            .map(|m| m.parent_branch_name.clone())
-            .unwrap_or_else(|| stack.trunk.clone());
-        branch_boundaries.push((branch.clone(), parent));
-    }
+    let branch_boundaries: Vec<(String, String)> = stack_branches
+        .iter()
+        .map(|branch| {
+            let parent = stack
+                .branches
+                .get(branch)
+                .and_then(|b| b.parent.clone())
+                .unwrap_or_else(|| stack.trunk.clone());
+            (branch.clone(), parent)
+        })
+        .collect();
 
     // Attribute each file to a branch
     let plan = attribute_files(workdir, &staged_files, &branch_boundaries)?;
@@ -121,13 +122,9 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
     }
 
     // Check if there are changes targeting other branches (not just current)
-    let other_branch_groups: Vec<_> = plan
-        .groups
-        .iter()
-        .filter(|(b, _)| *b != current)
-        .collect();
+    let has_other_targets = plan.groups.iter().any(|(b, _)| *b != current);
 
-    if other_branch_groups.is_empty() {
+    if !has_other_targets {
         println!(
             "{}",
             "All changes already target the current branch. Nothing to absorb.".dimmed()
@@ -135,16 +132,14 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Perform absorption: move changes to their target branches
-    // Strategy: extract patches per group, stash everything, apply to each branch
-    let mut patches: Vec<(String, String, Vec<String>)> = Vec::new(); // (branch, patch_content, files)
+    // Extract patches as raw bytes (preserves binary diffs)
+    let mut patches: Vec<(String, Vec<u8>, Vec<String>)> = Vec::new();
 
     for (branch, files) in &plan.groups {
         if *branch == current {
-            continue; // Leave current-branch changes staged
+            continue;
         }
 
-        // Extract patch for these files
         let mut diff_args = vec!["diff".to_string(), "--cached".to_string(), "--".to_string()];
         diff_args.extend(files.iter().cloned());
 
@@ -154,11 +149,7 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
             .output()?;
 
         if diff_output.status.success() && !diff_output.stdout.is_empty() {
-            patches.push((
-                branch.clone(),
-                String::from_utf8_lossy(&diff_output.stdout).to_string(),
-                files.clone(),
-            ));
+            patches.push((branch.clone(), diff_output.stdout, files.clone()));
         }
     }
 
@@ -174,7 +165,8 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
         .output()?;
 
     let stash_msg = String::from_utf8_lossy(&stash_output.stdout);
-    let stashed = stash_output.status.success() && !stash_msg.contains("No local changes to save");
+    let stashed =
+        stash_output.status.success() && !stash_msg.contains("No local changes to save");
 
     if !stashed {
         bail!("Failed to stash changes before absorbing");
@@ -183,7 +175,7 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
     let mut absorbed_files: Vec<String> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
-    for (branch, patch, files) in &patches {
+    for (branch, patch_bytes, files) in &patches {
         // Checkout target branch
         let co = Command::new("git")
             .args(["checkout", branch])
@@ -192,75 +184,70 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
 
         if !co.success() {
             errors.push(format!("Failed to checkout '{}'", branch));
-            let _ = Command::new("git")
-                .args(["checkout", &current])
-                .current_dir(workdir)
-                .status();
-            continue;
+            break; // Can't continue safely if checkout fails
         }
 
-        // Apply the patch
+        // Apply the patch (git apply reads from stdin when no path is given)
         let mut apply_cmd = Command::new("git")
-            .args(["apply", "--cached", "-"])
+            .args(["apply", "--cached"])
             .current_dir(workdir)
             .stdin(std::process::Stdio::piped())
             .spawn()?;
 
         if let Some(mut stdin) = apply_cmd.stdin.take() {
-            use std::io::Write;
-            let _ = stdin.write_all(patch.as_bytes());
-            drop(stdin); // Close stdin before wait to avoid deadlock
+            stdin.write_all(patch_bytes)?;
+            drop(stdin);
         }
         let apply_status = apply_cmd.wait()?;
 
         if !apply_status.success() {
             errors.push(format!(
-                "Failed to apply patch to '{}' (files may conflict)",
+                "Failed to apply patch to '{}' (files may have diverged)",
                 branch
             ));
-            // Reset and go back
-            let _ = Command::new("git")
-                .args(["reset"])
-                .current_dir(workdir)
-                .status();
-            let _ = Command::new("git")
-                .args(["checkout", &current])
-                .current_dir(workdir)
-                .status();
-            continue;
-        }
-
-        // Get the tip commit message for the fixup label
-        let tip_msg = get_branch_tip_message(workdir, branch);
-
-        // Commit
-        let commit_msg = format!("fixup! {}", tip_msg.unwrap_or_else(|| branch.clone()));
-        let commit_status = Command::new("git")
-            .args(["commit", "-m", &commit_msg])
-            .current_dir(workdir)
-            .status()?;
-
-        if !commit_status.success() {
-            errors.push(format!("Failed to commit fixup on '{}'", branch));
             let _ = Command::new("git")
                 .args(["reset"])
                 .current_dir(workdir)
                 .status();
         } else {
-            absorbed_files.extend(files.iter().cloned());
-            println!(
-                "  {} {} file(s) → {}",
-                "✓".green(),
-                files.len(),
-                branch.cyan()
-            );
+            // Get the tip commit message for the fixup label
+            let tip_msg = get_branch_tip_message(workdir, branch);
+            let commit_msg = format!("fixup! {}", tip_msg.unwrap_or_else(|| branch.clone()));
+            let commit_status = Command::new("git")
+                .args(["commit", "-m", &commit_msg])
+                .current_dir(workdir)
+                .status()?;
+
+            if !commit_status.success() {
+                errors.push(format!("Failed to commit fixup on '{}'", branch));
+                let _ = Command::new("git")
+                    .args(["reset"])
+                    .current_dir(workdir)
+                    .status();
+            } else {
+                absorbed_files.extend(files.iter().cloned());
+                println!(
+                    "  {} {} file(s) → {}",
+                    "✓".green(),
+                    files.len(),
+                    branch.cyan()
+                );
+            }
         }
 
-        // Return to original branch
-        let _ = Command::new("git")
+        // Return to original branch -- abort if this fails
+        let co_back = Command::new("git")
             .args(["checkout", &current])
             .current_dir(workdir)
-            .status();
+            .status()?;
+
+        if !co_back.success() {
+            errors.push(format!(
+                "Failed to return to '{}'. Repository may be on wrong branch.",
+                current
+            ));
+            break;
+        }
     }
 
     // Restore stash
@@ -280,22 +267,18 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
     // For tracked files: reset index + checkout from HEAD.
     // For untracked/new files: reset index + remove from working tree.
     for file in &absorbed_files {
-        // Unstage
         let _ = Command::new("git")
             .args(["reset", "HEAD", "--", file])
             .current_dir(workdir)
             .status();
 
-        // Try to checkout from HEAD (works for tracked files)
         let checkout = Command::new("git")
             .args(["checkout", "HEAD", "--", file])
             .current_dir(workdir)
             .status();
 
-        // If checkout failed (untracked file not in HEAD), remove it
         if checkout.map(|s| !s.success()).unwrap_or(true) {
-            let file_path = workdir.join(file);
-            let _ = std::fs::remove_file(file_path);
+            let _ = std::fs::remove_file(workdir.join(file));
         }
     }
 
@@ -351,13 +334,10 @@ fn attribute_files(
         }
 
         if !attributed {
-            // File was not modified by any stack branch (new file or changed on trunk)
-            // Default to current branch
             unattributed.push(file.clone());
         }
     }
 
-    // Build ordered groups matching the branch order
     let groups: Vec<(String, Vec<String>)> = branch_boundaries
         .iter()
         .filter_map(|(branch, _)| {

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -165,8 +165,7 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
         .output()?;
 
     let stash_msg = String::from_utf8_lossy(&stash_output.stdout);
-    let stashed =
-        stash_output.status.success() && !stash_msg.contains("No local changes to save");
+    let stashed = stash_output.status.success() && !stash_msg.contains("No local changes to save");
 
     if !stashed {
         bail!("Failed to stash changes before absorbing");
@@ -225,6 +224,19 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
                     .current_dir(workdir)
                     .status();
             } else {
+                let reset_status = Command::new("git")
+                    .args(["reset", "--hard", "HEAD"])
+                    .current_dir(workdir)
+                    .status()?;
+
+                if !reset_status.success() {
+                    errors.push(format!(
+                        "Failed to clean worktree after committing absorbed changes on '{}'",
+                        branch
+                    ));
+                    break;
+                }
+
                 absorbed_files.extend(files.iter().cloned());
                 println!(
                     "  {} {} file(s) → {}",
@@ -247,6 +259,20 @@ pub fn run(dry_run: bool, all: bool) -> Result<()> {
                 current
             ));
             break;
+        }
+    }
+
+    if repo.current_branch()? != current {
+        let co_back = Command::new("git")
+            .args(["checkout", &current])
+            .current_dir(workdir)
+            .status()?;
+
+        if !co_back.success() {
+            errors.push(format!(
+                "Failed to return to '{}'. Repository may be on wrong branch.",
+                current
+            ));
         }
     }
 

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -1,0 +1,395 @@
+use crate::engine::{BranchMetadata, Stack};
+use crate::git::GitRepo;
+use anyhow::{bail, Result};
+use colored::Colorize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Result of file-level attribution: which branch owns each changed file.
+struct AbsorbPlan {
+    /// Files grouped by target branch name.
+    groups: Vec<(String, Vec<String>)>,
+    /// Files that could not be attributed to any stack branch.
+    unattributed: Vec<String>,
+}
+
+pub fn run(dry_run: bool, all: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let stack = Stack::load(&repo)?;
+    let current = repo.current_branch()?;
+
+    if current == stack.trunk {
+        bail!("Cannot absorb on trunk. Checkout a stacked branch first.");
+    }
+
+    let workdir = repo.workdir()?;
+
+    // Stage all if requested
+    if all {
+        let status = Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(workdir)
+            .status()?;
+        if !status.success() {
+            bail!("Failed to stage changes");
+        }
+    }
+
+    // Get list of staged files
+    let staged_output = Command::new("git")
+        .args(["diff", "--cached", "--name-only"])
+        .current_dir(workdir)
+        .output()?;
+
+    if !staged_output.status.success() {
+        bail!("Failed to list staged files");
+    }
+
+    let staged_files: Vec<String> = String::from_utf8_lossy(&staged_output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+
+    if staged_files.is_empty() {
+        println!(
+            "{}",
+            "No staged changes to absorb. Stage files or use `st absorb -a`.".yellow()
+        );
+        return Ok(());
+    }
+
+    // Build the stack branch list (from trunk up to current, excluding trunk)
+    let ancestors = stack.ancestors(&current);
+    let mut stack_branches: Vec<String> = ancestors.into_iter().rev().collect();
+    stack_branches.push(current.clone());
+    // Remove trunk from the list
+    stack_branches.retain(|b| *b != stack.trunk);
+
+    if stack_branches.is_empty() {
+        bail!("No stack branches found above trunk.");
+    }
+
+    // For each branch, find its parent boundary for commit scoping
+    let mut branch_boundaries: Vec<(String, String)> = Vec::new();
+    for branch in &stack_branches {
+        let meta = BranchMetadata::read(repo.inner(), branch)?;
+        let parent = meta
+            .as_ref()
+            .map(|m| m.parent_branch_name.clone())
+            .unwrap_or_else(|| stack.trunk.clone());
+        branch_boundaries.push((branch.clone(), parent));
+    }
+
+    // Attribute each file to a branch
+    let plan = attribute_files(workdir, &staged_files, &branch_boundaries)?;
+
+    // Display the plan
+    if plan.groups.is_empty() && plan.unattributed.is_empty() {
+        println!("{}", "No changes to absorb.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "Absorb plan:".bold());
+    for (branch, files) in &plan.groups {
+        let marker = if *branch == current {
+            " (current)".dimmed().to_string()
+        } else {
+            String::new()
+        };
+        println!("  {} {}{}", "→".green(), branch.cyan(), marker);
+        for file in files {
+            println!("    {}", file);
+        }
+    }
+    if !plan.unattributed.is_empty() {
+        println!(
+            "  {} {}",
+            "?".yellow(),
+            "unattributed (staying staged)".dimmed()
+        );
+        for file in &plan.unattributed {
+            println!("    {}", file);
+        }
+    }
+    println!();
+
+    if dry_run {
+        println!("{}", "Dry run — no changes made.".dimmed());
+        return Ok(());
+    }
+
+    // Check if there are changes targeting other branches (not just current)
+    let other_branch_groups: Vec<_> = plan
+        .groups
+        .iter()
+        .filter(|(b, _)| *b != current)
+        .collect();
+
+    if other_branch_groups.is_empty() {
+        println!(
+            "{}",
+            "All changes already target the current branch. Nothing to absorb.".dimmed()
+        );
+        return Ok(());
+    }
+
+    // Perform absorption: move changes to their target branches
+    // Strategy: extract patches per group, stash everything, apply to each branch
+    let mut patches: Vec<(String, String, Vec<String>)> = Vec::new(); // (branch, patch_content, files)
+
+    for (branch, files) in &plan.groups {
+        if *branch == current {
+            continue; // Leave current-branch changes staged
+        }
+
+        // Extract patch for these files
+        let mut diff_args = vec!["diff".to_string(), "--cached".to_string(), "--".to_string()];
+        diff_args.extend(files.iter().cloned());
+
+        let diff_output = Command::new("git")
+            .args(&diff_args)
+            .current_dir(workdir)
+            .output()?;
+
+        if diff_output.status.success() && !diff_output.stdout.is_empty() {
+            patches.push((
+                branch.clone(),
+                String::from_utf8_lossy(&diff_output.stdout).to_string(),
+                files.clone(),
+            ));
+        }
+    }
+
+    if patches.is_empty() {
+        println!("{}", "No changes to move to other branches.".dimmed());
+        return Ok(());
+    }
+
+    // Stash current state (include untracked files with -u)
+    let stash_output = Command::new("git")
+        .args(["stash", "push", "-u", "-m", "stax-absorb"])
+        .current_dir(workdir)
+        .output()?;
+
+    let stash_msg = String::from_utf8_lossy(&stash_output.stdout);
+    let stashed = stash_output.status.success() && !stash_msg.contains("No local changes to save");
+
+    if !stashed {
+        bail!("Failed to stash changes before absorbing");
+    }
+
+    let mut absorbed_files: Vec<String> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for (branch, patch, files) in &patches {
+        // Checkout target branch
+        let co = Command::new("git")
+            .args(["checkout", branch])
+            .current_dir(workdir)
+            .status()?;
+
+        if !co.success() {
+            errors.push(format!("Failed to checkout '{}'", branch));
+            let _ = Command::new("git")
+                .args(["checkout", &current])
+                .current_dir(workdir)
+                .status();
+            continue;
+        }
+
+        // Apply the patch
+        let mut apply_cmd = Command::new("git")
+            .args(["apply", "--cached", "-"])
+            .current_dir(workdir)
+            .stdin(std::process::Stdio::piped())
+            .spawn()?;
+
+        if let Some(mut stdin) = apply_cmd.stdin.take() {
+            use std::io::Write;
+            let _ = stdin.write_all(patch.as_bytes());
+            drop(stdin); // Close stdin before wait to avoid deadlock
+        }
+        let apply_status = apply_cmd.wait()?;
+
+        if !apply_status.success() {
+            errors.push(format!(
+                "Failed to apply patch to '{}' (files may conflict)",
+                branch
+            ));
+            // Reset and go back
+            let _ = Command::new("git")
+                .args(["reset"])
+                .current_dir(workdir)
+                .status();
+            let _ = Command::new("git")
+                .args(["checkout", &current])
+                .current_dir(workdir)
+                .status();
+            continue;
+        }
+
+        // Get the tip commit message for the fixup label
+        let tip_msg = get_branch_tip_message(workdir, branch);
+
+        // Commit
+        let commit_msg = format!("fixup! {}", tip_msg.unwrap_or_else(|| branch.clone()));
+        let commit_status = Command::new("git")
+            .args(["commit", "-m", &commit_msg])
+            .current_dir(workdir)
+            .status()?;
+
+        if !commit_status.success() {
+            errors.push(format!("Failed to commit fixup on '{}'", branch));
+            let _ = Command::new("git")
+                .args(["reset"])
+                .current_dir(workdir)
+                .status();
+        } else {
+            absorbed_files.extend(files.iter().cloned());
+            println!(
+                "  {} {} file(s) → {}",
+                "✓".green(),
+                files.len(),
+                branch.cyan()
+            );
+        }
+
+        // Return to original branch
+        let _ = Command::new("git")
+            .args(["checkout", &current])
+            .current_dir(workdir)
+            .status();
+    }
+
+    // Restore stash
+    let pop = Command::new("git")
+        .args(["stash", "pop"])
+        .current_dir(workdir)
+        .status()?;
+
+    if !pop.success() {
+        println!(
+            "{}",
+            "Warning: failed to pop stash. Run `git stash pop` manually.".yellow()
+        );
+    }
+
+    // Unstage and discard absorbed files.
+    // For tracked files: reset index + checkout from HEAD.
+    // For untracked/new files: reset index + remove from working tree.
+    for file in &absorbed_files {
+        // Unstage
+        let _ = Command::new("git")
+            .args(["reset", "HEAD", "--", file])
+            .current_dir(workdir)
+            .status();
+
+        // Try to checkout from HEAD (works for tracked files)
+        let checkout = Command::new("git")
+            .args(["checkout", "HEAD", "--", file])
+            .current_dir(workdir)
+            .status();
+
+        // If checkout failed (untracked file not in HEAD), remove it
+        if checkout.map(|s| !s.success()).unwrap_or(true) {
+            let file_path = workdir.join(file);
+            let _ = std::fs::remove_file(file_path);
+        }
+    }
+
+    if !errors.is_empty() {
+        println!();
+        println!("{}", "Some files could not be absorbed:".yellow());
+        for e in &errors {
+            println!("  {}", e);
+        }
+    }
+
+    println!();
+    println!("{}", "Absorb complete.".green());
+
+    Ok(())
+}
+
+/// Attribute each staged file to a stack branch based on which branch most recently
+/// modified it (file-level attribution via `git log`).
+fn attribute_files(
+    workdir: &Path,
+    files: &[String],
+    branch_boundaries: &[(String, String)],
+) -> Result<AbsorbPlan> {
+    let mut branch_files: HashMap<String, Vec<String>> = HashMap::new();
+    let mut unattributed: Vec<String> = Vec::new();
+
+    for file in files {
+        let mut attributed = false;
+
+        // Walk branches from top to bottom (most recent first)
+        for (branch, parent) in branch_boundaries.iter().rev() {
+            let output = Command::new("git")
+                .args([
+                    "log",
+                    "--oneline",
+                    "-1",
+                    &format!("{}..{}", parent, branch),
+                    "--",
+                    file,
+                ])
+                .current_dir(workdir)
+                .output()?;
+
+            if output.status.success() && !output.stdout.is_empty() {
+                branch_files
+                    .entry(branch.clone())
+                    .or_default()
+                    .push(file.clone());
+                attributed = true;
+                break;
+            }
+        }
+
+        if !attributed {
+            // File was not modified by any stack branch (new file or changed on trunk)
+            // Default to current branch
+            unattributed.push(file.clone());
+        }
+    }
+
+    // Build ordered groups matching the branch order
+    let groups: Vec<(String, Vec<String>)> = branch_boundaries
+        .iter()
+        .filter_map(|(branch, _)| {
+            branch_files
+                .get(branch)
+                .map(|files| (branch.clone(), files.clone()))
+        })
+        .collect();
+
+    Ok(AbsorbPlan {
+        groups,
+        unattributed,
+    })
+}
+
+/// Get the first-line commit message of a branch's tip.
+fn get_branch_tip_message(workdir: &Path, branch: &str) -> Option<String> {
+    Command::new("git")
+        .args(["log", "-1", "--format=%s", branch])
+        .current_dir(workdir)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                let msg = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                if msg.is_empty() {
+                    None
+                } else {
+                    Some(msg)
+                }
+            } else {
+                None
+            }
+        })
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod abort;
+pub mod absorb;
 pub mod auth;
 pub mod branch;
 pub mod cascade;

--- a/tests/absorb_tests.rs
+++ b/tests/absorb_tests.rs
@@ -1,0 +1,163 @@
+//! Tests for `st absorb` command.
+//!
+//! Verifies that staged changes are attributed to the correct stack branches
+//! based on which branch last modified each file.
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+
+#[test]
+fn absorb_on_trunk_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let output = repo.run_stax(&["absorb"]);
+    output.assert_failure();
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("trunk"),
+        "Should mention trunk in error: {}",
+        stderr
+    );
+}
+
+#[test]
+fn absorb_with_no_staged_changes_shows_message() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Create a branch
+    repo.run_stax(&["create", "feature"]).assert_success();
+    repo.create_file("a.txt", "hello");
+    repo.commit("add a.txt");
+
+    // No staged changes
+    let output = repo.run_stax(&["absorb"]);
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("No staged") || stdout.contains("no staged"),
+        "Should indicate no staged changes: {}",
+        stdout
+    );
+}
+
+#[test]
+fn absorb_dry_run_shows_plan() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Create a branch with a file
+    repo.run_stax(&["create", "feature-a"]).assert_success();
+    repo.create_file("a.txt", "hello from feature-a");
+    repo.commit("add a.txt in feature-a");
+
+    // Create a second branch with another file
+    repo.run_stax(&["create", "feature-b"]).assert_success();
+    repo.create_file("b.txt", "hello from feature-b");
+    repo.commit("add b.txt in feature-b");
+
+    // Now modify a.txt (should be attributed to feature-a)
+    repo.create_file("a.txt", "modified in feature-b");
+    repo.git(&["add", "a.txt"]);
+
+    // Run dry-run
+    let output = repo.run_stax(&["absorb", "--dry-run"]);
+    let stdout = TestRepo::stdout(&output);
+
+    // Should show the plan
+    assert!(
+        stdout.contains("Absorb plan") || stdout.contains("absorb plan"),
+        "Should show absorb plan: stdout={} stderr={}",
+        stdout,
+        TestRepo::stderr(&output)
+    );
+
+    // a.txt should be attributed to the branch that created it
+    assert!(
+        stdout.contains("a.txt"),
+        "Should mention a.txt in plan: {}",
+        stdout
+    );
+
+    // Should say dry run
+    assert!(
+        stdout.contains("Dry run") || stdout.contains("dry run"),
+        "Should indicate dry run: {}",
+        stdout
+    );
+}
+
+#[test]
+fn absorb_with_all_flag_stages_changes() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Create a branch with a file
+    repo.run_stax(&["create", "feature"]).assert_success();
+    repo.create_file("a.txt", "initial");
+    repo.commit("add a.txt");
+
+    // Modify the file (not staged)
+    repo.create_file("a.txt", "modified");
+
+    // --all should stage and show plan
+    let output = repo.run_stax(&["absorb", "-a", "--dry-run"]);
+    let stdout = TestRepo::stdout(&output);
+
+    assert!(
+        stdout.contains("a.txt"),
+        "Should show a.txt after staging with -a: {}",
+        stdout
+    );
+}
+
+#[test]
+fn absorb_new_files_are_unattributed() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Create a branch
+    repo.run_stax(&["create", "feature"]).assert_success();
+    repo.create_file("existing.txt", "existing");
+    repo.commit("add existing.txt");
+
+    // Create a brand new file that was never touched by any branch
+    repo.create_file("brand-new.txt", "new content");
+    repo.git(&["add", "brand-new.txt"]);
+
+    let output = repo.run_stax(&["absorb", "--dry-run"]);
+    let stdout = TestRepo::stdout(&output);
+
+    // brand-new.txt should be unattributed (or attributed to current branch)
+    assert!(
+        stdout.contains("brand-new.txt"),
+        "Should mention the new file: {}",
+        stdout
+    );
+}
+
+#[test]
+fn absorb_single_branch_stack_shows_current() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Create just one branch
+    repo.run_stax(&["create", "feature"]).assert_success();
+    repo.create_file("a.txt", "hello");
+    repo.commit("add a.txt");
+
+    // Modify the file
+    repo.create_file("a.txt", "modified");
+    repo.git(&["add", "a.txt"]);
+
+    let output = repo.run_stax(&["absorb", "--dry-run"]);
+    let stdout = TestRepo::stdout(&output);
+
+    // With a single branch, changes target the current branch
+    assert!(
+        stdout.contains("feature") || stdout.contains("current"),
+        "Should attribute to current/only branch: {}",
+        stdout
+    );
+}

--- a/tests/absorb_tests.rs
+++ b/tests/absorb_tests.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use common::{OutputAssertions, TestRepo};
+use std::fs;
 
 #[test]
 fn absorb_on_trunk_fails() {
@@ -159,5 +160,59 @@ fn absorb_single_branch_stack_shows_current() {
         stdout.contains("feature") || stdout.contains("current"),
         "Should attribute to current/only branch: {}",
         stdout
+    );
+}
+
+#[test]
+fn absorb_moves_changes_to_their_owning_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "feature-a"]).assert_success();
+    repo.create_file("a.txt", "hello from feature-a");
+    repo.commit("add a.txt in feature-a");
+    let feature_a = repo.current_branch();
+
+    repo.run_stax(&["create", "feature-b"]).assert_success();
+    repo.create_file("b.txt", "hello from feature-b");
+    repo.commit("add b.txt in feature-b");
+    let feature_b = repo.current_branch();
+
+    repo.create_file("a.txt", "updated from feature-b");
+    repo.git(&["add", "a.txt"]);
+
+    let output = repo.run_stax(&["absorb"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Absorb complete"),
+        "Expected completion message, got: {}",
+        stdout
+    );
+    assert_eq!(repo.current_branch(), feature_b);
+
+    let status = repo.git(&["status", "--short"]);
+    assert!(
+        !TestRepo::stdout(&status).contains("a.txt"),
+        "a.txt should no longer be staged on the current branch"
+    );
+
+    repo.run_stax(&["checkout", &feature_a]).assert_success();
+    assert_eq!(
+        fs::read_to_string(repo.path().join("a.txt")).unwrap(),
+        "updated from feature-b"
+    );
+    let feature_a_log = repo.git(&["log", "-1", "--format=%s"]);
+    assert!(
+        TestRepo::stdout(&feature_a_log).starts_with("fixup! add a.txt in feature-a"),
+        "Expected fixup commit on feature-a, got: {}",
+        TestRepo::stdout(&feature_a_log)
+    );
+
+    repo.run_stax(&["checkout", &feature_b]).assert_success();
+    assert_eq!(
+        fs::read_to_string(repo.path().join("a.txt")).unwrap(),
+        "hello from feature-a"
     );
 }


### PR DESCRIPTION
## Summary

- Add `st absorb` command that distributes staged changes to the correct stack branches
- Uses file-level attribution via `git log` to determine which branch last modified each file
- Groups changes by target branch and creates fixup commits via stash/checkout/apply/commit workflow
- Supports `--dry-run` to preview and `-a/--all` to stage everything first

Closes #244
Part of #242

## How it works

```
$ st absorb --dry-run
Absorb plan:
  → feature/auth (current)
    src/auth.rs
  → feature/api
    src/api/client.rs
  → feature/init
    src/main.rs
  ? unattributed (staying staged)
    brand-new-file.rs
```

## Known limitations

- File-level attribution (not line-level). A future version could use `git blame` for hunk-level precision.
- Patch context mismatch on diverged branches: if the target branch has very different file content, the patch may fail to apply. Failed files are reported and skipped.

## Test plan

- [x] `absorb_on_trunk_fails` -- rejects on trunk
- [x] `absorb_with_no_staged_changes_shows_message` -- graceful empty state
- [x] `absorb_dry_run_shows_plan` -- shows plan with file attribution
- [x] `absorb_with_all_flag_stages_changes` -- `-a` stages before absorbing
- [x] `absorb_new_files_are_unattributed` -- new files shown as unattributed
- [x] `absorb_single_branch_stack_shows_current` -- single-branch stack handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)