### PR TITLE
fix(sync): add ancestor check before trunk hard-reset

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -298,8 +298,15 @@ pub fn run(
                     }
                 }
             }
+        } else if !is_ancestor(&workdir, &stack.trunk, &remote_trunk_ref) {
+            // Local trunk has diverged from remote (has local-only commits).
+            // Refuse to reset to avoid silently losing those commits.
+            LiveTimer::maybe_finish_warn(
+                update_timer,
+                "diverged (local has commits not on remote; use --safe or resolve manually)",
+            );
         } else {
-            // Try reset to remote
+            // Local is ancestor of remote -- safe to reset (equivalent to fast-forward)
             let reset_output = Command::new("git")
                 .args(["reset", "--hard", &remote_trunk_ref])
                 .current_dir(&workdir)
@@ -342,6 +349,11 @@ pub fn run(
                         }
                     }
                 }
+            } else if !is_ancestor(&trunk_worktree_path, &stack.trunk, &remote_trunk_ref) {
+                LiveTimer::maybe_finish_warn(
+                    update_timer,
+                    "diverged (local has commits not on remote; use --safe or resolve manually)",
+                );
             } else {
                 let reset_output = Command::new("git")
                     .args(["reset", "--hard", &remote_trunk_ref])
@@ -1005,8 +1017,13 @@ pub fn run(
                     }
                 }
             }
+        } else if !is_ancestor(&workdir, &stack.trunk, &remote_trunk_ref) {
+            LiveTimer::maybe_finish_warn(
+                deferred_timer,
+                "diverged (local has commits not on remote; use --safe or resolve manually)",
+            );
         } else {
-            // Try reset to remote
+            // Local is ancestor of remote -- safe to reset
             let reset_output = Command::new("git")
                 .args(["reset", "--hard", &remote_trunk_ref])
                 .current_dir(&workdir)

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -303,7 +303,7 @@ pub fn run(
             // Refuse to reset to avoid silently losing those commits.
             LiveTimer::maybe_finish_warn(
                 update_timer,
-                "diverged (local has commits not on remote; use --safe or resolve manually)",
+                "diverged (local has commits not on remote; rebase or reset trunk manually)",
             );
         } else {
             // Local is ancestor of remote -- safe to reset (equivalent to fast-forward)
@@ -352,7 +352,7 @@ pub fn run(
             } else if !is_ancestor(&trunk_worktree_path, &stack.trunk, &remote_trunk_ref) {
                 LiveTimer::maybe_finish_warn(
                     update_timer,
-                    "diverged (local has commits not on remote; use --safe or resolve manually)",
+                    "diverged (local has commits not on remote; rebase or reset trunk manually)",
                 );
             } else {
                 let reset_output = Command::new("git")
@@ -1020,7 +1020,7 @@ pub fn run(
         } else if !is_ancestor(&workdir, &stack.trunk, &remote_trunk_ref) {
             LiveTimer::maybe_finish_warn(
                 deferred_timer,
-                "diverged (local has commits not on remote; use --safe or resolve manually)",
+                "diverged (local has commits not on remote; rebase or reset trunk manually)",
             );
         } else {
             // Local is ancestor of remote -- safe to reset


### PR DESCRIPTION
## Summary

- Add `is_ancestor()` check before all 3 `reset --hard` paths in sync
- Prevents silent loss of local trunk commits when remote trunk diverged
- Warns with actionable message instead of silently resetting

Closes #250, Part of #242

## Test plan

- [x] `cargo check` passes
- [ ] Manual: make local trunk commits, force-push remote trunk to different state, run `st sync`, verify warning instead of data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)