### PR TITLE
fix(split): hard-fail `--file` on multi-commit branches (#281)

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -61,7 +61,7 @@
 | `st` | | Launch TUI |
 | `st split` | | Split branch into stacked branches (commit-based; needs 2+ commits) |
 | `st split --hunk` | | Split a single commit into stacked branches by selecting individual diff hunks |
-| `st split --file <pathspec>` | | Split by extracting files matching pathspec into a new parent branch |
+| `st split --file <pathspec>` | | Split by extracting files matching pathspec into a new parent branch (single-commit branches only; use `st split --hunk` for multi-commit surgery) |
 | `st edit` | `e` | Interactively edit commits on current branch (pick, reword, squash, fixup, drop) |
 
 ## Recovery

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -97,18 +97,6 @@ fn split_by_file(
         );
     }
 
-    // 1. Check that the pathspecs actually match something in the diff
-    let diff_files = changed_files_between(workdir, parent, current, pathspecs)?;
-    if diff_files.is_empty() {
-        anyhow::bail!(
-            "No changes match the given pathspec(s) between '{}' and '{}'.\n\
-             Files checked: {}",
-            parent,
-            current,
-            pathspecs.join(", ")
-        );
-    }
-
     let commit_count = repo.commits_between(parent, current)?.len();
     if commit_count > 1 {
         anyhow::bail!(
@@ -120,6 +108,18 @@ fn split_by_file(
             commit_count,
             parent,
             "stax split --hunk".cyan()
+        );
+    }
+
+    // Check that the pathspecs actually match something in the diff
+    let diff_files = changed_files_between(workdir, parent, current, pathspecs)?;
+    if diff_files.is_empty() {
+        anyhow::bail!(
+            "No changes match the given pathspec(s) between '{}' and '{}'.\n\
+             Files checked: {}",
+            parent,
+            current,
+            pathspecs.join(", ")
         );
     }
 

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -111,16 +111,16 @@ fn split_by_file(
 
     let commit_count = repo.commits_between(parent, current)?.len();
     if commit_count > 1 {
-        println!(
-            "{}",
-            "Warning: `stax split --file` only rewrites the tip commit. Matching files may remain in earlier commits."
-                .yellow()
+        anyhow::bail!(
+            "`stax split --file` is unsafe on multi-commit branches: it only rewrites the tip \
+             commit, so matching files can remain in earlier commits of '{}' ({} commits above \
+             '{}').\n\
+             Use {} for commit-by-commit history surgery instead.",
+            current,
+            commit_count,
+            parent,
+            "stax split --hunk".cyan()
         );
-        println!(
-            "{}",
-            "Tip: use `stax split --hunk` for commit-by-commit history surgery.".dimmed()
-        );
-        println!();
     }
 
     println!(

--- a/tests/split_tests.rs
+++ b/tests/split_tests.rs
@@ -203,10 +203,10 @@ fn test_split_file_extracts_matching_paths_into_new_parent_branch() {
     repo.run_stax(&["status"]).assert_success();
     repo.run_stax(&["create", "feature"]).assert_success();
 
+    // Single commit touching both files — `split --file` requires one commit above parent.
     repo.create_file("keep.txt", "keep");
-    repo.commit("add keep");
     repo.create_file("move.txt", "move");
-    repo.commit("add move");
+    repo.commit("add keep and move");
 
     let feature_branch = repo.current_branch();
 
@@ -252,5 +252,49 @@ fn test_split_file_extracts_matching_paths_into_new_parent_branch() {
         !feature_files.contains("move.txt"),
         "Current branch should no longer carry move.txt in its own history, got: {}",
         feature_files
+    );
+}
+
+#[test]
+fn test_split_file_on_multi_commit_branch_fails() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["create", "feature"]).assert_success();
+
+    // Two commits on the branch above parent, both touching the same file.
+    repo.create_file("move.txt", "v1");
+    repo.commit("add move.txt");
+    repo.create_file("move.txt", "v2");
+    repo.commit("modify move.txt");
+
+    let branch_before = repo.current_branch();
+    let head_before = TestRepo::stdout(&repo.git(&["rev-parse", "HEAD"]))
+        .trim()
+        .to_string();
+
+    let output = repo.run_stax(&["split", "--file", "move.txt"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("multi-commit") && stderr.contains("stax split --hunk"),
+        "Expected guidance toward --hunk, got: {}",
+        stderr
+    );
+
+    // Branch state must be untouched after the hard-fail.
+    assert_eq!(repo.current_branch(), branch_before);
+    let head_after = TestRepo::stdout(&repo.git(&["rev-parse", "HEAD"]))
+        .trim()
+        .to_string();
+    assert_eq!(
+        head_before, head_after,
+        "HEAD should not move when split --file aborts"
+    );
+    let branches = TestRepo::stdout(&repo.git(&["branch", "--list"]));
+    assert!(
+        !branches.contains("feature-split"),
+        "No split branch should be created on hard-fail, got branches: {}",
+        branches
     );
 }

--- a/tests/split_tests.rs
+++ b/tests/split_tests.rs
@@ -261,16 +261,13 @@ fn test_split_file_on_multi_commit_branch_fails() {
 
     repo.run_stax(&["create", "feature"]).assert_success();
 
-    // Two commits on the branch above parent, both touching the same file.
     repo.create_file("move.txt", "v1");
     repo.commit("add move.txt");
     repo.create_file("move.txt", "v2");
     repo.commit("modify move.txt");
 
     let branch_before = repo.current_branch();
-    let head_before = TestRepo::stdout(&repo.git(&["rev-parse", "HEAD"]))
-        .trim()
-        .to_string();
+    let head_before = repo.head_sha();
 
     let output = repo.run_stax(&["split", "--file", "move.txt"]);
     output.assert_failure();
@@ -282,19 +279,17 @@ fn test_split_file_on_multi_commit_branch_fails() {
         stderr
     );
 
-    // Branch state must be untouched after the hard-fail.
+    // Hard-fail must leave branch state untouched — no partial split left behind.
     assert_eq!(repo.current_branch(), branch_before);
-    let head_after = TestRepo::stdout(&repo.git(&["rev-parse", "HEAD"]))
-        .trim()
-        .to_string();
     assert_eq!(
-        head_before, head_after,
+        head_before,
+        repo.head_sha(),
         "HEAD should not move when split --file aborts"
     );
-    let branches = TestRepo::stdout(&repo.git(&["branch", "--list"]));
+    let branches = repo.list_branches();
     assert!(
-        !branches.contains("feature-split"),
-        "No split branch should be created on hard-fail, got branches: {}",
+        !branches.iter().any(|b| b.contains("feature-split")),
+        "No split branch should be created on hard-fail, got branches: {:?}",
         branches
     );
 }


### PR DESCRIPTION
## Summary

Closes #281. `stax split --file` on a branch with >1 commit above its parent now returns an error pointing to `stax split --hunk`, instead of silently rewriting only the tip commit and leaving matching files in earlier commits.

Concretely:
- `src/commands/split.rs`: flip the existing warning block into `anyhow::bail!`.
- `tests/split_tests.rs`: new `test_split_file_on_multi_commit_branch_fails` covering the failure message and asserting HEAD / branch list are untouched; reshaped the existing happy-path test as a single-commit case (was implicitly 2-commit, would regress under the new check).
- `docs/commands/reference.md`: note the single-commit constraint on `st split --file`.

## Decision: why option 1, not option 2 or a graphite-like prompt

The issue offers two options. I looked at both plus a third graphite-shaped alternative before picking option 1:

- **Option 1 — hard-fail (this PR)**. Closes the correctness gap with the smallest surface area. The only semantic change is that a previously-warning path now errors; every other code path is untouched. Safe to ship, safe to revert.
- **Option 2 — full history rewrite**. Would actually strip matching paths from every commit in `parent..current`. This is the more *useful* behavior, but it means a per-commit cherry-pick loop (or rebase --exec dance) with real edge cases: cherry-pick conflicts, commit author/date preservation, signed commits, pre-commit hooks firing per commit, empty-commit handling, descendant restacking. Worth doing, but deserves its own focused PR with dedicated tests — not bundled into a correctness fix.
- **Option 3 — graphite-like interactive fallback**. Graphite's public CLI (charcoal fork, [`split.ts`](https://github.com/danerwilliams/charcoal/blob/main/apps/cli/src/actions/split.ts)) prompts the user to choose `commit`/`hunk`/`abort` when mode is ambiguous on a multi-commit branch. Graphite's `--by-file` behavior is closed-source (moved to a private monorepo in July 2023), so we can't literally mirror it. A stax analog would be: on multi-commit `--file`, prompt to switch to `--hunk` or abort. That's reasonable UX but discards the user's explicit `-f` arg on the switch path, and needs a new interactive dependency for tests. Defer until we see whether the hard-fail actually bothers users.

If this fix proves too abrupt in practice, the graphite-like prompt is the natural next step; option 2 (full rewrite) is the real long-term answer.

## Test plan

- [x] `cargo test --test split_tests` — all 13 tests pass (new + reshaped happy-path + existing).
- [x] Verified 4 unrelated `commands::shell_setup::tests::posix_shell_snippet_*` unit-test failures reproduce on unmodified `main`, so they are pre-existing and out of scope for this PR.
- [ ] Manual smoke: run `stax split --file <path>` on a multi-commit branch and confirm the error message.
- [ ] Manual smoke: run `stax split --file <path>` on a single-commit branch and confirm it still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)