### PR TITLE
feat(ux): add post-operation next-step hints

### DIFF
--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -201,6 +201,14 @@ pub fn run(
         }
     }
 
+    if config.ui.tips {
+        println!(
+            "{}",
+            "Hint: Run `st ss` to submit, or add changes with `st modify -a -m \"message\"`"
+                .dimmed()
+        );
+    }
+
     Ok(())
 }
 

--- a/src/commands/modify.rs
+++ b/src/commands/modify.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::engine::BranchMetadata;
 use crate::git::GitRepo;
 use anyhow::{Context, Result};
@@ -161,6 +162,15 @@ pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool, res
             false,  // auto_stash_pop
             super::restack::SubmitAfterRestack::No,
         )?;
+    } else if !quiet {
+        let config = Config::load().unwrap_or_default();
+        if config.ui.tips {
+            println!(
+                "{}",
+                "Hint: Run `st restack` to update child branches, or `st ss` to submit."
+                    .dimmed()
+            );
+        }
     }
 
     Ok(())

--- a/src/commands/modify.rs
+++ b/src/commands/modify.rs
@@ -17,8 +17,15 @@ enum ModifyTarget {
 /// When files are already staged, only those files are committed.
 /// When nothing is staged, prompts to stage all (or use `-a`).
 /// On a fresh tracked branch, `-m` creates the first branch-local commit safely.
-pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool, restack: bool) -> Result<()> {
+pub fn run(
+    message: Option<String>,
+    all: bool,
+    quiet: bool,
+    no_verify: bool,
+    restack: bool,
+) -> Result<()> {
     let repo = GitRepo::open()?;
+    let config = Config::load()?;
     let workdir = repo.workdir()?;
     let current = repo.current_branch()?;
 
@@ -153,24 +160,20 @@ pub fn run(message: Option<String>, all: bool, quiet: bool, no_verify: bool, res
             println!();
         }
         super::restack::run(
-            false,  // all
-            false,  // stop_here
-            false,  // continue
-            false,  // dry_run
-            true,   // yes (skip confirmation)
+            false, // all
+            false, // stop_here
+            false, // continue
+            false, // dry_run
+            true,  // yes (skip confirmation)
             quiet,
-            false,  // auto_stash_pop
+            false, // auto_stash_pop
             super::restack::SubmitAfterRestack::No,
         )?;
-    } else if !quiet {
-        let config = Config::load().unwrap_or_default();
-        if config.ui.tips {
-            println!(
-                "{}",
-                "Hint: Run `st restack` to update child branches, or `st ss` to submit."
-                    .dimmed()
-            );
-        }
+    } else if !quiet && config.ui.tips {
+        println!(
+            "{}",
+            "Hint: Run `st restack` to update child branches, or `st ss` to submit.".dimmed()
+        );
     }
 
     Ok(())

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1226,6 +1226,14 @@ pub fn run(
             "Sync complete!".green().bold(),
             render_sync_footer(&stats, sync_started_at.elapsed())
         );
+
+        if !restack && stats.merged_branches_cleaned > 0 && config.ui.tips {
+            println!(
+                "{}",
+                "Hint: Run `st restack --all` to rebase branches onto the updated trunk."
+                    .dimmed()
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Add contextual next-step hints after `st create`, `st sync`, and `st modify` to guide users on what to do next (inspired by Graphite's UX)
- Hints are shown in dimmed text (non-intrusive) and gated behind `config.ui.tips` (default: true, can be disabled)
- After `st create`: suggests `st ss` or `st modify`; after `st sync` with deleted branches: suggests `st restack --all`; after `st modify` without `--restack`: suggests `st restack` or `st ss`

Closes #257, part of #242

## Test plan
- [ ] Run `st create my-branch` and verify the hint line appears after the success message
- [ ] Run `st create -m "message"` and verify the hint appears after the commit output
- [ ] Run `st sync` on a repo with merged branches and verify the restack hint appears
- [ ] Run `st sync --restack` and verify no duplicate hint appears
- [ ] Run `st modify -a -m "msg"` and verify the hint appears
- [ ] Run `st modify -a -m "msg" --restack` and verify no hint appears (restack runs instead)
- [ ] Set `ui.tips = false` in `~/.config/stax/config.toml` and verify hints are suppressed
- [ ] Run `cargo test` and confirm no new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)