### PR TITLE
feat(restack): show conflict position indicator in stack

### DIFF
--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -310,6 +310,7 @@ fn run_impl(
                     .filter(|(_, status)| status == "ok")
                     .map(|(name, _)| name.clone())
                     .collect();
+                let conflict_stack = live_stack.current_stack(branch);
                 print_restack_conflict(
                     repo,
                     &RestackConflictContext {
@@ -322,6 +323,7 @@ fn run_impl(
                             "stax continue",
                             "stax restack --continue",
                         ],
+                        stack_branches: &conflict_stack,
                     },
                 );
                 if stashed {

--- a/src/commands/restack_conflict.rs
+++ b/src/commands/restack_conflict.rs
@@ -7,12 +7,22 @@ pub(crate) struct RestackConflictContext<'a> {
     pub completed_branches: &'a [String],
     pub remaining_branches: usize,
     pub continue_commands: &'a [&'a str],
+    /// Ordered list of branches in the current stack (from trunk to leaf) for
+    /// the conflict position indicator.
+    pub stack_branches: &'a [String],
 }
 
 pub(crate) fn print_restack_conflict(repo: &GitRepo, context: &RestackConflictContext<'_>) {
     let conflicted_files = repo.conflicted_files().unwrap_or_default();
 
     println!();
+    if !context.stack_branches.is_empty() {
+        println!("{}", "Stack position:".yellow());
+        for line in render_stack_position(context.stack_branches, context.branch) {
+            println!("{}", line);
+        }
+        println!();
+    }
     println!("{}", "Restack stopped on conflict:".yellow());
     for line in render_restack_conflict_details(context, &conflicted_files) {
         println!("{}", line);
@@ -22,6 +32,30 @@ pub(crate) fn print_restack_conflict(repo: &GitRepo, context: &RestackConflictCo
     for command in context.continue_commands {
         println!("  {}", command.cyan());
     }
+}
+
+/// Render a mini stack diagram highlighting the conflicting branch.
+///
+/// Branches are displayed top-to-bottom (leaf first, trunk last) with
+/// `◉` for the conflicting branch and `○` for the rest.
+fn render_stack_position(stack_branches: &[String], conflict_branch: &str) -> Vec<String> {
+    // Display from leaf to trunk (reverse of the stored order).
+    stack_branches
+        .iter()
+        .rev()
+        .map(|name| {
+            if name == conflict_branch {
+                format!(
+                    "  {} {}    {}",
+                    "\u{25c9}".red().bold(),
+                    name.red().bold(),
+                    "\u{2190} conflict".red()
+                )
+            } else {
+                format!("  {} {}", "\u{25cb}".dimmed(), name.dimmed())
+            }
+        })
+        .collect()
 }
 
 fn render_restack_conflict_details(
@@ -69,11 +103,17 @@ fn branch_count_label(count: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{render_restack_conflict_details, RestackConflictContext};
+    use super::{render_restack_conflict_details, render_stack_position, RestackConflictContext};
 
     #[test]
     fn renders_progress_completed_branches_and_conflicted_files() {
         let completed = vec!["feature-a".to_string(), "feature-b".to_string()];
+        let stack_branches = vec![
+            "main".to_string(),
+            "feature-a".to_string(),
+            "feature-b".to_string(),
+            "feature-c".to_string(),
+        ];
         let conflicted_files = vec!["src/lib.rs".to_string(), "README.md".to_string()];
         let context = RestackConflictContext {
             branch: "feature-c",
@@ -81,6 +121,7 @@ mod tests {
             completed_branches: &completed,
             remaining_branches: 1,
             continue_commands: &["stax continue"],
+            stack_branches: &stack_branches,
         };
 
         let lines = render_restack_conflict_details(&context, &conflicted_files);
@@ -100,12 +141,14 @@ mod tests {
     #[test]
     fn renders_git_status_hint_when_conflicted_files_are_unknown() {
         let completed = Vec::new();
+        let stack_branches = vec!["main".to_string(), "feature-a".to_string()];
         let context = RestackConflictContext {
             branch: "feature-a",
             parent_branch: "main",
             completed_branches: &completed,
             remaining_branches: 0,
             continue_commands: &["stax continue"],
+            stack_branches: &stack_branches,
         };
 
         let lines = render_restack_conflict_details(&context, &[]);
@@ -120,5 +163,40 @@ mod tests {
             lines[3],
             "  Conflicted files: (not detected; run `git status`)"
         );
+    }
+
+    #[test]
+    fn renders_stack_position_with_conflict_highlighted() {
+        let stack = vec![
+            "main".to_string(),
+            "feature-a".to_string(),
+            "feature-b".to_string(),
+            "feature-c".to_string(),
+        ];
+
+        let lines = render_stack_position(&stack, "feature-b");
+
+        // Displayed leaf-first (reverse order). Check that 4 lines are
+        // produced and the conflict branch is in the expected position.
+        assert_eq!(lines.len(), 4);
+        // The conflict line (feature-b) should contain the marker.
+        assert!(lines[1].contains("feature-b"));
+        assert!(lines[1].contains("conflict"));
+        // Non-conflict lines should still mention their branch names.
+        assert!(lines[0].contains("feature-c"));
+        assert!(lines[2].contains("feature-a"));
+        assert!(lines[3].contains("main"));
+    }
+
+    #[test]
+    fn renders_stack_position_single_branch() {
+        let stack = vec!["main".to_string(), "solo".to_string()];
+
+        let lines = render_stack_position(&stack, "solo");
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("solo"));
+        assert!(lines[0].contains("conflict"));
+        assert!(lines[1].contains("main"));
     }
 }

--- a/src/commands/restack_conflict.rs
+++ b/src/commands/restack_conflict.rs
@@ -47,12 +47,12 @@ fn render_stack_position(stack_branches: &[String], conflict_branch: &str) -> Ve
             if name == conflict_branch {
                 format!(
                     "  {} {}    {}",
-                    "\u{25c9}".red().bold(),
+                    "◉".red().bold(),
                     name.red().bold(),
-                    "\u{2190} conflict".red()
+                    "← conflict".red()
                 )
             } else {
-                format!("  {} {}", "\u{25cb}".dimmed(), name.dimmed())
+                format!("  {} {}", "○".dimmed(), name.dimmed())
             }
         })
         .collect()

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1144,6 +1144,7 @@ pub fn run(
                             .filter(|(_, status)| status == "ok")
                             .map(|(name, _)| name.clone())
                             .collect();
+                        let conflict_stack = live_stack.current_stack(branch);
                         print_restack_conflict(
                             &repo,
                             &RestackConflictContext {
@@ -1156,6 +1157,7 @@ pub fn run(
                                     "stax continue",
                                     "stax sync --continue",
                                 ],
+                                stack_branches: &conflict_stack,
                             },
                         );
                         if stashed {

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -124,6 +124,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
             }
             RebaseResult::Conflict => {
                 println!("    {}", "✗ conflict".red());
+                let conflict_stack = live_stack.current_stack(branch);
                 print_restack_conflict(
                     &repo,
                     &RestackConflictContext {
@@ -136,6 +137,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
                             .map(|index| upstack.len().saturating_sub(index + 1))
                             .unwrap_or(0),
                         continue_commands: &["stax resolve", "stax continue"],
+                        stack_branches: &conflict_stack,
                     },
                 );
 


### PR DESCRIPTION
## Summary
- When a restack hits a conflict, renders a mini stack diagram showing the position of the conflicting branch within the stack
- The conflicting branch is highlighted with `◉` in red, other branches shown with `○` in dimmed text
- Applied consistently across `restack`, `upstack restack`, and `sync` commands

Example output:
```
Stack position:
  ○ feature-c
  ◉ feature-b    ← conflict
  ○ feature-a
  ○ main
```

Closes #256, part of #242.

## Test plan
- [x] Added unit test `renders_stack_position_with_conflict_highlighted` verifying correct ordering (leaf-first) and conflict marker placement
- [x] Added unit test `renders_stack_position_single_branch` verifying minimal two-branch stack rendering
- [x] Existing `render_restack_conflict_details` tests updated with new `stack_branches` field
- [x] Full `cargo build` passes
- [x] Full `cargo test --lib` passes (475/479; 4 pre-existing env-specific shell_setup failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)