### PR TITLE
fix(sync): reparent tracked children before delete-upstream-gone

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -484,7 +484,7 @@ pub fn run(
         drop(repo);
         let repo = GitRepo::open_from_path(&reopen_repo_path)?;
 
-        // Lazy-initialize forge client for updating PR bases (only if needed)
+        // Initialize forge client once up-front for any PR base updates below.
         let forge_client: Option<(tokio::runtime::Runtime, ForgeClient)> = {
             let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
 
@@ -640,76 +640,16 @@ pub fn run(
                         }
                     }
 
-                    // Reparent children of this branch to its parent before deleting
-                    let children: Vec<String> = stack
-                        .branches
-                        .iter()
-                        .filter(|(_, info)| info.parent.as_deref() == Some(branch))
-                        .map(|(name, _)| name.clone())
-                        .collect();
-                    let merged_branch_tip = repo.branch_commit(branch).ok();
-
-                    for child in &children {
-                        if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
-                            // Preserve the old-parent boundary so restack can run
-                            // `git rebase --onto <new> <old>` precisely.
-                            // Only use the merged branch's current tip when it is
-                            // actually in the child's ancestry.  If the parent was
-                            // rebased before deletion its tip may have moved out of
-                            // the child's commit graph (#120).
-                            let old_parent_boundary = merged_branch_tip
-                                .clone()
-                                .filter(|tip| repo.is_ancestor(tip, child).unwrap_or(false))
-                                .unwrap_or_else(|| child_meta.parent_branch_revision.clone());
-
-                            let updated_meta = BranchMetadata {
-                                parent_branch_name: parent_branch.clone(),
-                                parent_branch_revision: old_parent_boundary,
-                                ..child_meta.clone()
-                            };
-                            updated_meta.write(repo.inner(), child)?;
-
-                            // Update PR base on the forge if this branch has a PR
-                            if let Some(pr_info) = &child_meta.pr_info {
-                                if let Some((rt, client)) = &forge_client {
-                                    match rt.block_on(
-                                        client.update_pr_base(pr_info.number, &parent_branch),
-                                    ) {
-                                        Ok(()) => {
-                                            if !quiet {
-                                                println!(
-                                                    "    {} updated PR #{} base → {}",
-                                                    "↪".cyan(),
-                                                    pr_info.number,
-                                                    parent_branch.cyan()
-                                                );
-                                            }
-                                        }
-                                        Err(e) => {
-                                            // Log warning but don't fail - PR might already be closed/merged
-                                            if !quiet {
-                                                println!(
-                                                    "    {} couldn't update PR #{} base: {}",
-                                                    "⚠".yellow(),
-                                                    pr_info.number,
-                                                    e
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            if !quiet {
-                                println!(
-                                    "    {} reparented {} → {}",
-                                    "↪".cyan(),
-                                    child.cyan(),
-                                    parent_branch.cyan()
-                                );
-                            }
-                        }
-                    }
+                    // Reparent tracked children onto the surviving parent before
+                    // deleting, preserving the old-parent boundary for later restack.
+                    reparent_children_for_deletion(
+                        &repo,
+                        &stack,
+                        branch,
+                        &parent_branch,
+                        forge_client.as_ref(),
+                        quiet,
+                    )?;
 
                     let local_delete = delete_local_branch_for_sync(
                         &repo,
@@ -866,7 +806,7 @@ pub fn run(
             // to degrade gracefully rather than aborting a mid-sync run.
             let mut live_stack = Stack::load(&repo).unwrap_or_else(|_| stack.clone());
 
-            // Lazy-initialize forge client once for any PR base updates below.
+            // Initialize forge client once up-front for any PR base updates below.
             let forge_client: Option<(tokio::runtime::Runtime, ForgeClient)> = {
                 let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
                 if let Some(info) = remote_info {
@@ -1926,14 +1866,11 @@ fn resolve_fallback_parent_skipping_doomed(
     let mut visited: std::collections::HashSet<String> =
         std::collections::HashSet::from([branch.to_string()]);
 
-    loop {
-        if !visited.insert(current.clone()) {
-            // Cycle guard: fall back to trunk
-            break;
-        }
+    // Walk up the recorded-parent chain. `visited.insert` doubles as the cycle
+    // guard: once we revisit a branch we fall through to the trunk fallback.
+    while visited.insert(current.clone()) {
         let is_doomed = doomed.iter().any(|d| d == &current);
-        let exists_locally = local_branch_exists(workdir, &current);
-        if !is_doomed && exists_locally {
+        if !is_doomed && local_branch_exists(workdir, &current) {
             let fallback_from = if current == recorded_parent {
                 None
             } else {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -860,9 +860,11 @@ pub fn run(
                 println!();
             }
 
-            // Reload the stack so the merged-branch path's reparenting is reflected
-            // before we start resolving the upstream-gone branches' metadata.
-            let live_stack = Stack::load(&repo)?;
+            // Reload the stack so the merged-branch path's reparenting is
+            // reflected before we resolve upstream-gone branches. Fall back to
+            // the snapshot captured at the top of sync() if the reload fails,
+            // to degrade gracefully rather than aborting a mid-sync run.
+            let mut live_stack = Stack::load(&repo).unwrap_or_else(|_| stack.clone());
 
             // Lazy-initialize forge client once for any PR base updates below.
             let forge_client: Option<(tokio::runtime::Runtime, ForgeClient)> = {
@@ -889,15 +891,28 @@ pub fn run(
                     plan_blocking_worktree_cleanup(&repo, branch, force)?
                 };
 
-                // Resolve the parent children will be reparented to:
-                // recorded parent if it still exists locally, otherwise trunk.
-                let recorded_parent_branch = live_stack
-                    .branches
-                    .get(branch)
-                    .and_then(|b| b.parent.clone())
-                    .unwrap_or_else(|| stack.trunk.clone());
+                // Resolve the parent children will be reparented to. Walks up
+                // the recorded-parent chain skipping any branch that is itself
+                // scheduled for deletion in this pass, so a stack like A -> B -> C
+                // (where A and B both have upstream gone) lands C on trunk
+                // rather than on the soon-to-be-deleted A.
                 let (fallback_parent, parent_fallback_from) =
-                    resolve_effective_parent(&workdir, &recorded_parent_branch, &stack.trunk);
+                    resolve_fallback_parent_skipping_doomed(
+                        &workdir, &live_stack, branch, &gone,
+                    );
+
+                // Print the parent-fallback hint BEFORE the confirm prompt so the
+                // user knows why the prompt mentions a non-recorded parent.
+                if !quiet {
+                    if let Some(missing_parent) = &parent_fallback_from {
+                        println!(
+                            "    {} parent {} not available; using {}",
+                            "↪".yellow(),
+                            missing_parent.yellow(),
+                            fallback_parent.cyan()
+                        );
+                    }
+                }
 
                 let prompt = sync_delete_prompt(
                     branch,
@@ -932,17 +947,6 @@ pub fn run(
                     continue;
                 }
 
-                if !quiet {
-                    if let Some(missing_parent) = &parent_fallback_from {
-                        println!(
-                            "    {} parent {} not found locally; using {}",
-                            "↪".yellow(),
-                            missing_parent.yellow(),
-                            fallback_parent.cyan()
-                        );
-                    }
-                }
-
                 if is_current_branch {
                     match checkout_branch_for_cleanup(&repo, &workdir, &fallback_parent) {
                         Ok(()) => {
@@ -972,75 +976,24 @@ pub fn run(
                     }
                 }
 
-                // Reparent tracked children of this branch to the fallback parent
-                // before deleting, so descendants don't point at a branch that no
-                // longer exists. Mirrors the merged-branch cleanup path.
-                let children: Vec<String> = live_stack
-                    .branches
-                    .iter()
-                    .filter(|(_, info)| info.parent.as_deref() == Some(branch))
-                    .map(|(name, _)| name.clone())
-                    .collect();
-                let gone_branch_tip = repo.branch_commit(branch).ok();
+                // Reparent tracked children to the fallback parent before
+                // deleting. The shared helper also mirrors the merged-branch
+                // path's ancestor-check rationale from issue #120.
+                reparent_children_for_deletion(
+                    &repo,
+                    &live_stack,
+                    branch,
+                    &fallback_parent,
+                    forge_client.as_ref(),
+                    quiet,
+                )?;
 
-                for child in &children {
-                    if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
-                        // Preserve the old-parent boundary so restack can run
-                        // `git rebase --onto <new> <old>` precisely. Only use the
-                        // deleted branch's tip when it is still in the child's
-                        // ancestry; otherwise keep the recorded revision.
-                        let old_parent_boundary = gone_branch_tip
-                            .clone()
-                            .filter(|tip| repo.is_ancestor(tip, child).unwrap_or(false))
-                            .unwrap_or_else(|| child_meta.parent_branch_revision.clone());
-
-                        let updated_meta = BranchMetadata {
-                            parent_branch_name: fallback_parent.clone(),
-                            parent_branch_revision: old_parent_boundary,
-                            ..child_meta.clone()
-                        };
-                        updated_meta.write(repo.inner(), child)?;
-
-                        // Best-effort PR base update. Upstream-gone branches usually
-                        // have closed PRs, so failures here are expected and logged.
-                        if let Some(pr_info) = &child_meta.pr_info {
-                            if let Some((rt, client)) = &forge_client {
-                                match rt.block_on(
-                                    client.update_pr_base(pr_info.number, &fallback_parent),
-                                ) {
-                                    Ok(()) => {
-                                        if !quiet {
-                                            println!(
-                                                "    {} updated PR #{} base → {}",
-                                                "↪".cyan(),
-                                                pr_info.number,
-                                                fallback_parent.cyan()
-                                            );
-                                        }
-                                    }
-                                    Err(e) => {
-                                        if !quiet {
-                                            println!(
-                                                "    {} couldn't update PR #{} base: {}",
-                                                "⚠".yellow(),
-                                                pr_info.number,
-                                                e
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        if !quiet {
-                            println!(
-                                "    {} reparented {} → {}",
-                                "↪".cyan(),
-                                child.cyan(),
-                                fallback_parent.cyan()
-                            );
-                        }
-                    }
+                // Refresh the in-memory stack so subsequent iterations see the
+                // just-reparented children under the new parent (preventing a
+                // later iteration from bouncing them again). Fall back to the
+                // current live_stack if the reload fails.
+                if let Ok(refreshed) = Stack::load(&repo) {
+                    live_stack = refreshed;
                 }
 
                 let local_delete = delete_local_branch_for_sync(
@@ -1950,6 +1903,139 @@ fn resolve_effective_parent(
     }
 
     (recorded_parent.to_string(), None)
+}
+
+/// Walk the parent chain from `branch` skipping any branch in `doomed` (e.g.
+/// branches scheduled for deletion in the same sync pass). Returns the first
+/// ancestor that is not doomed and still exists locally, falling back to trunk.
+/// This prevents reparenting children onto a branch that is about to be deleted
+/// when multiple branches in the same stack have their upstream gone.
+fn resolve_fallback_parent_skipping_doomed(
+    workdir: &std::path::Path,
+    stack: &Stack,
+    branch: &str,
+    doomed: &[String],
+) -> (String, Option<String>) {
+    let recorded_parent = stack
+        .branches
+        .get(branch)
+        .and_then(|b| b.parent.clone())
+        .unwrap_or_else(|| stack.trunk.clone());
+
+    let mut current = recorded_parent.clone();
+    let mut visited: std::collections::HashSet<String> =
+        std::collections::HashSet::from([branch.to_string()]);
+
+    loop {
+        if !visited.insert(current.clone()) {
+            // Cycle guard: fall back to trunk
+            break;
+        }
+        let is_doomed = doomed.iter().any(|d| d == &current);
+        let exists_locally = local_branch_exists(workdir, &current);
+        if !is_doomed && exists_locally {
+            let fallback_from = if current == recorded_parent {
+                None
+            } else {
+                Some(recorded_parent.clone())
+            };
+            return (current, fallback_from);
+        }
+        // Walk up to the parent of `current`; if none, break to trunk.
+        match stack.branches.get(&current).and_then(|b| b.parent.clone()) {
+            Some(next) if next != current => current = next,
+            _ => break,
+        }
+    }
+
+    // Fall back to trunk if nothing else worked.
+    let fallback_from = if recorded_parent == stack.trunk {
+        None
+    } else {
+        Some(recorded_parent)
+    };
+    (stack.trunk.clone(), fallback_from)
+}
+
+/// Reparent tracked children of `branch` onto `new_parent`, preserving the old
+/// parent boundary for later restack (see issue #120 rationale). Best-effort
+/// updates the PR base on the forge when a child has a tracked PR.
+///
+/// Used by both the merged-branch and upstream-gone cleanup paths.
+fn reparent_children_for_deletion(
+    repo: &GitRepo,
+    stack_snapshot: &Stack,
+    branch: &str,
+    new_parent: &str,
+    forge_client: Option<&(tokio::runtime::Runtime, ForgeClient)>,
+    quiet: bool,
+) -> Result<()> {
+    let children: Vec<String> = stack_snapshot
+        .branches
+        .iter()
+        .filter(|(_, info)| info.parent.as_deref() == Some(branch))
+        .map(|(name, _)| name.clone())
+        .collect();
+    let doomed_tip = repo.branch_commit(branch).ok();
+
+    for child in &children {
+        let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? else {
+            continue;
+        };
+
+        // Preserve the old-parent boundary so restack can run `git rebase
+        // --onto <new> <old>` precisely. Only use the deleted branch's tip
+        // when it is still in the child's ancestry; otherwise keep the
+        // recorded revision (see #120).
+        let old_parent_boundary = doomed_tip
+            .clone()
+            .filter(|tip| repo.is_ancestor(tip, child).unwrap_or(false))
+            .unwrap_or_else(|| child_meta.parent_branch_revision.clone());
+
+        let updated_meta = BranchMetadata {
+            parent_branch_name: new_parent.to_string(),
+            parent_branch_revision: old_parent_boundary,
+            ..child_meta.clone()
+        };
+        updated_meta.write(repo.inner(), child)?;
+
+        // Best-effort PR base update. Expected to fail when upstream is gone
+        // (PR closed) — log and continue.
+        if let (Some(pr_info), Some((rt, client))) = (&child_meta.pr_info, forge_client) {
+            match rt.block_on(client.update_pr_base(pr_info.number, new_parent)) {
+                Ok(()) => {
+                    if !quiet {
+                        println!(
+                            "    {} updated PR #{} base → {}",
+                            "↪".cyan(),
+                            pr_info.number,
+                            new_parent.cyan()
+                        );
+                    }
+                }
+                Err(e) => {
+                    if !quiet {
+                        println!(
+                            "    {} couldn't update PR #{} base: {}",
+                            "⚠".yellow(),
+                            pr_info.number,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        if !quiet {
+            println!(
+                "    {} reparented {} → {}",
+                "↪".cyan(),
+                child.cyan(),
+                new_parent.cyan()
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Record CI history for merged branches before they are deleted

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -860,6 +860,23 @@ pub fn run(
                 println!();
             }
 
+            // Reload the stack so the merged-branch path's reparenting is reflected
+            // before we start resolving the upstream-gone branches' metadata.
+            let live_stack = Stack::load(&repo)?;
+
+            // Lazy-initialize forge client once for any PR base updates below.
+            let forge_client: Option<(tokio::runtime::Runtime, ForgeClient)> = {
+                let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
+                if let Some(info) = remote_info {
+                    tokio::runtime::Runtime::new().ok().and_then(|rt| {
+                        let _enter = rt.enter();
+                        ForgeClient::new(&info).ok().map(|client| (rt, client))
+                    })
+                } else {
+                    None
+                }
+            };
+
             for branch in &gone {
                 if !local_branch_exists(&workdir, branch) {
                     continue;
@@ -871,7 +888,17 @@ pub fn run(
                 } else {
                     plan_blocking_worktree_cleanup(&repo, branch, force)?
                 };
-                let fallback_parent = &stack.trunk;
+
+                // Resolve the parent children will be reparented to:
+                // recorded parent if it still exists locally, otherwise trunk.
+                let recorded_parent_branch = live_stack
+                    .branches
+                    .get(branch)
+                    .and_then(|b| b.parent.clone())
+                    .unwrap_or_else(|| stack.trunk.clone());
+                let (fallback_parent, parent_fallback_from) =
+                    resolve_effective_parent(&workdir, &recorded_parent_branch, &stack.trunk);
+
                 let prompt = sync_delete_prompt(
                     branch,
                     if is_current_branch {
@@ -905,8 +932,19 @@ pub fn run(
                     continue;
                 }
 
+                if !quiet {
+                    if let Some(missing_parent) = &parent_fallback_from {
+                        println!(
+                            "    {} parent {} not found locally; using {}",
+                            "↪".yellow(),
+                            missing_parent.yellow(),
+                            fallback_parent.cyan()
+                        );
+                    }
+                }
+
                 if is_current_branch {
-                    match checkout_branch_for_cleanup(&repo, &workdir, fallback_parent) {
+                    match checkout_branch_for_cleanup(&repo, &workdir, &fallback_parent) {
                         Ok(()) => {
                             current_after_deletions = fallback_parent.clone();
                             if !quiet {
@@ -930,6 +968,77 @@ pub fn run(
                                 );
                             }
                             continue;
+                        }
+                    }
+                }
+
+                // Reparent tracked children of this branch to the fallback parent
+                // before deleting, so descendants don't point at a branch that no
+                // longer exists. Mirrors the merged-branch cleanup path.
+                let children: Vec<String> = live_stack
+                    .branches
+                    .iter()
+                    .filter(|(_, info)| info.parent.as_deref() == Some(branch))
+                    .map(|(name, _)| name.clone())
+                    .collect();
+                let gone_branch_tip = repo.branch_commit(branch).ok();
+
+                for child in &children {
+                    if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
+                        // Preserve the old-parent boundary so restack can run
+                        // `git rebase --onto <new> <old>` precisely. Only use the
+                        // deleted branch's tip when it is still in the child's
+                        // ancestry; otherwise keep the recorded revision.
+                        let old_parent_boundary = gone_branch_tip
+                            .clone()
+                            .filter(|tip| repo.is_ancestor(tip, child).unwrap_or(false))
+                            .unwrap_or_else(|| child_meta.parent_branch_revision.clone());
+
+                        let updated_meta = BranchMetadata {
+                            parent_branch_name: fallback_parent.clone(),
+                            parent_branch_revision: old_parent_boundary,
+                            ..child_meta.clone()
+                        };
+                        updated_meta.write(repo.inner(), child)?;
+
+                        // Best-effort PR base update. Upstream-gone branches usually
+                        // have closed PRs, so failures here are expected and logged.
+                        if let Some(pr_info) = &child_meta.pr_info {
+                            if let Some((rt, client)) = &forge_client {
+                                match rt.block_on(
+                                    client.update_pr_base(pr_info.number, &fallback_parent),
+                                ) {
+                                    Ok(()) => {
+                                        if !quiet {
+                                            println!(
+                                                "    {} updated PR #{} base → {}",
+                                                "↪".cyan(),
+                                                pr_info.number,
+                                                fallback_parent.cyan()
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        if !quiet {
+                                            println!(
+                                                "    {} couldn't update PR #{} base: {}",
+                                                "⚠".yellow(),
+                                                pr_info.number,
+                                                e
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if !quiet {
+                            println!(
+                                "    {} reparented {} → {}",
+                                "↪".cyan(),
+                                child.cyan(),
+                                fallback_parent.cyan()
+                            );
                         }
                     }
                 }

--- a/src/engine/stack.rs
+++ b/src/engine/stack.rs
@@ -17,6 +17,7 @@ pub struct StackBranch {
 }
 
 /// The full stack structure
+#[derive(Debug, Clone)]
 pub struct Stack {
     pub branches: HashMap<String, StackBranch>,
     pub trunk: String,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4251,6 +4251,75 @@ fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
 }
 
 #[test]
+fn test_sync_delete_upstream_gone_reparents_tracked_children() {
+    // Regression test for #200: sync --delete-upstream-gone must reparent
+    // tracked children before deleting, so descendants do not end up
+    // pointing at a branch that no longer exists.
+    let repo = TestRepo::new_with_remote();
+
+    // Build main -> parent-200 -> child-200
+    repo.run_stax(&["bc", "parent-200"]);
+    let parent_branch = repo.current_branch();
+    repo.create_file("parent.txt", "parent content");
+    repo.commit("Parent commit");
+    repo.git(&["push", "-u", "origin", &parent_branch]);
+
+    repo.run_stax(&["bc", "child-200"]);
+    let child_branch = repo.current_branch();
+    repo.create_file("child.txt", "child content");
+    repo.commit("Child commit");
+    repo.git(&["push", "-u", "origin", &child_branch]);
+
+    // Delete the parent on the remote so its upstream is gone
+    repo.git(&["checkout", "main"]);
+    repo.git(&["push", "origin", "--delete", &parent_branch]);
+
+    // Run sync --delete-upstream-gone; parent should be deleted and the
+    // child should be reparented to main (the nearest surviving ancestor).
+    let output = repo.run_stax(&["sync", "--force", "--delete-upstream-gone"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.iter().any(|b| *b == parent_branch),
+        "Expected parent to be deleted, still have: {:?}",
+        branches
+    );
+    assert!(
+        branches.iter().any(|b| *b == child_branch),
+        "Expected child to survive, got: {:?}",
+        branches
+    );
+
+    // Child's recorded parent must no longer point at the deleted branch.
+    let status = repo.run_stax(&["status", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("valid JSON");
+    let child_entry = json["branches"]
+        .as_array()
+        .expect("branches array")
+        .iter()
+        .find(|b| b["name"].as_str() == Some(&child_branch))
+        .expect("child in status");
+    let new_parent = child_entry["parent"]
+        .as_str()
+        .expect("child has a parent field");
+    assert_ne!(
+        new_parent, parent_branch,
+        "Child still points at the deleted parent"
+    );
+    assert_eq!(
+        new_parent, "main",
+        "Expected child to be reparented to main, got: {}",
+        new_parent
+    );
+}
+
+#[test]
 fn test_sync_detects_branch_with_empty_diff_against_trunk() {
     let repo = TestRepo::new_with_remote();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4320,6 +4320,83 @@ fn test_sync_delete_upstream_gone_reparents_tracked_children() {
 }
 
 #[test]
+fn test_sync_delete_upstream_gone_reparents_across_multiple_doomed_ancestors() {
+    // Regression guard: if both the parent AND the grandparent are upstream-gone,
+    // the deepest descendant must land on the first non-doomed ancestor (trunk
+    // in this case), NOT on a soon-to-be-deleted ancestor.
+    let repo = TestRepo::new_with_remote();
+
+    // Build main -> grand-200 -> mid-200 -> leaf-200
+    repo.run_stax(&["bc", "grand-200"]);
+    let grand = repo.current_branch();
+    repo.create_file("grand.txt", "grand");
+    repo.commit("grand");
+    repo.git(&["push", "-u", "origin", &grand]);
+
+    repo.run_stax(&["bc", "mid-200"]);
+    let mid = repo.current_branch();
+    repo.create_file("mid.txt", "mid");
+    repo.commit("mid");
+    repo.git(&["push", "-u", "origin", &mid]);
+
+    repo.run_stax(&["bc", "leaf-200"]);
+    let leaf = repo.current_branch();
+    repo.create_file("leaf.txt", "leaf");
+    repo.commit("leaf");
+    repo.git(&["push", "-u", "origin", &leaf]);
+
+    // Delete both grand AND mid on the remote. Leaf survives remotely.
+    repo.git(&["checkout", "main"]);
+    repo.git(&["push", "origin", "--delete", &grand]);
+    repo.git(&["push", "origin", "--delete", &mid]);
+
+    let output = repo.run_stax(&["sync", "--force", "--delete-upstream-gone"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.iter().any(|b| *b == grand),
+        "grand should be deleted, got: {:?}",
+        branches
+    );
+    assert!(
+        !branches.iter().any(|b| *b == mid),
+        "mid should be deleted, got: {:?}",
+        branches
+    );
+    assert!(
+        branches.iter().any(|b| *b == leaf),
+        "leaf should survive, got: {:?}",
+        branches
+    );
+
+    // Leaf must NOT point at either deleted branch; it should land on main.
+    let status = repo.run_stax(&["status", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("valid JSON");
+    let leaf_entry = json["branches"]
+        .as_array()
+        .expect("branches array")
+        .iter()
+        .find(|b| b["name"].as_str() == Some(&leaf))
+        .expect("leaf in status");
+    let new_parent = leaf_entry["parent"]
+        .as_str()
+        .expect("leaf has a parent field");
+    assert_ne!(new_parent, mid, "leaf still points at deleted mid");
+    assert_ne!(new_parent, grand, "leaf still points at deleted grand");
+    assert_eq!(
+        new_parent, "main",
+        "Expected leaf to be reparented to main, got: {}",
+        new_parent
+    );
+}
+
+#[test]
 fn test_sync_detects_branch_with_empty_diff_against_trunk() {
     let repo = TestRepo::new_with_remote();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4285,12 +4285,12 @@ fn test_sync_delete_upstream_gone_reparents_tracked_children() {
 
     let branches = repo.list_branches();
     assert!(
-        !branches.iter().any(|b| *b == parent_branch),
+        !branches.contains(&parent_branch),
         "Expected parent to be deleted, still have: {:?}",
         branches
     );
     assert!(
-        branches.iter().any(|b| *b == child_branch),
+        branches.contains(&child_branch),
         "Expected child to survive, got: {:?}",
         branches
     );
@@ -4359,17 +4359,17 @@ fn test_sync_delete_upstream_gone_reparents_across_multiple_doomed_ancestors() {
 
     let branches = repo.list_branches();
     assert!(
-        !branches.iter().any(|b| *b == grand),
+        !branches.contains(&grand),
         "grand should be deleted, got: {:?}",
         branches
     );
     assert!(
-        !branches.iter().any(|b| *b == mid),
+        !branches.contains(&mid),
         "mid should be deleted, got: {:?}",
         branches
     );
     assert!(
-        branches.iter().any(|b| *b == leaf),
+        branches.contains(&leaf),
         "leaf should survive, got: {:?}",
         branches
     );


### PR DESCRIPTION
## Summary

Before deleting a branch whose upstream has been removed, reparent any tracked children to a sensible fallback (the recorded parent if it still exists locally, otherwise trunk) and preserve the old-parent boundary so restack can run cleanly afterwards.

Previously \`stax sync --delete-upstream-gone\` deleted the branch without reparenting, leaving descendants pointing at a branch that no longer exists. \`stax status --json\` then reported the child with \`\"parent\": \"<deleted-branch>\"\` and \`needs_restack: false\`, breaking the stack.

Closes #200

## Approach

Mirror the merged-branch cleanup flow:
- reload the stack so prior merged-branch reparenting is visible
- resolve a fallback parent (recorded parent if still local, else trunk)
- reparent tracked children, preserving the old parent boundary via the same ancestor check the merged path uses (#120)
- best-effort PR base update when a child has a tracked PR (failures are expected — upstream is gone — and logged rather than fatal)

## Test plan

- [x] New integration test: \`test_sync_delete_upstream_gone_reparents_tracked_children\`
  - builds main → parent → child
  - deletes parent on the remote
  - runs \`stax sync --force --delete-upstream-gone\`
  - asserts parent is gone, child survives, child's recorded parent is \`main\`
- [x] Existing test \`test_sync_delete_upstream_gone_deletes_untracked_local_branch\` still passes (untracked-branch path unaffected)
- [x] \`cargo check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)