### PR TITLE
fix(push): use --force-with-lease instead of -f for all force pushes

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -364,7 +364,7 @@ pub fn run(
                 LiveTimer::maybe_new(!quiet, &format!("Pushing {}...", next_branch.branch));
 
             let push_status = Command::new("git")
-                .args(["push", "-f", &remote_info.name, &next_branch.branch])
+                .args(["push", "--force-with-lease", &remote_info.name, &next_branch.branch])
                 .current_dir(repo.workdir()?)
                 .output()
                 .context("Failed to push")?;
@@ -439,7 +439,7 @@ pub fn run(
                     }
 
                     let _ = Command::new("git")
-                        .args(["push", "-f", &remote_info.name, &remaining.branch])
+                        .args(["push", "--force-with-lease", &remote_info.name, &remaining.branch])
                         .current_dir(repo.workdir()?)
                         .output();
 

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -396,7 +396,7 @@ pub fn run(
                 LiveTimer::maybe_new(!quiet, &format!("Pushing {}...", next_branch_name));
 
             let push_status = Command::new("git")
-                .args(["push", "-f", &remote_info.name, &next_branch_name])
+                .args(["push", "--force-with-lease", &remote_info.name, &next_branch_name])
                 .current_dir(repo.workdir()?)
                 .output()
                 .context("Failed to push")?;
@@ -447,7 +447,7 @@ pub fn run(
                     }
 
                     let _ = Command::new("git")
-                        .args(["push", "-f", &remote_info.name, &remaining.branch])
+                        .args(["push", "--force-with-lease", &remote_info.name, &remaining.branch])
                         .current_dir(repo.workdir()?)
                         .output();
 

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1134,7 +1134,7 @@ pub fn run(
 
 fn push_branch(workdir: &std::path::Path, remote: &str, branch: &str) -> Result<()> {
     let status = Command::new("git")
-        .args(["push", "-f", "-u", remote, branch])
+        .args(["push", "--force-with-lease", "-u", remote, branch])
         .current_dir(workdir)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1960,7 +1960,7 @@ Use --auto-stash-pop or stash/commit changes first.",
     /// Force push a branch to remote
     pub fn force_push(&self, remote: &str, branch: &str) -> Result<()> {
         let status = Command::new("git")
-            .args(["push", "-f", remote, branch])
+            .args(["push", "--force-with-lease", remote, branch])
             .current_dir(self.workdir()?)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1957,7 +1957,7 @@ Use --auto-stash-pop or stash/commit changes first.",
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
-    /// Force push a branch to remote
+    /// Lease-protected force push a branch to the remote.
     pub fn force_push(&self, remote: &str, branch: &str) -> Result<()> {
         let status = Command::new("git")
             .args(["push", "--force-with-lease", remote, branch])
@@ -1965,10 +1965,10 @@ Use --auto-stash-pop or stash/commit changes first.",
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .context("Failed to run git push -f")?;
+            .context("Failed to run git push --force-with-lease")?;
 
         if !status.success() {
-            anyhow::bail!("git push -f {} {} failed", remote, branch);
+            anyhow::bail!("git push --force-with-lease {} {} failed", remote, branch);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Replace all `git push -f` with `git push --force-with-lease` across the entire codebase
- Prevents silent overwrites when teammates push to the same branch
- 6 call sites changed across 4 files

Closes #249, Part of #242

## Test plan

- [x] `cargo check` passes
- [ ] Manual: push a branch, have another user push to it, verify stax refuses to overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)