### PR TITLE
feat(upstack): add st upstack onto for mass reparent with descendants

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -48,6 +48,7 @@
 | `st detach` | | Remove branch from stack, reparent children |
 | `st reorder` | | Interactively reorder branches in stack |
 | `st upstack restack` | | Restack current + descendants |
+| `st upstack onto <branch>` | | Reparent current + all descendants onto a new parent |
 | `st upstack submit` | | Submit current + descendants |
 | `st downstack get` | | Show branches below current |
 | `st downstack submit` | | Submit ancestors + current |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -48,7 +48,7 @@
 | `st detach` | | Remove branch from stack, reparent children |
 | `st reorder` | | Interactively reorder branches in stack |
 | `st upstack restack` | | Restack current + descendants |
-| `st upstack onto <branch>` | | Reparent current + all descendants onto a new parent |
+| `st upstack onto [branch]` | | Reparent current + all descendants onto a new parent (interactive picker if omitted) |
 | `st upstack submit` | | Submit current + descendants |
 | `st downstack get` | | Show branches below current |
 | `st downstack submit` | | Submit ancestors + current |

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -19,6 +19,7 @@ stax uses the same metadata format as freephite (`refs/branch-metadata/<branch>`
 | `fp ls` | `gt log` | `st status` / `st ls` |
 | — | `gt modify` | `st modify` / `st m` |
 | — | `gt edit` | `st edit` / `st e` |
+| — | `gt upstack onto` | `st upstack onto` |
 | `fp restack` | `gt restack` | `st restack` / `st sr` |
 | — | `gt restack --upstack` | `st upstack restack` |
 | — | `gt merge` | `st merge` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1130,6 +1130,15 @@ enum UpstackCommands {
         auto_stash_pop: bool,
     },
 
+    /// Reparent current branch and all descendants onto a new parent
+    Onto {
+        /// Target parent branch (interactive picker if omitted)
+        target: Option<String>,
+        /// Restack the moved branches after reparenting
+        #[arg(long)]
+        restack: bool,
+    },
+
     /// Submit current branch and descendants
     Submit {
         #[command(flatten)]
@@ -1746,6 +1755,9 @@ pub fn run() -> Result<()> {
         Commands::Upstack(cmd) => match cmd {
             UpstackCommands::Restack { auto_stash_pop } => {
                 commands::upstack::restack::run(auto_stash_pop)
+            }
+            UpstackCommands::Onto { target, restack } => {
+                commands::upstack::onto::run(target, restack)
             }
             UpstackCommands::Submit { submit } => {
                 run_submit(submit, commands::submit::SubmitScope::Upstack)

--- a/src/commands/upstack/mod.rs
+++ b/src/commands/upstack/mod.rs
@@ -1,1 +1,2 @@
+pub mod onto;
 pub mod restack;

--- a/src/commands/upstack/onto.rs
+++ b/src/commands/upstack/onto.rs
@@ -1,0 +1,131 @@
+use crate::engine::{BranchMetadata, Stack};
+use crate::git::GitRepo;
+use anyhow::{bail, Result};
+use colored::Colorize;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::FuzzySelect;
+
+/// Reparent the current branch AND all its descendants onto a new parent.
+/// The subtree structure is preserved -- only the root's parent changes.
+pub fn run(target: Option<String>, restack: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let stack = Stack::load(&repo)?;
+    let current = repo.current_branch()?;
+    let trunk = repo.trunk_branch()?;
+
+    if current == trunk {
+        bail!("Cannot reparent trunk. Checkout a stacked branch first.");
+    }
+
+    // Determine new parent
+    let new_parent = match target {
+        Some(t) => {
+            if repo.branch_commit(&t).is_err() {
+                bail!("Branch '{}' does not exist", t);
+            }
+            t
+        }
+        None => pick_parent_interactively(&repo, &current, &trunk)?,
+    };
+
+    if new_parent == current {
+        bail!("Cannot reparent a branch onto itself.");
+    }
+
+    // Prevent circular dependency: new parent cannot be a descendant of current
+    let descendants = stack.descendants(&current);
+    if descendants.contains(&new_parent) {
+        bail!(
+            "Cannot reparent '{}' onto '{}': would create circular dependency.\n\
+             '{}' is a descendant of '{}'.",
+            current,
+            new_parent,
+            new_parent,
+            current
+        );
+    }
+
+    // Collect the subtree: current + all descendants
+    let mut subtree = vec![current.clone()];
+    subtree.extend(descendants);
+
+    // Read old parent info for the root branch
+    let old_meta = BranchMetadata::read(repo.inner(), &current)?;
+
+    // Update only the root branch's parent pointer
+    let parent_rev = repo.branch_commit(&new_parent)?;
+    let merge_base = repo
+        .merge_base(&new_parent, &current)
+        .unwrap_or_else(|_| parent_rev.clone());
+
+    let updated = if let Some(meta) = old_meta {
+        BranchMetadata {
+            parent_branch_name: new_parent.clone(),
+            parent_branch_revision: merge_base,
+            ..meta
+        }
+    } else {
+        BranchMetadata::new(&new_parent, &merge_base)
+    };
+    updated.write(repo.inner(), &current)?;
+
+    println!(
+        "✓ Reparented '{}' onto '{}'",
+        current.green(),
+        new_parent.blue()
+    );
+    if subtree.len() > 1 {
+        println!(
+            "  {} descendant branch(es) moved with it:",
+            (subtree.len() - 1).to_string().cyan()
+        );
+        for desc in &subtree[1..] {
+            println!("    {}", desc.dimmed());
+        }
+    }
+
+    if restack {
+        println!();
+        println!("{}", "Restacking moved branches...".bold());
+        // Restack the full subtree using the existing upstack restack logic
+        super::restack::run(false)?;
+    } else {
+        println!(
+            "{}",
+            "Run `stax restack` to rebase the moved branches onto their new parent."
+                .yellow()
+        );
+    }
+
+    Ok(())
+}
+
+fn pick_parent_interactively(repo: &GitRepo, current: &str, trunk: &str) -> Result<String> {
+    let mut branches = repo.list_branches()?;
+    // Remove current and its descendants (can't reparent onto them)
+    let stack = Stack::load(repo)?;
+    let descendants = stack.descendants(current);
+    branches.retain(|b| b != current && !descendants.contains(b));
+    branches.sort();
+
+    // Put trunk first
+    if let Some(pos) = branches.iter().position(|b| b == trunk) {
+        branches.remove(pos);
+        branches.insert(0, trunk.to_string());
+    }
+
+    if branches.is_empty() {
+        bail!("No branches available as a new parent");
+    }
+
+    let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!(
+            "Select new parent for '{}' (and all its descendants)",
+            current
+        ))
+        .items(&branches)
+        .default(0)
+        .interact()?;
+
+    Ok(branches[selection].clone())
+}

--- a/src/commands/upstack/onto.rs
+++ b/src/commands/upstack/onto.rs
@@ -1,5 +1,5 @@
 use crate::engine::{BranchMetadata, Stack};
-use crate::git::GitRepo;
+use crate::git::{GitRepo, RebaseResult};
 use anyhow::{bail, Result};
 use colored::Colorize;
 use dialoguer::theme::ColorfulTheme;
@@ -17,6 +17,17 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
         bail!("Cannot reparent trunk. Checkout a stacked branch first.");
     }
 
+    // Ensure the branch is tracked
+    let old_meta = BranchMetadata::read(repo.inner(), &current)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Branch '{}' is not tracked by stax. Run `st branch track` first.",
+                current
+            )
+        })?;
+
+    let descendants = stack.descendants(&current);
+
     // Determine new parent
     let new_parent = match target {
         Some(t) => {
@@ -25,15 +36,24 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
             }
             t
         }
-        None => pick_parent_interactively(&repo, &current, &trunk)?,
+        None => pick_parent_interactively(&repo, &current, &trunk, &descendants)?,
     };
 
     if new_parent == current {
         bail!("Cannot reparent a branch onto itself.");
     }
 
-    // Prevent circular dependency: new parent cannot be a descendant of current
-    let descendants = stack.descendants(&current);
+    // No-op: already parented onto the target
+    if old_meta.parent_branch_name == new_parent {
+        println!(
+            "{}",
+            format!("'{}' is already parented onto '{}'. Nothing to do.", current, new_parent)
+                .dimmed()
+        );
+        return Ok(());
+    }
+
+    // Prevent circular dependency
     if descendants.contains(&new_parent) {
         bail!(
             "Cannot reparent '{}' onto '{}': would create circular dependency.\n\
@@ -45,12 +65,13 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
         );
     }
 
-    // Collect the subtree: current + all descendants
+    // Collect the subtree for display
     let mut subtree = vec![current.clone()];
-    subtree.extend(descendants);
+    subtree.extend(descendants.iter().cloned());
 
-    // Read old parent info for the root branch
-    let old_meta = BranchMetadata::read(repo.inner(), &current)?;
+    // Save old parent info for rebase upstream calculation
+    let old_parent_name = old_meta.parent_branch_name.clone();
+    let old_parent_rev = old_meta.parent_branch_revision.clone();
 
     // Update only the root branch's parent pointer
     let parent_rev = repo.branch_commit(&new_parent)?;
@@ -58,14 +79,10 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
         .merge_base(&new_parent, &current)
         .unwrap_or_else(|_| parent_rev.clone());
 
-    let updated = if let Some(meta) = old_meta {
-        BranchMetadata {
-            parent_branch_name: new_parent.clone(),
-            parent_branch_revision: merge_base,
-            ..meta
-        }
-    } else {
-        BranchMetadata::new(&new_parent, &merge_base)
+    let updated = BranchMetadata {
+        parent_branch_name: new_parent.clone(),
+        parent_branch_revision: merge_base.clone(),
+        ..old_meta
     };
     updated.write(repo.inner(), &current)?;
 
@@ -87,12 +104,55 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
     if restack {
         println!();
         println!("{}", "Restacking moved branches...".bold());
-        // Restack the full subtree using the existing upstack restack logic
-        super::restack::run(false)?;
+
+        // Rebase the root branch directly using old parent info as upstream
+        // (same approach as reparent.rs -- we need the old parent boundary
+        // because the metadata was already overwritten)
+        let rebase_upstream = resolve_rebase_upstream(&repo, &old_parent_name, &old_parent_rev, &current, &merge_base)?;
+
+        match repo.rebase_branch_onto_with_provenance(
+            &current,
+            &new_parent,
+            &rebase_upstream,
+            false,
+        )? {
+            RebaseResult::Success => {
+                // Update metadata with new parent rev after rebase
+                let new_parent_rev = repo.branch_commit(&new_parent)?;
+                if let Some(mut meta) = BranchMetadata::read(repo.inner(), &current)? {
+                    meta.parent_branch_revision = new_parent_rev;
+                    meta.write(repo.inner(), &current)?;
+                }
+                println!(
+                    "  {} rebased '{}' onto '{}'",
+                    "✓".green(),
+                    current,
+                    new_parent
+                );
+
+                // Now restack descendants via upstack restack
+                if subtree.len() > 1 {
+                    super::restack::run(false)?;
+                }
+            }
+            RebaseResult::Conflict => {
+                bail!(
+                    "Rebase conflict while rebasing '{}' onto '{}'. \
+                     Resolve conflicts, then run `st continue` or `st abort`.",
+                    current,
+                    new_parent
+                );
+            }
+        }
+
+        // Return to original branch
+        if repo.current_branch()? != current {
+            let _ = repo.checkout(&current);
+        }
     } else {
         println!(
             "{}",
-            "Run `stax restack` to rebase the moved branches onto their new parent."
+            "Run `st restack` to rebase the moved branches onto their new parent."
                 .yellow()
         );
     }
@@ -100,15 +160,41 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
     Ok(())
 }
 
-fn pick_parent_interactively(repo: &GitRepo, current: &str, trunk: &str) -> Result<String> {
+/// Determine the upstream commit for `git rebase --onto` when reparenting.
+/// Uses the old parent's tip if it is an ancestor of the target branch,
+/// otherwise falls back to the stored parent revision or merge-base.
+fn resolve_rebase_upstream(
+    repo: &GitRepo,
+    old_parent_name: &str,
+    old_parent_rev: &str,
+    target: &str,
+    merge_base: &str,
+) -> Result<String> {
+    // Try old parent's current tip
+    if let Ok(tip) = repo.branch_commit(old_parent_name) {
+        if repo.is_ancestor(&tip, target)? {
+            return Ok(tip);
+        }
+    }
+
+    // Try stored parent revision
+    if !old_parent_rev.is_empty() && repo.is_ancestor(old_parent_rev, target)? {
+        return Ok(old_parent_rev.to_string());
+    }
+
+    Ok(merge_base.to_string())
+}
+
+fn pick_parent_interactively(
+    repo: &GitRepo,
+    current: &str,
+    trunk: &str,
+    descendants: &[String],
+) -> Result<String> {
     let mut branches = repo.list_branches()?;
-    // Remove current and its descendants (can't reparent onto them)
-    let stack = Stack::load(repo)?;
-    let descendants = stack.descendants(current);
     branches.retain(|b| b != current && !descendants.contains(b));
     branches.sort();
 
-    // Put trunk first
     if let Some(pos) = branches.iter().position(|b| b == trunk) {
         branches.remove(pos);
         branches.insert(0, trunk.to_string());

--- a/tests/upstack_onto_tests.rs
+++ b/tests/upstack_onto_tests.rs
@@ -1,0 +1,131 @@
+//! Tests for `st upstack onto` -- mass reparent current + descendants onto new parent.
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+
+#[test]
+fn upstack_onto_moves_branch_and_descendants() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Build: main -> a -> b -> c
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "b");
+    repo.commit("commit b");
+
+    repo.run_stax(&["create", "c"]).assert_success();
+    repo.create_file("c.txt", "c");
+    repo.commit("commit c");
+
+    // Go to b, run upstack onto main
+    repo.run_stax(&["checkout", "b"]);
+    let output = repo.run_stax(&["upstack", "onto", "main"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented"),
+        "Should mention reparenting: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("descendant"),
+        "Should mention descendants: {}",
+        stdout
+    );
+
+    // Verify b's parent is now main (via status --json)
+    let status = repo.run_stax(&["status", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("valid json");
+    let branches = json["branches"].as_array().expect("branches array");
+
+    let b_entry = branches.iter().find(|b| {
+        b["name"]
+            .as_str()
+            .map(|n| n.contains("b"))
+            .unwrap_or(false)
+    });
+    assert!(b_entry.is_some(), "Should find branch b in status");
+    let b_parent = b_entry.unwrap()["parent"].as_str().unwrap_or("");
+    assert_eq!(b_parent, "main", "b's parent should be main, got: {}", b_parent);
+
+    // c should still be a descendant of b (not moved to main)
+    let c_entry = branches.iter().find(|b| {
+        b["name"]
+            .as_str()
+            .map(|n| n.contains("c"))
+            .unwrap_or(false)
+    });
+    assert!(c_entry.is_some(), "Should find branch c in status");
+}
+
+#[test]
+fn upstack_onto_from_trunk_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let output = repo.run_stax(&["upstack", "onto", "main"]);
+    output.assert_failure();
+    output.assert_stderr_contains("trunk");
+}
+
+#[test]
+fn upstack_onto_circular_dependency_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Build: main -> a -> b
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "b");
+    repo.commit("commit b");
+
+    // Go to a, try to reparent onto b (descendant) -- should fail
+    repo.run_stax(&["checkout", "a"]);
+    let output = repo.run_stax(&["upstack", "onto", "b"]);
+    output.assert_failure();
+    output.assert_stderr_contains("circular");
+}
+
+#[test]
+fn upstack_onto_single_branch_no_descendants() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Build: main -> a, main -> b (siblings, no parent-child)
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    repo.run_stax(&["trunk"]).assert_success();
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "b");
+    repo.commit("commit b");
+
+    // Move a onto b (no descendants)
+    repo.run_stax(&["checkout", "a"]);
+    let output = repo.run_stax(&["upstack", "onto", "b"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented"),
+        "Should reparent: {}",
+        stdout
+    );
+    // Should NOT mention descendants (none exist)
+    assert!(
+        !stdout.contains("descendant"),
+        "Should not mention descendants for leaf branch: {}",
+        stdout
+    );
+}

--- a/tests/upstack_onto_tests.rs
+++ b/tests/upstack_onto_tests.rs
@@ -4,6 +4,16 @@ mod common;
 
 use common::{OutputAssertions, TestRepo};
 
+/// Helper: find a branch entry in status JSON by exact suffix match.
+fn find_branch<'a>(
+    branches: &'a [serde_json::Value],
+    suffix: &str,
+) -> Option<&'a serde_json::Value> {
+    branches
+        .iter()
+        .find(|b| b["name"].as_str().map(|n| n.ends_with(suffix)).unwrap_or(false))
+}
+
 #[test]
 fn upstack_onto_moves_branch_and_descendants() {
     let repo = TestRepo::new();
@@ -28,41 +38,26 @@ fn upstack_onto_moves_branch_and_descendants() {
     output.assert_success();
 
     let stdout = TestRepo::stdout(&output);
-    assert!(
-        stdout.contains("Reparented"),
-        "Should mention reparenting: {}",
-        stdout
-    );
-    assert!(
-        stdout.contains("descendant"),
-        "Should mention descendants: {}",
-        stdout
-    );
+    assert!(stdout.contains("Reparented"), "Should mention reparenting: {}", stdout);
+    assert!(stdout.contains("descendant"), "Should mention descendants: {}", stdout);
 
-    // Verify b's parent is now main (via status --json)
+    // Verify b's parent is now main
     let status = repo.run_stax(&["status", "--json"]);
     let json: serde_json::Value =
         serde_json::from_str(&TestRepo::stdout(&status)).expect("valid json");
     let branches = json["branches"].as_array().expect("branches array");
 
-    let b_entry = branches.iter().find(|b| {
-        b["name"]
-            .as_str()
-            .map(|n| n.contains("b"))
-            .unwrap_or(false)
-    });
-    assert!(b_entry.is_some(), "Should find branch b in status");
-    let b_parent = b_entry.unwrap()["parent"].as_str().unwrap_or("");
-    assert_eq!(b_parent, "main", "b's parent should be main, got: {}", b_parent);
+    let b_entry = find_branch(branches, "b").expect("should find branch b");
+    assert_eq!(b_entry["parent"].as_str().unwrap(), "main");
 
-    // c should still be a descendant of b (not moved to main)
-    let c_entry = branches.iter().find(|b| {
-        b["name"]
-            .as_str()
-            .map(|n| n.contains("c"))
-            .unwrap_or(false)
-    });
-    assert!(c_entry.is_some(), "Should find branch c in status");
+    // c should still be a child of b (subtree preserved)
+    let c_entry = find_branch(branches, "c").expect("should find branch c");
+    let c_parent = c_entry["parent"].as_str().unwrap();
+    assert!(
+        c_parent.ends_with("b"),
+        "c's parent should still be b, got: {}",
+        c_parent
+    );
 }
 
 #[test]
@@ -80,7 +75,6 @@ fn upstack_onto_circular_dependency_fails() {
     let repo = TestRepo::new();
     repo.run_stax(&["init"]).assert_success();
 
-    // Build: main -> a -> b
     repo.run_stax(&["create", "a"]).assert_success();
     repo.create_file("a.txt", "a");
     repo.commit("commit a");
@@ -89,7 +83,7 @@ fn upstack_onto_circular_dependency_fails() {
     repo.create_file("b.txt", "b");
     repo.commit("commit b");
 
-    // Go to a, try to reparent onto b (descendant) -- should fail
+    // Go to a, try to reparent onto b (descendant)
     repo.run_stax(&["checkout", "a"]);
     let output = repo.run_stax(&["upstack", "onto", "b"]);
     output.assert_failure();
@@ -101,7 +95,7 @@ fn upstack_onto_single_branch_no_descendants() {
     let repo = TestRepo::new();
     repo.run_stax(&["init"]).assert_success();
 
-    // Build: main -> a, main -> b (siblings, no parent-child)
+    // Build: main -> a, main -> b (siblings)
     repo.run_stax(&["create", "a"]).assert_success();
     repo.create_file("a.txt", "a");
     repo.commit("commit a");
@@ -111,21 +105,61 @@ fn upstack_onto_single_branch_no_descendants() {
     repo.create_file("b.txt", "b");
     repo.commit("commit b");
 
-    // Move a onto b (no descendants)
+    // Move a onto b
     repo.run_stax(&["checkout", "a"]);
     let output = repo.run_stax(&["upstack", "onto", "b"]);
     output.assert_success();
 
     let stdout = TestRepo::stdout(&output);
+    assert!(stdout.contains("Reparented"), "Should reparent: {}", stdout);
+    assert!(!stdout.contains("descendant"), "Leaf branch should have no descendants: {}", stdout);
+}
+
+#[test]
+fn upstack_onto_same_parent_is_noop() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    // Try to reparent onto the current parent (main)
+    let output = repo.run_stax(&["upstack", "onto", "main"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("Reparented"),
-        "Should reparent: {}",
+        stdout.contains("already parented") || stdout.contains("Nothing to do"),
+        "Should detect no-op: {}",
         stdout
     );
-    // Should NOT mention descendants (none exist)
-    assert!(
-        !stdout.contains("descendant"),
-        "Should not mention descendants for leaf branch: {}",
-        stdout
-    );
+}
+
+#[test]
+fn upstack_onto_nonexistent_target_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    let output = repo.run_stax(&["upstack", "onto", "nonexistent"]);
+    output.assert_failure();
+    output.assert_stderr_contains("does not exist");
+}
+
+#[test]
+fn upstack_onto_self_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    let output = repo.run_stax(&["upstack", "onto", "a"]);
+    output.assert_failure();
+    output.assert_stderr_contains("itself");
 }


### PR DESCRIPTION
## Summary

- Add `st upstack onto <target>` -- reparent current branch + all descendants onto a new parent
- Interactive fuzzy picker when no target specified
- Circular dependency detection (can't reparent onto a descendant)
- `--restack` flag to immediately rebase the moved subtree
- Documentation in command reference and compatibility matrix

Closes #273, Part of #242

## Example

```
Before:                    After `st upstack onto main` from b:
main                       main
├── a                      ├── a
│   ├── b                  └── b        (moved)
│   │   └── c                  └── c    (preserved)
```

## Test plan

- [x] `upstack_onto_moves_branch_and_descendants` -- verifies parent updated + descendants preserved
- [x] `upstack_onto_from_trunk_fails` -- rejects on trunk
- [x] `upstack_onto_circular_dependency_fails` -- prevents reparent onto descendant
- [x] `upstack_onto_single_branch_no_descendants` -- leaf branch (no descendants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)