### PR TITLE
feat(split): add --file flag for pathspec-based splitting

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -61,6 +61,7 @@
 | `st` | | Launch TUI |
 | `st split` | | Split branch into stacked branches (commit-based; needs 2+ commits) |
 | `st split --hunk` | | Split a single commit into stacked branches by selecting individual diff hunks |
+| `st split --file <pathspec>` | | Split by extracting files matching pathspec into a new parent branch |
 | `st edit` | `e` | Interactively edit commits on current branch (pick, reword, squash, fixup, drop) |
 
 ## Recovery
@@ -228,3 +229,5 @@ Worktree launch examples:
 - `st create --insert` (reparent children of current branch to the new branch)
 - `st submit --publish` (convert existing draft PRs to published)
 - `st submit --draft` (convert existing PRs to draft)
+- `st split --file src/auth.rs` (extract matching files into new parent branch)
+- `st split -f "src/api/*"` (short form, supports globs)

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -27,6 +27,7 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 | — | — | `st cascade` |
 | — | `gt absorb` | `st absorb` |
 | — | — | `st undo` / `st redo` |
+| — | `gt split -f <path>` | `st split --file <path>` |
 
 ## Short alias: `st`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -589,8 +589,12 @@ enum Commands {
     /// Split the current branch into multiple stacked branches (interactive)
     Split {
         /// Split by selecting individual hunks instead of by commit
-        #[arg(long)]
+        #[arg(long, conflicts_with = "file")]
         hunk: bool,
+
+        /// Extract changes to matching files into a new parent branch (repeatable)
+        #[arg(long, short = 'f', num_args = 1.., conflicts_with = "hunk")]
+        file: Vec<String>,
 
         /// Skip pre-commit hooks when committing split branches
         #[arg(long)]
@@ -1651,7 +1655,11 @@ pub fn run() -> Result<()> {
             interval,
             verbose,
         } => commands::ci::run(all, stack, json, refresh, watch, interval, verbose),
-        Commands::Split { hunk, no_verify } => commands::split::run(hunk, no_verify),
+        Commands::Split {
+            hunk,
+            file,
+            no_verify,
+        } => commands::split::run(hunk, file, no_verify),
         Commands::Absorb { dry_run, all } => commands::absorb::run(dry_run, all),
         Commands::Copy { pr } => {
             let target = if pr {
@@ -2352,5 +2360,37 @@ mod tests {
     fn s_alone_shows_stack_group() {
         let result = try_parse_cli(&["stax", "s"]);
         assert!(result.is_err(), "bare `s` should require a subcommand");
+    }
+
+    #[test]
+    fn split_parses_file_flag() {
+        let cli = parse_cli(&["stax", "split", "--file", "src/main.rs"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Split {
+                hunk: false,
+                ref file,
+                no_verify: false,
+            }) if file == &["src/main.rs"]
+        ));
+    }
+
+    #[test]
+    fn split_parses_short_file_flag() {
+        let cli = parse_cli(&["stax", "split", "-f", "src/main.rs", "src/lib.rs"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Split {
+                hunk: false,
+                ref file,
+                no_verify: false,
+            }) if file == &["src/main.rs", "src/lib.rs"]
+        ));
+    }
+
+    #[test]
+    fn split_file_and_hunk_conflict() {
+        let result = try_parse_cli(&["stax", "split", "--hunk", "--file", "foo.rs"]);
+        assert!(result.is_err(), "--hunk and --file should conflict");
     }
 }

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -143,152 +143,71 @@ fn split_by_file(
         anyhow::bail!("Diff is empty for the given pathspecs. Nothing to split.");
     }
 
+    // Closure that rolls back the entire split on any failure.
+    let rollback = || {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+    };
+
+    // Helper: run a fallible operation; rollback and return on error.
+    macro_rules! try_or_rollback {
+        ($expr:expr) => {
+            match $expr {
+                Ok(val) => val,
+                Err(err) => {
+                    rollback();
+                    return Err(err);
+                }
+            }
+        };
+    }
+
     // 4. Create the new branch at parent's tip
     repo.create_branch_at(&new_branch, parent)?;
-    if let Err(err) = repo.checkout(&new_branch) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(repo.checkout(&new_branch));
 
     // 5. Apply the diff on the new branch
-    if let Err(err) = apply_diff(workdir, &diff_output) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(apply_diff(workdir, &diff_output));
 
     // 6. Stage and commit
-    if let Err(err) = stage_files(workdir, &diff_files) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(stage_files(workdir, &diff_files));
     let commit_msg = format!("split: extract {} from {}", pathspecs.join(", "), current);
-    if let Err(err) = commit(workdir, &commit_msg, no_verify) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(commit(workdir, &commit_msg, no_verify));
 
     // 7. Record stax metadata: new branch is child of parent
     let parent_rev = repo.branch_commit(parent)?;
     let meta = BranchMetadata::new(parent, &parent_rev);
-    if let Err(err) = meta.write(repo.inner(), &new_branch) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(meta.write(repo.inner(), &new_branch));
 
     // 8. Switch back to the original branch
-    if let Err(err) = repo.checkout(current) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(repo.checkout(current));
 
     // 9. Remove the extracted files from the current branch by restoring them
-    //    to the state they have on the new branch (i.e. undo our changes to those files).
-    //    We checkout the files from the *parent* so the diff parent..current no longer
-    //    includes them, then amend.
-    if let Err(err) = restore_paths_from_ref(workdir, parent, &diff_files) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    //    to the parent state so the diff parent..current no longer includes them.
+    try_or_rollback!(restore_paths_from_ref(workdir, parent, &diff_files));
 
-    // Stage and amend
-    if let Err(err) = stage_all_changes(workdir) {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
-    let tip_becomes_empty = match index_matches_head_parent(workdir) {
-        Ok(result) => result,
-        Err(err) => {
-            rollback_split_by_file(
-                repo,
-                current,
-                &current_head_before_split,
-                current_meta_before_split.as_ref(),
-                &new_branch,
-            );
-            return Err(err);
-        }
-    };
+    // Stage and amend (or drop if tip becomes empty)
+    try_or_rollback!(stage_all_changes(workdir));
+    let tip_becomes_empty = try_or_rollback!(index_matches_head_parent(workdir));
 
     let rewrite_result = if tip_becomes_empty {
         drop_head_commit(workdir)
     } else {
         amend_head(workdir, no_verify)
     };
-
-    if let Err(err) = rewrite_result {
-        rollback_split_by_file(
-            repo,
-            current,
-            &current_head_before_split,
-            current_meta_before_split.as_ref(),
-            &new_branch,
-        );
-        return Err(err);
-    }
+    try_or_rollback!(rewrite_result);
 
     // 10. Update current branch metadata: parent is now the new branch
     let new_branch_rev = repo.branch_commit(&new_branch)?;
     if let Some(mut meta) = BranchMetadata::read(repo.inner(), current)? {
         meta.parent_branch_name = new_branch.clone();
         meta.parent_branch_revision = new_branch_rev;
-        if let Err(err) = meta.write(repo.inner(), current) {
-            rollback_split_by_file(
-                repo,
-                current,
-                &current_head_before_split,
-                current_meta_before_split.as_ref(),
-                &new_branch,
-            );
-            return Err(err);
-        }
+        try_or_rollback!(meta.write(repo.inner(), current));
     }
 
     println!();

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -1,11 +1,13 @@
-use crate::engine::Stack;
+use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use crate::tui;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
 use std::io::IsTerminal;
+use std::path::Path;
+use std::process::Command;
 
-pub fn run(hunk_mode: bool, no_verify: bool) -> Result<()> {
+pub fn run(hunk_mode: bool, file_pathspecs: Vec<String>, no_verify: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let stack = Stack::load(&repo)?;
     let current = repo.current_branch()?;
@@ -29,6 +31,12 @@ pub fn run(hunk_mode: bool, no_verify: bool) -> Result<()> {
     let parent = branch_info.and_then(|b| b.parent.as_ref());
     if parent.is_none() {
         anyhow::bail!("Branch '{}' has no parent to split from.", current);
+    }
+
+    // Dispatch to file-based split (non-interactive)
+    if !file_pathspecs.is_empty() {
+        let parent_ref = parent.unwrap().clone();
+        return split_by_file(&repo, &current, &parent_ref, &file_pathspecs, no_verify);
     }
 
     if !hunk_mode {
@@ -62,4 +70,301 @@ pub fn run(hunk_mode: bool, no_verify: bool) -> Result<()> {
     }
 
     tui::split::run()
+}
+
+/// Split by extracting file-level changes into a new parent branch.
+///
+/// Strategy:
+///   1. Compute the aggregate diff `parent..current` restricted to the pathspecs.
+///   2. Create a new branch at parent's tip.
+///   3. Apply the diff there and commit.
+///   4. Reparent the current branch onto the new one.
+///   5. On the current branch, revert the extracted files to the new-branch state
+///      (which already contains them) so the current branch no longer carries those changes.
+fn split_by_file(
+    repo: &GitRepo,
+    current: &str,
+    parent: &str,
+    pathspecs: &[String],
+    no_verify: bool,
+) -> Result<()> {
+    let workdir = repo.workdir()?;
+
+    // Bail early if the working tree is dirty
+    if repo.is_dirty()? {
+        anyhow::bail!(
+            "Working tree has uncommitted changes. Please commit or stash them before splitting."
+        );
+    }
+
+    // 1. Check that the pathspecs actually match something in the diff
+    let diff_files = changed_files_between(workdir, parent, current, pathspecs)?;
+    if diff_files.is_empty() {
+        anyhow::bail!(
+            "No changes match the given pathspec(s) between '{}' and '{}'.\n\
+             Files checked: {}",
+            parent,
+            current,
+            pathspecs.join(", ")
+        );
+    }
+
+    println!(
+        "Splitting {} file(s) from '{}' into a new parent branch:",
+        diff_files.len().to_string().cyan(),
+        current.green()
+    );
+    for f in &diff_files {
+        println!("  {}", f.dimmed());
+    }
+
+    // 2. Generate a new branch name
+    let new_branch = generate_split_branch_name(current, repo)?;
+
+    // 3. Get the aggregate diff for the matching files
+    let diff_output = git_diff_for_paths(workdir, parent, current, pathspecs)?;
+    if diff_output.is_empty() {
+        anyhow::bail!("Diff is empty for the given pathspecs. Nothing to split.");
+    }
+
+    // 4. Create the new branch at parent's tip
+    repo.create_branch_at(&new_branch, parent)?;
+    repo.checkout(&new_branch)?;
+
+    // 5. Apply the diff on the new branch
+    apply_diff(workdir, &diff_output)?;
+
+    // 6. Stage and commit
+    stage_files(workdir, &diff_files)?;
+    let commit_msg = format!(
+        "split: extract {} from {}",
+        pathspecs.join(", "),
+        current
+    );
+    commit(workdir, &commit_msg, no_verify)?;
+
+    // 7. Record stax metadata: new branch is child of parent
+    let parent_rev = repo.branch_commit(parent)?;
+    let meta = BranchMetadata::new(parent, &parent_rev);
+    meta.write(repo.inner(), &new_branch)?;
+
+    // 8. Switch back to the original branch
+    repo.checkout(current)?;
+
+    // 9. Remove the extracted files from the current branch by restoring them
+    //    to the state they have on the new branch (i.e. undo our changes to those files).
+    //    We checkout the files from the *parent* so the diff parent..current no longer
+    //    includes them, then amend.
+    checkout_paths_from_ref(workdir, &new_branch, pathspecs)?;
+
+    // Stage and amend
+    stage_files(workdir, &diff_files)?;
+    amend_head(workdir, no_verify)?;
+
+    // 10. Update current branch metadata: parent is now the new branch
+    let new_branch_rev = repo.branch_commit(&new_branch)?;
+    if let Some(mut meta) = BranchMetadata::read(repo.inner(), current)? {
+        meta.parent_branch_name = new_branch.clone();
+        meta.parent_branch_revision = new_branch_rev;
+        meta.write(repo.inner(), current)?;
+    }
+
+    println!();
+    println!(
+        "Created '{}' (stacked on '{}')",
+        new_branch.green(),
+        parent.blue()
+    );
+    println!(
+        "Reparented '{}' onto '{}'",
+        current.green(),
+        new_branch.blue()
+    );
+    println!(
+        "{}",
+        "Tip: run `stax restack` if descendants need rebasing.".dimmed()
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/// Return the list of files that changed between `base` and `head` matching pathspecs.
+fn changed_files_between(
+    workdir: &Path,
+    base: &str,
+    head: &str,
+    pathspecs: &[String],
+) -> Result<Vec<String>> {
+    let mut args = vec!["diff", "--name-only"];
+    let range = format!("{}..{}", base, head);
+    args.push(&range);
+    args.push("--");
+    let pathspec_refs: Vec<&str> = pathspecs.iter().map(|s| s.as_str()).collect();
+    args.extend_from_slice(&pathspec_refs);
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .output()
+        .context("Failed to run git diff --name-only")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("git diff --name-only failed: {}", stderr);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
+/// Get the raw diff output for the given pathspecs.
+fn git_diff_for_paths(
+    workdir: &Path,
+    base: &str,
+    head: &str,
+    pathspecs: &[String],
+) -> Result<Vec<u8>> {
+    let range = format!("{}..{}", base, head);
+    let mut args = vec!["diff", &range, "--"];
+    let pathspec_refs: Vec<&str> = pathspecs.iter().map(|s| s.as_str()).collect();
+    args.extend_from_slice(&pathspec_refs);
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .output()
+        .context("Failed to run git diff")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("git diff failed: {}", stderr);
+    }
+
+    Ok(output.stdout)
+}
+
+/// Apply a diff via `git apply`.
+fn apply_diff(workdir: &Path, diff: &[u8]) -> Result<()> {
+    let mut child = Command::new("git")
+        .args(["apply", "--index", "-"])
+        .current_dir(workdir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("Failed to spawn git apply")?;
+
+    use std::io::Write;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(diff)?;
+    }
+
+    let output = child.wait_with_output().context("git apply failed")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("git apply --index failed: {}", stderr);
+    }
+
+    Ok(())
+}
+
+/// Stage specific files.
+fn stage_files(workdir: &Path, files: &[String]) -> Result<()> {
+    if files.is_empty() {
+        return Ok(());
+    }
+    let status = Command::new("git")
+        .arg("add")
+        .arg("--")
+        .args(files)
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git add")?;
+
+    if !status.success() {
+        anyhow::bail!("git add failed");
+    }
+    Ok(())
+}
+
+/// Commit staged changes.
+fn commit(workdir: &Path, message: &str, no_verify: bool) -> Result<()> {
+    let mut args = vec!["commit", "-m", message];
+    if no_verify {
+        args.push("--no-verify");
+    }
+    let status = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git commit")?;
+
+    if !status.success() {
+        anyhow::bail!("git commit failed");
+    }
+    Ok(())
+}
+
+/// Amend HEAD without changing the commit message.
+fn amend_head(workdir: &Path, no_verify: bool) -> Result<()> {
+    let mut args = vec!["commit", "--amend", "--no-edit"];
+    if no_verify {
+        args.push("--no-verify");
+    }
+    let status = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git commit --amend")?;
+
+    if !status.success() {
+        anyhow::bail!("git commit --amend failed");
+    }
+    Ok(())
+}
+
+/// Checkout specific paths from a given ref.
+fn checkout_paths_from_ref(workdir: &Path, refspec: &str, pathspecs: &[String]) -> Result<()> {
+    let mut args = vec!["checkout", refspec, "--"];
+    let pathspec_refs: Vec<&str> = pathspecs.iter().map(|s| s.as_str()).collect();
+    args.extend_from_slice(&pathspec_refs);
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .output()
+        .context("Failed to run git checkout <ref> -- <paths>")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("git checkout {} -- <paths> failed: {}", refspec, stderr);
+    }
+    Ok(())
+}
+
+/// Generate a branch name for the split-off branch (e.g. "feature-split-1").
+fn generate_split_branch_name(base_name: &str, repo: &GitRepo) -> Result<String> {
+    let existing = repo.list_branches()?;
+    let stem = format!("{}-split", base_name);
+    if !existing.contains(&stem) {
+        return Ok(stem);
+    }
+    for i in 2..1000 {
+        let candidate = format!("{}-{}", stem, i);
+        if !existing.contains(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!(
+        "Cannot generate a unique split branch name from '{}'",
+        base_name
+    );
 }

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -109,6 +109,20 @@ fn split_by_file(
         );
     }
 
+    let commit_count = repo.commits_between(parent, current)?.len();
+    if commit_count > 1 {
+        println!(
+            "{}",
+            "Warning: `stax split --file` only rewrites the tip commit. Matching files may remain in earlier commits."
+                .yellow()
+        );
+        println!(
+            "{}",
+            "Tip: use `stax split --hunk` for commit-by-commit history surgery.".dimmed()
+        );
+        println!();
+    }
+
     println!(
         "Splitting {} file(s) from '{}' into a new parent branch:",
         diff_files.len().to_string().cyan(),
@@ -120,53 +134,161 @@ fn split_by_file(
 
     // 2. Generate a new branch name
     let new_branch = generate_split_branch_name(current, repo)?;
+    let current_head_before_split = repo.branch_commit(current)?;
+    let current_meta_before_split = BranchMetadata::read(repo.inner(), current)?;
 
     // 3. Get the aggregate diff for the matching files
-    let diff_output = git_diff_for_paths(workdir, parent, current, pathspecs)?;
+    let diff_output = git_diff_for_files(workdir, parent, current, &diff_files)?;
     if diff_output.is_empty() {
         anyhow::bail!("Diff is empty for the given pathspecs. Nothing to split.");
     }
 
     // 4. Create the new branch at parent's tip
     repo.create_branch_at(&new_branch, parent)?;
-    repo.checkout(&new_branch)?;
+    if let Err(err) = repo.checkout(&new_branch) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // 5. Apply the diff on the new branch
-    apply_diff(workdir, &diff_output)?;
+    if let Err(err) = apply_diff(workdir, &diff_output) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // 6. Stage and commit
-    stage_files(workdir, &diff_files)?;
-    let commit_msg = format!(
-        "split: extract {} from {}",
-        pathspecs.join(", "),
-        current
-    );
-    commit(workdir, &commit_msg, no_verify)?;
+    if let Err(err) = stage_files(workdir, &diff_files) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
+    let commit_msg = format!("split: extract {} from {}", pathspecs.join(", "), current);
+    if let Err(err) = commit(workdir, &commit_msg, no_verify) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // 7. Record stax metadata: new branch is child of parent
     let parent_rev = repo.branch_commit(parent)?;
     let meta = BranchMetadata::new(parent, &parent_rev);
-    meta.write(repo.inner(), &new_branch)?;
+    if let Err(err) = meta.write(repo.inner(), &new_branch) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // 8. Switch back to the original branch
-    repo.checkout(current)?;
+    if let Err(err) = repo.checkout(current) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // 9. Remove the extracted files from the current branch by restoring them
     //    to the state they have on the new branch (i.e. undo our changes to those files).
     //    We checkout the files from the *parent* so the diff parent..current no longer
     //    includes them, then amend.
-    checkout_paths_from_ref(workdir, &new_branch, pathspecs)?;
+    if let Err(err) = restore_paths_from_ref(workdir, parent, &diff_files) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // Stage and amend
-    stage_files(workdir, &diff_files)?;
-    amend_head(workdir, no_verify)?;
+    if let Err(err) = stage_all_changes(workdir) {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
+    let tip_becomes_empty = match index_matches_head_parent(workdir) {
+        Ok(result) => result,
+        Err(err) => {
+            rollback_split_by_file(
+                repo,
+                current,
+                &current_head_before_split,
+                current_meta_before_split.as_ref(),
+                &new_branch,
+            );
+            return Err(err);
+        }
+    };
+
+    let rewrite_result = if tip_becomes_empty {
+        drop_head_commit(workdir)
+    } else {
+        amend_head(workdir, no_verify)
+    };
+
+    if let Err(err) = rewrite_result {
+        rollback_split_by_file(
+            repo,
+            current,
+            &current_head_before_split,
+            current_meta_before_split.as_ref(),
+            &new_branch,
+        );
+        return Err(err);
+    }
 
     // 10. Update current branch metadata: parent is now the new branch
     let new_branch_rev = repo.branch_commit(&new_branch)?;
     if let Some(mut meta) = BranchMetadata::read(repo.inner(), current)? {
         meta.parent_branch_name = new_branch.clone();
         meta.parent_branch_revision = new_branch_rev;
-        meta.write(repo.inner(), current)?;
+        if let Err(err) = meta.write(repo.inner(), current) {
+            rollback_split_by_file(
+                repo,
+                current,
+                &current_head_before_split,
+                current_meta_before_split.as_ref(),
+                &new_branch,
+            );
+            return Err(err);
+        }
     }
 
     println!();
@@ -185,6 +307,19 @@ fn split_by_file(
         "Tip: run `stax restack` if descendants need rebasing.".dimmed()
     );
 
+    Ok(())
+}
+
+fn stage_all_changes(workdir: &Path) -> Result<()> {
+    let status = Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git add -A")?;
+
+    if !status.success() {
+        anyhow::bail!("git add -A failed");
+    }
     Ok(())
 }
 
@@ -226,16 +361,11 @@ fn changed_files_between(
 }
 
 /// Get the raw diff output for the given pathspecs.
-fn git_diff_for_paths(
-    workdir: &Path,
-    base: &str,
-    head: &str,
-    pathspecs: &[String],
-) -> Result<Vec<u8>> {
+fn git_diff_for_files(workdir: &Path, base: &str, head: &str, files: &[String]) -> Result<Vec<u8>> {
     let range = format!("{}..{}", base, head);
     let mut args = vec!["diff", &range, "--"];
-    let pathspec_refs: Vec<&str> = pathspecs.iter().map(|s| s.as_str()).collect();
-    args.extend_from_slice(&pathspec_refs);
+    let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
+    args.extend_from_slice(&file_refs);
 
     let output = Command::new("git")
         .args(&args)
@@ -282,7 +412,7 @@ fn stage_files(workdir: &Path, files: &[String]) -> Result<()> {
         return Ok(());
     }
     let status = Command::new("git")
-        .arg("add")
+        .args(["add", "-A"])
         .arg("--")
         .args(files)
         .current_dir(workdir)
@@ -331,23 +461,104 @@ fn amend_head(workdir: &Path, no_verify: bool) -> Result<()> {
     Ok(())
 }
 
-/// Checkout specific paths from a given ref.
-fn checkout_paths_from_ref(workdir: &Path, refspec: &str, pathspecs: &[String]) -> Result<()> {
-    let mut args = vec!["checkout", refspec, "--"];
-    let pathspec_refs: Vec<&str> = pathspecs.iter().map(|s| s.as_str()).collect();
-    args.extend_from_slice(&pathspec_refs);
+fn drop_head_commit(workdir: &Path) -> Result<()> {
+    let status = Command::new("git")
+        .args(["reset", "--hard", "HEAD^"])
+        .current_dir(workdir)
+        .status()
+        .context("Failed to drop now-empty tip commit")?;
 
+    if !status.success() {
+        anyhow::bail!("git reset --hard HEAD^ failed");
+    }
+    Ok(())
+}
+
+fn index_matches_head_parent(workdir: &Path) -> Result<bool> {
+    let status = Command::new("git")
+        .args(["diff", "--cached", "--quiet", "HEAD^"])
+        .current_dir(workdir)
+        .status()
+        .context("Failed to compare staged changes against HEAD^")?;
+
+    Ok(status.success())
+}
+
+/// Restore specific paths to the state they have in `refspec`.
+///
+/// Paths that do not exist in `refspec` are removed from the current branch.
+fn restore_paths_from_ref(workdir: &Path, refspec: &str, paths: &[String]) -> Result<()> {
+    for path in paths {
+        if path_exists_in_ref(workdir, refspec, path)? {
+            let output = Command::new("git")
+                .args(["checkout", refspec, "--", path])
+                .current_dir(workdir)
+                .output()
+                .context("Failed to run git checkout <ref> -- <path>")?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                anyhow::bail!("git checkout {} -- {} failed: {}", refspec, path, stderr);
+            }
+        } else {
+            let output = Command::new("git")
+                .args(["rm", "-f", "--ignore-unmatch", "--", path])
+                .current_dir(workdir)
+                .output()
+                .context("Failed to run git rm")?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                anyhow::bail!("git rm {} failed: {}", path, stderr);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn path_exists_in_ref(workdir: &Path, refspec: &str, path: &str) -> Result<bool> {
     let output = Command::new("git")
-        .args(&args)
+        .args(["ls-tree", "-r", "--name-only", refspec, "--", path])
         .current_dir(workdir)
         .output()
-        .context("Failed to run git checkout <ref> -- <paths>")?;
+        .context("Failed to run git ls-tree")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        anyhow::bail!("git checkout {} -- <paths> failed: {}", refspec, stderr);
+        anyhow::bail!("git ls-tree {} -- {} failed: {}", refspec, path, stderr);
     }
-    Ok(())
+
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn rollback_split_by_file(
+    repo: &GitRepo,
+    original_branch: &str,
+    original_head: &str,
+    original_meta: Option<&BranchMetadata>,
+    new_branch: &str,
+) {
+    if let Ok(workdir) = repo.workdir() {
+        let _ = Command::new("git")
+            .args(["reset", "--hard"])
+            .current_dir(workdir)
+            .status();
+        let _ = Command::new("git")
+            .args(["checkout", original_branch])
+            .current_dir(workdir)
+            .status();
+        let _ = Command::new("git")
+            .args(["reset", "--hard", original_head])
+            .current_dir(workdir)
+            .status();
+    }
+
+    if let Some(meta) = original_meta {
+        let _ = meta.write(repo.inner(), original_branch);
+    }
+
+    let _ = repo.delete_branch(new_branch, true);
+    let _ = BranchMetadata::delete(repo.inner(), new_branch);
 }
 
 /// Generate a branch name for the split-off branch (e.g. "feature-split-1").

--- a/tests/split_tests.rs
+++ b/tests/split_tests.rs
@@ -195,3 +195,62 @@ fn test_split_from_middle_of_stack_passes_validation() {
         stderr
     );
 }
+
+#[test]
+fn test_split_file_extracts_matching_paths_into_new_parent_branch() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["status"]).assert_success();
+    repo.run_stax(&["create", "feature"]).assert_success();
+
+    repo.create_file("keep.txt", "keep");
+    repo.commit("add keep");
+    repo.create_file("move.txt", "move");
+    repo.commit("add move");
+
+    let feature_branch = repo.current_branch();
+
+    let output = repo.run_stax(&["split", "--file", "move.txt"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Created") && stdout.contains("Reparented"),
+        "Expected split summary, got: {}",
+        stdout
+    );
+
+    let split_branch = repo
+        .find_branch_containing("feature-split")
+        .expect("expected split branch to be created");
+    assert_eq!(repo.current_branch(), feature_branch);
+
+    let parent_output = repo.git(&["show", &format!("refs/branch-metadata/{}", feature_branch)]);
+    let parent_metadata = TestRepo::stdout(&parent_output);
+    assert!(
+        parent_metadata.contains(&split_branch),
+        "Expected current branch metadata to point to split branch, got: {}",
+        parent_metadata
+    );
+
+    let split_diff = repo.git(&["diff", "--name-only", "main", &split_branch]);
+    let split_files = TestRepo::stdout(&split_diff);
+    assert!(
+        split_files.contains("move.txt"),
+        "Split branch should contain move.txt, got: {}",
+        split_files
+    );
+
+    let feature_diff = repo.git(&["diff", "--name-only", "main", &feature_branch]);
+    let feature_files = TestRepo::stdout(&feature_diff);
+    assert!(
+        feature_files.contains("keep.txt"),
+        "Current branch should still contain keep.txt vs main, got: {}",
+        feature_files
+    );
+    assert!(
+        !feature_files.contains("move.txt"),
+        "Current branch should no longer carry move.txt in its own history, got: {}",
+        feature_files
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `--file` / `-f` repeatable flag to `stax split` that extracts changes to matching file pathspecs into a new parent branch
- Creates a new branch at the parent's tip, applies the aggregate diff for the matching files, reparents the current branch onto it, and amends the current branch to remove the extracted changes
- Adds 3 CLI parsing tests for the new flag (single file, multiple files, conflict with `--hunk`)

Closes #255, part of #242.

## Test plan
- [ ] `stax split -f src/foo.rs` on a branch with changes to `src/foo.rs` and other files -- verify the new parent branch contains only `src/foo.rs` changes
- [ ] `stax split -f "*.rs"` with glob pathspec -- verify all matching `.rs` file changes are extracted
- [ ] `stax split --file a.rs b.rs` with multiple files -- verify both are extracted
- [ ] `stax split --hunk --file foo.rs` -- verify CLI rejects conflicting flags
- [ ] `stax split -f nonexistent.rs` -- verify helpful error message
- [ ] Run on dirty worktree -- verify bail with clean error
- [ ] Run on trunk -- verify bail
- [ ] Run on untracked branch -- verify bail
- [ ] Verify `stax status` shows correct parent/child relationships after split

🤖 Generated with [Claude Code](https://claude.com/claude-code)