### PR TITLE
Add refresh command for sync/restack/submit flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ st ls
 st ss
 
 # 4. After the bottom PR merges on GitHub…
-st rs --restack    # pull trunk, clean merged, rebase the rest
+st refresh         # sync trunk, restack this stack, update PRs
 ```
 
 Picked the wrong trunk? Run `st trunk main` or `st init --trunk <branch>` to reconfigure.
@@ -251,6 +251,7 @@ st config --set-ai
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
+| `st refresh` | Sync trunk, restack current stack, then push/update PRs |
 | `st restack` | Rebase current stack onto parents locally |
 | `st cascade` | Restack + push + open/update PRs |
 | `st split` | Split a branch into stacked branches (by commit or `--hunk`) |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -11,6 +11,7 @@
 | `st merge --when-ready` | Merge in explicit wait-for-ready mode (legacy alias: `st merge-when-ready`) |
 | `st rs` | Pull trunk and clean merged branches (no rebasing; confirmed cleanup can remove safe linked worktrees) |
 | `st rs --restack` | Pull trunk, clean merged branches, **then** rebase current stack |
+| `st refresh` | Pull trunk, clean merged branches, restack current stack, then push/update PRs |
 | `st restack` | Rebase current stack onto parents (local only, no fetch/delete; `--stop-here` skips descendants) |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st cascade` | Restack, push, and create/update PRs |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -13,6 +13,7 @@
 | `st sync` | `rs` | Pull trunk from remote, detect and delete merged branches (incl. squash merges), reparent their children — **no rebasing; confirmed cleanup can also remove a safe linked worktree that still owns the branch** |
 | `st sync --restack` | `rs --restack` | Everything `sync` does, **then** rebase the current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
+| `st refresh` | | Run `sync --restack`, then push branches and create/update PRs for the current stack |
 | `st restack` | | Rebase current stack onto parents (local only, no fetch/delete) — auto-normalizes missing or merged parents before rebasing; `--stop-here` limits scope to ancestors + current |
 | `st cascade` | | Restack from bottom and submit updates |
 | `st diff` | | Show per-branch diffs vs parent |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -43,6 +43,9 @@ st restack
 
 # Or do both in one shot:
 st rs --restack
+
+# Or run the full catch-up + PR update flow in one shot:
+st refresh
 ```
 
 ## Next

--- a/docs/reference/windows.md
+++ b/docs/reference/windows.md
@@ -11,7 +11,7 @@ Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github
 All core stax features work on Windows without modification:
 
 - Stacked branches: `st create`, `st ls`, `st ll`, `st restack`
-- PR workflows: `st ss`, `st merge`, `st cascade`, `st pr`
+- PR workflows: `st ss`, `st merge`, `st cascade`, `st refresh`, `st pr`
 - Sync and cleanup: `st rs`, `st sync`
 - Undo/redo safety: `st undo`, `st redo`
 - Interactive TUI: `st` (no arguments)

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -108,3 +108,14 @@ During merge flows, descendant branches are rebased with provenance-aware bounda
 | `st cascade --no-pr` | restack -> push |
 | `st cascade --no-submit` | restack only |
 | `st cascade --auto-stash-pop` | auto stash/pop dirty worktrees |
+
+## `st refresh`
+
+`st refresh` is the "bottom PR merged, catch me up" command. It prints the plan up front, runs `st sync --restack`, then hands off to the normal submit flow for the current stack.
+
+| Command | Behavior |
+|---|---|
+| `st refresh` | sync -> restack -> push -> create/update PRs |
+| `st refresh --no-pr` | sync -> restack -> push |
+| `st refresh --no-submit` | sync -> restack |
+| `st refresh --force` | force the sync step instead of prompting |

--- a/skills.md
+++ b/skills.md
@@ -218,6 +218,10 @@ stax sync --force                  # Force sync without prompts
 stax sync --prune                  # Prune stale remotes
 stax sync --no-delete              # Keep merged branches
 stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
+stax refresh                       # Sync, restack, then submit
+stax refresh --no-pr               # Push only after sync/restack
+stax refresh --no-submit           # Sync/restack only
+stax refresh --force               # Force sync without prompts first
 
 stax restack                       # Restack current branch onto parent
 stax restack --all                 # Restack whole stack
@@ -390,8 +394,7 @@ stax merge --when-ready --interval 15
 ### After Base PR Merges
 
 ```bash
-stax rs --restack
-stax ss
+stax refresh
 ```
 
 ### Resolve Rebase Conflicts

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -371,6 +371,25 @@ enum Commands {
         auto_stash_pop: bool,
     },
 
+    /// Sync trunk, restack current stack, then submit updates
+    Refresh {
+        /// Push branches to remote but skip PR creation/updates
+        #[arg(long)]
+        no_pr: bool,
+        /// Skip all remote interaction after restack (local refresh only)
+        #[arg(long)]
+        no_submit: bool,
+        /// Force sync without prompts
+        #[arg(short, long)]
+        force: bool,
+        /// Avoid hard reset when updating trunk
+        #[arg(long)]
+        safe: bool,
+        /// Auto-stash and auto-pop dirty target worktrees during sync/restack
+        #[arg(long)]
+        auto_stash_pop: bool,
+    },
+
     /// Checkout a branch in the stack
     #[command(visible_aliases = ["co", "bco"])]
     Checkout {
@@ -1736,6 +1755,13 @@ pub fn run() -> Result<()> {
             no_submit,
             auto_stash_pop,
         } => commands::cascade::run(no_pr, no_submit, auto_stash_pop),
+        Commands::Refresh {
+            no_pr,
+            no_submit,
+            force,
+            safe,
+            auto_stash_pop,
+        } => commands::refresh::run(no_pr, no_submit, force, safe, auto_stash_pop),
         Commands::Checkout {
             branch,
             pr,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -32,6 +32,7 @@ pub mod open;
 pub mod pr;
 pub mod range_diff;
 pub mod redo;
+pub mod refresh;
 pub mod reorder;
 pub mod resolve;
 pub(crate) mod resolve_pr;

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -1,0 +1,90 @@
+use crate::commands;
+use crate::git::{local_branch_exists_in, GitRepo};
+use anyhow::Result;
+use colored::Colorize;
+
+pub fn run(
+    no_pr: bool,
+    no_submit: bool,
+    force: bool,
+    safe: bool,
+    auto_stash_pop: bool,
+) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let original = repo.current_branch()?;
+    let workdir = repo.workdir()?.to_path_buf();
+
+    println!("{}", "Refreshing stack...".bold());
+    println!("  1. Sync trunk and clean merged branches");
+    println!("  2. Restack current stack onto updated parents");
+    if no_submit {
+        println!("  3. Skip push and PR updates (--no-submit)");
+    } else if no_pr {
+        println!("  3. Push branches without updating PRs");
+    } else {
+        println!("  3. Push branches and update PRs");
+    }
+
+    commands::sync::run(
+        true,  // restack
+        false, // prune
+        false, // full
+        true,  // delete_merged
+        false, // delete_upstream_gone
+        force,
+        safe,
+        false, // continue
+        false, // quiet
+        false, // verbose
+        auto_stash_pop,
+    )?;
+
+    if repo.rebase_in_progress()? {
+        return Ok(());
+    }
+
+    if no_submit {
+        return restore_original_branch(&repo, &workdir, &original);
+    }
+
+    commands::submit::run(
+        commands::submit::SubmitScope::Stack,
+        false,  // draft
+        false,  // publish
+        no_pr,  // no_pr
+        false,  // no_fetch
+        false,  // force
+        false,  // yes
+        false,  // no_prompt
+        vec![], // reviewers
+        vec![], // labels
+        vec![], // assignees
+        false,  // quiet
+        false,  // open
+        false,  // verbose
+        None,   // template
+        false,  // no_template
+        false,  // edit
+        false,  // ai_body
+        false,  // rerequest_review
+        false,  // squash
+        false,  // update_title
+    )?;
+
+    restore_original_branch(&repo, &workdir, &original)
+}
+
+fn restore_original_branch(
+    repo: &GitRepo,
+    workdir: &std::path::Path,
+    original: &str,
+) -> Result<()> {
+    if !repo.rebase_in_progress()?
+        && repo.current_branch()? != original
+        && local_branch_exists_in(workdir, original)
+    {
+        repo.checkout(original)?;
+    }
+
+    Ok(())
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -221,6 +221,18 @@ fn test_sync_alias_rs() {
 }
 
 #[test]
+fn test_refresh_help() {
+    let output = stax(&["refresh", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Sync trunk"));
+    assert!(stdout.contains("no-pr"));
+    assert!(stdout.contains("no-submit"));
+    assert!(stdout.contains("force"));
+    assert!(stdout.contains("safe"));
+}
+
+#[test]
 fn test_run_command_help() {
     let output = stax(&["run", "--help"]);
     assert!(output.status.success());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2275,6 +2275,181 @@ fn test_cascade_conflict_reports_restack_context() {
 }
 
 // =============================================================================
+// Refresh Tests
+// =============================================================================
+
+#[test]
+fn test_refresh_no_submit_keeps_original_branch_and_restacks_stack() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "refresh-base"]);
+    let base = repo.current_branch();
+    repo.create_file("base.txt", "base");
+    repo.commit("base commit");
+
+    repo.run_stax(&["bc", "refresh-middle"]);
+    let middle = repo.current_branch();
+    repo.create_file("middle.txt", "middle");
+    repo.commit("middle commit");
+
+    repo.run_stax(&["bc", "refresh-tip"]);
+    let tip = repo.current_branch();
+    repo.create_file("tip.txt", "tip");
+    repo.commit("tip commit");
+
+    repo.simulate_remote_commit("main-update.txt", "main update", "main update");
+
+    repo.run_stax(&["checkout", &middle]);
+    let original = repo.current_branch();
+
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
+    assert!(
+        output.status.success(),
+        "refresh --no-submit failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Refreshing stack..."),
+        "Expected refresh banner, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("1. Sync trunk and clean merged branches"),
+        "Expected sync step, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("2. Restack current stack onto updated parents"),
+        "Expected restack step, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("3. Skip push and PR updates (--no-submit)"),
+        "Expected no-submit step, got: {}",
+        stdout
+    );
+
+    let after = repo.current_branch();
+    assert_eq!(after, original, "refresh should restore original branch");
+
+    let after_output = repo.run_stax(&["status", "--json"]);
+    assert!(
+        after_output.status.success(),
+        "status failed after refresh\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&after_output),
+        TestRepo::stderr(&after_output)
+    );
+    let after_json: Value =
+        serde_json::from_str(&TestRepo::stdout(&after_output)).expect("Invalid JSON");
+    let after_branches = after_json["branches"]
+        .as_array()
+        .expect("Expected branches array");
+    for name in [&base, &middle, &tip] {
+        let branch = after_branches
+            .iter()
+            .find(|b| b["name"].as_str() == Some(name.as_str()))
+            .unwrap_or_else(|| panic!("Missing branch {} in status output", name));
+        assert_eq!(
+            branch["needs_restack"],
+            Value::Bool(false),
+            "Expected {} to be fully restacked by refresh",
+            name
+        );
+    }
+}
+
+#[test]
+fn test_refresh_no_pr_pushes_current_stack() {
+    let repo = TestRepo::new_with_remote();
+    configure_submit_remote(&repo);
+
+    repo.run_stax(&["bc", "refresh-push"]);
+    let branch = repo.current_branch();
+    repo.create_file("push.txt", "push");
+    repo.commit("push commit");
+
+    let output = repo.run_stax(&["refresh", "--no-pr"]);
+    assert!(
+        output.status.success(),
+        "refresh --no-pr failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("3. Push branches without updating PRs"),
+        "Expected no-pr step, got: {}",
+        stdout
+    );
+
+    let remote_branches = repo.list_remote_branches();
+    assert!(
+        remote_branches.iter().any(|name| name == &branch),
+        "Expected {} to be pushed to origin, remote branches: {:?}",
+        branch,
+        remote_branches
+    );
+}
+
+#[test]
+fn test_refresh_conflict_reports_restack_context() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "refresh-progress-parent"]);
+    let _parent = repo.current_branch();
+    repo.create_file("parent.txt", "parent content\n");
+    repo.commit("Parent commit");
+
+    repo.run_stax(&["bc", "refresh-progress-child"]);
+    let child = repo.current_branch();
+    repo.create_file("conflict.txt", "child content\n");
+    repo.commit("Child conflict commit");
+
+    repo.simulate_remote_commit("conflict.txt", "main content\n", "Main conflict commit");
+
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
+    assert!(
+        !output.status.success(),
+        "refresh should exit non-zero on conflict\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Refreshing stack..."),
+        "Expected refresh banner, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Restack stopped on conflict:"),
+        "Expected restack conflict block, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("Stopped at: {}", child)),
+        "Expected stopped-at branch in refresh output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Conflicted files:") && stdout.contains("conflict.txt"),
+        "Expected conflicted files in output, got: {}",
+        stdout
+    );
+
+    let abort = repo.git(&["rebase", "--abort"]);
+    assert!(
+        abort.status.success(),
+        "Failed to abort rebase during cleanup: {}",
+        TestRepo::stderr(&abort)
+    );
+}
+
+// =============================================================================
 // Rename Tests
 // =============================================================================
 


### PR DESCRIPTION
## Motivation

`st refresh` is intended to be the "bottom PR merged, catch me up" command: sync trunk, restack the current stack, then update the corresponding remote branches / PRs.

## Description of changes / notes for reviewers

- add a new top-level `refresh` command that prints its plan up front, runs `sync --restack`, then hands off to the normal submit flow
- support `--no-pr`, `--no-submit`, `--force`, `--safe`, and `--auto-stash-pop` on `refresh`
- keep `cascade` unchanged; `refresh` is the clearer name for the sync/restack/submit workflow
- add CLI and integration coverage for the new command, including a conflict path and a push-only path
- update README / docs / `skills.md` to document `refresh`
- keep the manual `rs` / `restack` / `rs --restack` examples in quick start, and present `refresh` as the full-flow alternative rather than a replacement

## Verification

- `cargo test --test cli_tests test_refresh_help`
- `cargo test --test integration_tests test_refresh_`
