### PR TITLE
feat(submit): add --publish/--draft toggle for existing PRs

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -226,3 +226,5 @@ Worktree launch examples:
 - `st edit --yes` (skip final confirmation; interactive commit selection still required)
 - `st edit --no-verify` (skip pre-commit hooks during rebase)
 - `st create --insert` (reparent children of current branch to the new branch)
+- `st submit --publish` (convert existing draft PRs to published)
+- `st submit --draft` (convert existing PRs to draft)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,9 +16,12 @@ struct Cli {
 
 #[derive(Args, Clone)]
 struct SubmitOptions {
-    /// Create PRs as drafts
-    #[arg(short, long)]
+    /// Create new PRs as drafts; convert existing PRs to draft
+    #[arg(short, long, conflicts_with = "publish")]
     draft: bool,
+    /// Create new PRs as published; convert existing draft PRs to published
+    #[arg(long, conflicts_with = "draft")]
+    publish: bool,
     /// Only push, don't create/update PRs
     #[arg(long)]
     no_pr: bool,
@@ -1300,6 +1303,7 @@ fn run_submit(submit: SubmitOptions, scope: commands::submit::SubmitScope) -> Re
     commands::submit::run(
         scope,
         submit.draft,
+        submit.publish,
         submit.no_pr,
         submit.no_fetch,
         submit.force,

--- a/src/commands/cascade.rs
+++ b/src/commands/cascade.rs
@@ -41,6 +41,7 @@ pub fn run(no_pr: bool, no_submit: bool, auto_stash_pop: bool) -> Result<()> {
         commands::submit::run(
             commands::submit::SubmitScope::Stack,
             false,  // draft
+            false,  // publish
             no_pr,  // no_pr (push but skip PR creation/updates)
             false,  // no_fetch
             false,  // force

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -730,6 +730,7 @@ fn submit_after_restack(quiet: bool) -> Result<()> {
     crate::commands::submit::run(
         crate::commands::submit::SubmitScope::Stack,
         false,  // draft
+        false,  // publish
         false,  // no_pr
         false,  // no_fetch
         false,  // force

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -44,6 +44,7 @@ struct PrPlan {
     branch: String,
     parent: String,
     existing_pr: Option<u64>,
+    existing_pr_is_draft: Option<bool>,
     // For new PRs, we'll collect these upfront
     title: Option<String>,
     body: Option<String>,
@@ -398,6 +399,7 @@ pub fn run(
                 branch: branch.clone(),
                 parent: meta.parent_branch_name,
                 existing_pr,
+                existing_pr_is_draft: None,
                 title: None,
                 body: None,
                 is_draft: None,
@@ -564,6 +566,7 @@ pub fn run(
                 branch: branch.clone(),
                 parent: base,
                 existing_pr: pr_number,
+                existing_pr_is_draft: existing_pr.as_ref().map(|pr| pr.info.is_draft),
                 title: None,
                 body: None,
                 is_draft: None,
@@ -927,6 +930,13 @@ pub fn run(
 
             let meta = BranchMetadata::read(repo.inner(), &plan.branch)?
                 .context(format!("No metadata for branch {}", plan.branch))?;
+            let desired_draft_state = if draft {
+                Some(true)
+            } else if publish {
+                Some(false)
+            } else {
+                None
+            };
 
             if let Some(existing_pr_number) = plan.existing_pr {
                 if plan.needs_pr_update {
@@ -944,11 +954,23 @@ pub fn run(
                     apply_pr_metadata(&client, existing_pr_number, &reviewers, &labels, &assignees)
                         .await?;
 
-                    // Toggle draft status if --draft or --publish was passed
-                    if draft || publish {
-                        client
-                            .set_pr_draft(existing_pr_number, draft)
-                            .await?;
+                    // Toggle draft status if --draft or --publish was passed.
+                    if let Some(is_draft) = desired_draft_state {
+                        if plan.existing_pr_is_draft == Some(is_draft) {
+                            let reason = if is_draft {
+                                "already draft"
+                            } else {
+                                "already published"
+                            };
+                            if verbose && !quiet {
+                                println!(
+                                    "      Skipping draft toggle for #{} ({})",
+                                    existing_pr_number, reason
+                                );
+                            }
+                        } else {
+                            client.set_pr_draft(existing_pr_number, is_draft).await?;
+                        }
                     }
 
                     // Re-request review from existing reviewers if flag is set
@@ -985,32 +1007,45 @@ pub fn run(
                     });
                 } else {
                     // Toggle draft status even when no other update is needed
-                    if draft || publish {
+                    if let Some(is_draft) = desired_draft_state {
                         let draft_timer = LiveTimer::maybe_new(
                             !quiet,
                             &format!(
                                 "{} {} #{}...",
-                                if draft { "Converting to draft" } else { "Publishing" },
+                                if is_draft {
+                                    "Converting to draft"
+                                } else {
+                                    "Publishing"
+                                },
                                 plan.branch,
                                 existing_pr_number,
                             ),
                         );
-                        client
-                            .set_pr_draft(existing_pr_number, draft)
-                            .await?;
-                        LiveTimer::maybe_finish_ok(draft_timer, "done");
+                        if plan.existing_pr_is_draft == Some(is_draft) {
+                            LiveTimer::maybe_finish_skipped(
+                                draft_timer,
+                                if is_draft {
+                                    "already draft"
+                                } else {
+                                    "already published"
+                                },
+                            );
+                        } else {
+                            client.set_pr_draft(existing_pr_number, is_draft).await?;
+                            LiveTimer::maybe_finish_ok(draft_timer, "done");
 
-                        // Refresh metadata after draft status change
-                        let pr = client.get_pr(existing_pr_number).await?;
-                        let updated_meta = BranchMetadata {
-                            pr_info: Some(crate::engine::metadata::PrInfo {
-                                number: pr.number,
-                                state: pr.state.clone(),
-                                is_draft: Some(pr.is_draft),
-                            }),
-                            ..meta
-                        };
-                        updated_meta.write(repo.inner(), &plan.branch)?;
+                            // Refresh metadata after draft status change
+                            let pr = client.get_pr(existing_pr_number).await?;
+                            let updated_meta = BranchMetadata {
+                                pr_info: Some(crate::engine::metadata::PrInfo {
+                                    number: pr.number,
+                                    state: pr.state.clone(),
+                                    is_draft: Some(pr.is_draft),
+                                }),
+                                ..meta
+                            };
+                            updated_meta.write(repo.inner(), &plan.branch)?;
+                        }
                     }
 
                     pr_infos.push(StackPrInfo {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -68,11 +68,14 @@ const PR_TYPE_DEFAULT_INDEX: usize = 0;
 
 fn resolve_is_draft_without_prompt(
     draft_flag_set: bool,
+    publish_flag_set: bool,
     draft: bool,
     no_prompt: bool,
 ) -> Option<bool> {
     if draft_flag_set {
         Some(draft)
+    } else if publish_flag_set {
+        Some(false)
     } else if no_prompt {
         Some(true)
     } else {
@@ -84,6 +87,7 @@ fn resolve_is_draft_without_prompt(
 pub fn run(
     scope: SubmitScope,
     draft: bool,
+    publish: bool,
     no_pr: bool,
     no_fetch: bool,
     _force: bool, // kept for CLI compatibility
@@ -746,9 +750,9 @@ pub fn run(
                 }
             };
 
-            // Ask about draft vs publish (only if --draft wasn't explicitly set)
+            // Ask about draft vs publish (only if --draft/--publish wasn't explicitly set)
             let is_draft = if let Some(is_draft) =
-                resolve_is_draft_without_prompt(draft_flag_set, draft, no_prompt)
+                resolve_is_draft_without_prompt(draft_flag_set, publish, draft, no_prompt)
             {
                 is_draft
             } else {
@@ -940,6 +944,13 @@ pub fn run(
                     apply_pr_metadata(&client, existing_pr_number, &reviewers, &labels, &assignees)
                         .await?;
 
+                    // Toggle draft status if --draft or --publish was passed
+                    if draft || publish {
+                        client
+                            .set_pr_draft(existing_pr_number, draft)
+                            .await?;
+                    }
+
                     // Re-request review from existing reviewers if flag is set
                     if rerequest_review {
                         let existing_reviewers = client
@@ -973,7 +984,35 @@ pub fn run(
                         pr_number: Some(pr.number),
                     });
                 } else {
-                    // No-op - just add to pr_infos for summary
+                    // Toggle draft status even when no other update is needed
+                    if draft || publish {
+                        let draft_timer = LiveTimer::maybe_new(
+                            !quiet,
+                            &format!(
+                                "{} {} #{}...",
+                                if draft { "Converting to draft" } else { "Publishing" },
+                                plan.branch,
+                                existing_pr_number,
+                            ),
+                        );
+                        client
+                            .set_pr_draft(existing_pr_number, draft)
+                            .await?;
+                        LiveTimer::maybe_finish_ok(draft_timer, "done");
+
+                        // Refresh metadata after draft status change
+                        let pr = client.get_pr(existing_pr_number).await?;
+                        let updated_meta = BranchMetadata {
+                            pr_info: Some(crate::engine::metadata::PrInfo {
+                                number: pr.number,
+                                state: pr.state.clone(),
+                                is_draft: Some(pr.is_draft),
+                            }),
+                            ..meta
+                        };
+                        updated_meta.write(repo.inner(), &plan.branch)?;
+                    }
+
                     pr_infos.push(StackPrInfo {
                         branch: plan.branch.clone(),
                         pr_number: Some(existing_pr_number),
@@ -1666,7 +1705,7 @@ mod tests {
     #[test]
     fn no_prompt_defaults_to_draft() {
         assert_eq!(
-            resolve_is_draft_without_prompt(false, false, true),
+            resolve_is_draft_without_prompt(false, false, false, true),
             Some(true)
         );
     }
@@ -1674,14 +1713,33 @@ mod tests {
     #[test]
     fn explicit_draft_flag_still_forces_draft() {
         assert_eq!(
-            resolve_is_draft_without_prompt(true, true, false),
+            resolve_is_draft_without_prompt(true, false, true, false),
             Some(true)
         );
     }
 
     #[test]
     fn explicit_no_draft_flag_still_requires_prompt() {
-        assert_eq!(resolve_is_draft_without_prompt(false, false, false), None);
+        assert_eq!(
+            resolve_is_draft_without_prompt(false, false, false, false),
+            None
+        );
+    }
+
+    #[test]
+    fn publish_flag_forces_non_draft() {
+        assert_eq!(
+            resolve_is_draft_without_prompt(false, true, false, false),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn publish_flag_overrides_no_prompt_default() {
+        assert_eq!(
+            resolve_is_draft_without_prompt(false, true, false, true),
+            Some(false)
+        );
     }
 
     #[test]

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -110,6 +110,11 @@ struct UpdatePullRequest<'a> {
 }
 
 #[derive(Serialize)]
+struct UpdatePullRequestDraft {
+    draft: bool,
+}
+
+#[derive(Serialize)]
 struct MergePullRequest<'a> {
     #[serde(rename = "MergeTitleField", skip_serializing_if = "Option::is_none")]
     merge_title: Option<&'a str>,
@@ -228,6 +233,17 @@ impl GiteaClient {
             base: None,
             body: Some(body),
         };
+        let _: GiteaPull = patch_json(
+            &self.client,
+            &self.repo_url(&format!("/pulls/{}", number)),
+            &request,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        let request = UpdatePullRequestDraft { draft: is_draft };
         let _: GiteaPull = patch_json(
             &self.client,
             &self.repo_url(&format!("/pulls/{}", number)),

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -107,11 +107,8 @@ struct UpdatePullRequest<'a> {
     base: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     body: Option<&'a str>,
-}
-
-#[derive(Serialize)]
-struct UpdatePullRequestDraft {
-    draft: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    draft: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -218,6 +215,7 @@ impl GiteaClient {
         let request = UpdatePullRequest {
             base: Some(new_base),
             body: None,
+            draft: None,
         };
         let _: GiteaPull = patch_json(
             &self.client,
@@ -232,6 +230,7 @@ impl GiteaClient {
         let request = UpdatePullRequest {
             base: None,
             body: Some(body),
+            draft: None,
         };
         let _: GiteaPull = patch_json(
             &self.client,
@@ -243,7 +242,11 @@ impl GiteaClient {
     }
 
     pub async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
-        let request = UpdatePullRequestDraft { draft: is_draft };
+        let request = UpdatePullRequest {
+            base: None,
+            body: None,
+            draft: Some(is_draft),
+        };
         let _: GiteaPull = patch_json(
             &self.client,
             &self.repo_url(&format!("/pulls/{}", number)),

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -105,12 +105,9 @@ struct UpdateMrRequest<'a> {
     target_branch: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<&'a str>,
-}
-
-#[derive(Serialize)]
-struct UpdateMrDraftRequest {
     /// GitLab 14.0+ supports setting draft status directly via the `draft` field.
-    draft: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    draft: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -232,6 +229,7 @@ impl GitLabClient {
         let request = UpdateMrRequest {
             target_branch: Some(new_base),
             description: None,
+            draft: None,
         };
         let _: GitLabMr = put_json(
             &self.client,
@@ -246,6 +244,7 @@ impl GitLabClient {
         let request = UpdateMrRequest {
             target_branch: None,
             description: Some(body),
+            draft: None,
         };
         let _: GitLabMr = put_json(
             &self.client,
@@ -257,7 +256,11 @@ impl GitLabClient {
     }
 
     pub async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
-        let request = UpdateMrDraftRequest { draft: is_draft };
+        let request = UpdateMrRequest {
+            target_branch: None,
+            description: None,
+            draft: Some(is_draft),
+        };
         let _: GitLabMr = put_json(
             &self.client,
             &self.project_url(&format!("/merge_requests/{}", number)),

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -108,6 +108,12 @@ struct UpdateMrRequest<'a> {
 }
 
 #[derive(Serialize)]
+struct UpdateMrDraftRequest {
+    /// GitLab 14.0+ supports setting draft status directly via the `draft` field.
+    draft: bool,
+}
+
+#[derive(Serialize)]
 struct MergeMrRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     merge_commit_message: Option<&'a str>,
@@ -241,6 +247,17 @@ impl GitLabClient {
             target_branch: None,
             description: Some(body),
         };
+        let _: GitLabMr = put_json(
+            &self.client,
+            &self.project_url(&format!("/merge_requests/{}", number)),
+            &request,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        let request = UpdateMrDraftRequest { draft: is_draft };
         let _: GitLabMr = put_json(
             &self.client,
             &self.project_url(&format!("/merge_requests/{}", number)),

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -169,6 +169,12 @@ impl ForgeClient {
         dispatch!(self, update_pr_base(number, new_base))
     }
 
+    /// Set the draft status of an existing PR.
+    /// `is_draft = true` converts to draft, `is_draft = false` marks ready for review.
+    pub async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        dispatch!(self, set_pr_draft(number, is_draft))
+    }
+
     /// Enqueue a PR into the forge's merge queue (GitHub) or merge train (GitLab).
     /// Not supported on Gitea/Forgejo (no merge queue feature).
     pub async fn enqueue_pr(&self, number: u64) -> Result<crate::github::pr::EnqueueResult> {

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -541,6 +541,64 @@ impl GitHubClient {
         Ok(())
     }
 
+    /// Set the draft status of an existing PR.
+    ///
+    /// Uses GraphQL mutations because the REST API does not support toggling draft status.
+    /// - `convertPullRequestToDraft` to mark as draft
+    /// - `markPullRequestReadyForReview` to publish
+    pub async fn set_pr_draft(&self, pr_number: u64, is_draft: bool) -> Result<()> {
+        let node_id = self.get_pr_node_id(pr_number).await?;
+
+        let mutation = if is_draft {
+            self.record_api_call("pulls.convertToDraft");
+            format!(
+                r#"
+                mutation {{
+                    convertPullRequestToDraft(input: {{ pullRequestId: "{}" }}) {{
+                        pullRequest {{ isDraft }}
+                    }}
+                }}
+                "#,
+                node_id
+            )
+        } else {
+            self.record_api_call("pulls.markReadyForReview");
+            format!(
+                r#"
+                mutation {{
+                    markPullRequestReadyForReview(input: {{ pullRequestId: "{}" }}) {{
+                        pullRequest {{ isDraft }}
+                    }}
+                }}
+                "#,
+                node_id
+            )
+        };
+
+        let response: GraphQLResponse<serde_json::Value> = self
+            .octocrab
+            .graphql(&serde_json::json!({ "query": mutation }))
+            .await
+            .context("Failed to update PR draft status")?;
+
+        if let Some(errors) = response.errors {
+            if !errors.is_empty() {
+                anyhow::bail!(
+                    "Failed to {} PR #{}: {}",
+                    if is_draft {
+                        "convert to draft"
+                    } else {
+                        "mark ready for review"
+                    },
+                    pr_number,
+                    errors[0].message
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Merge the pull request base branch into the head branch (GitHub "Update branch" button).
     ///
     /// See <https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch>.


### PR DESCRIPTION
## Summary

- Add `--publish` flag to `st submit` (conflicts with `--draft`) that converts existing draft PRs to published and creates new PRs as non-draft
- Add `--draft` support for converting existing PRs to draft (previously only affected new PR creation)
- Implement `set_pr_draft` on all three forge backends: GitHub (GraphQL mutations), GitLab (REST `draft` field), and Gitea (REST `draft` field)

Closes #253, part of #242

## Test plan

- [ ] `st submit --draft` on a stack with existing published PRs converts them to draft
- [ ] `st submit --publish` on a stack with existing draft PRs converts them to published
- [ ] `st submit` without flags preserves existing PR draft state (no regression)
- [ ] `st submit --draft --publish` is rejected by clap as conflicting
- [ ] New PR creation respects `--publish` (creates as non-draft) and `--draft` (creates as draft)
- [ ] Unit tests pass: `cargo test --lib -- submit::tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)