### PR TITLE
feat(create): add --insert flag for mid-stack branch insertion

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -219,3 +219,4 @@ Worktree launch examples:
 - `st redo --yes --no-push --quiet`
 - `st edit --yes` (skip final confirmation; interactive commit selection still required)
 - `st edit --no-verify` (skip pre-commit hooks during rebase)
+- `st create --insert` (reparent children of current branch to the new branch)

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -13,6 +13,7 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 | `fp ds submit` | `gt downstack submit` | `st downstack submit` |
 | `fp rs` | `gt sync` | `st sync` / `st rs` |
 | `fp bc` | `gt create` | `st create` / `st bc` |
+| — | `gt create --insert` | `st create --insert` |
 | `fp bco` | `gt checkout` | `st checkout` / `st co` |
 | `fp bu` | `gt up` | `st up` / `st bu` |
 | `fp bd` | `gt down` | `st down` / `st bd` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -531,6 +531,9 @@ enum Commands {
         /// Override branch prefix (e.g. "feature/")
         #[arg(long)]
         prefix: Option<String>,
+        /// Insert between current branch and its children (reparent children)
+        #[arg(long)]
+        insert: bool,
     },
 
     /// Open the current branch PR or list repo pull requests
@@ -838,6 +841,9 @@ enum Commands {
         /// Override branch prefix (e.g. "feature/")
         #[arg(long)]
         prefix: Option<String>,
+        /// Insert between current branch and its children (reparent children)
+        #[arg(long)]
+        insert: bool,
     },
     #[command(hide = true)]
     Bu {
@@ -996,6 +1002,9 @@ enum BranchCommands {
         /// Override branch prefix (e.g. "feature/")
         #[arg(long)]
         prefix: Option<String>,
+        /// Insert between current branch and its children (reparent children)
+        #[arg(long)]
+        insert: bool,
     },
 
     /// Checkout a branch in the stack
@@ -1598,7 +1607,8 @@ pub fn run() -> Result<()> {
             message,
             from,
             prefix,
-        } => commands::branch::create::run(name, message, from, prefix, all),
+            insert,
+        } => commands::branch::create::run(name, message, from, prefix, all, insert),
         Commands::Pr { command } => match command.unwrap_or(PrCommands::Open) {
             PrCommands::Open => commands::pr::run_open(),
             PrCommands::List { limit, json } => commands::pr::run_list(limit, json),
@@ -1707,7 +1717,8 @@ pub fn run() -> Result<()> {
                 message,
                 from,
                 prefix,
-            } => commands::branch::create::run(name, message, from, prefix, all),
+                insert,
+            } => commands::branch::create::run(name, message, from, prefix, all, insert),
             BranchCommands::Checkout {
                 branch,
                 trunk,
@@ -1790,7 +1801,8 @@ pub fn run() -> Result<()> {
             message,
             from,
             prefix,
-        } => commands::branch::create::run(name, message, from, prefix, all),
+            insert,
+        } => commands::branch::create::run(name, message, from, prefix, all, insert),
         Commands::Bu { count } => commands::navigate::up(count),
         Commands::Bd { count } => commands::navigate::down(count),
         Commands::Bs { submit } => run_submit(submit, commands::submit::SubmitScope::Branch),

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::engine::BranchMetadata;
+use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use crate::remote;
 use anyhow::{bail, Result};
@@ -15,6 +15,7 @@ pub fn run(
     from: Option<String>,
     prefix: Option<String>,
     all: bool,
+    insert: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let config = Config::load()?;
@@ -139,6 +140,49 @@ pub fn run(
     if let Err(e) = meta.write(repo.inner(), &branch_name) {
         rollback_create(&repo, &current, &branch_name);
         return Err(e);
+    }
+
+    // If --insert, reparent children of the parent branch to the new branch
+    if insert {
+        let stack = Stack::load(&repo)?;
+        if let Some(parent_info) = stack.branches.get(&parent_branch) {
+            let children: Vec<String> = parent_info
+                .children
+                .iter()
+                .filter(|c| *c != &branch_name)
+                .cloned()
+                .collect();
+
+            if !children.is_empty() {
+                let new_parent_rev = repo.branch_commit(&branch_name)?;
+                for child in &children {
+                    if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
+                        let merge_base = repo
+                            .merge_base(&branch_name, child)
+                            .unwrap_or_else(|_| new_parent_rev.clone());
+                        let updated = BranchMetadata {
+                            parent_branch_name: branch_name.clone(),
+                            parent_branch_revision: merge_base,
+                            ..child_meta
+                        };
+                        updated.write(repo.inner(), child)?;
+                    }
+                }
+
+                println!(
+                    "Reparented {} child branch(es) to '{}'",
+                    children.len(),
+                    branch_name.green()
+                );
+                for child in &children {
+                    println!("  {} -> {}", child.cyan(), branch_name.green());
+                }
+                println!(
+                    "{}",
+                    "Run `stax restack --all` to rebase the reparented branches.".yellow()
+                );
+            }
+        }
     }
 
     // Checkout the new branch

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -157,12 +157,9 @@ pub fn run(
                 let new_parent_rev = repo.branch_commit(&branch_name)?;
                 for child in &children {
                     if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
-                        let merge_base = repo
-                            .merge_base(&branch_name, child)
-                            .unwrap_or_else(|_| new_parent_rev.clone());
                         let updated = BranchMetadata {
                             parent_branch_name: branch_name.clone(),
-                            parent_branch_revision: merge_base,
+                            parent_branch_revision: new_parent_rev.clone(),
                             ..child_meta
                         };
                         updated.write(repo.inner(), child)?;

--- a/tests/create_insert_tests.rs
+++ b/tests/create_insert_tests.rs
@@ -110,9 +110,7 @@ fn test_create_insert_via_bc_alias() {
     repo.run_stax(&["checkout", &branches[1]]);
     let b_parent = repo.get_current_parent();
     assert!(
-        b_parent
-            .as_ref()
-            .map_or(false, |p| p.contains("alias-mid")),
+        b_parent.as_ref().map_or(false, |p| p.contains("alias-mid")),
         "B should be reparented to alias-mid, got parent: {:?}",
         b_parent
     );
@@ -144,10 +142,50 @@ fn test_create_without_insert_does_not_reparent() {
     repo.run_stax(&["checkout", &branches[1]]);
     let b_parent = repo.get_current_parent();
     assert!(
+        b_parent.as_ref().map_or(false, |p| p.contains("norep-a")),
+        "B should still have A as parent, got parent: {:?}",
+        b_parent
+    );
+}
+
+#[test]
+fn test_create_insert_from_trunk_reparents_direct_children() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["status"]).assert_success();
+
+    let trunk_a = repo.create_stack(&["trunk-a"]);
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    let trunk_b = repo.create_stack(&["trunk-b"]);
+
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    let output = repo.run_stax(&["create", "trunk-mid", "--insert"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented"),
+        "Expected reparent message from trunk insert, got: {}",
+        stdout
+    );
+
+    repo.run_stax(&["checkout", &trunk_a[0]]).assert_success();
+    let a_parent = repo.get_current_parent();
+    assert!(
+        a_parent
+            .as_ref()
+            .is_some_and(|parent| parent.contains("trunk-mid")),
+        "trunk-a should be reparented to trunk-mid, got parent: {:?}",
+        a_parent
+    );
+
+    repo.run_stax(&["checkout", &trunk_b[0]]).assert_success();
+    let b_parent = repo.get_current_parent();
+    assert!(
         b_parent
             .as_ref()
-            .map_or(false, |p| p.contains("norep-a")),
-        "B should still have A as parent, got parent: {:?}",
+            .is_some_and(|parent| parent.contains("trunk-mid")),
+        "trunk-b should be reparented to trunk-mid, got parent: {:?}",
         b_parent
     );
 }

--- a/tests/create_insert_tests.rs
+++ b/tests/create_insert_tests.rs
@@ -1,0 +1,153 @@
+mod common;
+use common::{OutputAssertions, TestRepo};
+
+#[test]
+fn test_create_insert_reparents_children() {
+    let repo = TestRepo::new();
+
+    // Initialize stax
+    repo.run_stax(&["status"]).assert_success();
+
+    // Create a stack: main -> A -> B, main -> A -> C
+    let branches = repo.create_stack(&["insert-a", "insert-b"]);
+
+    // Go back to A to create another child
+    repo.run_stax(&["checkout", &branches[0]]);
+    let extra = repo.create_stack(&["insert-c"]);
+
+    // Now A has children: B and C
+    // Go back to A and create a new branch with --insert
+    repo.run_stax(&["checkout", &branches[0]]);
+    let output = repo.run_stax(&["create", "insert-mid", "--insert"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented"),
+        "Expected reparent message, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("restack"),
+        "Expected restack hint, got: {}",
+        stdout
+    );
+
+    // The new branch should be the current branch
+    assert!(repo.current_branch_contains("insert-mid"));
+
+    // B and C should now have insert-mid as parent
+    repo.run_stax(&["checkout", &branches[1]]);
+    let b_parent = repo.get_current_parent();
+    assert!(
+        b_parent
+            .as_ref()
+            .map_or(false, |p| p.contains("insert-mid")),
+        "B should be reparented to insert-mid, got parent: {:?}",
+        b_parent
+    );
+
+    repo.run_stax(&["checkout", &extra[0]]);
+    let c_parent = repo.get_current_parent();
+    assert!(
+        c_parent
+            .as_ref()
+            .map_or(false, |p| p.contains("insert-mid")),
+        "C should be reparented to insert-mid, got parent: {:?}",
+        c_parent
+    );
+}
+
+#[test]
+fn test_create_insert_no_children_noop() {
+    let repo = TestRepo::new();
+
+    // Initialize stax
+    repo.run_stax(&["status"]).assert_success();
+
+    // Create a single branch (leaf with no children)
+    let _branches = repo.create_stack(&["leaf-only"]);
+
+    // Use --insert on a leaf branch (no children to reparent)
+    let output = repo.run_stax(&["create", "after-leaf", "--insert"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    // Should NOT contain reparent message since there were no children
+    assert!(
+        !stdout.contains("Reparented"),
+        "Should not reparent when there are no children, got: {}",
+        stdout
+    );
+
+    // The new branch should be current and stacked on the leaf
+    assert!(repo.current_branch_contains("after-leaf"));
+}
+
+#[test]
+fn test_create_insert_via_bc_alias() {
+    let repo = TestRepo::new();
+
+    // Initialize stax
+    repo.run_stax(&["status"]).assert_success();
+
+    // Create a stack: main -> A -> B
+    let branches = repo.create_stack(&["alias-a", "alias-b"]);
+
+    // Go back to A and use bc (alias) with --insert
+    repo.run_stax(&["checkout", &branches[0]]);
+    let output = repo.run_stax(&["bc", "alias-mid", "--insert"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented"),
+        "Expected reparent message via bc alias, got: {}",
+        stdout
+    );
+
+    // B should now have alias-mid as parent
+    repo.run_stax(&["checkout", &branches[1]]);
+    let b_parent = repo.get_current_parent();
+    assert!(
+        b_parent
+            .as_ref()
+            .map_or(false, |p| p.contains("alias-mid")),
+        "B should be reparented to alias-mid, got parent: {:?}",
+        b_parent
+    );
+}
+
+#[test]
+fn test_create_without_insert_does_not_reparent() {
+    let repo = TestRepo::new();
+
+    // Initialize stax
+    repo.run_stax(&["status"]).assert_success();
+
+    // Create a stack: main -> A -> B
+    let branches = repo.create_stack(&["norep-a", "norep-b"]);
+
+    // Go back to A and create a branch WITHOUT --insert
+    repo.run_stax(&["checkout", &branches[0]]);
+    let output = repo.run_stax(&["create", "norep-sibling"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        !stdout.contains("Reparented"),
+        "Should not reparent without --insert, got: {}",
+        stdout
+    );
+
+    // B should still have A as parent (not norep-sibling)
+    repo.run_stax(&["checkout", &branches[1]]);
+    let b_parent = repo.get_current_parent();
+    assert!(
+        b_parent
+            .as_ref()
+            .map_or(false, |p| p.contains("norep-a")),
+        "B should still have A as parent, got parent: {:?}",
+        b_parent
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `--insert` flag to `st create` / `st bc` that creates a new branch between the current branch and its children, automatically reparenting all children to the new branch
- Prints a summary of reparented branches and a hint to run `stax restack --all`
- Follows the same reparenting pattern used by `stax detach`

Closes #252
Part of #242

## Test plan

- [x] `cargo check` compiles cleanly
- [x] All existing CLI tests pass (89 integration + 22 unit)
- [x] All existing detach tests pass (no regressions in reparent logic)
- [x] New tests in `tests/create_insert_tests.rs`:
  - `test_create_insert_reparents_children` -- verifies multiple children are reparented
  - `test_create_insert_no_children_noop` -- verifies no-op on leaf branches
  - `test_create_insert_via_bc_alias` -- verifies the `bc` shortcut works
  - `test_create_without_insert_does_not_reparent` -- verifies default behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)