### PR TITLE
feat(lane): add --yolo and --agent-arg flags to st lane and st wt create

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -144,6 +144,8 @@ Full guide: [Worktrees](../worktrees/index.md)
 Worktree launch examples:
 - `st lane`
 - `st lane review-pass "address PR comments"`
+- `st lane fix-flaky --agent claude --yolo "stabilize the flaky tests"` (auto-accept permission prompts)
+- `st lane big-refactor --agent claude --agent-arg=--verbose "split the auth module"` (pass extra flags to the agent)
 - `st wt go ui-polish --run "cursor ." --tmux`
 
 ## Common flags

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -156,6 +156,36 @@ Notes:
 - if you omit `--agent`, stax uses your configured default agent
 - the optional `[prompt]` is passed through to the launched agent
 
+## Auto-accepting Permission Prompts (`--yolo`)
+
+By default every agent launches with its normal interactive permission flow. For well-scoped work in an isolated lane, you often want the agent to run autonomously. `--yolo` injects each agent's permission-bypass flag:
+
+| Agent | Injected flag |
+|---|---|
+| `claude` | `--dangerously-skip-permissions` |
+| `codex` | `--dangerously-bypass-approvals-and-sandbox` |
+| `opencode` | `--dangerously-skip-permissions` |
+| `gemini` | `--yolo` |
+
+```bash
+st lane fix-flaky --agent claude --yolo "stabilize the flaky test suite"
+st lane refactor --agent codex --yolo "split the auth module"
+```
+
+`--yolo` only makes sense with `--agent` (it needs to know which flag to inject).
+
+**Use with care**: yolo mode lets the agent edit files, run commands, and touch your environment without prompting. The lane's worktree is isolated, but everything the agent runs is still running as you.
+
+## Extra Agent Flags (`--agent-arg`)
+
+For any flag not covered by `--yolo`, use `--agent-arg` (repeatable):
+
+```bash
+st lane big-refactor --agent claude --agent-arg=--thinking --agent-arg=--verbose "pull apart the auth module"
+```
+
+Values are forwarded to the agent verbatim, before the prompt.
+
 ## VS Code (or Cursor) Integration
 
 By default, `st lane` launches the agent in a tmux session and does not open your editor. If you want your **existing** VS Code / Cursor window to show each new lane as an extra folder in the Explorer — without spawning a new window per lane — add two worktree hooks to `~/.config/stax/config.toml`:

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -164,15 +164,17 @@ By default every agent launches with its normal interactive permission flow. For
 |---|---|
 | `claude` | `--dangerously-skip-permissions` |
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
-| `opencode` | `--dangerously-skip-permissions` |
 | `gemini` | `--yolo` |
+| `opencode` | *not supported via `--yolo`; use `--agent-arg`* |
 
 ```bash
 st lane fix-flaky --agent claude --yolo "stabilize the flaky test suite"
 st lane refactor --agent codex --yolo "split the auth module"
 ```
 
-`--yolo` only makes sense with `--agent` (it needs to know which flag to inject).
+`--yolo` only makes sense with `--agent` (it needs to know which flag to inject). Running `st lane --agent opencode --yolo` errors out with guidance to use `--agent-arg` instead.
+
+Note: `--yolo` is a no-op when reattaching to an existing tmux session (no new agent is started). Pass a new prompt — e.g. `st lane mylane --agent claude --yolo "next subtask"` — to open a fresh agent window where the flag takes effect.
 
 **Use with care**: yolo mode lets the agent edit files, run commands, and touch your environment without prompting. The lane's worktree is isolated, but everything the agent runs is still running as you.
 
@@ -181,10 +183,12 @@ st lane refactor --agent codex --yolo "split the auth module"
 For any flag not covered by `--yolo`, use `--agent-arg` (repeatable):
 
 ```bash
-st lane big-refactor --agent claude --agent-arg=--thinking --agent-arg=--verbose "pull apart the auth module"
+st lane big-refactor --agent claude --agent-arg=--verbose "pull apart the auth module"
 ```
 
-Values are forwarded to the agent verbatim, before the prompt.
+Values are forwarded to the agent verbatim, in this order: `<model flag> <yolo flag> <--agent-arg values> <prompt>`. Do not pass `--model` via `--agent-arg` — stax already handles the model flag via `--model`.
+
+Like `--yolo`, `--agent-arg` is ignored when reattaching to an existing tmux session.
 
 ## VS Code (or Cursor) Integration
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,14 @@ struct WorktreeLaunchArgs {
     /// Override the tmux session name (defaults to the worktree name)
     #[arg(long, requires = "tmux")]
     tmux_session: Option<String>,
+    /// Auto-accept agent permission prompts (claude: --dangerously-skip-permissions,
+    /// codex: --dangerously-bypass-approvals-and-sandbox, opencode: --dangerously-skip-permissions,
+    /// gemini: --yolo). Use with care.
+    #[arg(long, requires = "agent")]
+    yolo: bool,
+    /// Pass an extra argument to the launched agent (repeatable)
+    #[arg(long = "agent-arg", requires = "agent")]
+    agent_arg: Vec<String>,
     /// Arguments passed through to the launched agent or command (after `--`)
     #[arg(last = true)]
     args: Vec<String>,
@@ -128,6 +136,14 @@ struct AiLaneArgs {
     /// Override the tmux session name (defaults to the lane name)
     #[arg(long, conflicts_with = "no_tmux")]
     tmux_session: Option<String>,
+    /// Auto-accept agent permission prompts (claude: --dangerously-skip-permissions,
+    /// codex: --dangerously-bypass-approvals-and-sandbox, opencode: --dangerously-skip-permissions,
+    /// gemini: --yolo). Use with care.
+    #[arg(long)]
+    yolo: bool,
+    /// Pass an extra argument to the launched agent (repeatable)
+    #[arg(long = "agent-arg")]
+    agent_arg: Vec<String>,
 }
 
 #[derive(Subcommand)]
@@ -1889,6 +1905,8 @@ pub fn run() -> Result<()> {
                 launch.tmux,
                 launch.tmux_session,
                 launch.args,
+                launch.yolo,
+                launch.agent_arg,
             ),
             Some(WorktreeCommands::List { json }) => commands::worktree::list::run(json),
             Some(WorktreeCommands::LongList { json }) => commands::worktree::ll::run(json),
@@ -1907,6 +1925,8 @@ pub fn run() -> Result<()> {
                 launch.tmux,
                 launch.tmux_session,
                 launch.args,
+                launch.yolo,
+                launch.agent_arg,
             ),
             Some(WorktreeCommands::Path { name }) => commands::worktree::go::run_path(&name),
             Some(WorktreeCommands::Remove {
@@ -1940,6 +1960,8 @@ pub fn run() -> Result<()> {
             ai.model,
             ai.no_tmux,
             ai.tmux_session,
+            ai.yolo,
+            ai.agent_arg,
         ),
         // Hidden worktree shortcuts
         Commands::W => commands::worktree::list::run(false),
@@ -1964,6 +1986,8 @@ pub fn run() -> Result<()> {
             launch.tmux,
             launch.tmux_session,
             launch.args,
+            launch.yolo,
+            launch.agent_arg,
         ),
         Commands::Wtls => commands::worktree::list::run(false),
         Commands::Wtll { json } => commands::worktree::ll::run(json),
@@ -1982,6 +2006,8 @@ pub fn run() -> Result<()> {
             launch.tmux,
             launch.tmux_session,
             launch.args,
+            launch.yolo,
+            launch.agent_arg,
         ),
         Commands::Wtrm {
             name,

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -200,6 +200,8 @@ pub fn run(
             false,
             None,
             Vec::new(),
+            false,
+            Vec::new(),
         )?;
     } else if target == current {
         if shell_output {

--- a/src/commands/worktree/ai.rs
+++ b/src/commands/worktree/ai.rs
@@ -261,6 +261,15 @@ fn prepare_ai_launch_with_tmux_probe(
                 let session_exists = sessions.iter().any(|session| session.name == session_name);
 
                 if request.prompt.is_none() && session_exists {
+                    // Reattaching to an existing tmux session -- no agent is
+                    // launched, so --yolo / --agent-arg have no effect here.
+                    if request.yolo || !request.agent_args.is_empty() {
+                        messages.push(
+                            "Reattaching to existing tmux session; --yolo / --agent-arg are ignored. \
+                             Pass a new prompt to launch a fresh agent window."
+                                .to_string(),
+                        );
+                    }
                     let launch = build_tmux_launch_spec(
                         session_name,
                         None,
@@ -698,9 +707,7 @@ mod tests {
         let prepared = prepare_ai_launch_with_tmux_probe(
             &config,
             "review-pass",
-            &AiLaneRequest {
-                ..Default::default()
-            },
+            &AiLaneRequest::default(),
             Ok(vec![crate::commands::worktree::shared::TmuxSession {
                 name: "review-pass".to_string(),
                 attached_clients: 0,
@@ -725,9 +732,7 @@ mod tests {
         let prepared = prepare_ai_launch_with_tmux_probe(
             &config,
             "review-pass",
-            &AiLaneRequest {
-                ..Default::default()
-            },
+            &AiLaneRequest::default(),
             Err(anyhow!("tmux unavailable")),
         )
         .expect("prepare launch");

--- a/src/commands/worktree/ai.rs
+++ b/src/commands/worktree/ai.rs
@@ -1,10 +1,10 @@
 use super::shared::{
-    build_agent_launch_spec, build_tmux_launch_spec, compute_worktree_details, default_create_base,
-    default_tmux_session_name, derive_unique_worktree_name, emit_shell_message, emit_shell_payload,
-    ensure_gitignore, ensure_managed_worktrees_root, find_worktree, format_create_message,
-    format_go_message, list_tmux_sessions, managed_worktrees_dir, resolve_branch_name,
-    run_blocking_hook, spawn_background_hook, status_labels, ExistingTmuxSessionBehavior,
-    LaunchSpec, TmuxSession,
+    build_agent_launch_spec_with_options, build_tmux_launch_spec, compute_worktree_details,
+    default_create_base, default_tmux_session_name, derive_unique_worktree_name,
+    emit_shell_message, emit_shell_payload, ensure_gitignore, ensure_managed_worktrees_root,
+    find_worktree, format_create_message, format_go_message, list_tmux_sessions,
+    managed_worktrees_dir, resolve_branch_name, run_blocking_hook, spawn_background_hook,
+    status_labels, ExistingTmuxSessionBehavior, LaunchSpec, TmuxSession,
 };
 use crate::commands::generate;
 use crate::config::Config;
@@ -21,13 +21,15 @@ use std::fs;
 use std::io::IsTerminal;
 use std::path::Path;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 struct AiLaneRequest {
     prompt: Option<String>,
     agent: Option<String>,
     model: Option<String>,
     no_tmux: bool,
     tmux_session: Option<String>,
+    yolo: bool,
+    agent_args: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +56,8 @@ pub fn run(
     model: Option<String>,
     no_tmux: bool,
     tmux_session: Option<String>,
+    yolo: bool,
+    agent_args: Vec<String>,
 ) -> Result<()> {
     if name.is_none() && tmux_session.is_some() {
         bail!("--tmux-session requires an explicit lane name");
@@ -74,6 +78,8 @@ pub fn run(
         model,
         no_tmux,
         tmux_session,
+        yolo,
+        agent_args,
     };
 
     let (name, prompt) = match name {
@@ -273,7 +279,13 @@ fn prepare_ai_launch_with_tmux_probe(
                     .clone()
                     .or_else(|| config.ai.lane.model.clone());
                 generate::print_using_agent(&agent, model.as_deref());
-                let inner = build_agent_launch_spec(&agent, model, prompt_args)?;
+                let inner = build_agent_launch_spec_with_options(
+                    &agent,
+                    model,
+                    prompt_args,
+                    request.yolo,
+                    &request.agent_args,
+                )?;
                 let behavior = if request.prompt.is_some() {
                     ExistingTmuxSessionBehavior::NewWindow
                 } else {
@@ -297,7 +309,13 @@ fn prepare_ai_launch_with_tmux_probe(
         .clone()
         .or_else(|| config.ai.lane.model.clone());
     generate::print_using_agent(&agent, model.as_deref());
-    let launch = build_agent_launch_spec(&agent, model, prompt_args)?;
+    let launch = build_agent_launch_spec_with_options(
+        &agent,
+        model,
+        prompt_args,
+        request.yolo,
+        &request.agent_args,
+    )?;
     Ok(PreparedAiLaunch { launch, messages })
 }
 
@@ -621,10 +639,8 @@ mod tests {
             "review-pass",
             &AiLaneRequest {
                 prompt: Some("fix macOS build".to_string()),
-                agent: None,
-                model: None,
                 no_tmux: true,
-                tmux_session: None,
+                ..Default::default()
             },
             Err(anyhow!("tmux unavailable")),
         )
@@ -650,10 +666,9 @@ mod tests {
             "review-pass",
             &AiLaneRequest {
                 prompt: Some("fix macOS build".to_string()),
-                agent: None,
                 model: Some("claude-sonnet-4-5-20250929".to_string()),
                 no_tmux: true,
-                tmux_session: None,
+                ..Default::default()
             },
             Err(anyhow!("tmux unavailable")),
         )
@@ -684,11 +699,7 @@ mod tests {
             &config,
             "review-pass",
             &AiLaneRequest {
-                prompt: None,
-                agent: None,
-                model: None,
-                no_tmux: false,
-                tmux_session: None,
+                ..Default::default()
             },
             Ok(vec![crate::commands::worktree::shared::TmuxSession {
                 name: "review-pass".to_string(),
@@ -715,11 +726,7 @@ mod tests {
             &config,
             "review-pass",
             &AiLaneRequest {
-                prompt: None,
-                agent: None,
-                model: None,
-                no_tmux: false,
-                tmux_session: None,
+                ..Default::default()
             },
             Err(anyhow!("tmux unavailable")),
         )

--- a/src/commands/worktree/create.rs
+++ b/src/commands/worktree/create.rs
@@ -26,6 +26,8 @@ pub fn run(
     tmux: bool,
     tmux_session: Option<String>,
     args: Vec<String>,
+    yolo: bool,
+    agent_args: Vec<String>,
 ) -> Result<()> {
     if pick && name.is_some() {
         bail!("Use either a name or --pick, not both.");
@@ -40,6 +42,8 @@ pub fn run(
         tmux,
         tmux_session,
         args,
+        yolo,
+        agent_args,
     };
 
     if let Some(ref target) = name {

--- a/src/commands/worktree/go.rs
+++ b/src/commands/worktree/go.rs
@@ -28,6 +28,8 @@ pub fn run_go(
     tmux: bool,
     tmux_session: Option<String>,
     args: Vec<String>,
+    yolo: bool,
+    agent_args: Vec<String>,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let worktree = match name {
@@ -46,6 +48,8 @@ pub fn run_go(
         tmux,
         tmux_session,
         args,
+        yolo,
+        agent_args,
     )
 }
 
@@ -60,6 +64,8 @@ pub(crate) fn run_go_on_worktree(
     tmux: bool,
     tmux_session: Option<String>,
     args: Vec<String>,
+    yolo: bool,
+    agent_args: Vec<String>,
 ) -> Result<()> {
     let config = Config::load()?;
     let launch = build_launch_spec(
@@ -71,6 +77,8 @@ pub(crate) fn run_go_on_worktree(
             tmux,
             tmux_session,
             args,
+            yolo,
+            agent_args,
         },
         &worktree.name,
     )?;

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -686,23 +686,20 @@ pub fn build_launch_spec(
     Ok(base_launch)
 }
 
-#[cfg(test)]
-pub fn build_agent_launch_spec(
-    agent: &str,
-    model: Option<String>,
-    passthrough_args: Vec<String>,
-) -> Result<LaunchSpec> {
-    build_agent_launch_spec_with_options(agent, model, passthrough_args, false, &[])
-}
-
-/// Return the per-agent flag that auto-accepts permission prompts, or `None` if
-/// the agent has no known equivalent.
+/// Return the per-agent flag that auto-accepts permission prompts.
+///
+/// Returns `None` for agents where stax has not verified a supported yolo flag.
+/// Note on opencode: `--dangerously-skip-permissions` is documented for
+/// `opencode run`, but stax launches the top-level `opencode` command. Until
+/// that invocation path is updated (or we confirm the flag is accepted on the
+/// top-level CLI), treat opencode yolo as unsupported.
 pub fn yolo_flag_for_agent(agent: &str) -> Option<&'static str> {
     match agent {
         "claude" => Some("--dangerously-skip-permissions"),
         "codex" => Some("--dangerously-bypass-approvals-and-sandbox"),
-        "opencode" => Some("--dangerously-skip-permissions"),
         "gemini" => Some("--yolo"),
+        // "opencode" intentionally unsupported until the top-level CLI accepts
+        // the flag; see function-level docstring.
         _ => None,
     }
 }
@@ -734,16 +731,19 @@ pub fn build_agent_launch_spec_with_options(
 
     // Inject the per-agent permission-bypass flag before any user-supplied args.
     if yolo {
-        if let Some(flag) = yolo_flag_for_agent(agent) {
-            args.push(flag.to_string());
+        match yolo_flag_for_agent(agent) {
+            Some(flag) => args.push(flag.to_string()),
+            None => bail!(
+                "--yolo is not supported for agent '{}'. \
+                 Use --agent-arg to pass a bypass flag manually.",
+                agent
+            ),
         }
     }
 
     // Raw agent passthrough (--agent-arg) flags come before the prompt so agents
     // that treat trailing positional args as the prompt still work.
-    for extra in extra_agent_args {
-        args.push(extra.clone());
-    }
+    args.extend(extra_agent_args.iter().cloned());
 
     args.extend(passthrough_args);
 
@@ -1121,10 +1121,10 @@ fn parse_tmux_sessions_output(output: &str) -> Result<Vec<TmuxSession>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_agent_launch_spec, build_agent_launch_spec_with_options, build_launch_spec,
-        build_tmux_launch_spec, default_tmux_session_name, is_tmux_no_server_error,
-        parse_tmux_sessions_output, worktree_removal_blockers_for_cleanup, yolo_flag_for_agent,
-        ExistingTmuxSessionBehavior, LaunchOptions, LaunchSpec, WorktreeDetails,
+        build_agent_launch_spec_with_options, build_launch_spec, build_tmux_launch_spec,
+        default_tmux_session_name, is_tmux_no_server_error, parse_tmux_sessions_output,
+        worktree_removal_blockers_for_cleanup, yolo_flag_for_agent, ExistingTmuxSessionBehavior,
+        LaunchOptions, LaunchSpec, WorktreeDetails,
     };
     use crate::config::Config;
     use crate::git::repo::WorktreeInfo;
@@ -1208,10 +1208,12 @@ mod tests {
 
     #[test]
     fn build_agent_launch_spec_adds_agent_specific_model_flag() {
-        let launch = build_agent_launch_spec(
+        let launch = build_agent_launch_spec_with_options(
             "gemini",
             Some("gemini-2.5-flash".to_string()),
             vec!["fix flaky tests".to_string()],
+            false,
+            &[],
         )
         .expect("agent launch");
 
@@ -1246,12 +1248,28 @@ mod tests {
             yolo_flag_for_agent("codex"),
             Some("--dangerously-bypass-approvals-and-sandbox")
         );
-        assert_eq!(
-            yolo_flag_for_agent("opencode"),
-            Some("--dangerously-skip-permissions")
-        );
         assert_eq!(yolo_flag_for_agent("gemini"), Some("--yolo"));
+        // opencode is intentionally unsupported for --yolo right now
+        // (see yolo_flag_for_agent docstring).
+        assert_eq!(yolo_flag_for_agent("opencode"), None);
         assert_eq!(yolo_flag_for_agent("unknown"), None);
+    }
+
+    #[test]
+    fn build_agent_launch_spec_bails_when_yolo_unsupported_for_agent() {
+        let err = build_agent_launch_spec_with_options(
+            "opencode",
+            None,
+            vec!["fix flaky tests".to_string()],
+            true,
+            &[],
+        )
+        .expect_err("opencode yolo should bail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--yolo is not supported") && msg.contains("opencode"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -137,6 +137,8 @@ pub struct LaunchOptions {
     pub tmux: bool,
     pub tmux_session: Option<String>,
     pub args: Vec<String>,
+    pub yolo: bool,
+    pub agent_args: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -633,51 +635,21 @@ pub fn build_launch_spec(
     if options.tmux_session.is_some() && !options.tmux {
         bail!("--tmux-session requires --tmux");
     }
+    if options.yolo && options.agent.is_none() {
+        bail!("--yolo requires --agent");
+    }
+    if !options.agent_args.is_empty() && options.agent.is_none() {
+        bail!("--agent-arg requires --agent");
+    }
 
     let base_launch = if let Some(agent) = options.agent.as_deref() {
-        generate::validate_agent_name(agent)?;
-        let model = options
-            .model
-            .clone()
-            .filter(|value| !value.trim().is_empty());
-
-        let mut args = Vec::new();
-        match agent {
-            "claude" => {
-                if let Some(ref model) = model {
-                    args.extend(["--model".to_string(), model.clone()]);
-                }
-            }
-            "codex" => {
-                if let Some(ref model) = model {
-                    args.extend(["--model".to_string(), model.clone()]);
-                }
-            }
-            "gemini" => {
-                if let Some(ref model) = model {
-                    args.extend(["-m".to_string(), model.clone()]);
-                }
-            }
-            "opencode" => {
-                if let Some(ref model) = model {
-                    args.extend(["--model".to_string(), model.clone()]);
-                }
-            }
-            _ => bail!("Unsupported AI agent: {}", agent),
-        }
-        args.extend(options.args.clone());
-
-        let display = if let Some(model) = model {
-            format!("{} ({})", agent, model)
-        } else {
-            agent.to_string()
-        };
-
-        Some(LaunchSpec::Process {
-            program: agent.to_string(),
-            args,
-            display,
-        })
+        Some(build_agent_launch_spec_with_options(
+            agent,
+            options.model.clone(),
+            options.args.clone(),
+            options.yolo,
+            &options.agent_args,
+        )?)
     } else if let Some(command) = options.run.as_deref() {
         let full_command = if options.args.is_empty() {
             command.to_string()
@@ -714,10 +686,33 @@ pub fn build_launch_spec(
     Ok(base_launch)
 }
 
+#[cfg(test)]
 pub fn build_agent_launch_spec(
     agent: &str,
     model: Option<String>,
     passthrough_args: Vec<String>,
+) -> Result<LaunchSpec> {
+    build_agent_launch_spec_with_options(agent, model, passthrough_args, false, &[])
+}
+
+/// Return the per-agent flag that auto-accepts permission prompts, or `None` if
+/// the agent has no known equivalent.
+pub fn yolo_flag_for_agent(agent: &str) -> Option<&'static str> {
+    match agent {
+        "claude" => Some("--dangerously-skip-permissions"),
+        "codex" => Some("--dangerously-bypass-approvals-and-sandbox"),
+        "opencode" => Some("--dangerously-skip-permissions"),
+        "gemini" => Some("--yolo"),
+        _ => None,
+    }
+}
+
+pub fn build_agent_launch_spec_with_options(
+    agent: &str,
+    model: Option<String>,
+    passthrough_args: Vec<String>,
+    yolo: bool,
+    extra_agent_args: &[String],
 ) -> Result<LaunchSpec> {
     generate::validate_agent_name(agent)?;
     let model = model.filter(|value| !value.trim().is_empty());
@@ -736,6 +731,20 @@ pub fn build_agent_launch_spec(
         }
         _ => bail!("Unsupported AI agent: {}", agent),
     }
+
+    // Inject the per-agent permission-bypass flag before any user-supplied args.
+    if yolo {
+        if let Some(flag) = yolo_flag_for_agent(agent) {
+            args.push(flag.to_string());
+        }
+    }
+
+    // Raw agent passthrough (--agent-arg) flags come before the prompt so agents
+    // that treat trailing positional args as the prompt still work.
+    for extra in extra_agent_args {
+        args.push(extra.clone());
+    }
+
     args.extend(passthrough_args);
 
     let display = if let Some(model) = model {
@@ -1112,10 +1121,10 @@ fn parse_tmux_sessions_output(output: &str) -> Result<Vec<TmuxSession>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_agent_launch_spec, build_launch_spec, build_tmux_launch_spec,
-        default_tmux_session_name, is_tmux_no_server_error, parse_tmux_sessions_output,
-        worktree_removal_blockers_for_cleanup, ExistingTmuxSessionBehavior, LaunchOptions,
-        LaunchSpec, WorktreeDetails,
+        build_agent_launch_spec, build_agent_launch_spec_with_options, build_launch_spec,
+        build_tmux_launch_spec, default_tmux_session_name, is_tmux_no_server_error,
+        parse_tmux_sessions_output, worktree_removal_blockers_for_cleanup, yolo_flag_for_agent,
+        ExistingTmuxSessionBehavior, LaunchOptions, LaunchSpec, WorktreeDetails,
     };
     use crate::config::Config;
     use crate::git::repo::WorktreeInfo;
@@ -1225,6 +1234,141 @@ mod tests {
             }
             LaunchSpec::Shell { .. } => panic!("expected process launch"),
         }
+    }
+
+    #[test]
+    fn yolo_flag_for_agent_maps_each_supported_agent() {
+        assert_eq!(
+            yolo_flag_for_agent("claude"),
+            Some("--dangerously-skip-permissions")
+        );
+        assert_eq!(
+            yolo_flag_for_agent("codex"),
+            Some("--dangerously-bypass-approvals-and-sandbox")
+        );
+        assert_eq!(
+            yolo_flag_for_agent("opencode"),
+            Some("--dangerously-skip-permissions")
+        );
+        assert_eq!(yolo_flag_for_agent("gemini"), Some("--yolo"));
+        assert_eq!(yolo_flag_for_agent("unknown"), None);
+    }
+
+    #[test]
+    fn build_agent_launch_spec_injects_yolo_flag_per_agent() {
+        let launch = build_agent_launch_spec_with_options(
+            "claude",
+            None,
+            vec!["fix flaky tests".to_string()],
+            true,
+            &[],
+        )
+        .expect("claude yolo");
+        match launch {
+            LaunchSpec::Process { args, .. } => {
+                assert!(
+                    args.contains(&"--dangerously-skip-permissions".to_string()),
+                    "claude yolo flag missing: {:?}",
+                    args
+                );
+            }
+            _ => panic!("expected process launch"),
+        }
+
+        let launch = build_agent_launch_spec_with_options(
+            "codex",
+            None,
+            vec!["fix flaky tests".to_string()],
+            true,
+            &[],
+        )
+        .expect("codex yolo");
+        match launch {
+            LaunchSpec::Process { args, .. } => {
+                assert!(
+                    args.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()),
+                    "codex yolo flag missing: {:?}",
+                    args
+                );
+            }
+            _ => panic!("expected process launch"),
+        }
+
+        let launch = build_agent_launch_spec_with_options(
+            "gemini",
+            None,
+            vec!["fix flaky tests".to_string()],
+            true,
+            &[],
+        )
+        .expect("gemini yolo");
+        match launch {
+            LaunchSpec::Process { args, .. } => {
+                assert!(
+                    args.contains(&"--yolo".to_string()),
+                    "gemini yolo flag missing: {:?}",
+                    args
+                );
+            }
+            _ => panic!("expected process launch"),
+        }
+    }
+
+    #[test]
+    fn build_agent_launch_spec_forwards_agent_args_before_prompt() {
+        let launch = build_agent_launch_spec_with_options(
+            "claude",
+            None,
+            vec!["the prompt".to_string()],
+            false,
+            &["--verbose".to_string(), "--debug".to_string()],
+        )
+        .expect("agent args launch");
+
+        match launch {
+            LaunchSpec::Process { args, .. } => {
+                // --verbose + --debug come before the prompt
+                assert_eq!(
+                    args,
+                    vec![
+                        "--verbose".to_string(),
+                        "--debug".to_string(),
+                        "the prompt".to_string(),
+                    ]
+                );
+            }
+            _ => panic!("expected process launch"),
+        }
+    }
+
+    #[test]
+    fn build_launch_spec_rejects_yolo_without_agent() {
+        let config = Config::default();
+        let err = build_launch_spec(
+            &config,
+            &LaunchOptions {
+                yolo: true,
+                ..LaunchOptions::default()
+            },
+            "session",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--yolo requires --agent"));
+    }
+
+    #[test]
+    fn build_launch_spec_rejects_agent_arg_without_agent() {
+        let config = Config::default();
+        let err = build_launch_spec(
+            &config,
+            &LaunchOptions {
+                agent_args: vec!["--verbose".to_string()],
+                ..LaunchOptions::default()
+            },
+            "session",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--agent-arg requires --agent"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add \`--yolo\` to \`st lane\` and \`st worktree create\` that injects the per-agent permission-bypass flag
- Add \`--agent-arg <value>\` (repeatable) as a raw passthrough escape hatch
- Both flags require \`--agent\`

## Per-agent mapping

| Agent | Injected flag |
|---|---|
| \`claude\` | \`--dangerously-skip-permissions\` |
| \`codex\` | \`--dangerously-bypass-approvals-and-sandbox\` |
| \`opencode\` | \`--dangerously-skip-permissions\` |
| \`gemini\` | \`--yolo\` |

Closes #277

## Examples

\`\`\`bash
# Let Claude run autonomously in a fresh lane
st lane fix-flaky --agent claude --yolo \"stabilize the flaky test suite\"

# Forward any other flag the agent supports
st lane big-refactor --agent claude --agent-arg=--verbose \"split the auth module\"
\`\`\`

## Test plan

- [x] Unit tests for \`yolo_flag_for_agent\` mapping
- [x] Unit test that \`--yolo\` injects the correct flag for claude/codex/gemini
- [x] Unit test that \`--agent-arg\` values are forwarded before the prompt
- [x] Unit tests that \`--yolo\` / \`--agent-arg\` without \`--agent\` error out
- [x] \`cargo check\` + lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)