### PR TITLE
fix: persist reparent metadata only after successful restack

### DIFF
--- a/src/commands/branch/reparent.rs
+++ b/src/commands/branch/reparent.rs
@@ -113,8 +113,6 @@ pub fn run(branch: Option<String>, parent: Option<String>, restack: bool) -> Res
         BranchMetadata::new(&parent_branch, &merge_base)
     };
 
-    updated.write(repo.inner(), &target)?;
-
     let config = crate::config::Config::load()?;
     if let Ok(remote_branches) = remote::get_remote_branches(repo.workdir()?, config.remote_name())
     {
@@ -129,6 +127,10 @@ pub fn run(branch: Option<String>, parent: Option<String>, restack: bool) -> Res
                 .yellow()
             );
         }
+    }
+
+    if !restack {
+        updated.write(repo.inner(), &target)?;
     }
 
     println!(
@@ -146,10 +148,9 @@ pub fn run(branch: Option<String>, parent: Option<String>, restack: bool) -> Res
         )? {
             RebaseResult::Success => {
                 let new_parent_rev = repo.branch_commit(&parent_branch)?;
-                if let Some(mut meta) = BranchMetadata::read(repo.inner(), &target)? {
-                    meta.parent_branch_revision = new_parent_rev;
-                    meta.write(repo.inner(), &target)?;
-                }
+                let mut persisted = updated.clone();
+                persisted.parent_branch_revision = new_parent_rev;
+                persisted.write(repo.inner(), &target)?;
                 println!(
                     "{}",
                     format!("✓ Rebased '{}' onto '{}'", target, parent_branch).green()

--- a/src/commands/upstack/onto.rs
+++ b/src/commands/upstack/onto.rs
@@ -84,7 +84,10 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
         parent_branch_revision: merge_base.clone(),
         ..old_meta
     };
-    updated.write(repo.inner(), &current)?;
+
+    if !restack {
+        updated.write(repo.inner(), &current)?;
+    }
 
     println!(
         "✓ Reparented '{}' onto '{}'",
@@ -117,12 +120,11 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
             false,
         )? {
             RebaseResult::Success => {
-                // Update metadata with new parent rev after rebase
+                // Persist metadata only after the root rebase succeeds
                 let new_parent_rev = repo.branch_commit(&new_parent)?;
-                if let Some(mut meta) = BranchMetadata::read(repo.inner(), &current)? {
-                    meta.parent_branch_revision = new_parent_rev;
-                    meta.write(repo.inner(), &current)?;
-                }
+                let mut persisted = updated.clone();
+                persisted.parent_branch_revision = new_parent_rev;
+                persisted.write(repo.inner(), &current)?;
                 println!(
                     "  {} rebased '{}' onto '{}'",
                     "✓".green(),


### PR DESCRIPTION
## Summary
- delay writing reparent metadata until the restack/rebase succeeds
- keep non-restack reparent behavior unchanged
- apply the same fix to \

## Why
Issue #275 reports that aborting a conflicted restack can leave stack metadata pointing at the new parent even though git history rolled back. This change makes metadata persistence happen only after a successful rebase, so aborting a conflict leaves metadata aligned with reality.

Closes #275