### PR TITLE
fix(sync): warn on metadata deletion failures instead of silently ignoring

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -726,14 +726,20 @@ pub fn run(
                     let local_still_exists = local_branch_exists(&workdir, branch);
 
                     let metadata_deleted = if !local_still_exists {
-                        if let Err(e) = crate::git::refs::delete_metadata(repo.inner(), branch) {
-                            eprintln!(
-                                "{}",
-                                format!("Warning: failed to delete metadata for '{}': {}", branch, e)
+                        match crate::git::refs::delete_metadata(repo.inner(), branch) {
+                            Ok(()) => true,
+                            Err(e) => {
+                                println!(
+                                    "{}",
+                                    format!(
+                                        "Warning: failed to delete metadata for '{}': {}",
+                                        branch, e
+                                    )
                                     .yellow()
-                            );
+                                );
+                                false
+                            }
                         }
-                        true
                     } else {
                         false
                     };
@@ -933,14 +939,20 @@ pub fn run(
                 let local_still_exists = local_branch_exists(&workdir, branch);
 
                 let metadata_deleted = if !local_still_exists {
-                    if let Err(e) = crate::git::refs::delete_metadata(repo.inner(), branch) {
-                        eprintln!(
-                            "{}",
-                            format!("Warning: failed to delete metadata for '{}': {}", branch, e)
+                    match crate::git::refs::delete_metadata(repo.inner(), branch) {
+                        Ok(()) => true,
+                        Err(e) => {
+                            println!(
+                                "{}",
+                                format!(
+                                    "Warning: failed to delete metadata for '{}': {}",
+                                    branch, e
+                                )
                                 .yellow()
-                        );
+                            );
+                            false
+                        }
                     }
-                    true
                 } else {
                     false
                 };

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -726,7 +726,13 @@ pub fn run(
                     let local_still_exists = local_branch_exists(&workdir, branch);
 
                     let metadata_deleted = if !local_still_exists {
-                        let _ = crate::git::refs::delete_metadata(repo.inner(), branch);
+                        if let Err(e) = crate::git::refs::delete_metadata(repo.inner(), branch) {
+                            eprintln!(
+                                "{}",
+                                format!("Warning: failed to delete metadata for '{}': {}", branch, e)
+                                    .yellow()
+                            );
+                        }
                         true
                     } else {
                         false
@@ -927,7 +933,13 @@ pub fn run(
                 let local_still_exists = local_branch_exists(&workdir, branch);
 
                 let metadata_deleted = if !local_still_exists {
-                    let _ = crate::git::refs::delete_metadata(repo.inner(), branch);
+                    if let Err(e) = crate::git::refs::delete_metadata(repo.inner(), branch) {
+                        eprintln!(
+                            "{}",
+                            format!("Warning: failed to delete metadata for '{}': {}", branch, e)
+                                .yellow()
+                        );
+                    }
                     true
                 } else {
                     false


### PR DESCRIPTION
## Summary

- Replace `let _ = delete_metadata(...)` with warning on failure
- Prevents silent accumulation of stale metadata after sync

Closes #251, Part of #242

## Test plan

- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)