### PR TITLE
fix: make st setup install by default

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -857,11 +857,11 @@ enum Commands {
     /// Setup shell integration and enable git rerere
     #[command(name = "setup", visible_alias = "shell-setup")]
     Setup {
-        /// Write shell integration under ~/.config/stax and source it from your shell config
+        /// Print shell integration snippet instead of installing
         #[arg(long)]
-        install: bool,
+        print: bool,
         /// Refresh already-installed generated shell snippets in-place
-        #[arg(long, hide = true, conflicts_with = "install")]
+        #[arg(long, hide = true, conflicts_with = "print")]
         refresh: bool,
     },
 
@@ -1369,8 +1369,8 @@ pub fn run() -> Result<()> {
 
     let cli = Cli::parse();
 
-    if let Some(Commands::Setup { install, refresh }) = &cli.command {
-        let result = commands::shell_setup::run(*install, *refresh);
+    if let Some(Commands::Setup { print, refresh }) = &cli.command {
+        let result = commands::shell_setup::run(*print, *refresh);
         update::show_update_notification();
         update::check_in_background();
         return result;

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -365,8 +365,8 @@ function sw
 end"#
 }
 
-/// Print the shell snippet to stdout for manual shell setup.
-pub fn run(install: bool, refresh: bool) -> Result<()> {
+/// Setup shell integration and enable rerere. By default installs; use --print to just see the snippet.
+pub fn run(print: bool, refresh: bool) -> Result<()> {
     if refresh {
         return refresh_installed_snippets();
     }
@@ -380,16 +380,21 @@ pub fn run(install: bool, refresh: bool) -> Result<()> {
         );
     }
 
-    if install {
-        let result = install_to_shell_config();
-        if result.is_ok() {
-            enable_rerere_if_in_repo()?;
-        }
-        result
-    } else {
+    let result = if print {
+        // Just print the snippet for manual setup
         println!("{}", shell_snippet(detect_shell_kind()));
         Ok(())
+    } else {
+        // Default: install shell integration
+        install_to_shell_config()
+    };
+
+    // Always enable rerere when in a git repo (unless we're just printing)
+    if result.is_ok() && !print {
+        enable_rerere_if_in_repo()?;
     }
+
+    result
 }
 
 /// Enable git rerere if we're in a git repository


### PR DESCRIPTION
## Summary
- Change `st setup` to install shell integration by default (no flag needed)
- Add `--print` flag to just print the snippet (for manual setup)
- Keep `--refresh` flag for updating already-installed snippets
- Enable rerere when installing (not when just printing)

This makes the UX more intuitive - "setup" actually sets things up
without requiring an --install flag. Users who want to manually copy
the snippet can use `st setup --print`.

## Changes
- **src/cli.rs** - Change `install: bool` to `print: bool`
- **src/commands/shell_setup.rs** - Invert logic: install by default, print is opt-in

## Breaking Change
`st setup` now installs instead of printing. Use `st setup --print` for the old behavior.

## Testing
- ✅ All unit tests pass
- ✅ Code compiles without warnings
- ✅ `st setup` now installs shell integration
- ✅ `st setup --print` prints the snippet

## Stacked PR Chain
This is **PR #1** in the stack:
1. ← **YOU ARE HERE** - Fix: st setup UX
2. Phase 5: exit codes

🤖 Generated with Claude Code