### PR TITLE
fix(restack): hold auto-stashes until restack finishes

### DIFF
--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -8,8 +8,10 @@ use crate::progress::LiveTimer;
 use anyhow::Result;
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,15 +88,21 @@ fn run_impl(
     restore_branch: Option<String>,
 ) -> Result<()> {
     let current = repo.current_branch()?;
+    let current_workdir = canonical_workdir(repo)?;
     let restore_branch = restore_branch.unwrap_or_else(|| current.clone());
     let mut stack = Stack::load(repo)?;
 
-    let mut stashed = false;
+    let mut stashed_worktrees: Vec<PathBuf> = Vec::new();
+    let mut stashed_worktree_set: HashSet<PathBuf> = HashSet::new();
     if repo.is_dirty()? {
         if auto_stash_pop {
-            stashed = repo.stash_push()?;
+            let stashed = repo.stash_push()?;
             if stashed && !quiet {
                 println!("{}", "✓ Stashed working tree changes.".green());
+            }
+            if stashed {
+                stashed_worktree_set.insert(current_workdir.clone());
+                stashed_worktrees.push(current_workdir.clone());
             }
         } else if quiet {
             anyhow::bail!("Working tree is dirty. Please stash or commit changes first.");
@@ -105,9 +113,13 @@ fn run_impl(
                 .interact()?;
 
             if stash {
-                stashed = repo.stash_push()?;
+                let stashed = repo.stash_push()?;
                 auto_stash_pop = true;
                 println!("{}", "✓ Stashed working tree changes.".green());
+                if stashed {
+                    stashed_worktree_set.insert(current_workdir.clone());
+                    stashed_worktrees.push(current_workdir.clone());
+                }
             } else {
                 println!("{}", "Aborted.".red());
                 return Ok(());
@@ -163,9 +175,7 @@ fn run_impl(
         if !quiet {
             println!("{}", "✓ Stack is up to date, nothing to restack.".green());
         }
-        if stashed {
-            repo.stash_pop()?;
-        }
+        restore_stashed_worktrees(repo, &stashed_worktrees, quiet)?;
         return Ok(());
     }
 
@@ -206,9 +216,7 @@ fn run_impl(
         }
 
         if dry_run {
-            if stashed {
-                repo.stash_pop()?;
-            }
+            restore_stashed_worktrees(repo, &stashed_worktrees, quiet)?;
             return Ok(());
         }
 
@@ -218,9 +226,7 @@ fn run_impl(
                 .default(true)
                 .interact()?;
             if !confirm {
-                if stashed {
-                    repo.stash_pop()?;
-                }
+                restore_stashed_worktrees(repo, &stashed_worktrees, quiet)?;
                 return Ok(());
             }
         }
@@ -280,6 +286,21 @@ fn run_impl(
             &format!("{} onto {}", branch, meta.parent_branch_name),
         );
 
+        // Pre-stash dirty target worktrees so the rebase can proceed
+        let target_workdir = repo.branch_rebase_target_workdir(branch)?;
+        if auto_stash_pop
+            && !stashed_worktree_set.contains(&target_workdir)
+            && repo.is_dirty_at(&target_workdir)?
+        {
+            if repo.stash_push_at(&target_workdir)? {
+                stashed_worktree_set.insert(target_workdir.clone());
+                stashed_worktrees.push(target_workdir.clone());
+                if !quiet {
+                    print_stash_message(&current_workdir, &target_workdir);
+                }
+            }
+        }
+
         // Rebase using provenance-aware upstream inference to avoid replaying
         // already-integrated commits after squash/cherry-pick merges.
         match repo.rebase_branch_onto_with_provenance(
@@ -324,8 +345,8 @@ fn run_impl(
                         ],
                     },
                 );
-                if stashed {
-                    println!("{}", "Stash kept to avoid conflicts.".yellow());
+                if !stashed_worktrees.is_empty() {
+                    println!("{}", "Auto-stash kept to avoid conflicts.".yellow());
                 }
                 summary.push((branch.clone(), "conflict".to_string()));
 
@@ -360,12 +381,7 @@ fn run_impl(
     // Check for merged branches and offer to delete them
     cleanup_merged_branches(repo, quiet, yes)?;
 
-    if stashed {
-        repo.stash_pop()?;
-        if !quiet {
-            println!("{}", "✓ Restored stashed changes.".green());
-        }
-    }
+    restore_stashed_worktrees(repo, &stashed_worktrees, quiet)?;
 
     let should_submit = should_submit_after_restack(&summary, quiet, submit_after)?;
 
@@ -373,6 +389,44 @@ fn run_impl(
         submit_after_restack(quiet)?;
     }
 
+    Ok(())
+}
+
+fn canonical_workdir(repo: &GitRepo) -> Result<PathBuf> {
+    let workdir = repo.workdir()?.to_path_buf();
+    Ok(std::fs::canonicalize(&workdir).unwrap_or(workdir))
+}
+
+fn print_stash_message(current_workdir: &Path, target_workdir: &Path) {
+    if target_workdir == current_workdir {
+        println!("{}", "✓ Stashed working tree changes.".green());
+    } else {
+        println!(
+            "{}",
+            format!(
+                "✓ Stashed working tree changes in {}.",
+                target_workdir.display()
+            )
+            .green()
+        );
+    }
+}
+
+fn restore_stashed_worktrees(repo: &GitRepo, worktrees: &[PathBuf], quiet: bool) -> Result<()> {
+    let current_workdir = canonical_workdir(repo)?;
+    for worktree in worktrees.iter().rev() {
+        repo.stash_pop_at(worktree)?;
+        if !quiet {
+            if *worktree == current_workdir {
+                println!("{}", "✓ Restored stashed changes.".green());
+            } else {
+                println!(
+                    "{}",
+                    format!("✓ Restored stashed changes in {}.", worktree.display()).green()
+                );
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -88,7 +88,7 @@ fn run_impl(
     restore_branch: Option<String>,
 ) -> Result<()> {
     let current = repo.current_branch()?;
-    let current_workdir = canonical_workdir(repo)?;
+    let current_workdir = normalized_workdir(repo)?;
     let restore_branch = restore_branch.unwrap_or_else(|| current.clone());
     let mut stack = Stack::load(repo)?;
 
@@ -392,9 +392,8 @@ fn run_impl(
     Ok(())
 }
 
-fn canonical_workdir(repo: &GitRepo) -> Result<PathBuf> {
-    let workdir = repo.workdir()?.to_path_buf();
-    Ok(std::fs::canonicalize(&workdir).unwrap_or(workdir))
+fn normalized_workdir(repo: &GitRepo) -> Result<PathBuf> {
+    Ok(GitRepo::normalize_path(repo.workdir()?))
 }
 
 fn print_stash_message(current_workdir: &Path, target_workdir: &Path) {
@@ -413,18 +412,35 @@ fn print_stash_message(current_workdir: &Path, target_workdir: &Path) {
 }
 
 fn restore_stashed_worktrees(repo: &GitRepo, worktrees: &[PathBuf], quiet: bool) -> Result<()> {
-    let current_workdir = canonical_workdir(repo)?;
+    let current_workdir = normalized_workdir(repo)?;
+    let mut errors: Vec<String> = Vec::new();
     for worktree in worktrees.iter().rev() {
-        repo.stash_pop_at(worktree)?;
-        if !quiet {
-            if *worktree == current_workdir {
-                println!("{}", "✓ Restored stashed changes.".green());
-            } else {
-                println!(
-                    "{}",
-                    format!("✓ Restored stashed changes in {}.", worktree.display()).green()
-                );
+        match repo.stash_pop_at(worktree) {
+            Ok(()) => {
+                if !quiet {
+                    if *worktree == current_workdir {
+                        println!("{}", "✓ Restored stashed changes.".green());
+                    } else {
+                        println!(
+                            "{}",
+                            format!("✓ Restored stashed changes in {}.", worktree.display())
+                                .green()
+                        );
+                    }
+                }
             }
+            Err(e) => {
+                errors.push(format!("{}: {}", worktree.display(), e));
+            }
+        }
+    }
+    if !errors.is_empty() {
+        println!(
+            "{}",
+            "Warning: some stash pops failed. Run `git stash pop` manually in:".yellow()
+        );
+        for e in &errors {
+            println!("  {}", e);
         }
     }
     Ok(())

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -292,7 +292,7 @@ impl GitRepo {
             .with_context(|| format!("Failed to run git {}", args.join(" ")))
     }
 
-    fn normalize_path(path: &Path) -> PathBuf {
+    pub(crate) fn normalize_path(path: &Path) -> PathBuf {
         std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
     }
 

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -910,18 +910,16 @@ impl GitRepo {
         self.rebase_with_args_in_path(cwd, &["rebase", "--onto", onto, upstream])
     }
 
-    fn prepare_branch_rebase_context(&self, branch: &str) -> Result<(PathBuf, PathBuf)> {
+    /// Resolve the worktree path where a branch rebase would run.
+    /// Returns the linked worktree path if one exists, otherwise the main workdir.
+    pub(crate) fn branch_rebase_target_workdir(&self, branch: &str) -> Result<PathBuf> {
         let current_workdir = Self::normalize_path(self.workdir()?);
         let target_workdir = self
             .branch_worktree_path(branch)?
             .unwrap_or_else(|| current_workdir.clone());
         let target_workdir = Self::normalize_path(&target_workdir);
 
-        if target_workdir == current_workdir {
-            if self.current_branch()? != branch {
-                self.checkout(branch)?;
-            }
-        } else {
+        if target_workdir != current_workdir {
             let current_in_target = self.current_branch_in_path(&target_workdir)?;
             if current_in_target != branch {
                 anyhow::bail!(
@@ -930,6 +928,19 @@ impl GitRepo {
                     target_workdir.display(),
                     current_in_target
                 );
+            }
+        }
+
+        Ok(target_workdir)
+    }
+
+    fn prepare_branch_rebase_context(&self, branch: &str) -> Result<(PathBuf, PathBuf)> {
+        let current_workdir = Self::normalize_path(self.workdir()?);
+        let target_workdir = self.branch_rebase_target_workdir(branch)?;
+
+        if target_workdir == current_workdir {
+            if self.current_branch()? != branch {
+                self.checkout(branch)?;
             }
         }
 

--- a/tests/additional_coverage_tests.rs
+++ b/tests/additional_coverage_tests.rs
@@ -222,6 +222,36 @@ fn test_restack_with_parent_changes() {
 }
 
 #[test]
+fn test_restack_auto_stash_pop_restores_dirty_current_worktree() {
+    let repo = TestRepo::new();
+    let branches = repo.create_stack(&["a", "b", "c"]);
+
+    // Move trunk forward so branches need restack
+    repo.run_stax(&["t"]);
+    repo.create_file("main-update.txt", "main update");
+    repo.commit("Main update");
+
+    // Go to tip branch, make dirty changes
+    repo.run_stax(&["checkout", &branches[2]]);
+    repo.create_file("dirty.txt", "committed content\n");
+    repo.commit("Add dirty file");
+    repo.create_file("dirty.txt", "committed content\nlocal change\n");
+
+    // Restack with auto-stash -- dirty changes should be restored after
+    let output = repo.run_stax(&["restack", "--auto-stash-pop"]);
+    output.assert_success();
+
+    let status = repo.git(&["status", "--porcelain"]);
+    assert!(status.status.success());
+    let stdout = TestRepo::stdout(&status);
+    assert!(
+        stdout.contains("dirty.txt"),
+        "Expected dirty current worktree changes to be restored, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn test_restack_stop_here_excludes_descendants() {
     let repo = TestRepo::new();
     let branches = repo.create_stack(&["stop-a", "stop-b", "stop-c"]);


### PR DESCRIPTION
## Summary

- Keep restack auto-stashes in place until the full restack finishes
- Pre-stash worktrees that will be reused during restack before running branch rebases in them
- Add coverage for dirty current worktree being restored after a successful full-stack restack

Addresses #125, Part of #242

## Changes

| File | Change |
|------|--------|
| `src/commands/restack.rs` | Track stashed worktrees in Vec, restore in reverse at end |
| `src/git/repo.rs` | Extract `branch_rebase_target_workdir()` as pub(crate) |
| `tests/additional_coverage_tests.rs` | New test for dirty worktree restoration |

## Test plan

- [x] `test_restack_auto_stash_pop_restores_dirty_current_worktree` passes
- [x] `cargo check` passes
- [ ] Manual: create linked worktrees, dirty both, restack with `--auto-stash-pop`, verify both restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)