### PR TITLE
fix: conflict handling exit code, rebase guard, resume loop, and auth error messages

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::{commands, config::Config, tui, update};
+use crate::{commands, config::Config, errors::ConflictStopped, git::GitRepo, tui, update};
 use anyhow::Result;
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use std::{io::IsTerminal, time::Duration};
@@ -1461,6 +1461,18 @@ pub fn run() -> Result<()> {
     // Ensure repo is initialized for all other commands
     commands::init::ensure_initialized()?;
 
+    // Block non-rebase-aware commands when a rebase is in progress.
+    if !is_rebase_aware_command(&command) {
+        if let Ok(repo) = GitRepo::open() {
+            if repo.rebase_in_progress().unwrap_or(false) {
+                anyhow::bail!(
+                    "A rebase is in progress. Resolve conflicts and run one of:\n  \
+                     stax resolve\n  stax continue\n  stax abort"
+                );
+            }
+        }
+    }
+
     let result = match command {
         Commands::Status {
             json,
@@ -2039,7 +2051,30 @@ pub fn run() -> Result<()> {
     update::show_update_notification();
     update::check_in_background();
 
-    result
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.is::<ConflictStopped>() => std::process::exit(1),
+        Err(e) => Err(e),
+    }
+}
+
+fn is_rebase_aware_command(cmd: &Commands) -> bool {
+    matches!(
+        cmd,
+        Commands::Continue
+            | Commands::Resolve { .. }
+            | Commands::Abort
+            | Commands::Undo { .. }
+            | Commands::Redo { .. }
+            | Commands::Restack {
+                r#continue: true,
+                ..
+            }
+            | Commands::Sync {
+                r#continue: true,
+                ..
+            }
+    )
 }
 
 fn detect_interactive_stdio() -> (bool, bool) {

--- a/src/commands/continue_cmd.rs
+++ b/src/commands/continue_cmd.rs
@@ -25,7 +25,7 @@ pub(crate) fn continue_rebase_and_update_metadata(repo: &GitRepo) -> Result<Reba
     }
 }
 
-fn latest_failed_restack(repo: &GitRepo) -> Result<Option<OpReceipt>> {
+pub(crate) fn latest_failed_restack(repo: &GitRepo) -> Result<Option<OpReceipt>> {
     let git_dir = repo.git_dir()?;
     let current = repo.current_branch()?;
     let workdir = repo.workdir()?.to_string_lossy().to_string();
@@ -39,6 +39,22 @@ fn latest_failed_restack(repo: &GitRepo) -> Result<Option<OpReceipt>> {
                 .as_ref()
                 .and_then(|error| error.failed_branch.as_deref())
                 == Some(current.as_str())
+    }))
+}
+
+/// Like `latest_failed_restack` but does not require the current branch to
+/// match. Used by `restack --continue` to recover metadata when the user
+/// may have finished the rebase via `git rebase --continue` directly.
+pub(crate) fn latest_failed_restack_receipt(repo: &GitRepo) -> Result<Option<OpReceipt>> {
+    let git_dir = repo.git_dir()?;
+    let workdir = repo.workdir()?.to_string_lossy().to_string();
+
+    Ok(OpReceipt::load_latest(git_dir)?.filter(|receipt| {
+        matches!(
+            receipt.kind,
+            OpKind::Restack | OpKind::SyncRestack | OpKind::UpstackRestack
+        ) && receipt.status == OpStatus::Failed
+            && receipt.repo_workdir == workdir
     }))
 }
 

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -5,6 +5,7 @@ use crate::git::{GitRepo, RebaseResult};
 use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
+use crate::errors::ConflictStopped;
 use anyhow::Result;
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
@@ -34,10 +35,46 @@ pub fn run(
 ) -> Result<()> {
     let repo = GitRepo::open()?;
 
+    let mut completed_from_receipt: HashSet<String> = HashSet::new();
+
     if r#continue {
         crate::commands::continue_cmd::run()?;
         if repo.rebase_in_progress()? {
             return Ok(());
+        }
+
+        // Recover metadata + completed list from the failed receipt.
+        if let Some(receipt) =
+            crate::commands::continue_cmd::latest_failed_restack_receipt(&repo)?
+        {
+            completed_from_receipt
+                .extend(receipt.completed_branches.iter().cloned());
+
+            // If the user finished the rebase via `git rebase --continue`
+            // directly, the failed branch's metadata was never updated.
+            if let Some(failed_branch) = receipt
+                .error
+                .as_ref()
+                .and_then(|e| e.failed_branch.as_deref())
+            {
+                if let Some(meta) =
+                    BranchMetadata::read(repo.inner(), failed_branch)?
+                {
+                    if let Ok(actual_parent_rev) =
+                        repo.branch_commit(&meta.parent_branch_name)
+                    {
+                        if meta.parent_branch_revision != actual_parent_rev {
+                            let updated = BranchMetadata {
+                                parent_branch_revision: actual_parent_rev,
+                                ..meta
+                            };
+                            updated.write(repo.inner(), failed_branch)?;
+                        }
+                    }
+                }
+                completed_from_receipt
+                    .insert(failed_branch.to_string());
+            }
         }
     }
 
@@ -52,6 +89,7 @@ pub fn run(
         submit_after,
         r#continue,
         None,
+        completed_from_receipt,
     )
 }
 
@@ -71,6 +109,7 @@ pub(crate) fn resume_after_rebase(
         SubmitAfterRestack::No,
         true,
         restore_branch,
+        HashSet::new(),
     )
 }
 
@@ -86,6 +125,7 @@ fn run_impl(
     submit_after: SubmitAfterRestack,
     skip_prediction: bool,
     restore_branch: Option<String>,
+    completed_from_receipt: HashSet<String>,
 ) -> Result<()> {
     let current = repo.current_branch()?;
     let current_workdir = normalized_workdir(repo)?;
@@ -265,6 +305,10 @@ fn run_impl(
     let mut summary: Vec<(String, String)> = Vec::new();
 
     for (index, branch) in scope_branches.iter().enumerate() {
+        if completed_from_receipt.contains(branch) {
+            continue;
+        }
+
         let live_stack = Stack::load(repo)?;
         let needs_restack = live_stack
             .branches
@@ -319,6 +363,7 @@ fn run_impl(
 
                 // Record the after-OID for this branch
                 tx.record_after(repo, branch)?;
+                tx.push_completed_branch(branch);
 
                 LiveTimer::maybe_finish_ok(restack_timer, "done");
                 summary.push((branch.clone(), "ok".to_string()));
@@ -354,7 +399,7 @@ fn run_impl(
                 // Finish transaction with error
                 tx.finish_err("Rebase conflict", Some("rebase"), Some(branch))?;
 
-                return Ok(());
+                return Err(ConflictStopped.into());
             }
         }
     }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,4 +1,5 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
+use crate::errors::ConflictStopped;
 use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
 use crate::commands::restack_parent::normalize_scope_parents_for_restack;
 use crate::commands::worktree::{
@@ -1175,6 +1176,7 @@ pub fn run(
 
                         // Record after-OID
                         tx.record_after(&repo, branch)?;
+                        tx.push_completed_branch(branch);
 
                         LiveTimer::maybe_finish_timed(restack_timer);
                         restacked_branches += 1;
@@ -1211,7 +1213,7 @@ pub fn run(
                         // Finish transaction with error
                         tx.finish_err("Rebase conflict", Some("restack"), Some(branch))?;
 
-                        return Ok(());
+                        return Err(ConflictStopped.into());
                     }
                 }
             }

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -1,4 +1,5 @@
 use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
+use crate::errors::ConflictStopped;
 use crate::commands::restack_parent::normalize_scope_parents_for_restack;
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
@@ -118,6 +119,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
 
                 // Record the after-OID for this branch
                 tx.record_after(&repo, branch)?;
+                tx.push_completed_branch(branch);
 
                 completed_branches.push(branch.clone());
                 println!("    {}", "✓ done".green());
@@ -144,7 +146,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
                 // Finish transaction with error
                 tx.finish_err("Rebase conflict", Some("rebase"), Some(branch))?;
 
-                return Ok(());
+                return Err(ConflictStopped.into());
             }
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -418,6 +418,12 @@ impl Config {
         Self::resolve_github_auth_with_config(&auth_config).map(|(_, token)| token)
     }
 
+    /// Like `github_token` but also returns the source for error messages.
+    pub fn github_token_with_source() -> Option<(GitHubAuthSource, String)> {
+        let auth_config = Self::load().map(|c| c.auth).unwrap_or_default();
+        Self::resolve_github_auth_with_config(&auth_config)
+    }
+
     /// Get the saved credentials-file token written by `stax auth`.
     ///
     /// This stored token is forge-agnostic and can be reused across GitHub,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,16 @@
+/// Sentinel error returned when a rebase stops on conflict.
+///
+/// This is not a "real" error — the conflict information has already been
+/// printed. The sentinel propagates through `anyhow::Result` so that
+/// `cli::run()` can intercept it and exit with code 1 without printing
+/// an additional `Error: …` line.
+#[derive(Debug)]
+pub struct ConflictStopped;
+
+impl std::fmt::Display for ConflictStopped {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Stopped on rebase conflict")
+    }
+}
+
+impl std::error::Error for ConflictStopped {}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::config::Config;
+use crate::config::{Config, GitHubAuthSource};
 use crate::forge::{PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity};
 
 const GITHUB_API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -21,17 +21,17 @@ pub struct GitHubClient {
     pub octocrab: Octocrab,
     pub owner: String,
     pub repo: String,
+    auth_source: Option<GitHubAuthSource>,
     api_call_tracker: Arc<ApiCallTracker>,
 }
 
 impl Clone for GitHubClient {
     fn clone(&self) -> Self {
-        // Note: Octocrab doesn't implement Clone, so we create a minimal placeholder
-        // This is only used in tests where we create fresh clients anyway
         Self {
             octocrab: self.octocrab.clone(),
             owner: self.owner.clone(),
             repo: self.repo.clone(),
+            auth_source: self.auth_source,
             api_call_tracker: self.api_call_tracker.clone(),
         }
     }
@@ -172,7 +172,7 @@ struct RepoListIssue {
 impl GitHubClient {
     /// Create a new GitHub client from config
     pub fn new(owner: &str, repo: &str, api_base_url: Option<String>) -> Result<Self> {
-        let token = Config::github_token().context(
+        let (auth_source, token) = Config::github_token_with_source().context(
             "GitHub auth not configured. Use one of: `stax auth`, `stax auth --from-gh`, \
              `gh auth login`, or set `STAX_GITHUB_TOKEN`.",
         )?;
@@ -195,6 +195,7 @@ impl GitHubClient {
             octocrab,
             owner: owner.to_string(),
             repo: repo.to_string(),
+            auth_source: Some(auth_source),
             api_call_tracker: Arc::new(ApiCallTracker::default()),
         })
     }
@@ -206,6 +207,7 @@ impl GitHubClient {
             octocrab,
             owner: owner.to_string(),
             repo: repo.to_string(),
+            auth_source: None,
             api_call_tracker: Arc::new(ApiCallTracker::default()),
         }
     }
@@ -216,6 +218,32 @@ impl GitHubClient {
 
     pub(crate) fn record_api_call(&self, operation: &'static str) {
         self.api_call_tracker.record(operation, 1);
+    }
+
+    /// Enrich an API error with auth troubleshooting context when it looks
+    /// like a token permissions issue (GitHub returns 404 for private repos
+    /// when the token lacks access, not 403).
+    pub(crate) fn enrich_api_error(&self, err: anyhow::Error) -> anyhow::Error {
+        let msg = format!("{:#}", err);
+        if msg.contains("Not Found")
+            || msg.contains("404")
+            || msg.contains("Unauthorized")
+            || msg.contains("401")
+            || msg.contains("Bad credentials")
+        {
+            let source_hint = match self.auth_source {
+                Some(s) => format!("Current auth source: {}.", s.display_name()),
+                None => "No auth source recorded.".to_string(),
+            };
+            err.context(format!(
+                "GitHub API error for {}/{}. This often means your token is expired or \
+                 lacks access to this repository. {}\n\
+                 To fix: run `stax auth --from-gh` to refresh, or check your token scopes.",
+                self.owner, self.repo, source_hint,
+            ))
+        } else {
+            err
+        }
     }
 
     /// Get combined CI status from both commit statuses AND check runs (GitHub Actions)
@@ -1182,5 +1210,83 @@ mod tests {
     fn test_github_client_clone() {
         // This test just verifies Clone is implemented
         // We can't actually test it without a mock server setup
+    }
+
+    #[tokio::test]
+    async fn test_enrich_api_error_adds_auth_context_on_not_found() {
+        ensure_crypto_provider();
+        let octocrab = Octocrab::builder()
+            .personal_token("expired-token".to_string())
+            .build()
+            .unwrap();
+
+        let mut client = GitHubClient::with_octocrab(octocrab, "myorg", "myrepo");
+        client.auth_source = Some(GitHubAuthSource::CredentialsFile);
+
+        let original = anyhow::anyhow!("Not Found");
+        let enriched = client.enrich_api_error(original);
+        let msg = format!("{:#}", enriched);
+
+        assert!(
+            msg.contains("token is expired or lacks access"),
+            "Expected auth hint, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("credentials file"),
+            "Expected auth source in message, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("stax auth --from-gh"),
+            "Expected fix suggestion, got: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enrich_api_error_passes_through_non_auth_errors() {
+        ensure_crypto_provider();
+        let octocrab = Octocrab::builder()
+            .personal_token("token".to_string())
+            .build()
+            .unwrap();
+
+        let client = GitHubClient::with_octocrab(octocrab, "myorg", "myrepo");
+
+        let original = anyhow::anyhow!("Connection timeout");
+        let enriched = client.enrich_api_error(original);
+        let msg = format!("{:#}", enriched);
+
+        assert!(
+            !msg.contains("token is expired"),
+            "Non-auth errors should not get auth hint, got: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_open_pr_by_head_404_gives_auth_hint() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found",
+                "documentation_url": "https://docs.github.com/rest"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.find_open_pr_by_head("test-owner", "my-branch").await;
+
+        assert!(result.is_err(), "Expected error on 404");
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("token is expired or lacks access"),
+            "Expected auth hint in 404 error, got: {}",
+            err_msg
+        );
     }
 }

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -332,7 +332,7 @@ impl GitHubClient {
         branch: &str,
     ) -> Result<Option<PrInfoWithHead>> {
         self.record_api_call("pulls.list.head");
-        let prs = self
+        let prs = match self
             .octocrab
             .pulls(&self.owner, &self.repo)
             .list()
@@ -342,7 +342,11 @@ impl GitHubClient {
             .sort(Sort::Created)
             .send()
             .await
-            .context("Failed to list PRs by head")?;
+            .context("Failed to list PRs by head")
+        {
+            Ok(prs) => prs,
+            Err(e) => return Err(self.enrich_api_error(e)),
+        };
 
         for pr in &prs.items {
             if pr.head.ref_field != branch {
@@ -403,7 +407,7 @@ impl GitHubClient {
 
         loop {
             self.record_api_call("pulls.list.open.page");
-            let prs = self
+            let prs = match self
                 .octocrab
                 .pulls(&self.owner, &self.repo)
                 .list()
@@ -413,7 +417,11 @@ impl GitHubClient {
                 .sort(Sort::Created)
                 .send()
                 .await
-                .context("Failed to list PRs")?;
+                .context("Failed to list PRs")
+            {
+                Ok(prs) => prs,
+                Err(e) => return Err(self.enrich_api_error(e)),
+            };
 
             for pr in &prs.items {
                 let head = pr.head.ref_field.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cli;
 mod commands;
 mod config;
 mod engine;
+pub(crate) mod errors;
 mod forge;
 mod git;
 mod ops;

--- a/src/ops/receipt.rs
+++ b/src/ops/receipt.rs
@@ -126,6 +126,9 @@ pub struct OpReceipt {
     pub plan_summary: PlanSummary,
     /// Error information if failed
     pub error: Option<OpError>,
+    /// Branches that completed successfully before a conflict stopped the operation
+    #[serde(default)]
+    pub completed_branches: Vec<String>,
 }
 
 impl OpReceipt {
@@ -153,6 +156,7 @@ impl OpReceipt {
             remote_refs: Vec::new(),
             plan_summary: PlanSummary::default(),
             error: None,
+            completed_branches: Vec::new(),
         }
     }
 

--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -100,6 +100,11 @@ impl Transaction {
         self.receipt.auto_stash_pop = auto_stash_pop;
     }
 
+    /// Record a branch that completed successfully during this operation.
+    pub fn push_completed_branch(&mut self, branch: &str) {
+        self.receipt.completed_branches.push(branch.to_string());
+    }
+
     /// Create backup refs and write the in-progress receipt
     pub fn snapshot(&mut self) -> Result<()> {
         if self.snapshotted {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -479,6 +479,16 @@ impl TestRepo {
             .expect("Failed to run git command")
     }
 
+    /// Run a raw git command with additional environment variables
+    pub fn git_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
+        let mut cmd = hermetic_git_command();
+        cmd.args(args).current_dir(self.path());
+        for (key, value) in env {
+            cmd.env(key, value);
+        }
+        cmd.output().expect("Failed to run git command")
+    }
+
     /// Run a raw git command in a specific directory
     pub fn git_in(&self, cwd: &Path, args: &[&str]) -> Output {
         hermetic_git_command()

--- a/tests/conflict_handling_tests.rs
+++ b/tests/conflict_handling_tests.rs
@@ -1,0 +1,381 @@
+//! Tests for conflict handling behavior (TDD: written before fixes).
+//!
+//! Bug 1: Conflict-stop should return non-zero exit code
+//! Bug 2: Non-rebase-aware commands during active rebase should give clear error
+//! Bug 3: restack --continue should resume from checkpoint, not restart
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+
+// =============================================================================
+// Bug 1: Conflict-stop must exit non-zero
+// =============================================================================
+
+#[test]
+fn test_restack_conflict_exits_nonzero() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase in progress after conflict"
+    );
+    output.assert_failure();
+
+    repo.abort_rebase();
+}
+
+#[test]
+fn test_sync_conflict_exits_nonzero() {
+    let repo = TestRepo::new_with_remote();
+    repo.create_conflict_scenario();
+
+    let output = repo.run_stax(&["sync", "--force", "--quiet"]);
+
+    if repo.has_rebase_in_progress() {
+        output.assert_failure();
+        repo.abort_rebase();
+    }
+}
+
+#[test]
+fn test_upstack_restack_conflict_exits_nonzero() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+
+    let output = repo.run_stax(&["upstack", "restack", "--yes", "--quiet"]);
+
+    if repo.has_rebase_in_progress() {
+        output.assert_failure();
+        repo.abort_rebase();
+    }
+}
+
+#[test]
+fn test_restack_conflict_still_prints_conflict_info() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+
+    let output = repo.run_stax(&["restack", "--yes"]);
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("conflict") || stdout.contains("Conflict"),
+        "Expected conflict info in output, got:\n{}",
+        stdout
+    );
+
+    repo.abort_rebase();
+}
+
+#[test]
+fn test_restack_no_conflict_exits_zero() {
+    let repo = TestRepo::new();
+    let branches = repo.create_stack(&["feature-a", "feature-b"]);
+
+    repo.run_stax(&["checkout", &branches[0]]);
+    repo.create_file("extra.txt", "extra content");
+    repo.commit("Extra commit on feature-a");
+
+    repo.run_stax(&["checkout", &branches[1]]);
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+
+    output.assert_success();
+}
+
+// =============================================================================
+// Bug 2: Commands mid-rebase should give clear error
+// =============================================================================
+
+#[test]
+fn test_status_during_rebase_gives_clear_error() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase in progress"
+    );
+
+    let output = repo.run_stax(&["status"]);
+
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        combined.contains("rebase is in progress")
+            || combined.contains("rebase in progress"),
+        "Expected 'rebase in progress' message, got:\n{}",
+        combined
+    );
+    output.assert_failure();
+
+    repo.abort_rebase();
+}
+
+#[test]
+fn test_log_during_rebase_gives_clear_error() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase in progress"
+    );
+
+    let output = repo.run_stax(&["log"]);
+
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        combined.contains("rebase is in progress")
+            || combined.contains("rebase in progress"),
+        "Expected 'rebase in progress' message, got:\n{}",
+        combined
+    );
+    output.assert_failure();
+
+    repo.abort_rebase();
+}
+
+#[test]
+fn test_continue_during_rebase_still_works() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase in progress"
+    );
+
+    // `continue` should NOT be blocked by the rebase guard.
+    // It will report "more conflicts" since we haven't resolved, but it
+    // should not say "rebase is in progress" as a blocking error.
+    let output = repo.run_stax(&["continue"]);
+
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        !combined.contains("A rebase is in progress. Resolve"),
+        "continue should not be blocked by rebase guard, got:\n{}",
+        combined
+    );
+
+    repo.abort_rebase();
+}
+
+#[test]
+fn test_abort_during_rebase_clears_state() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase in progress"
+    );
+
+    let output = repo.run_stax(&["abort"]);
+
+    output.assert_success();
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected rebase to be cleared after abort"
+    );
+}
+
+// =============================================================================
+// Bug 3: restack --continue should resume, not restart
+// =============================================================================
+
+/// Helper: create a 3-branch stack where branch C conflicts but B does not.
+/// Returns (branch_a, branch_b, branch_c).
+fn create_multi_branch_conflict_scenario(repo: &TestRepo) -> (String, String, String) {
+    // branch A: clean change
+    repo.run_stax(&["bc", "stack-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "content for a");
+    repo.commit("Commit for stack-a");
+
+    // branch B: clean change
+    repo.run_stax(&["bc", "stack-b"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("b.txt", "content for b");
+    repo.commit("Commit for stack-b");
+
+    // branch C: will conflict
+    repo.run_stax(&["bc", "stack-c"]);
+    let branch_c = repo.current_branch();
+    repo.create_file("conflict.txt", "child content\n");
+    repo.commit("Commit for stack-c");
+
+    // Go to main and create conflicting change
+    repo.run_stax(&["t"]);
+    repo.create_file("main-update.txt", "main update\n");
+    repo.create_file("conflict.txt", "main content\n");
+    repo.commit("Main conflicting commit");
+
+    // Go back to C
+    repo.run_stax(&["checkout", &branch_c]);
+
+    (branch_a, branch_b, branch_c)
+}
+
+#[test]
+fn test_restack_continue_does_not_restack_already_completed_branches() {
+    let repo = TestRepo::new();
+    let (_branch_a, branch_b, _branch_c) = create_multi_branch_conflict_scenario(&repo);
+
+    // Restack — A and B succeed, C conflicts
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected conflict on stack-c"
+    );
+
+    // Record B's SHA before continue
+    let b_sha_before = {
+        let output = repo.git(&["rev-parse", &branch_b]);
+        TestRepo::stdout(&output).trim().to_string()
+    };
+
+    // Resolve conflict and continue
+    repo.resolve_conflicts_ours();
+    let output = repo.run_stax(&["restack", "--continue"]);
+
+    // B should NOT have been rebased again — its SHA should be unchanged
+    let b_sha_after = {
+        let output = repo.git(&["rev-parse", &branch_b]);
+        TestRepo::stdout(&output).trim().to_string()
+    };
+
+    assert_eq!(
+        b_sha_before, b_sha_after,
+        "Branch B was rebased again during --continue (SHA changed from {} to {}). \
+         Expected it to be skipped since it was already completed.",
+        b_sha_before, b_sha_after
+    );
+
+    // The continue should have finished successfully
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected rebase to be finished after continue. Output: {}",
+        TestRepo::stdout(&output)
+    );
+}
+
+#[test]
+fn test_restack_continue_after_git_rebase_continue() {
+    let repo = TestRepo::new();
+    repo.create_conflict_scenario();
+
+    // Drive into conflict
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase in progress"
+    );
+
+    // Resolve via git directly (bypassing stax)
+    repo.resolve_conflicts_ours();
+    let git_continue = repo.git_with_env(
+        &["rebase", "--continue"],
+        &[("GIT_EDITOR", "true")],
+    );
+    assert!(
+        git_continue.status.success(),
+        "git rebase --continue failed: {}",
+        TestRepo::stderr(&git_continue)
+    );
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected rebase to be finished after git rebase --continue"
+    );
+
+    // Now stax restack --continue should NOT re-conflict
+    let output = repo.run_stax(&["restack", "--continue"]);
+
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected no rebase in progress after stax restack --continue. Output: {}",
+        TestRepo::stdout(&output)
+    );
+}
+
+#[test]
+fn test_restack_continue_completes_remaining_branches() {
+    let repo = TestRepo::new();
+
+    // branch A: clean
+    repo.run_stax(&["bc", "remain-a"]);
+    let _branch_a = repo.current_branch();
+    repo.create_file("a.txt", "content for a");
+    repo.commit("Commit for remain-a");
+
+    // branch B: will conflict
+    repo.run_stax(&["bc", "remain-b"]);
+    let _branch_b = repo.current_branch();
+    repo.create_file("conflict.txt", "branch b content\n");
+    repo.commit("Commit for remain-b");
+
+    // branch C: clean (downstream of B)
+    repo.run_stax(&["bc", "remain-c"]);
+    let _branch_c = repo.current_branch();
+    repo.create_file("c.txt", "content for c");
+    repo.commit("Commit for remain-c");
+
+    // branch D: clean (downstream of C)
+    repo.run_stax(&["bc", "remain-d"]);
+    let branch_d = repo.current_branch();
+    repo.create_file("d.txt", "content for d");
+    repo.commit("Commit for remain-d");
+
+    // Go to main and create conflicting change
+    repo.run_stax(&["t"]);
+    repo.create_file("main-update.txt", "main update\n");
+    repo.create_file("conflict.txt", "main content\n");
+    repo.commit("Main conflicting commit");
+
+    // Go back to D and restack entire stack
+    repo.run_stax(&["checkout", &branch_d]);
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected conflict on remain-b"
+    );
+
+    // Resolve and continue
+    repo.resolve_conflicts_ours();
+    let output = repo.run_stax(&["restack", "--continue"]);
+
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected rebase to complete after continue. Output: {}",
+        TestRepo::stdout(&output)
+    );
+
+    // All branches should now be up-to-date (no longer needing restack)
+    // Verify by checking that a clean restack reports nothing to do
+    repo.run_stax(&["checkout", &branch_d]);
+    let restack_output = repo.run_stax(&["restack", "--quiet"]);
+    let stdout = TestRepo::stdout(&restack_output);
+    assert!(
+        stdout.contains("up to date") || stdout.contains("nothing to restack") || stdout.is_empty(),
+        "Expected stack to be up-to-date after continue, got:\n{}",
+        stdout
+    );
+}

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -219,8 +219,8 @@ fn test_continue_resumes_remaining_restack_after_conflict() {
 
     let output = repo.run_stax(&["restack", "--quiet"]);
     assert!(
-        output.status.success(),
-        "Restack should stop on conflict without failing\nstdout: {}\nstderr: {}",
+        !output.status.success(),
+        "Restack should exit non-zero on conflict\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2056,8 +2056,8 @@ fn test_restack_conflict_reports_branch_progress_and_files() {
 
     let output = repo.run_stax(&["restack", "--yes"]);
     assert!(
-        output.status.success(),
-        "restack failed\nstdout: {}\nstderr: {}",
+        !output.status.success(),
+        "restack should exit non-zero on conflict\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );
@@ -2221,8 +2221,8 @@ fn test_cascade_conflict_reports_restack_context() {
 
     let output = repo.run_stax(&["cascade", "--no-submit"]);
     assert!(
-        output.status.success(),
-        "cascade failed\nstdout: {}\nstderr: {}",
+        !output.status.success(),
+        "cascade should exit non-zero on conflict\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );


### PR DESCRIPTION
## Summary

- **Bug 1 (exit code):** Rebase conflicts now exit non-zero (was 0), preventing chained commands like `stax restack && stax submit` from continuing after a conflict. Uses a `ConflictStopped` sentinel error intercepted in `cli.rs` to `exit(1)` without printing a redundant `Error: ...` line.
- **Bug 2 (rebase guard):** Non-rebase-aware commands (`status`, `log`, etc.) during an active rebase now show "A rebase is in progress" with actionable guidance (`stax resolve`, `stax continue`, `stax abort`) instead of the confusing "HEAD is detached" error. Rebase-aware commands (`continue`, `resolve`, `abort`, `undo`, `redo`, `restack --continue`, `sync --continue`) are allowlisted.
- **Bug 3 (resume loop):** `restack --continue` now resumes from where it left off instead of re-evaluating the entire stack from scratch. The receipt tracks `completed_branches` so the resume path skips them. The continue path also recovers branch metadata if the user ran `git rebase --continue` directly instead of `stax continue`.
- **Bug 4 (auth errors):** GitHub API 404 errors (common with expired/insufficient-scope tokens on private repos) now include auth troubleshooting context — identifying the current token source and suggesting `stax auth --from-gh` to refresh.

## Files changed

| Area | Files |
|------|-------|
| New sentinel error | `src/errors.rs` (new), `src/lib.rs` |
| Exit code fix | `src/commands/restack.rs`, `src/commands/sync.rs`, `src/commands/upstack/restack.rs`, `src/cli.rs` |
| Rebase guard | `src/cli.rs` |
| Resume from receipt | `src/ops/receipt.rs`, `src/ops/tx.rs`, `src/commands/restack.rs`, `src/commands/continue_cmd.rs` |
| Auth error enrichment | `src/config/mod.rs`, `src/github/client.rs`, `src/github/pr.rs` |
| Tests | `tests/conflict_handling_tests.rs` (new, 12 tests), `tests/common/mod.rs`, `tests/continue_tests.rs`, `tests/integration_tests.rs` |

## Test plan

- [x] 12 new integration tests in `tests/conflict_handling_tests.rs` covering all 3 rebase bugs
- [x] 3 new unit tests in `src/github/client.rs` for auth error enrichment
- [x] Updated 2 existing tests that relied on conflict returning exit 0
- [x] All 493 library unit tests pass
- [x] All existing integration test suites pass (continue, resolve, command_coverage, integration, abort, additional_coverage)
- [x] Pre-existing split_hunk test failures confirmed unrelated (fail on upstream/main too)


Made with [Cursor](https://cursor.com)