### PR TITLE
fix(create): run commit before creating branch so interrupts leave no orphan

### DIFF
--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -164,43 +164,10 @@ pub fn run(
         return Err(e);
     }
 
-    // If --insert, reparent children of the parent branch to the new branch
     if insert {
-        let stack = Stack::load(&repo)?;
-        if let Some(parent_info) = stack.branches.get(&parent_branch) {
-            let children: Vec<String> = parent_info
-                .children
-                .iter()
-                .filter(|c| *c != &branch_name)
-                .cloned()
-                .collect();
-
-            if !children.is_empty() {
-                let new_parent_rev = repo.branch_commit(&branch_name)?;
-                for child in &children {
-                    if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
-                        let updated = BranchMetadata {
-                            parent_branch_name: branch_name.clone(),
-                            parent_branch_revision: new_parent_rev.clone(),
-                            ..child_meta
-                        };
-                        updated.write(repo.inner(), child)?;
-                    }
-                }
-
-                println!(
-                    "Reparented {} child branch(es) to '{}'",
-                    children.len(),
-                    branch_name.green()
-                );
-                for child in &children {
-                    println!("  {} -> {}", child.cyan(), branch_name.green());
-                }
-                println!(
-                    "{}",
-                    "Run `stax restack --all` to rebase the reparented branches.".yellow()
-                );
-            }
+        if let Err(e) = apply_insert_reparenting(&repo, &parent_branch, &branch_name) {
+            rollback_create(&repo, &current, &branch_name);
+            return Err(e);
         }
     }
 
@@ -210,20 +177,7 @@ pub fn run(
         return Err(e);
     }
 
-    if let Ok(remote_branches) = remote::get_remote_branches(repo.workdir()?, config.remote_name())
-    {
-        if !remote_branches.contains(&parent_branch) {
-            println!(
-                "{}",
-                format!(
-                    "Warning: parent '{}' is not on remote '{}'.",
-                    parent_branch,
-                    config.remote_name()
-                )
-                .yellow()
-            );
-        }
-    }
+    print_remote_parent_warning(&repo, &config, &parent_branch);
 
     println!(
         "Created and switched to branch '{}' (stacked on {})",
@@ -364,7 +318,10 @@ fn run_commit_first(
             return Err(e);
         }
         if insert {
-            apply_insert_reparenting(repo, current, branch_name)?;
+            if let Err(e) = apply_insert_reparenting(repo, current, branch_name) {
+                rollback_create(repo, current, branch_name);
+                return Err(e);
+            }
         }
         if let Err(e) = repo.checkout(branch_name) {
             rollback_create(repo, current, branch_name);

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -2,12 +2,19 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use crate::remote;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use std::path::Path;
 use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StageMode {
+    None,
+    ExistingOnly,
+    All,
+}
 
 pub fn run(
     name: Option<String>,
@@ -31,13 +38,6 @@ pub fn run(
     // When using -m, the message is used for both branch name and commit message.
     // `stax create -m` respects already-staged changes. When nothing is staged
     // it prompts interactively (or bails in non-TTY). Use -a/--all to skip the prompt.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    enum StageMode {
-        None,
-        ExistingOnly,
-        All,
-    }
-
     // When neither name nor message is provided, launch interactive wizard.
     let (input, commit_message, stage_mode) = match (&name, &message) {
         (Some(n), _) => (
@@ -126,6 +126,28 @@ pub fn run(
     } else {
         false
     };
+
+    // Commit-first path: when the user supplied -m and the new branch stacks on
+    // the current branch, run the commit on the current branch BEFORE creating
+    // or switching to the new branch. If pre-commit hooks fail (or the user
+    // hits Ctrl+C) we exit with no refs touched: no orphan branch, no name
+    // drift to `-2`/`-3`, and the user stays on their original branch with
+    // their working tree preserved. Only on a successful commit do we split
+    // it off to the new branch and move the parent ref back.
+    if let Some(msg) = commit_message.as_deref() {
+        if parent_branch == current {
+            return run_commit_first(
+                &repo,
+                &config,
+                &current,
+                &branch_name,
+                msg,
+                stage_mode,
+                needs_stage_all,
+                insert,
+            );
+        }
+    }
 
     // Create the branch
     if parent_branch == current {
@@ -300,6 +322,226 @@ fn rollback_create(repo: &GitRepo, original_branch: &str, new_branch: &str) {
     }
     let _ = repo.delete_branch(new_branch, true);
     let _ = BranchMetadata::delete(repo.inner(), new_branch);
+}
+
+/// Graphite-style commit-first flow: commit on the current branch, then split
+/// the new commit off to a new branch and move the current branch ref back.
+///
+/// The key property: nothing observable changes until `git commit` returns
+/// successfully. If pre-commit hooks reject the commit, or the user hits
+/// Ctrl+C during the commit, no branch is created, no metadata is written,
+/// and HEAD is untouched — so retrying the exact same command is a clean
+/// operation that does not drift into `mybranch-2`, `mybranch-3`, etc.
+///
+/// Precondition: `parent_branch == current` (i.e. no explicit `--from`).
+#[allow(clippy::too_many_arguments)]
+fn run_commit_first(
+    repo: &GitRepo,
+    config: &Config,
+    current: &str,
+    branch_name: &str,
+    message: &str,
+    stage_mode: StageMode,
+    needs_stage_all: bool,
+    insert: bool,
+) -> Result<()> {
+    let workdir = repo.workdir()?;
+
+    // Stage (if requested) BEFORE the commit so hooks see the final tree.
+    if stage_mode == StageMode::All || needs_stage_all {
+        stage_all(workdir)?;
+    }
+
+    // If nothing is staged by the time we reach here, there is no commit to
+    // make. Fall back to creating an empty branch (mirrors the "No changes to
+    // commit" path from the branch-first flow).
+    if is_staging_area_empty(workdir) {
+        repo.create_branch(branch_name)?;
+        let parent_rev = repo.branch_commit(current)?;
+        let meta = BranchMetadata::new(current, &parent_rev);
+        if let Err(e) = meta.write(repo.inner(), branch_name) {
+            rollback_create(repo, current, branch_name);
+            return Err(e);
+        }
+        if insert {
+            apply_insert_reparenting(repo, current, branch_name)?;
+        }
+        if let Err(e) = repo.checkout(branch_name) {
+            rollback_create(repo, current, branch_name);
+            return Err(e);
+        }
+        print_remote_parent_warning(repo, config, current);
+        println!(
+            "Created and switched to branch '{}' (stacked on {})",
+            branch_name.green(),
+            current.blue()
+        );
+        println!("{}", "No changes to commit".dimmed());
+        print_tips(config);
+        return Ok(());
+    }
+
+    // Capture the pre-commit SHA so we can move the current branch back to it
+    // after splitting the new commit off.
+    let old_parent_sha = repo.branch_commit(current)?;
+
+    // Run the commit on the current branch. `--quiet` suppresses git's
+    // "[<branch> <sha>] <msg>" summary that would otherwise show the commit
+    // landing on the original branch — we move it off a few calls later and
+    // print our own summary. Pre-commit hook output is not suppressed by -q.
+    let commit_status = Command::new("git")
+        .args(["commit", "--quiet", "-m", message])
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git commit")?;
+
+    if !commit_status.success() {
+        bail!(
+            "Commit failed (pre-commit hook or other error). \
+             No branch was created — fix the issue and retry with the same command."
+        );
+    }
+
+    // From here on the commit exists on the current branch. Any failure must
+    // undo the commit with a soft reset so the user's working tree and staged
+    // changes are preserved.
+    let new_sha = repo.branch_commit(current)?;
+
+    if let Err(e) = repo.create_branch_at_commit(branch_name, &new_sha) {
+        rollback_after_commit(workdir, &old_parent_sha, None, repo);
+        return Err(e);
+    }
+
+    let meta = BranchMetadata::new(current, &old_parent_sha);
+    if let Err(e) = meta.write(repo.inner(), branch_name) {
+        rollback_after_commit(workdir, &old_parent_sha, Some(branch_name), repo);
+        return Err(e);
+    }
+
+    if insert {
+        if let Err(e) = apply_insert_reparenting(repo, current, branch_name) {
+            rollback_after_commit(workdir, &old_parent_sha, Some(branch_name), repo);
+            return Err(e);
+        }
+    }
+
+    // Move the current branch ref back to the pre-commit SHA. The new commit
+    // now lives only on `branch_name`.
+    let current_ref = format!("refs/heads/{}", current);
+    if let Err(e) = repo.update_ref(&current_ref, &old_parent_sha) {
+        rollback_after_commit(workdir, &old_parent_sha, Some(branch_name), repo);
+        return Err(e);
+    }
+
+    // Switch to the new branch. HEAD still points at `current` (now at the old
+    // SHA) while the working tree matches the new commit; `git checkout` moves
+    // HEAD without touching the working tree since it's already correct. If
+    // this fails there's nothing to undo — the commit lives on the new branch,
+    // `current` is reset — the user just needs `git checkout <new>` manually.
+    repo.checkout(branch_name)?;
+
+    print_remote_parent_warning(repo, config, current);
+    println!(
+        "Created and switched to branch '{}' (stacked on {})",
+        branch_name.green(),
+        current.blue()
+    );
+    println!("Committed: {}", message.cyan());
+    print_tips(config);
+
+    Ok(())
+}
+
+/// Undo the partial state left by `run_commit_first` when a step after
+/// `git commit` (branch creation, metadata write, ref update) fails.
+///
+/// `--soft` keeps the working tree and index exactly as git left them after
+/// the successful commit, so the user can retry without re-staging.
+fn rollback_after_commit(workdir: &Path, old_sha: &str, new_branch: Option<&str>, repo: &GitRepo) {
+    if let Some(name) = new_branch {
+        let _ = BranchMetadata::delete(repo.inner(), name);
+        let _ = repo.delete_branch(name, true);
+    }
+    let _ = Command::new("git")
+        .args(["reset", "--soft", old_sha])
+        .current_dir(workdir)
+        .status();
+}
+
+/// Reparent children of `parent_branch` onto `new_branch` and print the usual
+/// `--insert` summary. Extracted from the branch-first path so both flows
+/// share the same behaviour.
+fn apply_insert_reparenting(repo: &GitRepo, parent_branch: &str, new_branch: &str) -> Result<()> {
+    let stack = Stack::load(repo)?;
+    let Some(parent_info) = stack.branches.get(parent_branch) else {
+        return Ok(());
+    };
+    let children: Vec<String> = parent_info
+        .children
+        .iter()
+        .filter(|c| c.as_str() != new_branch)
+        .cloned()
+        .collect();
+
+    if children.is_empty() {
+        return Ok(());
+    }
+
+    let new_parent_rev = repo.branch_commit(new_branch)?;
+    for child in &children {
+        if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
+            let updated = BranchMetadata {
+                parent_branch_name: new_branch.to_string(),
+                parent_branch_revision: new_parent_rev.clone(),
+                ..child_meta
+            };
+            updated.write(repo.inner(), child)?;
+        }
+    }
+
+    println!(
+        "Reparented {} child branch(es) to '{}'",
+        children.len(),
+        new_branch.green()
+    );
+    for child in &children {
+        println!("  {} -> {}", child.cyan(), new_branch.green());
+    }
+    println!(
+        "{}",
+        "Run `stax restack --all` to rebase the reparented branches.".yellow()
+    );
+
+    Ok(())
+}
+
+fn print_remote_parent_warning(repo: &GitRepo, config: &Config, parent_branch: &str) {
+    let Ok(workdir) = repo.workdir() else {
+        return;
+    };
+    if let Ok(remote_branches) = remote::get_remote_branches(workdir, config.remote_name()) {
+        if !remote_branches.contains(&parent_branch.to_string()) {
+            println!(
+                "{}",
+                format!(
+                    "Warning: parent '{}' is not on remote '{}'.",
+                    parent_branch,
+                    config.remote_name()
+                )
+                .yellow()
+            );
+        }
+    }
+}
+
+fn print_tips(config: &Config) {
+    if config.ui.tips {
+        println!(
+            "{}",
+            "Hint: Run `st ss` to submit, or add changes with `st modify -a -m \"message\"`"
+                .dimmed()
+        );
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -1,3 +1,21 @@
+//! `stax create` — create a new branch, optionally with a first commit.
+//!
+//! Two flows live in this file:
+//!
+//! - **Commit-first** (the default when `-m "msg"` is used and the new branch
+//!   stacks on the current branch): `git commit` runs on the current branch
+//!   *before* any stax ref is created. On hook failure or Ctrl+C nothing is
+//!   touched — no orphan branch, no `mybranch-2` drift on retry. The new
+//!   commit is then split off to the new branch and the current branch ref is
+//!   moved back to its pre-commit SHA.
+//! - **Branch-first** (everything else: name-only `st create`, `--from
+//!   <other>`, no-op `-m` with a clean tree): create the branch and switch to
+//!   it first, then optionally commit. Failures here use the legacy
+//!   `rollback_create` cleanup.
+//!
+//! Both flows share `create_branch_with_banner` for the create → metadata →
+//! `--insert` → checkout → summary sequence.
+
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
@@ -149,41 +167,14 @@ pub fn run(
         }
     }
 
-    // Create the branch
-    if parent_branch == current {
-        repo.create_branch(&branch_name)?;
-    } else {
-        repo.create_branch_at(&branch_name, &parent_branch)?;
-    }
-
-    // Track it with current branch as parent
-    let parent_rev = repo.branch_commit(&parent_branch)?;
-    let meta = BranchMetadata::new(&parent_branch, &parent_rev);
-    if let Err(e) = meta.write(repo.inner(), &branch_name) {
-        rollback_create(&repo, &current, &branch_name);
-        return Err(e);
-    }
-
-    if insert {
-        if let Err(e) = apply_insert_reparenting(&repo, &parent_branch, &branch_name) {
-            rollback_create(&repo, &current, &branch_name);
-            return Err(e);
-        }
-    }
-
-    // Checkout the new branch
-    if let Err(e) = repo.checkout(&branch_name) {
-        rollback_create(&repo, &current, &branch_name);
-        return Err(e);
-    }
-
-    print_remote_parent_warning(&repo, &config, &parent_branch);
-
-    println!(
-        "Created and switched to branch '{}' (stacked on {})",
-        branch_name.green(),
-        parent_branch.blue()
-    );
+    create_branch_with_banner(
+        &repo,
+        &config,
+        &current,
+        &parent_branch,
+        &branch_name,
+        insert,
+    )?;
 
     // Stage/commit behavior:
     // - StageMode::All / needs_stage_all => run `git add -A`
@@ -199,48 +190,15 @@ pub fn run(
             }
         }
 
-        // Only commit if -m was provided
+        // Only commit if -m was provided. This block only runs for the
+        // `--from <other>` + `-m` path; the common `-m` without `--from` case
+        // returns early via `run_commit_first`.
         if let Some(msg) = commit_message {
-            // Check if there are staged changes to commit
-            let diff_output = Command::new("git")
-                .args(["diff", "--cached", "--quiet"])
-                .current_dir(workdir)
-                .status();
-
-            let diff_output = match diff_output {
-                Ok(status) => status,
-                Err(e) => {
-                    rollback_create(&repo, &current, &branch_name);
-                    return Err(e.into());
-                }
-            };
-
-            if !diff_output.success() {
-                // There are staged changes, commit them
-                let commit_status = Command::new("git")
-                    .args(["commit", "-m", &msg])
-                    .current_dir(workdir)
-                    .status();
-
-                let commit_status = match commit_status {
-                    Ok(status) => status,
-                    Err(e) => {
-                        rollback_create(&repo, &current, &branch_name);
-                        return Err(e.into());
-                    }
-                };
-
-                if !commit_status.success() {
-                    rollback_create(&repo, &current, &branch_name);
-                    bail!(
-                        "Commit failed (pre-commit hook or other error). \
-                         Branch rolled back. Fix the issue and retry."
-                    );
-                }
-
-                println!("Committed: {}", msg.cyan());
-            } else {
+            if is_staging_area_empty(workdir) {
                 println!("{}", "No changes to commit".dimmed());
+            } else {
+                commit_or_rollback(workdir, &msg, &repo, &current, &branch_name)?;
+                println!("Committed: {}", msg.cyan());
             }
         } else if stage_mode == StageMode::All {
             println!("{}", "Changes staged".dimmed());
@@ -256,6 +214,38 @@ pub fn run(
     }
 
     Ok(())
+}
+
+/// Run `git commit -m <msg>` on the currently checked-out branch. On any
+/// failure (spawn error, non-zero exit, hook rejection), invoke
+/// `rollback_create` to clean up the partially-created branch before
+/// returning the error. Used only by the branch-first path — commit-first
+/// runs its own bare `git commit` because there's nothing to roll back yet.
+fn commit_or_rollback(
+    workdir: &Path,
+    message: &str,
+    repo: &GitRepo,
+    original: &str,
+    new_branch: &str,
+) -> Result<()> {
+    let status = Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(workdir)
+        .status();
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        Ok(_) => {
+            rollback_create(repo, original, new_branch);
+            bail!(
+                "Commit failed (pre-commit hook or other error). \
+                 Branch rolled back. Fix the issue and retry."
+            );
+        }
+        Err(e) => {
+            rollback_create(repo, original, new_branch);
+            Err(anyhow::Error::from(e).context("Failed to run git commit"))
+        }
+    }
 }
 
 /// Best-effort rollback: unstage changes, checkout the original branch,
@@ -307,32 +297,10 @@ fn run_commit_first(
     }
 
     // If nothing is staged by the time we reach here, there is no commit to
-    // make. Fall back to creating an empty branch (mirrors the "No changes to
-    // commit" path from the branch-first flow).
+    // make. Fall back to creating an empty branch — same shape as the
+    // branch-first path without the trailing commit.
     if is_staging_area_empty(workdir) {
-        repo.create_branch(branch_name)?;
-        let parent_rev = repo.branch_commit(current)?;
-        let meta = BranchMetadata::new(current, &parent_rev);
-        if let Err(e) = meta.write(repo.inner(), branch_name) {
-            rollback_create(repo, current, branch_name);
-            return Err(e);
-        }
-        if insert {
-            if let Err(e) = apply_insert_reparenting(repo, current, branch_name) {
-                rollback_create(repo, current, branch_name);
-                return Err(e);
-            }
-        }
-        if let Err(e) = repo.checkout(branch_name) {
-            rollback_create(repo, current, branch_name);
-            return Err(e);
-        }
-        print_remote_parent_warning(repo, config, current);
-        println!(
-            "Created and switched to branch '{}' (stacked on {})",
-            branch_name.green(),
-            current.blue()
-        );
+        create_branch_with_banner(repo, config, current, current, branch_name, insert)?;
         println!("{}", "No changes to commit".dimmed());
         print_tips(config);
         return Ok(());
@@ -423,6 +391,62 @@ fn rollback_after_commit(workdir: &Path, old_sha: &str, new_branch: Option<&str>
         .args(["reset", "--soft", old_sha])
         .current_dir(workdir)
         .status();
+}
+
+/// Create `branch_name` stacked on `parent_branch`, write stax metadata,
+/// apply `--insert` reparenting, check out the new branch, and print the
+/// "Created and switched…" banner. On any failure, undo all of it with
+/// `rollback_create` so the caller sees a clean failure.
+///
+/// `original` is the branch the user was on when `st create` was invoked; it's
+/// where `rollback_create` checks out on failure. For the commit-first
+/// no-changes fallback `original == parent_branch == current`; for the
+/// branch-first flow `original == current`, and `parent_branch` may or may not
+/// equal it (the `--from` case).
+///
+/// The caller owns whatever comes next — the trailing "No changes to commit"
+/// note, the stage/commit block, or the tips line.
+fn create_branch_with_banner(
+    repo: &GitRepo,
+    config: &Config,
+    original: &str,
+    parent_branch: &str,
+    branch_name: &str,
+    insert: bool,
+) -> Result<()> {
+    if parent_branch == original {
+        repo.create_branch(branch_name)?;
+    } else {
+        repo.create_branch_at(branch_name, parent_branch)?;
+    }
+
+    let parent_rev = repo.branch_commit(parent_branch)?;
+    let meta = BranchMetadata::new(parent_branch, &parent_rev);
+    if let Err(e) = meta.write(repo.inner(), branch_name) {
+        rollback_create(repo, original, branch_name);
+        return Err(e);
+    }
+
+    if insert {
+        if let Err(e) = apply_insert_reparenting(repo, parent_branch, branch_name) {
+            rollback_create(repo, original, branch_name);
+            return Err(e);
+        }
+    }
+
+    if let Err(e) = repo.checkout(branch_name) {
+        rollback_create(repo, original, branch_name);
+        return Err(e);
+    }
+
+    print_remote_parent_warning(repo, config, parent_branch);
+    println!(
+        "Created and switched to branch '{}' (stacked on {})",
+        branch_name.green(),
+        parent_branch.blue()
+    );
+
+    Ok(())
 }
 
 /// Reparent children of `parent_branch` onto `new_branch` and print the usual

--- a/tests/create_rollback_tests.rs
+++ b/tests/create_rollback_tests.rs
@@ -1,8 +1,14 @@
-//! Tests for `st create` rollback behavior when commit fails.
+//! Tests for `st create -m` behaviour when the commit step fails.
 //!
-//! Verifies that when a pre-commit hook (or other commit failure) occurs during
-//! `st create -m`, the branch and metadata are cleaned up so the user can retry
-//! without accumulating orphaned branches (mybranch, mybranch-2, mybranch-3, ...).
+//! The graphite-style commit-first flow runs `git commit` on the current branch
+//! before creating the new branch. When a pre-commit hook rejects the commit
+//! (or the user interrupts with Ctrl+C) the command exits with no refs touched
+//! — no orphan branch is created, the current branch's HEAD is unchanged, and
+//! retrying with the same message does not drift into `mybranch-2`,
+//! `mybranch-3`, etc.
+//!
+//! A legacy rollback path still exists for the less common branch-first flow
+//! (e.g. `st create -m "msg" --from <other>`); this file covers both.
 //!
 //! Most tests require Unix (pre-commit hooks use `#!/bin/sh` and chmod).
 
@@ -33,29 +39,40 @@ fn remove_pre_commit_hook(repo: &TestRepo) {
 
 #[test]
 #[cfg(unix)]
-fn create_with_failing_hook_rolls_back_branch() {
+fn create_with_failing_hook_leaves_no_branch() {
     let repo = TestRepo::new();
     repo.run_stax(&["init"]).assert_success();
     repo.create_file("test.txt", "hello");
 
     install_failing_pre_commit_hook(&repo);
 
+    let main_before = repo.head_sha();
+
     let output = repo.run_stax(&["create", "-a", "-m", "my feature"]);
     output.assert_failure();
 
-    // Branch should NOT exist after rollback
+    // No branch should have been created at all — commit-first means the
+    // branch is never made if the commit fails.
     let branches = repo.list_branches();
     assert!(
         !branches.iter().any(|b| b.contains("my-feature")),
-        "Orphaned branch should not exist after rollback. Branches: {:?}",
+        "No orphan branch should exist when commit fails. Branches: {:?}",
         branches
     );
 
-    // Should be back on main
+    // User stays on main — no switch happened.
     assert_eq!(repo.current_branch(), "main");
 
-    // Error message should mention rollback
-    output.assert_stderr_contains("rolled back");
+    // Main's HEAD must not have moved: the commit either didn't happen or was
+    // undone. Nothing stacked on top.
+    assert_eq!(
+        repo.head_sha(),
+        main_before,
+        "main's HEAD must not advance when the commit fails",
+    );
+
+    // Error message should guide the user to retry.
+    output.assert_stderr_contains("No branch was created");
 }
 
 #[test]
@@ -97,6 +114,33 @@ fn create_with_successful_commit_still_works() {
         repo.current_branch().contains("my-feature"),
         "Should be on the new branch. Current: {}",
         repo.current_branch()
+    );
+}
+
+/// Verifies the commit-first ordering: on success, the new commit lives only
+/// on the new branch and `main`'s HEAD does not advance.
+#[test]
+fn create_commit_lives_only_on_new_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let main_before = repo.get_commit_sha("main");
+
+    repo.create_file("test.txt", "hello");
+    repo.run_stax(&["create", "-a", "-m", "my feature"])
+        .assert_success();
+
+    let main_after = repo.get_commit_sha("main");
+    assert_eq!(
+        main_before, main_after,
+        "main's HEAD must not move when `st create -m` splits the commit off",
+    );
+
+    let new_branch = repo.current_branch();
+    let new_branch_sha = repo.get_commit_sha(&new_branch);
+    assert_ne!(
+        new_branch_sha, main_before,
+        "new branch must point at a new commit, not at main's HEAD",
     );
 }
 

--- a/tests/create_rollback_tests.rs
+++ b/tests/create_rollback_tests.rs
@@ -144,6 +144,88 @@ fn create_commit_lives_only_on_new_branch() {
     );
 }
 
+/// `--insert` + `-m` exercises the commit-first flow AND the reparenting path.
+/// Verifies children get reparented to the newly-created (and now committed)
+/// branch, and the split-off commit still only lives on that branch.
+#[test]
+fn create_commit_first_with_insert_reparents_children_onto_new_commit() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    // main -> insert-a -> insert-b
+    let branches = repo.create_stack(&["insert-a", "insert-b"]);
+
+    // Back on insert-a, create a new branch WITH a commit, inserting above A.
+    repo.run_stax(&["checkout", &branches[0]]).assert_success();
+    repo.create_file("insert_mid.txt", "new work");
+
+    let insert_a_before = repo.get_commit_sha(&branches[0]);
+
+    let output = repo.run_stax(&["create", "-a", "-m", "mid feature", "--insert"]);
+    output.assert_success();
+
+    // insert-a (the parent) must not have moved — the new commit lives only on
+    // the inserted branch.
+    assert_eq!(
+        repo.get_commit_sha(&branches[0]),
+        insert_a_before,
+        "parent branch must not advance in commit-first + --insert",
+    );
+
+    // The previously-direct child of insert-a should now be reparented.
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented"),
+        "Expected reparent message, got: {}",
+        stdout
+    );
+
+    // insert-b's parent should now be the inserted branch.
+    repo.run_stax(&["checkout", &branches[1]]).assert_success();
+    let b_parent = repo.get_current_parent();
+    assert!(
+        b_parent
+            .as_deref()
+            .is_some_and(|p| p.contains("mid-feature")),
+        "insert-b should be reparented onto the mid-feature branch, got: {:?}",
+        b_parent,
+    );
+}
+
+/// After a failing pre-commit hook, the user's working-tree changes must still
+/// be present so they can fix the hook and retry with the same command — the
+/// whole point of commit-first is that retrying is a clean operation.
+#[test]
+#[cfg(unix)]
+fn create_failing_hook_preserves_working_tree_changes() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_file("notes.txt", "draft idea");
+
+    install_failing_pre_commit_hook(&repo);
+
+    repo.run_stax(&["create", "-a", "-m", "my feature"])
+        .assert_failure();
+
+    // The file the user wanted committed must still be on disk, unchanged.
+    let contents = std::fs::read_to_string(repo.path().join("notes.txt"))
+        .expect("notes.txt should still exist");
+    assert_eq!(contents, "draft idea");
+
+    // Remove hook and retry — must succeed with the original branch name (no
+    // `-2` suffix) because nothing was left behind.
+    remove_pre_commit_hook(&repo);
+    repo.run_stax(&["create", "-a", "-m", "my feature"])
+        .assert_success();
+
+    let branch = repo.current_branch();
+    assert!(
+        branch.contains("my-feature") && !branch.contains("my-feature-2"),
+        "Retry should use the original branch name, got: {}",
+        branch,
+    );
+}
+
 #[test]
 #[cfg(unix)]
 fn create_without_message_unaffected_by_hook() {

--- a/tests/create_rollback_tests.rs
+++ b/tests/create_rollback_tests.rs
@@ -273,3 +273,49 @@ fn create_rollback_then_succeed_after_hook_removed() {
         branch
     );
 }
+
+/// The `--from <other> -m "msg"` path still uses branch-first + the
+/// `rollback_create` fallback (commit-first only applies when the new branch
+/// stacks on the current branch). Guard that path: a failing hook must roll
+/// back the branch so retry is clean, just like the commit-first path.
+///
+/// `-m` is passed without a positional name so the branch name is derived
+/// from the message — when both are given, stax uses the positional name and
+/// discards the message, which would suppress the commit entirely.
+#[test]
+#[cfg(unix)]
+fn create_from_other_branch_with_failing_hook_rolls_back() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // Seed a second branch so we have somewhere to point --from at.
+    let branches = repo.create_stack(&["sibling"]);
+
+    // Back on main, install a failing hook and drop an uncommitted file that
+    // `-a` will pick up after the branch switch.
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    install_failing_pre_commit_hook(&repo);
+    repo.create_file("wip.txt", "wip");
+
+    let output = repo.run_stax(&[
+        "create",
+        "--from",
+        &branches[0],
+        "-a",
+        "-m",
+        "off sibling feature",
+    ]);
+    output.assert_failure();
+
+    // The branch must have been rolled back — no orphan, and the error must
+    // name the rollback so users know what happened.
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|b| b.contains("off-sibling-feature")),
+        "new branch must be rolled back after hook failure. Branches: {:?}",
+        repo.list_branches(),
+    );
+    output.assert_stderr_contains("rolled back");
+}


### PR DESCRIPTION
## Summary

- Reorder `st create -m` to commit-first: run `git commit` on the current branch before creating the new branch. If pre-commit hooks fail (or the user hits Ctrl+C) no ref is touched — no orphan branch, no drift into `mybranch-2`, `mybranch-3`, …
- Keep the branch-first path (and its existing `rollback_create`) for `-m` + `--from <other>` and for name-only `st create`.
- Update `tests/create_rollback_tests.rs` to assert the stronger guarantee (the branch is never created) and add a regression test that `main`'s HEAD does not advance when the split-off succeeds.

## Why

PR #246 added `rollback_create()` to cover the case where `git commit` returns non-zero. But that rollback only runs when the `stax` process is alive to execute it — a `Ctrl+C` during a slow pre-commit hook kills stax before it can clean up, leaving the user switched to an orphan branch. Retrying the same `-m "..."` command then drifts into `mybranch-2`, `mybranch-3`, … via the name-dedup logic, which is exactly the user-visible misbehaviour #243 was meant to eliminate.

The graphite-style commit-first ordering makes the cleanup unnecessary for the failure path: the branch/metadata simply aren't created if the commit doesn't succeed, so there's nothing for SIGINT to leave behind.

Closes #291
Part of #242

## Test plan

- [x] `cargo nextest run --test create_rollback_tests` — 9/9 pass
- [x] `cargo nextest run -E 'test(create)'` — 88/88 pass (includes create_insert, integration create tests, wizard, TUI create)
- [x] `cargo nextest run --lib --bins` — 502/502 pass
- [x] `cargo nextest run -E 'binary(integration_tests)'` — 185/185 pass
- [x] `cargo fmt --check` on touched files — clean
- [x] `cargo clippy` — no new warnings
- [ ] Manual: `st create -m "feat: foo"` with a failing pre-commit hook → no branch created, user on main, retry works with same name
- [ ] Manual: `st create -m "feat: foo"` then Ctrl+C during a slow hook → no branch created, user on main, retry works with same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)