### PR TITLE
fix(merge): push remaining branches before retargeting PR base (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+- Merge: Only retarget remaining PR bases after the rewritten branch has been pushed successfully; surface push failures instead of silently ignoring them (#312)
+
 ## [0.55.0] - 2026-04-20
 
 ### Added

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -435,23 +435,16 @@ pub fn run(
 
             match rebase_result {
                 Ok(RebaseResult::Success) => {
-                    if let Some(pr_num) = remaining.pr_number {
-                        let _ = rt.block_on(async {
-                            client.update_pr_base(pr_num, &parent_branch).await
-                        });
-                    }
-
-                    let _ = Command::new("git")
-                        .args([
-                            "push",
-                            "--force-with-lease",
-                            &remote_info.name,
-                            &remaining.branch,
-                        ])
-                        .current_dir(repo.workdir()?)
-                        .output();
-
-                    LiveTimer::maybe_finish_ok(remaining_timer, "done");
+                    finalize_remaining_branch_push(
+                        &repo,
+                        &rt,
+                        &client,
+                        &remote_info.name,
+                        &remaining.branch,
+                        remaining.pr_number,
+                        &parent_branch,
+                        remaining_timer,
+                    )?;
                 }
                 Ok(RebaseResult::Conflict) => {
                     let abort_dir = repo
@@ -1014,6 +1007,67 @@ fn wait_for_github_head_sync(
         }
         std::thread::sleep(poll_interval);
     }
+}
+
+/// Extract a concise, user-visible reason from `git push` stderr output.
+/// Returns the first non-empty line, or a generic fallback when stderr is empty.
+pub(crate) fn summarize_git_stderr(stderr: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr);
+    text.lines()
+        .map(|line| line.trim())
+        .find(|line| !line.is_empty())
+        .unwrap_or("push rejected")
+        .to_string()
+}
+
+/// Push a rebased remaining-stack branch and — only on success — retarget its
+/// PR base. Surfaces push or retarget failures via the supplied `LiveTimer`;
+/// on any failure the PR base is left pointing at the previous parent so the
+/// on-forge state cannot diverge from the remote branch contents.
+///
+/// Use this from the "remaining branches" rebase pass in both `merge` and
+/// `merge --when-ready`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn finalize_remaining_branch_push(
+    repo: &GitRepo,
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    remote_name: &str,
+    branch: &str,
+    pr_number: Option<u64>,
+    new_base: &str,
+    timer: Option<LiveTimer>,
+) -> Result<()> {
+    let push_output = Command::new("git")
+        .args(["push", "--force-with-lease", remote_name, branch])
+        .current_dir(repo.workdir()?)
+        .output();
+
+    let push_err = match &push_output {
+        Ok(out) if out.status.success() => None,
+        Ok(out) => Some(summarize_git_stderr(&out.stderr)),
+        Err(e) => Some(e.to_string()),
+    };
+
+    if let Some(reason) = push_err {
+        LiveTimer::maybe_finish_err(
+            timer,
+            &format!("push failed; PR base unchanged ({})", reason),
+        );
+        return Ok(());
+    }
+
+    if let Some(pr_num) = pr_number {
+        if let Err(e) =
+            rt.block_on(async { client.update_pr_base(pr_num, new_base).await })
+        {
+            LiveTimer::maybe_finish_err(timer, &format!("retarget failed: {:#}", e));
+            return Ok(());
+        }
+    }
+
+    LiveTimer::maybe_finish_ok(timer, "done");
+    Ok(())
 }
 
 /// After a force-push, briefly wait for the forge to acknowledge the new head

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -1,5 +1,5 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
-use crate::commands::merge::sync_head_after_push;
+use crate::commands::merge::{finalize_remaining_branch_push, sync_head_after_push};
 use crate::commands::merge_rebase::{
     fetch_remote_for_descendant_rebase, rebase_descendant_onto_remote_trunk_with_provenance,
 };
@@ -448,22 +448,16 @@ pub fn run(
 
             match rebase_result {
                 Ok(RebaseResult::Success) => {
-                    if let Some(pr_num) = remaining.pr_number {
-                        let _ = rt
-                            .block_on(async { client.update_pr_base(pr_num, &scope.trunk).await });
-                    }
-
-                    let _ = Command::new("git")
-                        .args([
-                            "push",
-                            "--force-with-lease",
-                            &remote_info.name,
-                            &remaining.branch,
-                        ])
-                        .current_dir(repo.workdir()?)
-                        .output();
-
-                    LiveTimer::maybe_finish_ok(remaining_timer, "done");
+                    finalize_remaining_branch_push(
+                        &repo,
+                        &rt,
+                        &client,
+                        &remote_info.name,
+                        &remaining.branch,
+                        remaining.pr_number,
+                        &scope.trunk,
+                        remaining_timer,
+                    )?;
                 }
                 Ok(RebaseResult::Conflict) => {
                     let abort_dir = repo

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9460,4 +9460,356 @@ mod forge_mock_tests {
         let merge_idx = find_request_index(&requests, "POST", "/repos/test/repo/pulls/201/merge");
         assert!(retarget_idx > merge_idx);
     }
+
+    /// Install a `pre-receive` hook on the bare fake remote that rejects every
+    /// subsequent push with a non-zero exit. The initial pushes performed during
+    /// test setup complete before the hook is installed, so only pushes issued
+    /// during the stax command under test are rejected.
+    #[cfg(unix)]
+    fn install_reject_all_pre_receive(remote_root: &TempDir) {
+        use std::os::unix::fs::PermissionsExt;
+        let remote_repo = remote_root.path().join("test").join("repo.git");
+        let hooks_dir = remote_repo.join("hooks");
+        std::fs::create_dir_all(&hooks_dir).expect("Failed to create hooks dir");
+        let hook_path = hooks_dir.join("pre-receive");
+        std::fs::write(
+            &hook_path,
+            "#!/bin/sh\necho 'simulated push rejection' >&2\nexit 1\n",
+        )
+        .expect("Failed to write pre-receive hook");
+        let mut perms = std::fs::metadata(&hook_path)
+            .expect("Failed to read hook perms")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&hook_path, perms).expect("Failed to set hook perms");
+    }
+
+    /// Regression for #312: when the rebased remaining branch fails to push,
+    /// stax must NOT retarget the dependent PR base on GitHub. Doing so leaves
+    /// the PR pointing at a base the remote branch never adopted.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_merge_preserves_remaining_pr_base_when_push_fails() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        // Build a two-branch stack: pushfail-a (to merge), pushfail-b (remaining).
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "pushfail-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "pushfail-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        // Move back to branch_a so branch_b becomes a descendant outside the
+        // merge scope (the "remaining" branch path exercised by this test).
+        let checkout = git_with_env(&repo, home.path(), &["checkout", &branch_a]);
+        assert!(checkout.status.success(), "{}", TestRepo::stderr(&checkout));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/401",
+                    "id": 401,
+                    "number": 401,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_a, "sha": "sha-a", "label": format!("test:{}", branch_a) },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/402",
+                    "id": 402,
+                    "number": 402,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                    "base": { "ref": branch_a, "sha": "sha-a" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/401"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/401",
+                "id": 401,
+                "number": 401,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": branch_a, "sha": "sha-a", "label": format!("test:{}", branch_a) },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/402"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/402",
+                "id": 402,
+                "number": 402,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                "base": { "ref": branch_a, "sha": "sha-a" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // This PATCH must NOT be called when the remaining-branch push fails.
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/402"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/402",
+                "id": 402,
+                "number": 402,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/401/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        install_reject_all_pre_receive(&remote_root);
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let stdout = TestRepo::stdout(&merge_output);
+        assert!(
+            stdout.contains("push failed") && stdout.contains("PR base unchanged"),
+            "Expected push-failure surfacing in output. stdout was:\n{}",
+            stdout
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_402_calls = requests
+            .iter()
+            .filter(|r| {
+                r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/402"
+            })
+            .count();
+        assert_eq!(
+            patch_402_calls, 0,
+            "Expected PR #402 base NOT to be retargeted when push failed. Requests: {:?}",
+            requests
+                .iter()
+                .map(|r| format!("{} {}", r.method, r.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression for #312 (merge --when-ready variant): when the rebased
+    /// remaining branch fails to push, stax must NOT retarget the dependent
+    /// PR base on GitHub.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_merge_when_ready_preserves_remaining_pr_base_when_push_fails() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mwrpush-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mwrpush-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        let checkout = git_with_env(&repo, home.path(), &["checkout", &branch_a]);
+        assert!(checkout.status.success(), "{}", TestRepo::stderr(&checkout));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/501",
+                    "id": 501,
+                    "number": 501,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_a, "sha": "sha-a", "label": format!("test:{}", branch_a) },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/502",
+                    "id": 502,
+                    "number": 502,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                    "base": { "ref": branch_a, "sha": "sha-a" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/501"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/501",
+                "id": 501,
+                "number": 501,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": branch_a, "sha": "sha-a", "label": format!("test:{}", branch_a) },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/502"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/502",
+                "id": 502,
+                "number": 502,
+                "state": "open",
+                "draft": false,
+                "merged_at": null,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                "base": { "ref": branch_a, "sha": "sha-a" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // This PATCH must NOT be called when the remaining-branch push fails.
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/502"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/502",
+                "id": 502,
+                "number": 502,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                "base": { "ref": "main", "sha": "main-sha" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/501/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        install_reject_all_pre_receive(&remote_root);
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &[
+                "merge",
+                "--when-ready",
+                "--yes",
+                "--no-delete",
+                "--timeout",
+                "1",
+                "--interval",
+                "1",
+                "--no-sync",
+            ],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge-when-ready failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let stdout = TestRepo::stdout(&merge_output);
+        assert!(
+            stdout.contains("push failed") && stdout.contains("PR base unchanged"),
+            "Expected push-failure surfacing in output. stdout was:\n{}",
+            stdout
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_502_calls = requests
+            .iter()
+            .filter(|r| {
+                r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/502"
+            })
+            .count();
+        assert_eq!(
+            patch_502_calls, 0,
+            "Expected PR #502 base NOT to be retargeted when push failed. Requests: {:?}",
+            requests
+                .iter()
+                .map(|r| format!("{} {}", r.method, r.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Both merge flows retargeted dependent PR bases before confirming the rebased branch had been force-pushed, then discarded the push result. If the push was rejected (stale lease, auth, network), the forge kept the new base while the remote branch stayed on the old content — leaving the PR pointing at a relationship that never existed.

- Reorder the remaining-branch loop: push first, retarget only on success
- Surface push/retarget failures via the live-timer channel instead of silently ignoring them
- Extract `finalize_remaining_branch_push` helper so both merge flows stay in lock-step

Fixes #312.

## Test plan
- [x] `make test` — full suite passes (Docker Linux)
- [x] New regression tests install a `pre-receive` hook on the fake remote to reject the force-push and assert the dependent PR's base is never PATCHed
  - `test_merge_preserves_remaining_pr_base_when_push_fails`
  - `test_merge_when_ready_preserves_remaining_pr_base_when_push_fails`

🤖 Generated with [Claude Code](https://claude.com/claude-code)