### PR TITLE
feat: add `st move`/`mv` alias and TUI move picker (gt move parity)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -649,6 +649,19 @@ enum Commands {
         yes: bool,
     },
 
+    /// Move the current branch (and its descendants) onto a new parent.
+    ///
+    /// Equivalent to `stax upstack onto`; kept as a top-level alias for
+    /// graphite parity (`gt move`).
+    #[command(visible_alias = "mv")]
+    Move {
+        /// Target parent branch (interactive picker if omitted)
+        target: Option<String>,
+        /// Restack the moved branches after reparenting
+        #[arg(long)]
+        restack: bool,
+    },
+
     /// Interactively reorder branches within a stack
     Reorder {
         /// Skip confirmation prompts
@@ -1844,6 +1857,7 @@ pub fn run() -> Result<()> {
                 run_submit(submit, commands::submit::SubmitScope::Upstack)
             }
         },
+        Commands::Move { target, restack } => commands::upstack::onto::run(target, restack),
         Commands::Downstack(cmd) => match cmd {
             DownstackCommands::Get => {
                 commands::status::run(false, None, false, false, false, false)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -660,22 +660,10 @@ impl App {
         }
         let source_name = source.name.clone();
 
-        // Same filter as the CLI picker (src/commands/upstack/onto.rs): all
-        // branches except the one being moved and its descendants. Trunk
-        // stays in the list but gets pinned to the top so it's the obvious
-        // default target.
+        let all_names: Vec<String> = self.branches.iter().map(|b| b.name.clone()).collect();
         let descendants = self.stack.descendants(&source_name);
-        let trunk = self.stack.trunk.clone();
-        let mut candidates: Vec<String> = self
-            .branches
-            .iter()
-            .map(|b| b.name.clone())
-            .filter(|n| n != &source_name && !descendants.contains(n))
-            .collect();
-        if let Some(pos) = candidates.iter().position(|n| n == &trunk) {
-            let t = candidates.remove(pos);
-            candidates.insert(0, t);
-        }
+        let candidates =
+            build_move_picker_candidates(&all_names, &source_name, &descendants, &self.stack.trunk);
         if candidates.is_empty() {
             return false;
         }
@@ -692,16 +680,7 @@ impl App {
     /// `move_picker_candidates`. Case-insensitive substring match, same
     /// shape as `update_search` for the main stack view.
     pub fn move_picker_filtered_indices(&self) -> Vec<usize> {
-        let query = self.move_picker_query.to_lowercase();
-        if query.is_empty() {
-            return (0..self.move_picker_candidates.len()).collect();
-        }
-        self.move_picker_candidates
-            .iter()
-            .enumerate()
-            .filter(|(_, n)| n.to_lowercase().contains(&query))
-            .map(|(i, _)| i)
-            .collect()
+        substring_filter_indices(&self.move_picker_candidates, &self.move_picker_query)
     }
 
     /// Currently highlighted candidate (after applying the filter).
@@ -1251,6 +1230,49 @@ impl App {
     }
 }
 
+/// Case-insensitive substring filter. Returns the indices of `candidates`
+/// that match `query`. Empty query returns every index in original order.
+///
+/// Extracted as a pure function so the filter behaviour is unit-testable
+/// without spinning up a full `App` (which needs a live `GitRepo`).
+fn substring_filter_indices(candidates: &[String], query: &str) -> Vec<usize> {
+    let q = query.to_lowercase();
+    if q.is_empty() {
+        return (0..candidates.len()).collect();
+    }
+    candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, n)| n.to_lowercase().contains(&q))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// Build the ordered candidate list for the move picker: every branch
+/// except `source` and its `descendants`, with `trunk` (if present) pinned
+/// to the top so it's the obvious default target.
+///
+/// Mirrors the filter used by the CLI's `pick_parent_interactively` in
+/// `src/commands/upstack/onto.rs`. Extracted so both the behaviour and the
+/// pinning are testable directly.
+fn build_move_picker_candidates(
+    all_branches: &[String],
+    source: &str,
+    descendants: &[String],
+    trunk: &str,
+) -> Vec<String> {
+    let mut candidates: Vec<String> = all_branches
+        .iter()
+        .filter(|n| n.as_str() != source && !descendants.iter().any(|d| d == *n))
+        .cloned()
+        .collect();
+    if let Some(pos) = candidates.iter().position(|n| n == trunk) {
+        let t = candidates.remove(pos);
+        candidates.insert(0, t);
+    }
+    candidates
+}
+
 fn parse_ci_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
     value.and_then(|timestamp| timestamp.parse::<DateTime<Utc>>().ok())
 }
@@ -1417,7 +1439,10 @@ fn spawn_ci_loader(repo_path: PathBuf, branch: String) -> Receiver<CiUpdate> {
 
 #[cfg(test)]
 mod tests {
-    use super::{live_ci_summary_text, run_in_tokio_runtime, BranchCiSummary};
+    use super::{
+        build_move_picker_candidates, live_ci_summary_text, run_in_tokio_runtime,
+        substring_filter_indices, BranchCiSummary,
+    };
     use anyhow::{anyhow, Result};
     use chrono::{TimeZone, Utc};
     use std::future::Ready;
@@ -1425,6 +1450,62 @@ mod tests {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
+
+    fn names(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn substring_filter_empty_query_returns_all_indices_in_order() {
+        let candidates = names(&["main", "feat-a", "feat-b"]);
+        assert_eq!(substring_filter_indices(&candidates, ""), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn substring_filter_matches_case_insensitively() {
+        let candidates = names(&["Main", "FEAT-A", "feat-b"]);
+        assert_eq!(substring_filter_indices(&candidates, "feat"), vec![1, 2]);
+        assert_eq!(substring_filter_indices(&candidates, "MAIN"), vec![0]);
+    }
+
+    #[test]
+    fn substring_filter_returns_empty_when_nothing_matches() {
+        let candidates = names(&["main", "feat-a"]);
+        assert!(substring_filter_indices(&candidates, "xyz").is_empty());
+    }
+
+    #[test]
+    fn move_picker_candidates_exclude_source_and_descendants() {
+        let all = names(&["main", "a", "b", "c", "sibling"]);
+        let descendants = names(&["b", "c"]);
+        let got = build_move_picker_candidates(&all, "a", &descendants, "main");
+        assert_eq!(got, names(&["main", "sibling"]));
+    }
+
+    #[test]
+    fn move_picker_candidates_pin_trunk_to_top() {
+        // 'main' appears after 'z-branch' in the source list — the helper
+        // must still place it first in the output.
+        let all = names(&["z-branch", "sibling", "main"]);
+        let got = build_move_picker_candidates(&all, "feat-self", &[], "main");
+        assert_eq!(got.first().map(String::as_str), Some("main"));
+    }
+
+    #[test]
+    fn move_picker_candidates_without_trunk_preserves_source_order() {
+        // If the trunk isn't in the candidates (e.g. detached scenario),
+        // the helper should not crash or reorder the remainder.
+        let all = names(&["z", "a", "m"]);
+        let got = build_move_picker_candidates(&all, "feat", &[], "unlisted-trunk");
+        assert_eq!(got, names(&["z", "a", "m"]));
+    }
+
+    #[test]
+    fn move_picker_candidates_empty_when_everything_is_source_or_descendant() {
+        let all = names(&["a", "b"]);
+        let got = build_move_picker_candidates(&all, "a", &names(&["b"]), "a");
+        assert!(got.is_empty());
+    }
 
     fn sample_summary() -> BranchCiSummary {
         BranchCiSummary {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -648,15 +648,16 @@ impl App {
 
     /// Prepare state for `Mode::MovePicker` and enter it.
     ///
-    /// Returns `false` (without changing mode) if the selected branch is
-    /// trunk or has no valid candidates — the caller should display a
-    /// status message in that case.
-    pub fn init_move_picker(&mut self) -> bool {
+    /// On `Err`, the static string is a user-facing reason suitable for
+    /// `set_status`. Returning a specific message from here (rather than a
+    /// bool) keeps the dispatcher from having to duplicate the trunk /
+    /// no-candidates checks to figure out what to show.
+    pub fn init_move_picker(&mut self) -> Result<(), &'static str> {
         let Some(source) = self.selected_branch() else {
-            return false;
+            return Err("No branch selected");
         };
         if source.is_trunk {
-            return false;
+            return Err("Cannot reparent trunk branch");
         }
         let source_name = source.name.clone();
 
@@ -665,7 +666,7 @@ impl App {
         let candidates =
             build_move_picker_candidates(&all_names, &source_name, &descendants, &self.stack.trunk);
         if candidates.is_empty() {
-            return false;
+            return Err("No eligible parents to move onto");
         }
 
         self.move_picker_source = source_name;
@@ -673,7 +674,7 @@ impl App {
         self.move_picker_query.clear();
         self.move_picker_selected = 0;
         self.mode = Mode::MovePicker;
-        true
+        Ok(())
     }
 
     /// Return the filtered subset of candidates as indices into

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -236,6 +236,10 @@ pub enum Mode {
     Confirm(ConfirmAction),
     Input(InputAction),
     Reorder,
+    /// Fuzzy-filter picker for selecting a new parent to reparent onto
+    /// (`gt move` equivalent). Parallel to `Search` — chars type into the
+    /// query, Enter confirms, Esc cancels.
+    MovePicker,
 }
 
 /// Actions that require text input
@@ -321,6 +325,16 @@ pub struct App {
     pub pending_command: Option<PendingCommand>,
     pub needs_refresh: bool,
     pub reorder_state: Option<ReorderState>,
+    /// Branch being reparented (snapshot taken when MovePicker opens so the
+    /// picker survives UI refreshes that change `selected_index`).
+    pub move_picker_source: String,
+    /// All eligible parent branches for the move (current + descendants
+    /// already excluded). Never changes while the picker is open.
+    pub move_picker_candidates: Vec<String>,
+    /// User's substring query (case-insensitive match against candidates).
+    pub move_picker_query: String,
+    /// Index into the filtered view (see `move_picker_filtered_indices`).
+    pub move_picker_selected: usize,
     diff_cache: HashMap<String, CachedDiff>,
     ci_states: HashMap<String, BranchCiState>,
     ci_loader: Option<Receiver<CiUpdate>>,
@@ -364,6 +378,10 @@ impl App {
             pending_command: None,
             needs_refresh: true,
             reorder_state: None,
+            move_picker_source: String::new(),
+            move_picker_candidates: Vec::new(),
+            move_picker_query: String::new(),
+            move_picker_selected: 0,
             diff_cache: HashMap::new(),
             ci_states: HashMap::new(),
             ci_loader: None,
@@ -626,6 +644,100 @@ impl App {
             .map(|(i, _)| i)
             .collect();
         self.selected_index = 0;
+    }
+
+    /// Prepare state for `Mode::MovePicker` and enter it.
+    ///
+    /// Returns `false` (without changing mode) if the selected branch is
+    /// trunk or has no valid candidates — the caller should display a
+    /// status message in that case.
+    pub fn init_move_picker(&mut self) -> bool {
+        let Some(source) = self.selected_branch() else {
+            return false;
+        };
+        if source.is_trunk {
+            return false;
+        }
+        let source_name = source.name.clone();
+
+        // Same filter as the CLI picker (src/commands/upstack/onto.rs): all
+        // branches except the one being moved and its descendants. Trunk
+        // stays in the list but gets pinned to the top so it's the obvious
+        // default target.
+        let descendants = self.stack.descendants(&source_name);
+        let trunk = self.stack.trunk.clone();
+        let mut candidates: Vec<String> = self
+            .branches
+            .iter()
+            .map(|b| b.name.clone())
+            .filter(|n| n != &source_name && !descendants.contains(n))
+            .collect();
+        if let Some(pos) = candidates.iter().position(|n| n == &trunk) {
+            let t = candidates.remove(pos);
+            candidates.insert(0, t);
+        }
+        if candidates.is_empty() {
+            return false;
+        }
+
+        self.move_picker_source = source_name;
+        self.move_picker_candidates = candidates;
+        self.move_picker_query.clear();
+        self.move_picker_selected = 0;
+        self.mode = Mode::MovePicker;
+        true
+    }
+
+    /// Return the filtered subset of candidates as indices into
+    /// `move_picker_candidates`. Case-insensitive substring match, same
+    /// shape as `update_search` for the main stack view.
+    pub fn move_picker_filtered_indices(&self) -> Vec<usize> {
+        let query = self.move_picker_query.to_lowercase();
+        if query.is_empty() {
+            return (0..self.move_picker_candidates.len()).collect();
+        }
+        self.move_picker_candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, n)| n.to_lowercase().contains(&query))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Currently highlighted candidate (after applying the filter).
+    pub fn move_picker_current(&self) -> Option<&str> {
+        let filtered = self.move_picker_filtered_indices();
+        let idx = *filtered.get(self.move_picker_selected)?;
+        self.move_picker_candidates.get(idx).map(String::as_str)
+    }
+
+    /// Move highlight up in the filtered view; clamps at 0.
+    pub fn move_picker_select_previous(&mut self) {
+        if self.move_picker_selected > 0 {
+            self.move_picker_selected -= 1;
+        }
+    }
+
+    /// Move highlight down in the filtered view; clamps at the last item.
+    pub fn move_picker_select_next(&mut self) {
+        let len = self.move_picker_filtered_indices().len();
+        if len > 0 && self.move_picker_selected + 1 < len {
+            self.move_picker_selected += 1;
+        }
+    }
+
+    /// After the query changes: reset the highlight to the first match so
+    /// the user doesn't land out-of-bounds when the filter shrinks.
+    pub fn move_picker_on_query_change(&mut self) {
+        self.move_picker_selected = 0;
+    }
+
+    /// Clear all picker state. Call when exiting the mode by any path.
+    pub fn clear_move_picker(&mut self) {
+        self.move_picker_source.clear();
+        self.move_picker_candidates.clear();
+        self.move_picker_query.clear();
+        self.move_picker_selected = 0;
     }
 
     /// Update the diff for the currently selected branch

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -35,6 +35,7 @@ pub enum KeyAction {
     Help,
     Quit,
     ReorderMode,
+    MovePicker,
 
     // Reorder mode actions
     MoveUp,
@@ -62,6 +63,7 @@ pub enum KeyContext {
     Confirm,
     Help,
     Reorder,
+    MovePicker,
 }
 
 impl From<KeyEvent> for KeyAction {
@@ -81,7 +83,10 @@ impl KeyAction {
 
         // Handle Shift modifiers
         if key.modifiers.contains(KeyModifiers::SHIFT)
-            && !matches!(context, KeyContext::Input | KeyContext::Search)
+            && !matches!(
+                context,
+                KeyContext::Input | KeyContext::Search | KeyContext::MovePicker,
+            )
         {
             match key.code {
                 KeyCode::Char('R') | KeyCode::Char('r') => return KeyAction::RestackAll,
@@ -228,5 +233,40 @@ mod tests {
             KeyContext::Input,
         );
         assert_eq!(action, KeyAction::Char('K'));
+    }
+
+    /// MovePicker is a text-input context (users type a filter query). Shift
+    /// must not remap `k`/`j`/`r` to MoveUp/MoveDown/RestackAll the way it
+    /// does in Normal/Reorder — those are valid characters in a branch name.
+    #[test]
+    fn move_picker_mode_treats_shortcut_letters_as_text() {
+        for c in ['n', 'r', 's', 'q', 'd', 'e', 'p', 'o', 'm', 'j', 'k'] {
+            let action = KeyAction::from_key(
+                KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE),
+                KeyContext::MovePicker,
+            );
+            assert_eq!(
+                action,
+                KeyAction::Char(c),
+                "char '{}' should pass through",
+                c
+            );
+        }
+    }
+
+    #[test]
+    fn move_picker_mode_allows_shifted_letters_as_text() {
+        for c in ['K', 'J', 'R'] {
+            let action = KeyAction::from_key(
+                KeyEvent::new(KeyCode::Char(c), KeyModifiers::SHIFT),
+                KeyContext::MovePicker,
+            );
+            assert_eq!(
+                action,
+                KeyAction::Char(c),
+                "Shift+'{}' should pass through",
+                c
+            );
+        }
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -287,15 +287,8 @@ fn handle_normal_action(app: &mut App, action: KeyAction) -> Result<()> {
             }
         }
         KeyAction::MovePicker => {
-            let Some(selected) = app.selected_branch() else {
-                return Ok(());
-            };
-            if selected.is_trunk {
-                app.set_status("Cannot reparent trunk branch");
-                return Ok(());
-            }
-            if !app.init_move_picker() {
-                app.set_status("No eligible parents to move onto");
+            if let Err(msg) = app.init_move_picker() {
+                app.set_status(msg);
             }
         }
         _ => {}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -100,6 +100,9 @@ fn run_app(
                 Mode::Search => {
                     handle_search_key(app, key)?;
                 }
+                Mode::MovePicker => {
+                    handle_move_picker_key(app, key)?;
+                }
                 _ => {
                     let context = match app.mode {
                         Mode::Normal => KeyContext::Normal,
@@ -108,6 +111,7 @@ fn run_app(
                         Mode::Confirm(_) => KeyContext::Confirm,
                         Mode::Input(_) => KeyContext::Input,
                         Mode::Reorder => KeyContext::Reorder,
+                        Mode::MovePicker => KeyContext::MovePicker,
                     };
                     let action = KeyAction::from_key(key, context);
                     handle_action(app, action)?;
@@ -139,6 +143,9 @@ fn handle_action(app: &mut App, action: KeyAction) -> Result<()> {
             handle_input_action(app, action, &input_action)?;
         }
         Mode::Reorder => handle_reorder_action(app, action)?,
+        // MovePicker is only reached here for actions that couldn't be
+        // handled by `handle_move_picker_key` — currently none.
+        Mode::MovePicker => {}
     }
     Ok(())
 }
@@ -161,6 +168,7 @@ fn handle_normal_action(app: &mut App, action: KeyAction) -> Result<()> {
                 '?' => Some(KeyAction::Help),
                 'q' => Some(KeyAction::Quit),
                 'o' => Some(KeyAction::ReorderMode),
+                'm' => Some(KeyAction::MovePicker),
                 _ => None,
             };
 
@@ -278,6 +286,18 @@ fn handle_normal_action(app: &mut App, action: KeyAction) -> Result<()> {
                 app.mode = Mode::Reorder;
             }
         }
+        KeyAction::MovePicker => {
+            let Some(selected) = app.selected_branch() else {
+                return Ok(());
+            };
+            if selected.is_trunk {
+                app.set_status("Cannot reparent trunk branch");
+                return Ok(());
+            }
+            if !app.init_move_picker() {
+                app.set_status("No eligible parents to move onto");
+            }
+        }
         _ => {}
     }
     Ok(())
@@ -312,6 +332,63 @@ fn handle_search_action(app: &mut App, action: KeyAction) -> Result<()> {
         KeyAction::Backspace => {
             app.search_query.pop();
             app.update_search();
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Key handler for `Mode::MovePicker`. Mirrors `handle_search_key` (chars
+/// feed the query, Up/Down navigate, Enter confirms, Esc cancels) but on
+/// Enter it queues `upstack onto <target>` instead of checkout.
+fn handle_move_picker_key(app: &mut App, key: KeyEvent) -> Result<()> {
+    if is_ctrl_c(&key) {
+        app.should_quit = true;
+        return Ok(());
+    }
+
+    match key.code {
+        KeyCode::Esc => {
+            app.clear_move_picker();
+            app.mode = Mode::Normal;
+        }
+        KeyCode::Enter => {
+            let Some(target) = app.move_picker_current().map(str::to_string) else {
+                app.set_status("No candidate selected");
+                return Ok(());
+            };
+            let source = app.move_picker_source.clone();
+            app.clear_move_picker();
+            app.mode = Mode::Normal;
+            // Run `checkout <source> && upstack onto <target>` so the
+            // reparent operates on the picker's source branch regardless
+            // of where HEAD is — `upstack onto` always reparents the
+            // *current* branch.
+            let mut commands = Vec::new();
+            if app.current_branch != source {
+                commands.push(vec!["checkout".to_string(), source.clone()]);
+            }
+            commands.push(vec![
+                "upstack".to_string(),
+                "onto".to_string(),
+                target.clone(),
+            ]);
+            queue_command(
+                app,
+                commands,
+                format!("Moved '{}' onto '{}'", source, target),
+                Some(source),
+            );
+        }
+        KeyCode::Up => app.move_picker_select_previous(),
+        KeyCode::Down => app.move_picker_select_next(),
+        KeyCode::Char(c) => {
+            app.move_picker_query.push(c);
+            app.move_picker_on_query_change();
+        }
+        KeyCode::Backspace => {
+            app.move_picker_query.pop();
+            app.move_picker_on_query_change();
         }
         _ => {}
     }
@@ -630,6 +707,7 @@ fn log_key_event(app: &App, key: &KeyEvent) {
         Mode::Confirm(_) => "confirm",
         Mode::Input(_) => "input",
         Mode::Reorder => "reorder",
+        Mode::MovePicker => "move_picker",
     };
 
     let Ok(mut file) = std::fs::OpenOptions::new()

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -419,13 +419,13 @@ fn render_input_modal(f: &mut Frame, action: &InputAction, input: &str, cursor: 
     f.render_widget(paragraph, area);
 }
 
-/// Render the move-picker modal (fuzzy parent selector for `gt move`).
+/// Render the move-picker modal (parent selector for `gt move`).
 ///
 /// Layout: a centered 60×60 box. First line is a bold prompt naming the
 /// source branch; second is the live query; remaining lines list filtered
 /// candidates with the selected one highlighted. Trailing line is the
 /// shortcut hint. The list truncates to fit — users scroll with ↑/↓.
-fn render_move_picker_modal(f: &mut Frame, app: &crate::tui::app::App) {
+fn render_move_picker_modal(f: &mut Frame, app: &App) {
     let area = centered_rect(60, 60, f.area());
 
     let filtered = app.move_picker_filtered_indices();
@@ -467,9 +467,10 @@ fn render_move_picker_modal(f: &mut Frame, app: &crate::tui::app::App) {
             Style::default().fg(Color::DarkGray),
         )));
     } else {
-        // Show a window around the selected index so scrolling feels natural
-        // on small terminals. The modal gives us ~N visible rows; cap the
-        // candidate list at 20 to leave room for header + hint.
+        // Scroll window: keep the selected row roughly centered. `start`
+        // is pulled back to `end - MAX_VISIBLE` after clamping `end` to
+        // the list length, so when `selected` is near the end of a long
+        // list we still show a full window instead of a half-empty tail.
         const MAX_VISIBLE: usize = 20;
         let start = selected.saturating_sub(MAX_VISIBLE / 2);
         let end = (start + MAX_VISIBLE).min(filtered.len());

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -51,6 +51,7 @@ pub fn render(f: &mut Frame, app: &App) {
         Mode::Help => render_help_modal(f),
         Mode::Confirm(action) => render_confirm_modal(f, action),
         Mode::Input(action) => render_input_modal(f, action, &app.input_buffer, app.input_cursor),
+        Mode::MovePicker => render_move_picker_modal(f, app),
         _ => {}
     }
 }
@@ -126,6 +127,20 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                 Span::styled("Esc", Style::default().fg(Color::Cyan)),
                 Span::raw(" cancel"),
             ]),
+            Mode::MovePicker => Line::from(vec![
+                Span::styled(
+                    " MOVE ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  pick new parent for "),
+                Span::styled(
+                    format!("'{}'", app.move_picker_source),
+                    Style::default().fg(Color::Cyan),
+                ),
+            ]),
         }
     };
 
@@ -160,6 +175,16 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
             Span::raw(" move  "),
             key_hint("Enter", Color::Green),
             Span::raw(" apply  "),
+            key_hint("Esc", Color::Red),
+            Span::raw(" cancel"),
+        ]),
+        Mode::MovePicker => Line::from(vec![
+            key_hint("Type", Color::Cyan),
+            Span::raw(" filter  "),
+            key_hint("↑↓", Color::Cyan),
+            Span::raw(" select  "),
+            key_hint("Enter", Color::Green),
+            Span::raw(" move  "),
             key_hint("Esc", Color::Red),
             Span::raw(" cancel"),
         ]),
@@ -198,6 +223,8 @@ fn build_normal_shortcuts(app: &App) -> Line<'static> {
 
     spans.push(key_hint("/", Color::Cyan));
     spans.push(Span::raw(" search  "));
+    spans.push(key_hint("m", Color::Magenta));
+    spans.push(Span::raw(" move  "));
     spans.push(key_hint("?", Color::Yellow));
     spans.push(Span::raw(" help  "));
     spans.push(key_hint("q", Color::Cyan));
@@ -248,7 +275,8 @@ fn render_help_modal(f: &mut Frame) {
         Line::from("  n        Create new branch"),
         Line::from("  e        Rename current branch"),
         Line::from("  d        Delete selected branch"),
-        Line::from("  o        Reorder stack (reparent)"),
+        Line::from("  o        Reorder stack (swap siblings)"),
+        Line::from("  m        Move branch onto a new parent"),
         Line::from(""),
         Line::from(vec![Span::styled(
             "Reorder Mode (press 'o' to enter)",
@@ -258,6 +286,15 @@ fn render_help_modal(f: &mut Frame) {
         Line::from("  Shift+↓/J  Move branch down in stack"),
         Line::from("  Enter      Apply reparenting and restack"),
         Line::from("  Esc        Cancel reorder"),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "Move Mode (press 'm' to enter)",
+            Style::default().add_modifier(Modifier::BOLD),
+        )]),
+        Line::from("  Type       Filter candidate parents"),
+        Line::from("  ↑/↓        Select candidate"),
+        Line::from("  Enter      Reparent and run `upstack onto`"),
+        Line::from("  Esc        Cancel"),
         Line::from(""),
         Line::from(vec![Span::styled(
             "Other",
@@ -375,6 +412,107 @@ fn render_input_modal(f: &mut Frame, action: &InputAction, input: &str, cursor: 
                 .borders(Borders::ALL)
                 .title(title)
                 .border_style(Style::default().fg(Color::Cyan)),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+/// Render the move-picker modal (fuzzy parent selector for `gt move`).
+///
+/// Layout: a centered 60×60 box. First line is a bold prompt naming the
+/// source branch; second is the live query; remaining lines list filtered
+/// candidates with the selected one highlighted. Trailing line is the
+/// shortcut hint. The list truncates to fit — users scroll with ↑/↓.
+fn render_move_picker_modal(f: &mut Frame, app: &crate::tui::app::App) {
+    let area = centered_rect(60, 60, f.area());
+
+    let filtered = app.move_picker_filtered_indices();
+    let selected = app.move_picker_selected;
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Move ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!("'{}'", app.move_picker_source),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " (and its descendants) onto:",
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("> ", Style::default().fg(Color::Cyan)),
+        Span::styled(
+            app.move_picker_query.clone(),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled(
+            "│",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::SLOW_BLINK),
+        ),
+    ]));
+    lines.push(Line::from(""));
+
+    if filtered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no matches)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        // Show a window around the selected index so scrolling feels natural
+        // on small terminals. The modal gives us ~N visible rows; cap the
+        // candidate list at 20 to leave room for header + hint.
+        const MAX_VISIBLE: usize = 20;
+        let start = selected.saturating_sub(MAX_VISIBLE / 2);
+        let end = (start + MAX_VISIBLE).min(filtered.len());
+        let start = end.saturating_sub(MAX_VISIBLE);
+
+        for (row, filter_idx) in filtered[start..end].iter().enumerate() {
+            let absolute_row = start + row;
+            let name = &app.move_picker_candidates[*filter_idx];
+            let is_selected = absolute_row == selected;
+            let marker = if is_selected { "▸ " } else { "  " };
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(marker, style),
+                Span::styled(name.clone(), style),
+            ]));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("Type", Style::default().fg(Color::DarkGray)),
+        Span::styled(" filter  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("↑↓", Style::default().fg(Color::DarkGray)),
+        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("⏎", Style::default().fg(Color::DarkGray)),
+        Span::styled(" move  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::DarkGray)),
+        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+    ]));
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Move onto ")
+                .border_style(Style::default().fg(Color::Magenta)),
         )
         .wrap(Wrap { trim: false });
 

--- a/tests/upstack_onto_tests.rs
+++ b/tests/upstack_onto_tests.rs
@@ -178,3 +178,88 @@ fn upstack_onto_self_fails() {
     output.assert_failure();
     output.assert_stderr_contains("itself");
 }
+
+/// `st move <target>` is a graphite-parity alias that dispatches to the same
+/// `commands::upstack::onto::run` as `st upstack onto <target>`. Behavioural
+/// parity is verified end-to-end: a stack of a → b gets reparented b onto
+/// main via the alias, and `status --json` shows the same resulting parent
+/// pointer that `upstack onto` produces.
+#[test]
+fn move_alias_reparents_like_upstack_onto() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "b");
+    repo.commit("commit b");
+
+    repo.run_stax(&["checkout", "b"]);
+    let output = repo.run_stax(&["move", "main"]);
+    output.assert_success();
+    assert!(
+        TestRepo::stdout(&output).contains("Reparented"),
+        "`st move` should print the same reparent summary as `st upstack onto`",
+    );
+
+    let status = repo.run_stax(&["status", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("valid json");
+    let branches = json["branches"].as_array().expect("branches array");
+    let b_entry = find_branch(branches, "b").expect("should find branch b");
+    assert_eq!(b_entry["parent"].as_str().unwrap(), "main");
+}
+
+/// `st mv` is the short form. Same dispatch, same outcome — just typing.
+#[test]
+fn mv_short_alias_works() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "b");
+    repo.commit("commit b");
+
+    repo.run_stax(&["checkout", "b"]);
+    let output = repo.run_stax(&["mv", "main"]);
+    output.assert_success();
+
+    let status = repo.run_stax(&["status", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("valid json");
+    let branches = json["branches"].as_array().expect("branches array");
+    let b_entry = find_branch(branches, "b").expect("should find branch b");
+    assert_eq!(b_entry["parent"].as_str().unwrap(), "main");
+}
+
+/// The alias must reject the same error cases `upstack onto` does, so the
+/// guards in `commands::upstack::onto::run` aren't silently bypassed.
+#[test]
+fn move_alias_rejects_trunk_and_circular() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // On trunk: "Cannot reparent trunk" — same as upstack onto.
+    let output = repo.run_stax(&["move", "main"]);
+    output.assert_failure();
+    output.assert_stderr_contains("trunk");
+
+    // Circular: reparent a onto its descendant b should fail.
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "a");
+    repo.commit("commit a");
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "b");
+    repo.commit("commit b");
+    repo.run_stax(&["checkout", "a"]);
+    let output = repo.run_stax(&["move", "b"]);
+    output.assert_failure();
+    output.assert_stderr_contains("circular");
+}


### PR DESCRIPTION
## Summary

- Add `st move` (and short `st mv`) as a top-level alias for `st upstack onto` — graphite `gt move` muscle memory works now.
- Add a new TUI mode `Mode::MovePicker` bound to `m` in the stack view: filter-as-you-type picker for the new parent. Candidates are computed with the same filter as the CLI picker (`list_branches − {current} − descendants(current)`, trunk pinned first).
- Help modal and bottom shortcut line updated so the new key is discoverable.

Closes #294.

## Why

Graphite users expect `gt move` to be at top-level. stax had the semantics under `upstack onto` and exposed a `FuzzySelect` picker from the CLI, but (a) the name wasn't discoverable via `st --help`, and (b) there was no way to pick a new parent from inside the TUI without dropping out to the shell.

## Shape of the change

**CLI** (~10 lines in `src/cli.rs`): a new `Commands::Move { target, restack }` variant with `visible_alias = \"mv\"` that forwards to `commands::upstack::onto::run`. No new business logic — the existing dispatch, guards, and interactive picker are reused verbatim.

**TUI** (`src/tui/{app,event,mod,ui}.rs`):
- `Mode::MovePicker` added alongside the existing `Input`/`Search`/`Reorder` modes.
- Picker state on `App`: `move_picker_source`, `move_picker_candidates`, `move_picker_query`, `move_picker_selected`. Same \"state on App, mode is the discriminator\" pattern the other text-input modes use.
- `KeyContext::MovePicker` added so shift-remapping (`K` → MoveUp, `R` → RestackAll) is suppressed while typing — users need to be able to enter branch names containing those letters.
- `handle_move_picker_key` mirrors `handle_search_key` (raw `KeyEvent` handling for chars/backspace/up-down/enter/esc).
- On Enter: queues `checkout <source> && upstack onto <target>` via the existing `PendingCommand` mechanism so the reparent operates on the *picker's* source branch regardless of where the user's HEAD is.

**Guards** match the CLI's semantics:
- Pressing `m` on trunk sets the status line \"Cannot reparent trunk branch\" (no mode change).
- If there are no eligible candidates, the status line says \"No eligible parents to move onto\" (no mode change).

## Test plan

- [x] `cargo nextest run --test upstack_onto_tests` — 13/13 pass, including three new ones (`move_alias_reparents_like_upstack_onto`, `mv_short_alias_works`, `move_alias_rejects_trunk_and_circular`).
- [x] `cargo nextest run --lib` — 504/504 pass; two new unit tests guard `KeyContext::MovePicker` against shortcut-char remapping.
- [x] `cargo clippy` — no new warnings on touched files.
- [x] `cargo fmt --check` — clean on touched files.
- [x] `cargo run -- move --help` and `cargo run -- mv --help` both render the new help text with the alias listed in `stax --help`.
- [ ] Manual TUI smoke: `st` → select branch → press `m` → type filter → Enter → reparent runs, TUI relaunches on the new state.

## Known scope limits

- Only a positional `target`; graphite also supports `--source <branch>`. Skipping for now — the picker always moves the currently-selected branch, matching `upstack onto`. Easy follow-up.
- Picker does plain substring match (same as `Search` mode), not fuzzy. Graphite's CLI fuzzy matcher is dialoguer-only and dialoguer doesn't integrate with ratatui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)