### PR TITLE
feat(doctor): add checks for diverged trunk, git config, stale PR metadata

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,10 +1,11 @@
 use crate::config::Config;
-use crate::engine::Stack;
+use crate::engine::{BranchMetadata, Stack};
 use crate::forge;
-use crate::git::GitRepo;
+use crate::git::{refs, GitRepo};
 use crate::remote::{self, RemoteInfo};
 use anyhow::Result;
 use colored::Colorize;
+use std::process::Command;
 
 pub fn run() -> Result<()> {
     println!("{}", "stax doctor".bold());
@@ -138,6 +139,112 @@ pub fn run() -> Result<()> {
         }
     }
 
+    // Check: diverged trunk detection
+    if let Ok(trunk) = repo.trunk_branch() {
+        let remote_trunk = format!("{}/{}", remote_name, trunk);
+        match repo.is_ancestor(&trunk, &remote_trunk) {
+            Ok(true) => {
+                println!(
+                    "{} {}",
+                    "✓".green(),
+                    "Local trunk is ancestor of remote trunk".dimmed()
+                );
+            }
+            Ok(false) => {
+                println!(
+                    "{} {}",
+                    "⚠".yellow(),
+                    format!(
+                        "Local {} has diverged from {}/{} (remote may have been force-pushed)",
+                        trunk, remote_name, trunk
+                    )
+                    .yellow()
+                );
+            }
+            Err(_) => {
+                // Remote trunk ref may not exist (e.g., never fetched); skip silently
+            }
+        }
+    }
+
+    // Check: git config recommendations for stacked workflows
+    {
+        let rerere_ok = git_config_is_true(repo.workdir().ok(), "rerere.enabled");
+        let autostash_ok = git_config_is_true(repo.workdir().ok(), "rebase.autoStash");
+
+        if rerere_ok && autostash_ok {
+            println!(
+                "{} {}",
+                "✓".green(),
+                "Git config: rerere.enabled and rebase.autoStash are set".dimmed()
+            );
+        } else {
+            let mut missing = Vec::new();
+            if !rerere_ok {
+                missing.push("rerere.enabled");
+            }
+            if !autostash_ok {
+                missing.push("rebase.autoStash");
+            }
+            println!(
+                "{} {}",
+                "⚠".yellow(),
+                format!(
+                    "Recommended git config not set: {}. Run: {}",
+                    missing.join(", "),
+                    missing
+                        .iter()
+                        .map(|k| format!("git config --global {} true", k))
+                        .collect::<Vec<_>>()
+                        .join(" && ")
+                )
+                .yellow()
+            );
+        }
+    }
+
+    // Check: stale PR metadata (OPEN PR on a branch that no longer exists locally)
+    {
+        let local_branches: std::collections::HashSet<String> =
+            repo.list_branches().unwrap_or_default().into_iter().collect();
+        let metadata_branches = refs::list_metadata_branches(repo.inner()).unwrap_or_default();
+        let mut stale = Vec::new();
+
+        for branch_name in &metadata_branches {
+            if local_branches.contains(branch_name) {
+                continue;
+            }
+            if let Ok(Some(meta)) = BranchMetadata::read(repo.inner(), branch_name) {
+                if let Some(pr) = &meta.pr_info {
+                    if pr.state == "OPEN" {
+                        stale.push((branch_name.clone(), pr.number));
+                    }
+                }
+            }
+        }
+
+        if stale.is_empty() {
+            println!(
+                "{} {}",
+                "✓".green(),
+                "No stale PR metadata found".dimmed()
+            );
+        } else {
+            println!(
+                "{} {}",
+                "⚠".yellow(),
+                format!(
+                    "{} branch(es) have OPEN PR metadata but no local branch:",
+                    stale.len()
+                )
+                .yellow()
+            );
+            for (branch, pr_num) in &stale {
+                println!("  {} (PR #{})", branch, pr_num);
+            }
+        }
+    }
+
     println!();
     if issues == 0 {
         println!("{}", "✓ Doctor check complete (no critical issues)".green());
@@ -146,4 +253,20 @@ pub fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Check whether a git config key is set to "true".
+fn git_config_is_true(workdir: Option<&std::path::Path>, key: &str) -> bool {
+    let mut cmd = Command::new("git");
+    cmd.args(["config", "--get", key]);
+    if let Some(cwd) = workdir {
+        cmd.current_dir(cwd);
+    }
+    match cmd.output() {
+        Ok(output) if output.status.success() => {
+            let value = String::from_utf8_lossy(&output.stdout).trim().to_lowercase();
+            value == "true"
+        }
+        _ => false,
+    }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -151,6 +151,7 @@ pub fn run() -> Result<()> {
                 );
             }
             Ok(false) => {
+                issues += 1;
                 println!(
                     "{} {}",
                     "⚠".yellow(),
@@ -205,8 +206,11 @@ pub fn run() -> Result<()> {
 
     // Check: stale PR metadata (OPEN PR on a branch that no longer exists locally)
     {
-        let local_branches: std::collections::HashSet<String> =
-            repo.list_branches().unwrap_or_default().into_iter().collect();
+        let local_branches: std::collections::HashSet<String> = repo
+            .list_branches()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
         let metadata_branches = refs::list_metadata_branches(repo.inner()).unwrap_or_default();
         let mut stale = Vec::new();
 
@@ -224,12 +228,9 @@ pub fn run() -> Result<()> {
         }
 
         if stale.is_empty() {
-            println!(
-                "{} {}",
-                "✓".green(),
-                "No stale PR metadata found".dimmed()
-            );
+            println!("{} {}", "✓".green(), "No stale PR metadata found".dimmed());
         } else {
+            issues += 1;
             println!(
                 "{} {}",
                 "⚠".yellow(),
@@ -264,7 +265,9 @@ fn git_config_is_true(workdir: Option<&std::path::Path>, key: &str) -> bool {
     }
     match cmd.output() {
         Ok(output) if output.status.success() => {
-            let value = String::from_utf8_lossy(&output.stdout).trim().to_lowercase();
+            let value = String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .to_lowercase();
             value == "true"
         }
         _ => false,


### PR DESCRIPTION
## Summary
- **Diverged trunk detection**: warns when local trunk is not an ancestor of remote trunk, indicating the remote may have been force-pushed.
- **Git config recommendations**: checks if `rerere.enabled` and `rebase.autoStash` are configured and suggests setting them for a better stacked workflow experience.
- **Stale PR metadata**: detects branches with OPEN PR metadata in refs but no corresponding local branch, warning about orphaned metadata.

Closes #258, part of #242

## Test plan
- [ ] Run `st doctor` in a repo where local trunk is behind remote trunk (should show green check)
- [ ] Run `st doctor` after force-pushing remote trunk so local diverges (should show yellow warning)
- [ ] Run `st doctor` without `rerere.enabled` / `rebase.autoStash` set (should suggest setting them)
- [ ] Run `st doctor` with both config values set to true (should show green check)
- [ ] Create a branch with OPEN PR metadata, delete the local branch, run `st doctor` (should warn about stale metadata)
- [ ] Run `st doctor` with no stale metadata (should show green check)
- [ ] Verify `cargo build` and `cargo test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)