### PR TITLE
fix(tui): sort move picker candidates to match CLI picker

### DIFF
--- a/src/commands/upstack/onto.rs
+++ b/src/commands/upstack/onto.rs
@@ -1,4 +1,4 @@
-use crate::engine::{BranchMetadata, Stack};
+use crate::engine::{build_parent_candidates, BranchMetadata, Stack};
 use crate::git::{GitRepo, RebaseResult};
 use anyhow::{bail, Result};
 use colored::Colorize;
@@ -202,14 +202,8 @@ fn pick_parent_interactively(
     trunk: &str,
     descendants: &[String],
 ) -> Result<String> {
-    let mut branches = repo.list_branches()?;
-    branches.retain(|b| b != current && !descendants.contains(b));
-    branches.sort();
-
-    if let Some(pos) = branches.iter().position(|b| b == trunk) {
-        branches.remove(pos);
-        branches.insert(0, trunk.to_string());
-    }
+    let all_branches = repo.list_branches()?;
+    let branches = build_parent_candidates(&all_branches, current, descendants, trunk);
 
     if branches.is_empty() {
         bail!("No branches available as a new parent");

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,5 +1,7 @@
 pub mod metadata;
+pub mod picker;
 pub mod stack;
 
 pub use metadata::{BranchMetadata, PrInfo};
+pub use picker::build_parent_candidates;
 pub use stack::Stack;

--- a/src/engine/picker.rs
+++ b/src/engine/picker.rs
@@ -18,7 +18,7 @@ pub fn build_parent_candidates(
 ) -> Vec<String> {
     let mut candidates: Vec<String> = all_branches
         .iter()
-        .filter(|n| n.as_str() != source && !descendants.iter().any(|d| d == *n))
+        .filter(|n| n.as_str() != source && !descendants.contains(*n))
         .cloned()
         .collect();
     candidates.sort();

--- a/src/engine/picker.rs
+++ b/src/engine/picker.rs
@@ -1,0 +1,73 @@
+/// Build the ordered list of candidate parents for a reparent operation.
+///
+/// Starting from `all_branches`, drops `source` and its `descendants`
+/// (since a branch can't be reparented onto itself or something that
+/// depends on it), sorts the remainder alphabetically for predictable
+/// keyboard navigation, then pins `trunk` (if present) to the top so it
+/// becomes the obvious default target.
+///
+/// Shared between the CLI picker (`pick_parent_interactively` in
+/// `src/commands/upstack/onto.rs`) and the TUI move picker
+/// (`init_move_picker` in `src/tui/app.rs`) so both surfaces present the
+/// same candidate set in the same order.
+pub fn build_parent_candidates(
+    all_branches: &[String],
+    source: &str,
+    descendants: &[String],
+    trunk: &str,
+) -> Vec<String> {
+    let mut candidates: Vec<String> = all_branches
+        .iter()
+        .filter(|n| n.as_str() != source && !descendants.iter().any(|d| d == *n))
+        .cloned()
+        .collect();
+    candidates.sort();
+    if let Some(pos) = candidates.iter().position(|n| n == trunk) {
+        let t = candidates.remove(pos);
+        candidates.insert(0, t);
+    }
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_parent_candidates;
+
+    fn names(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn excludes_source_and_descendants() {
+        let all = names(&["main", "a", "b", "c", "sibling"]);
+        let descendants = names(&["b", "c"]);
+        let got = build_parent_candidates(&all, "a", &descendants, "main");
+        assert_eq!(got, names(&["main", "sibling"]));
+    }
+
+    #[test]
+    fn pins_trunk_to_top_then_sorts_remainder() {
+        // Candidates are sorted alphabetically, then trunk is pinned to
+        // the top. `apple` sorts before `main`, so this test also proves
+        // the trunk pin moves it from a non-first position.
+        let all = names(&["z-branch", "sibling", "main", "apple"]);
+        let got = build_parent_candidates(&all, "feat-self", &[], "main");
+        assert_eq!(got, names(&["main", "apple", "sibling", "z-branch"]));
+    }
+
+    #[test]
+    fn sorts_alphabetically_when_trunk_absent() {
+        // Detached scenario: trunk isn't among the candidates. The
+        // remainder is still sorted so navigation stays predictable.
+        let all = names(&["z", "a", "m"]);
+        let got = build_parent_candidates(&all, "feat", &[], "unlisted-trunk");
+        assert_eq!(got, names(&["a", "m", "z"]));
+    }
+
+    #[test]
+    fn empty_when_everything_is_source_or_descendant() {
+        let all = names(&["a", "b"]);
+        let got = build_parent_candidates(&all, "a", &names(&["b"]), "a");
+        assert!(got.is_empty());
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -648,7 +648,7 @@ impl App {
 
     /// Prepare state for `Mode::MovePicker` and enter it.
     ///
-    /// On `Err`, the string is a user-facing reason suitable for
+    /// On `Err`, the static string is a user-facing reason suitable for
     /// `set_status`. Returning a specific message from here (rather than a
     /// bool) keeps the dispatcher from having to duplicate the trunk /
     /// no-candidates checks to figure out what to show.
@@ -657,19 +657,19 @@ impl App {
     /// universe the CLI `pick_parent_interactively` uses — so both
     /// surfaces offer the same targets, including local branches that
     /// aren't yet tracked in the stax stack.
-    pub fn init_move_picker(&mut self) -> Result<(), String> {
+    pub fn init_move_picker(&mut self) -> Result<(), &'static str> {
         let Some(source) = self.selected_branch() else {
-            return Err("No branch selected".to_string());
+            return Err("No branch selected");
         };
         if source.is_trunk {
-            return Err("Cannot reparent trunk branch".to_string());
+            return Err("Cannot reparent trunk branch");
         }
         let source_name = source.name.clone();
 
         let all_names = self
             .repo
             .list_branches()
-            .map_err(|e| format!("Failed to list branches: {e:#}"))?;
+            .map_err(|_| "Failed to list branches")?;
         let descendants = self.stack.descendants(&source_name);
         let candidates = build_parent_candidates(
             &all_names,
@@ -678,7 +678,7 @@ impl App {
             &self.stack.trunk,
         );
         if candidates.is_empty() {
-            return Err("No eligible parents to move onto".to_string());
+            return Err("No eligible parents to move onto");
         }
 
         self.move_picker_source = source_name;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,7 @@
 use crate::cache::CiCache;
 use crate::ci::{history, CheckRunInfo};
 use crate::config::Config;
-use crate::engine::Stack;
+use crate::engine::{build_parent_candidates, Stack};
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
 use crate::remote::RemoteInfo;
@@ -648,25 +648,37 @@ impl App {
 
     /// Prepare state for `Mode::MovePicker` and enter it.
     ///
-    /// On `Err`, the static string is a user-facing reason suitable for
+    /// On `Err`, the string is a user-facing reason suitable for
     /// `set_status`. Returning a specific message from here (rather than a
     /// bool) keeps the dispatcher from having to duplicate the trunk /
     /// no-candidates checks to figure out what to show.
-    pub fn init_move_picker(&mut self) -> Result<(), &'static str> {
+    ///
+    /// Candidates are sourced from `repo.list_branches()` — the same
+    /// universe the CLI `pick_parent_interactively` uses — so both
+    /// surfaces offer the same targets, including local branches that
+    /// aren't yet tracked in the stax stack.
+    pub fn init_move_picker(&mut self) -> Result<(), String> {
         let Some(source) = self.selected_branch() else {
-            return Err("No branch selected");
+            return Err("No branch selected".to_string());
         };
         if source.is_trunk {
-            return Err("Cannot reparent trunk branch");
+            return Err("Cannot reparent trunk branch".to_string());
         }
         let source_name = source.name.clone();
 
-        let all_names: Vec<String> = self.branches.iter().map(|b| b.name.clone()).collect();
+        let all_names = self
+            .repo
+            .list_branches()
+            .map_err(|e| format!("Failed to list branches: {e:#}"))?;
         let descendants = self.stack.descendants(&source_name);
-        let candidates =
-            build_move_picker_candidates(&all_names, &source_name, &descendants, &self.stack.trunk);
+        let candidates = build_parent_candidates(
+            &all_names,
+            &source_name,
+            &descendants,
+            &self.stack.trunk,
+        );
         if candidates.is_empty() {
-            return Err("No eligible parents to move onto");
+            return Err("No eligible parents to move onto".to_string());
         }
 
         self.move_picker_source = source_name;
@@ -1249,31 +1261,6 @@ fn substring_filter_indices(candidates: &[String], query: &str) -> Vec<usize> {
         .collect()
 }
 
-/// Build the ordered candidate list for the move picker: every branch
-/// except `source` and its `descendants`, with `trunk` (if present) pinned
-/// to the top so it's the obvious default target.
-///
-/// Mirrors the filter used by the CLI's `pick_parent_interactively` in
-/// `src/commands/upstack/onto.rs`. Extracted so both the behaviour and the
-/// pinning are testable directly.
-fn build_move_picker_candidates(
-    all_branches: &[String],
-    source: &str,
-    descendants: &[String],
-    trunk: &str,
-) -> Vec<String> {
-    let mut candidates: Vec<String> = all_branches
-        .iter()
-        .filter(|n| n.as_str() != source && !descendants.iter().any(|d| d == *n))
-        .cloned()
-        .collect();
-    if let Some(pos) = candidates.iter().position(|n| n == trunk) {
-        let t = candidates.remove(pos);
-        candidates.insert(0, t);
-    }
-    candidates
-}
-
 fn parse_ci_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
     value.and_then(|timestamp| timestamp.parse::<DateTime<Utc>>().ok())
 }
@@ -1441,8 +1428,7 @@ fn spawn_ci_loader(repo_path: PathBuf, branch: String) -> Receiver<CiUpdate> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_move_picker_candidates, live_ci_summary_text, run_in_tokio_runtime,
-        substring_filter_indices, BranchCiSummary,
+        live_ci_summary_text, run_in_tokio_runtime, substring_filter_indices, BranchCiSummary,
     };
     use anyhow::{anyhow, Result};
     use chrono::{TimeZone, Utc};
@@ -1473,39 +1459,6 @@ mod tests {
     fn substring_filter_returns_empty_when_nothing_matches() {
         let candidates = names(&["main", "feat-a"]);
         assert!(substring_filter_indices(&candidates, "xyz").is_empty());
-    }
-
-    #[test]
-    fn move_picker_candidates_exclude_source_and_descendants() {
-        let all = names(&["main", "a", "b", "c", "sibling"]);
-        let descendants = names(&["b", "c"]);
-        let got = build_move_picker_candidates(&all, "a", &descendants, "main");
-        assert_eq!(got, names(&["main", "sibling"]));
-    }
-
-    #[test]
-    fn move_picker_candidates_pin_trunk_to_top() {
-        // 'main' appears after 'z-branch' in the source list — the helper
-        // must still place it first in the output.
-        let all = names(&["z-branch", "sibling", "main"]);
-        let got = build_move_picker_candidates(&all, "feat-self", &[], "main");
-        assert_eq!(got.first().map(String::as_str), Some("main"));
-    }
-
-    #[test]
-    fn move_picker_candidates_without_trunk_preserves_source_order() {
-        // If the trunk isn't in the candidates (e.g. detached scenario),
-        // the helper should not crash or reorder the remainder.
-        let all = names(&["z", "a", "m"]);
-        let got = build_move_picker_candidates(&all, "feat", &[], "unlisted-trunk");
-        assert_eq!(got, names(&["z", "a", "m"]));
-    }
-
-    #[test]
-    fn move_picker_candidates_empty_when_everything_is_source_or_descendant() {
-        let all = names(&["a", "b"]);
-        let got = build_move_picker_candidates(&all, "a", &names(&["b"]), "a");
-        assert!(got.is_empty());
     }
 
     fn sample_summary() -> BranchCiSummary {


### PR DESCRIPTION
## Summary
- Extract a shared `build_parent_candidates` helper in `src/engine/picker.rs` and drive both `pick_parent_interactively` (CLI) and `init_move_picker` (TUI) through it, so the `move` flow is now structurally consistent — one place defines "drop source + descendants, sort, pin trunk."
- TUI picker now sources candidates from `repo.list_branches()` (all local branches), matching what the underlying `st upstack onto TARGET` command actually accepts. Previously the TUI only offered stax-tracked branches, narrowing the picker below what the command supported.
- Drop a stray `trunk.to_string()` allocation in the CLI picker by reusing the `String` already returned by `branches.remove(pos)`.
- `init_move_picker` now returns `Result<(), String>` so the `list_branches()` error text can propagate; `set_status` already accepts `impl Into<String>`, so the call site is unchanged.

Closes #303

## Behavior change
TUI move picker previously hid local branches that weren't tracked in the stax stack. They're now offered as candidates, matching the CLI.

## Test plan
- [x] `cargo test --lib engine::picker` — 4/4 new picker tests pass
- [x] `cargo test --lib tui::app` — 9/9 remaining TUI tests pass
- [x] `cargo clippy --lib -- -D warnings` — clean
- [ ] Manual: open TUI move picker on a repo with a mix of stax-tracked and untracked local branches; verify alphabetical ordering, trunk pinned first, and untracked branches offered as candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)