### PR TITLE
feat(submit): auto-update PR title from commit message

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -175,6 +175,7 @@ Worktree launch examples:
 - `st submit --no-template`
 - `st submit --edit`
 - `st submit --rerequest-review`
+- `st submit --update-title` (sync existing PR titles with the tip commit subject when they differ)
 - `~/.config/stax/config.toml`: set `[submit] stack_links = "comment"` (or `"body" | "both" | "off"`)
 - `st merge --all --method squash --yes`
 - `st merge --dry-run`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,9 @@ struct SubmitOptions {
     /// Squash all commits on each branch into one before pushing
     #[arg(long)]
     squash: bool,
+    /// Update existing PR titles when the tip commit subject has changed
+    #[arg(long)]
+    update_title: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -1321,6 +1324,7 @@ fn run_submit(submit: SubmitOptions, scope: commands::submit::SubmitScope) -> Re
         submit.ai_body,
         submit.rerequest_review,
         submit.squash,
+        submit.update_title,
     )
 }
 

--- a/src/commands/cascade.rs
+++ b/src/commands/cascade.rs
@@ -59,6 +59,7 @@ pub fn run(no_pr: bool, no_submit: bool, auto_stash_pop: bool) -> Result<()> {
             false,  // ai_body
             false,  // rerequest_review
             false,  // squash
+            false,  // update_title
         )?;
     }
 

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -748,6 +748,7 @@ fn submit_after_restack(quiet: bool) -> Result<()> {
         false, // ai_body
         false, // rerequest_review
         false, // squash
+        false, // update_title
     )?;
 
     Ok(())

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -110,6 +110,7 @@ pub fn run(
     ai_body: bool,
     rerequest_review: bool,
     squash: bool,
+    update_title: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let current = repo.current_branch()?;
@@ -568,17 +569,20 @@ pub fn run(
                 true // New PR always needs creation
             };
 
-            // Capture tip commit subject for auto-updating PR title on existing PRs
-            let tip_commit_subject = if pr_number.is_some() && !is_empty {
+            // Capture tip commit subject for auto-updating PR title on existing PRs.
+            // Only computed when the user opts in via `--update-title` so default submits
+            // do not silently rewrite PR titles from local commit messages.
+            let tip_commit_subject = if update_title && pr_number.is_some() && !is_empty {
                 tip_commit_subject(repo.workdir()?, branch)
             } else {
                 None
             };
-            let needs_title_update = existing_pr
-                .as_ref()
-                .zip(tip_commit_subject.as_ref())
-                .map(|(pr, commit_subject)| pr.title != *commit_subject)
-                .unwrap_or(false);
+            let needs_title_update = update_title
+                && existing_pr
+                    .as_ref()
+                    .zip(tip_commit_subject.as_ref())
+                    .map(|(pr, commit_subject)| pr.title != *commit_subject)
+                    .unwrap_or(false);
 
             plans.push(PrPlan {
                 branch: branch.clone(),

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -45,10 +45,10 @@ struct PrPlan {
     parent: String,
     existing_pr: Option<u64>,
     existing_pr_is_draft: Option<bool>,
-    /// Current PR title on the forge (for existing PRs)
-    existing_pr_title: Option<String>,
     /// Tip commit subject line (for auto-updating PR title)
     tip_commit_subject: Option<String>,
+    /// Whether the tip commit subject differs from the existing PR title.
+    needs_title_update: bool,
     // For new PRs, we'll collect these upfront
     title: Option<String>,
     body: Option<String>,
@@ -404,8 +404,8 @@ pub fn run(
                 parent: meta.parent_branch_name,
                 existing_pr,
                 existing_pr_is_draft: None,
-                existing_pr_title: None,
                 tip_commit_subject: None,
+                needs_title_update: false,
                 title: None,
                 body: None,
                 is_draft: None,
@@ -568,22 +568,25 @@ pub fn run(
                 true // New PR always needs creation
             };
 
-            let existing_pr_title = existing_pr.as_ref().map(|p| p.title.clone());
-
             // Capture tip commit subject for auto-updating PR title on existing PRs
             let tip_commit_subject = if pr_number.is_some() && !is_empty {
                 tip_commit_subject(repo.workdir()?, branch)
             } else {
                 None
             };
+            let needs_title_update = existing_pr
+                .as_ref()
+                .zip(tip_commit_subject.as_ref())
+                .map(|(pr, commit_subject)| pr.title != *commit_subject)
+                .unwrap_or(false);
 
             plans.push(PrPlan {
                 branch: branch.clone(),
                 parent: base,
                 existing_pr: pr_number,
                 existing_pr_is_draft: existing_pr.as_ref().map(|pr| pr.info.is_draft),
-                existing_pr_title,
                 tip_commit_subject,
+                needs_title_update,
                 title: None,
                 body: None,
                 is_draft: None,
@@ -969,13 +972,8 @@ pub fn run(
                         .await?;
 
                     // Auto-update PR title from tip commit subject when it has changed
-                    if let Some(ref commit_subject) = plan.tip_commit_subject {
-                        let title_changed = plan
-                            .existing_pr_title
-                            .as_ref()
-                            .map(|current| current != commit_subject)
-                            .unwrap_or(false);
-                        if title_changed {
+                    if plan.needs_title_update {
+                        if let Some(ref commit_subject) = plan.tip_commit_subject {
                             client
                                 .update_pr_title(existing_pr_number, commit_subject)
                                 .await?;
@@ -1079,6 +1077,24 @@ pub fn run(
                         }
                     }
 
+                    // Update PR title if opt-in and the tip commit subject drifted
+                    if plan.needs_title_update {
+                        let title_timer = LiveTimer::maybe_new(
+                            !quiet,
+                            &format!(
+                                "Updating title for {} #{}...",
+                                plan.branch, existing_pr_number
+                            ),
+                        );
+                        if let Some(ref commit_subject) = plan.tip_commit_subject {
+                            client
+                                .update_pr_title(existing_pr_number, commit_subject)
+                                .await?;
+                        }
+                        LiveTimer::maybe_finish_ok(title_timer, "done");
+                    }
+
+                    // No-op - just add to pr_infos for summary
                     pr_infos.push(StackPrInfo {
                         branch: plan.branch.clone(),
                         pr_number: Some(existing_pr_number),
@@ -1543,7 +1559,11 @@ fn tip_commit_subject(workdir: &Path, branch: &str) -> Option<String> {
         .filter(|o| o.status.success())
         .and_then(|o| {
             let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if s.is_empty() { None } else { Some(s) }
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
         })
 }
 

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -45,6 +45,10 @@ struct PrPlan {
     parent: String,
     existing_pr: Option<u64>,
     existing_pr_is_draft: Option<bool>,
+    /// Current PR title on the forge (for existing PRs)
+    existing_pr_title: Option<String>,
+    /// Tip commit subject line (for auto-updating PR title)
+    tip_commit_subject: Option<String>,
     // For new PRs, we'll collect these upfront
     title: Option<String>,
     body: Option<String>,
@@ -400,6 +404,8 @@ pub fn run(
                 parent: meta.parent_branch_name,
                 existing_pr,
                 existing_pr_is_draft: None,
+                existing_pr_title: None,
+                tip_commit_subject: None,
                 title: None,
                 body: None,
                 is_draft: None,
@@ -562,11 +568,22 @@ pub fn run(
                 true // New PR always needs creation
             };
 
+            let existing_pr_title = existing_pr.as_ref().map(|p| p.title.clone());
+
+            // Capture tip commit subject for auto-updating PR title on existing PRs
+            let tip_commit_subject = if pr_number.is_some() && !is_empty {
+                tip_commit_subject(repo.workdir()?, branch)
+            } else {
+                None
+            };
+
             plans.push(PrPlan {
                 branch: branch.clone(),
                 parent: base,
                 existing_pr: pr_number,
                 existing_pr_is_draft: existing_pr.as_ref().map(|pr| pr.info.is_draft),
+                existing_pr_title,
+                tip_commit_subject,
                 title: None,
                 body: None,
                 is_draft: None,
@@ -950,6 +967,20 @@ pub fn run(
                     client
                         .update_pr_base(existing_pr_number, &plan.parent)
                         .await?;
+
+                    // Auto-update PR title from tip commit subject when it has changed
+                    if let Some(ref commit_subject) = plan.tip_commit_subject {
+                        let title_changed = plan
+                            .existing_pr_title
+                            .as_ref()
+                            .map(|current| current != commit_subject)
+                            .unwrap_or(false);
+                        if title_changed {
+                            client
+                                .update_pr_title(existing_pr_number, commit_subject)
+                                .await?;
+                        }
+                    }
 
                     apply_pr_metadata(&client, existing_pr_number, &reviewers, &labels, &assignees)
                         .await?;
@@ -1500,6 +1531,20 @@ fn branch_matches_remote(workdir: &Path, remote: &str, branch: &str) -> bool {
         (Some(l), Some(r)) => l == r,
         _ => false,
     }
+}
+
+/// Get the subject line of the tip commit on a branch.
+fn tip_commit_subject(workdir: &Path, branch: &str) -> Option<String> {
+    Command::new("git")
+        .args(["log", "-1", "--format=%s", branch])
+        .current_dir(workdir)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if s.is_empty() { None } else { Some(s) }
+        })
 }
 
 fn collect_commit_messages(workdir: &Path, parent: &str, branch: &str) -> Vec<String> {

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -109,6 +109,8 @@ struct UpdatePullRequest<'a> {
     body: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     draft: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
 }
 
 #[derive(Serialize)]
@@ -216,6 +218,23 @@ impl GiteaClient {
             base: Some(new_base),
             body: None,
             draft: None,
+            title: None,
+        };
+        let _: GiteaPull = patch_json(
+            &self.client,
+            &self.repo_url(&format!("/pulls/{}", number)),
+            &request,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        let request = UpdatePullRequest {
+            base: None,
+            body: None,
+            draft: None,
+            title: Some(title),
         };
         let _: GiteaPull = patch_json(
             &self.client,
@@ -231,6 +250,7 @@ impl GiteaClient {
             base: None,
             body: Some(body),
             draft: None,
+            title: None,
         };
         let _: GiteaPull = patch_json(
             &self.client,
@@ -246,6 +266,7 @@ impl GiteaClient {
             base: None,
             body: None,
             draft: Some(is_draft),
+            title: None,
         };
         let _: GiteaPull = patch_json(
             &self.client,
@@ -658,6 +679,7 @@ fn pr_to_info_with_head(pr: GiteaPull) -> PrInfoWithHead {
         info: pr_to_info(&pr),
         head: pr.head.ref_name.clone(),
         head_label: pr.head.label.clone(),
+        title: pr.title.clone(),
     }
 }
 

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -108,6 +108,8 @@ struct UpdateMrRequest<'a> {
     /// GitLab 14.0+ supports setting draft status directly via the `draft` field.
     #[serde(skip_serializing_if = "Option::is_none")]
     draft: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
 }
 
 #[derive(Serialize)]
@@ -230,6 +232,23 @@ impl GitLabClient {
             target_branch: Some(new_base),
             description: None,
             draft: None,
+            title: None,
+        };
+        let _: GitLabMr = put_json(
+            &self.client,
+            &self.project_url(&format!("/merge_requests/{}", number)),
+            &request,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        let request = UpdateMrRequest {
+            target_branch: None,
+            description: None,
+            draft: None,
+            title: Some(title),
         };
         let _: GitLabMr = put_json(
             &self.client,
@@ -245,6 +264,7 @@ impl GitLabClient {
             target_branch: None,
             description: Some(body),
             draft: None,
+            title: None,
         };
         let _: GitLabMr = put_json(
             &self.client,
@@ -260,6 +280,7 @@ impl GitLabClient {
             target_branch: None,
             description: None,
             draft: Some(is_draft),
+            title: None,
         };
         let _: GitLabMr = put_json(
             &self.client,
@@ -727,6 +748,7 @@ fn mr_to_pr_with_head(mr: GitLabMr) -> PrInfoWithHead {
         info: mr_to_pr_info(&mr),
         head: mr.source_branch,
         head_label: mr.web_url,
+        title: mr.title,
     }
 }
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -200,6 +200,10 @@ impl ForgeClient {
         }
     }
 
+    pub async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        dispatch!(self, update_pr_title(number, title))
+    }
+
     pub async fn update_pr_body(&self, number: u64, body: &str) -> Result<()> {
         dispatch!(self, update_pr_body(number, body))
     }

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -94,6 +94,7 @@ pub struct PrInfoWithHead {
     pub info: PrInfo,
     pub head: String,
     pub head_label: Option<String>,
+    pub title: String,
 }
 
 /// Merge method for PRs
@@ -359,6 +360,7 @@ impl GitHubClient {
 
             return Ok(Some(PrInfoWithHead {
                 head_label: pr.head.label.clone(),
+                title: pr.title.clone().unwrap_or_default(),
                 info: PrInfo {
                     number: pr.number,
                     state: pr
@@ -423,6 +425,7 @@ impl GitHubClient {
                     head,
                     PrInfoWithHead {
                         head_label: pr.head.label.clone(),
+                        title: pr.title.clone().unwrap_or_default(),
                         info: PrInfo {
                             number: pr.number,
                             state: pr
@@ -515,6 +518,7 @@ impl GitHubClient {
         Ok(PrInfoWithHead {
             head: pr.head.ref_field.clone(),
             head_label: pr.head.label.clone(),
+            title: pr.title.clone().unwrap_or_default(),
             info: PrInfo {
                 number: pr.number,
                 state: pr
@@ -627,6 +631,19 @@ impl GitHubClient {
                 }
             }
         }
+    }
+
+    /// Update PR title
+    pub async fn update_pr_title(&self, pr_number: u64, title: &str) -> Result<()> {
+        self.record_api_call("pulls.update.title");
+        self.octocrab
+            .pulls(&self.owner, &self.repo)
+            .update(pr_number)
+            .title(title)
+            .send()
+            .await
+            .context("Failed to update PR title")?;
+        Ok(())
     }
 
     /// Update PR body text

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5799,6 +5799,41 @@ mod forge_mock_tests {
             .unwrap_or_else(|| panic!("Did not find request {} {}", method_name, path_name))
     }
 
+    /// Find a request to a PR/MR endpoint whose JSON payload contains a body/description key.
+    /// This distinguishes body-update requests from title-update requests (both hit the same URL).
+    /// Works for GitHub (PATCH + "body"), GitLab (PUT + "description"), and Gitea (PATCH + "body").
+    fn find_body_update<'a>(
+        requests: &'a [wiremock::Request],
+        method_name: &str,
+        path_name: &str,
+        json_key: &str,
+    ) -> &'a wiremock::Request {
+        requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == method_name
+                    && request.url.path() == path_name
+                    && serde_json::from_slice::<serde_json::Value>(&request.body)
+                        .ok()
+                        .and_then(|v| v.get(json_key).cloned())
+                        .is_some()
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "Did not find {} request to {} with '{}' in payload",
+                    method_name, path_name, json_key
+                )
+            })
+    }
+
+    /// Shorthand for GitHub/Gitea PATCH requests with "body" key.
+    fn find_body_patch<'a>(
+        requests: &'a [wiremock::Request],
+        path_name: &str,
+    ) -> &'a wiremock::Request {
+        find_body_update(requests, "PATCH", path_name, "body")
+    }
+
     fn issue_comment_fixture(id: u64, body: &str) -> serde_json::Value {
         serde_json::json!({
             "id": id,
@@ -6487,13 +6522,7 @@ mod forge_mock_tests {
             request.method.as_str() == "PATCH"
                 && request.url.path() == "/repos/test/repo/issues/comments/901"
         }));
-        let body_patch = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing body patch");
+        let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
         assert_eq!(payload["body"], "## Summary\n\nhello");
     }
@@ -6573,13 +6602,7 @@ mod forge_mock_tests {
             request.method.as_str() == "DELETE"
                 && request.url.path() == "/repos/test/repo/issues/comments/901"
         }));
-        let body_patch = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing body patch");
+        let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
         let body = payload["body"].as_str().unwrap();
         assert!(body.starts_with("## Summary\n\nhello"));
@@ -6667,13 +6690,7 @@ mod forge_mock_tests {
             request.method.as_str() == "PATCH"
                 && request.url.path() == "/repos/test/repo/issues/comments/901"
         }));
-        let body_patch = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing body patch");
+        let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
         assert!(payload["body"]
             .as_str()
@@ -6756,13 +6773,7 @@ mod forge_mock_tests {
             request.method.as_str() == "DELETE"
                 && request.url.path() == "/repos/test/repo/issues/comments/901"
         }));
-        let body_patch = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing body patch");
+        let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
         assert_eq!(payload["body"], "## Summary\n\nhello");
     }
@@ -8024,13 +8035,12 @@ mod forge_mock_tests {
             .unwrap()
             .contains("<!-- stax-stack-comment -->"));
 
-        let body_update = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PUT"
-                    && request.url.path() == "/projects/test%2Frepo/merge_requests/42"
-            })
-            .expect("missing GitLab body update request");
+        let body_update = find_body_update(
+            &requests,
+            "PUT",
+            "/projects/test%2Frepo/merge_requests/42",
+            "description",
+        );
         let body_payload: serde_json::Value = serde_json::from_slice(&body_update.body).unwrap();
         assert!(body_payload["description"]
             .as_str()
@@ -8128,13 +8138,12 @@ mod forge_mock_tests {
             request.method.as_str() == "DELETE"
                 && request.url.path() == "/projects/test%2Frepo/merge_requests/42/notes/900"
         }));
-        let body_update = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PUT"
-                    && request.url.path() == "/projects/test%2Frepo/merge_requests/42"
-            })
-            .expect("missing GitLab body update request");
+        let body_update = find_body_update(
+            &requests,
+            "PUT",
+            "/projects/test%2Frepo/merge_requests/42",
+            "description",
+        );
         let payload: serde_json::Value = serde_json::from_slice(&body_update.body).unwrap();
         assert_eq!(payload["description"], "## Summary\n\nhello");
     }
@@ -8720,13 +8729,7 @@ mod forge_mock_tests {
         assert!(output.status.success(), "{}", TestRepo::stderr(&output));
 
         let requests = mock_server.received_requests().await.unwrap();
-        let body_update = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing Gitea body update request");
+        let body_update = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_update.body).unwrap();
         assert!(payload["body"]
             .as_str()
@@ -8838,13 +8841,7 @@ mod forge_mock_tests {
             .unwrap()
             .contains("<!-- stax-stack-comment -->"));
 
-        let body_update = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing Gitea body update request");
+        let body_update = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let body_payload: serde_json::Value = serde_json::from_slice(&body_update.body).unwrap();
         assert!(body_payload["body"]
             .as_str()
@@ -8941,13 +8938,7 @@ mod forge_mock_tests {
             request.method.as_str() == "DELETE"
                 && request.url.path() == "/repos/test/repo/issues/comments/901"
         }));
-        let body_update = requests
-            .iter()
-            .find(|request| {
-                request.method.as_str() == "PATCH"
-                    && request.url.path() == "/repos/test/repo/pulls/42"
-            })
-            .expect("missing Gitea body update request");
+        let body_update = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_update.body).unwrap();
         assert_eq!(payload["body"], "## Summary\n\nhello");
     }


### PR DESCRIPTION
## Summary

- Auto-update PR title from tip commit subject during `st submit` when an existing PR's title differs from the current commit message
- Add `update_pr_title` method to all forge clients (GitHub, GitLab, Gitea)
- Add `title` field to `PrInfoWithHead` to track existing PR title for comparison

Closes #254, part of #242.

## Test plan

- [ ] Verify `cargo check` and `cargo test` pass (all forge/submit tests green)
- [ ] Create a branch with `st branch create`, submit it, then `st modify -m "new title"` and re-submit -- PR title should update
- [ ] Verify that PRs whose title already matches the commit message are not updated (no unnecessary API call)
- [ ] Verify new PR creation flow is unaffected
- [ ] Verify `--no-pr` mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)