### PR TITLE
fix(merge-when-ready): preserve remaining stack chain on rebase (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+- Merge (when-ready): Preserve the relative stack chain when rebasing remaining branches instead of flattening every descendant onto trunk (#311)
+
 ## [0.56.0] - 2026-04-21
 
 ### Changed

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -396,70 +396,22 @@ pub fn run(
         }
 
         for (idx, remaining) in scope.remaining.iter().enumerate() {
-            let parent_branch = if idx == 0 {
-                scope.trunk.clone()
+            let previous = if idx == 0 {
+                None
             } else {
-                scope.remaining[idx - 1].branch.clone()
+                Some(scope.remaining[idx - 1].branch.as_str())
             };
-            let parent_is_trunk = idx == 0;
-
-            let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching latest...");
-            let fetch_ok = fetch_remote_for_descendant_rebase(&repo, &remote_info.name)?;
-            if !fetch_ok {
-                LiveTimer::maybe_finish_warn(fetch_timer, "warning");
-            } else {
-                LiveTimer::maybe_finish_ok(fetch_timer, "done");
-            }
-
-            let remaining_timer = LiveTimer::maybe_new(
-                !quiet,
-                &format!("Rebasing {} onto {}...", remaining.branch, parent_branch),
-            );
-
-            let rebase_result = if parent_is_trunk {
-                rebase_descendant_onto_remote_trunk_with_provenance(
-                    &repo,
-                    &remaining.branch,
-                    &scope.trunk,
-                    &remote_info.name,
-                )
-            } else {
-                rebase_descendant_onto_parent_with_provenance(
-                    &repo,
-                    &remaining.branch,
-                    &parent_branch,
-                    &remote_info.name,
-                    false,
-                )
-            };
-
-            match rebase_result {
-                Ok(RebaseResult::Success) => {
-                    finalize_remaining_branch_push(
-                        &repo,
-                        &rt,
-                        &client,
-                        &remote_info.name,
-                        &remaining.branch,
-                        remaining.pr_number,
-                        &parent_branch,
-                        remaining_timer,
-                    )?;
-                }
-                Ok(RebaseResult::Conflict) => {
-                    let abort_dir = repo
-                        .branch_worktree_path(&remaining.branch)?
-                        .unwrap_or(repo.workdir()?.to_path_buf());
-                    let _ = Command::new("git")
-                        .args(["rebase", "--abort"])
-                        .current_dir(&abort_dir)
-                        .output();
-                    LiveTimer::maybe_finish_warn(remaining_timer, "conflict (skipped)");
-                }
-                Err(_) => {
-                    LiveTimer::maybe_finish_err(remaining_timer, "failed");
-                }
-            }
+            rebase_and_finalize_remaining_branch(
+                &repo,
+                &rt,
+                &client,
+                &remote_info.name,
+                &scope.trunk,
+                &remaining.branch,
+                remaining.pr_number,
+                previous,
+                quiet,
+            )?;
         }
     }
 
@@ -1011,7 +963,7 @@ fn wait_for_github_head_sync(
 
 /// Extract a concise, user-visible reason from `git push` stderr output.
 /// Returns the first non-empty line, or a generic fallback when stderr is empty.
-pub(crate) fn summarize_git_stderr(stderr: &[u8]) -> String {
+fn summarize_git_stderr(stderr: &[u8]) -> String {
     let text = String::from_utf8_lossy(stderr);
     text.lines()
         .map(|line| line.trim())
@@ -1024,11 +976,8 @@ pub(crate) fn summarize_git_stderr(stderr: &[u8]) -> String {
 /// PR base. Surfaces push or retarget failures via the supplied `LiveTimer`;
 /// on any failure the PR base is left pointing at the previous parent so the
 /// on-forge state cannot diverge from the remote branch contents.
-///
-/// Use this from the "remaining branches" rebase pass in both `merge` and
-/// `merge --when-ready`.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn finalize_remaining_branch_push(
+fn finalize_remaining_branch_push(
     repo: &GitRepo,
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
@@ -1067,6 +1016,87 @@ pub(crate) fn finalize_remaining_branch_push(
     }
 
     LiveTimer::maybe_finish_ok(timer, "done");
+    Ok(())
+}
+
+/// Fetch, rebase, push, and retarget a single remaining-stack branch while
+/// preserving the relative chain: when `previous_remaining` is `None` the
+/// branch rebases onto `trunk`, otherwise it rebases onto the preceding
+/// remaining branch so the stack topology stays intact.
+///
+/// Failures (fetch, rebase conflict, push rejection, retarget) are surfaced
+/// via live-timer messages but do not abort the outer loop — other remaining
+/// branches can still be processed.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn rebase_and_finalize_remaining_branch(
+    repo: &GitRepo,
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    remote_name: &str,
+    trunk: &str,
+    branch: &str,
+    pr_number: Option<u64>,
+    previous_remaining: Option<&str>,
+    quiet: bool,
+) -> Result<()> {
+    let parent_is_trunk = previous_remaining.is_none();
+    let parent_branch = previous_remaining
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| trunk.to_string());
+
+    let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching latest...");
+    let fetch_ok = fetch_remote_for_descendant_rebase(repo, remote_name)?;
+    if !fetch_ok {
+        LiveTimer::maybe_finish_warn(fetch_timer, "warning");
+    } else {
+        LiveTimer::maybe_finish_ok(fetch_timer, "done");
+    }
+
+    let remaining_timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!("Rebasing {} onto {}...", branch, parent_branch),
+    );
+
+    let rebase_result = if parent_is_trunk {
+        rebase_descendant_onto_remote_trunk_with_provenance(repo, branch, trunk, remote_name)
+    } else {
+        rebase_descendant_onto_parent_with_provenance(
+            repo,
+            branch,
+            &parent_branch,
+            remote_name,
+            false,
+        )
+    };
+
+    match rebase_result {
+        Ok(RebaseResult::Success) => {
+            finalize_remaining_branch_push(
+                repo,
+                rt,
+                client,
+                remote_name,
+                branch,
+                pr_number,
+                &parent_branch,
+                remaining_timer,
+            )?;
+        }
+        Ok(RebaseResult::Conflict) => {
+            let abort_dir = repo
+                .branch_worktree_path(branch)?
+                .unwrap_or(repo.workdir()?.to_path_buf());
+            let _ = Command::new("git")
+                .args(["rebase", "--abort"])
+                .current_dir(&abort_dir)
+                .output();
+            LiveTimer::maybe_finish_warn(remaining_timer, "conflict (skipped)");
+        }
+        Err(_) => {
+            LiveTimer::maybe_finish_err(remaining_timer, "failed");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -1,5 +1,5 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
-use crate::commands::merge::{finalize_remaining_branch_push, sync_head_after_push};
+use crate::commands::merge::{rebase_and_finalize_remaining_branch, sync_head_after_push};
 use crate::commands::merge_rebase::{
     fetch_remote_for_descendant_rebase, rebase_descendant_onto_remote_trunk_with_provenance,
 };
@@ -420,59 +420,33 @@ pub fn run(
         }
     }
 
-    // Rebase branches above the merge scope to keep descendant PRs open and correctly based.
+    // Rebase branches above the merge scope while preserving their relative
+    // stack chain. The first remaining branch rebases onto trunk; each
+    // subsequent branch rebases onto the previous remaining branch so PR
+    // topology and diff sizes stay stable across `merge --when-ready`.
     if !merged_prs.is_empty() && !remaining_branches.is_empty() && failed_pr.is_none() {
         if !quiet {
             println!();
             println!("{}", "Rebasing remaining stack branches...".dimmed());
         }
 
-        for remaining in &remaining_branches {
-            let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching latest...");
-            let fetch_ok = fetch_remote_for_descendant_rebase(&repo, &remote_info.name)?;
-            if !fetch_ok {
-                LiveTimer::maybe_finish_warn(fetch_timer, "warning");
+        for (idx, remaining) in remaining_branches.iter().enumerate() {
+            let previous = if idx == 0 {
+                None
             } else {
-                LiveTimer::maybe_finish_ok(fetch_timer, "done");
-            }
-
-            let remaining_timer =
-                LiveTimer::maybe_new(!quiet, &format!("Rebasing {}...", remaining.branch));
-
-            let rebase_result = rebase_descendant_onto_remote_trunk_with_provenance(
+                Some(remaining_branches[idx - 1].branch.as_str())
+            };
+            rebase_and_finalize_remaining_branch(
                 &repo,
-                &remaining.branch,
-                &scope.trunk,
+                &rt,
+                &client,
                 &remote_info.name,
-            );
-
-            match rebase_result {
-                Ok(RebaseResult::Success) => {
-                    finalize_remaining_branch_push(
-                        &repo,
-                        &rt,
-                        &client,
-                        &remote_info.name,
-                        &remaining.branch,
-                        remaining.pr_number,
-                        &scope.trunk,
-                        remaining_timer,
-                    )?;
-                }
-                Ok(RebaseResult::Conflict) => {
-                    let abort_dir = repo
-                        .branch_worktree_path(&remaining.branch)?
-                        .unwrap_or(repo.workdir()?.to_path_buf());
-                    let _ = Command::new("git")
-                        .args(["rebase", "--abort"])
-                        .current_dir(&abort_dir)
-                        .output();
-                    LiveTimer::maybe_finish_warn(remaining_timer, "conflict (skipped)");
-                }
-                Err(_) => {
-                    LiveTimer::maybe_finish_err(remaining_timer, "failed");
-                }
-            }
+                &scope.trunk,
+                &remaining.branch,
+                remaining.pr_number,
+                previous,
+                quiet,
+            )?;
         }
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10064,4 +10064,193 @@ mod forge_mock_tests {
                 .collect::<Vec<_>>()
         );
     }
+
+    /// Regression for #311: `merge --when-ready` must preserve the relative
+    /// stack chain of remaining branches rather than flattening every
+    /// descendant onto trunk. For a stack `main <- a <- b <- c <- d`, merging
+    /// `a` and `b` should leave `c` based on `main` and `d` based on `c`.
+    #[tokio::test]
+    async fn test_merge_when_ready_preserves_remaining_chain() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        // Build a four-branch stack and push each to the fake remote.
+        let mut branches: Vec<String> = Vec::new();
+        for name in ["chain-a", "chain-b", "chain-c", "chain-d"] {
+            let output = run_stax_with_env(&repo, home.path(), &["bc", name]);
+            assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+            let branch = repo.current_branch();
+            let filename = format!("{}.txt", name);
+            repo.create_file(&filename, &format!("{} content\n", name));
+            repo.commit(&format!("{} commit", name));
+            let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch]);
+            assert!(push.status.success(), "{}", TestRepo::stderr(&push));
+            branches.push(branch);
+        }
+        let branch_a = branches[0].clone();
+        let branch_b = branches[1].clone();
+        let branch_c = branches[2].clone();
+        let branch_d = branches[3].clone();
+
+        // Run merge --when-ready from branch_b so a+b are merged and c+d are
+        // the remaining chain that needs rebasing.
+        let checkout = git_with_env(&repo, home.path(), &["checkout", &branch_b]);
+        assert!(checkout.status.success(), "{}", TestRepo::stderr(&checkout));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/601",
+                    "id": 601,
+                    "number": 601,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_a, "sha": "sha-a", "label": format!("test:{}", branch_a) },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/602",
+                    "id": 602,
+                    "number": 602,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_b, "sha": "sha-b", "label": format!("test:{}", branch_b) },
+                    "base": { "ref": branch_a, "sha": "sha-a" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/603",
+                    "id": 603,
+                    "number": 603,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_c, "sha": "sha-c", "label": format!("test:{}", branch_c) },
+                    "base": { "ref": branch_b, "sha": "sha-b" }
+                },
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/604",
+                    "id": 604,
+                    "number": 604,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": branch_d, "sha": "sha-d", "label": format!("test:{}", branch_d) },
+                    "base": { "ref": branch_c, "sha": "sha-c" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        for (pr_id, head_ref, head_sha, base_ref, base_sha) in [
+            (601u64, &branch_a, "sha-a", "main", "main-sha"),
+            (602u64, &branch_b, "sha-b", &branch_a, "sha-a"),
+            (603u64, &branch_c, "sha-c", &branch_b, "sha-b"),
+            (604u64, &branch_d, "sha-d", &branch_c, "sha-c"),
+        ] {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/test/repo/pulls/{}", pr_id)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "url": format!("https://api.github.com/repos/test/repo/pulls/{}", pr_id),
+                    "id": pr_id,
+                    "number": pr_id,
+                    "state": "open",
+                    "draft": false,
+                    "merged_at": null,
+                    "mergeable": true,
+                    "mergeable_state": "clean",
+                    "head": { "ref": head_ref, "sha": head_sha, "label": format!("test:{}", head_ref) },
+                    "base": { "ref": base_ref, "sha": base_sha }
+                })))
+                .mount(&mock_server)
+                .await;
+        }
+
+        // Accept PATCH retargets on any of the remaining PRs — the assertion
+        // below inspects the body to verify each got the correct new base.
+        for pr_id in [602u64, 603, 604] {
+            Mock::given(method("PATCH"))
+                .and(path(format!("/repos/test/repo/pulls/{}", pr_id)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "url": format!("https://api.github.com/repos/test/repo/pulls/{}", pr_id),
+                    "id": pr_id,
+                    "number": pr_id,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": "placeholder", "sha": "placeholder", "label": "test:placeholder" },
+                    "base": { "ref": "main", "sha": "main-sha" }
+                })))
+                .mount(&mock_server)
+                .await;
+        }
+
+        for pr_id in [601u64, 602] {
+            Mock::given(method("PUT"))
+                .and(path(format!("/repos/test/repo/pulls/{}/merge", pr_id)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "sha": format!("merge-{}-commit", pr_id),
+                    "merged": true,
+                    "message": "Pull Request successfully merged"
+                })))
+                .mount(&mock_server)
+                .await;
+        }
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &[
+                "merge",
+                "--when-ready",
+                "--yes",
+                "--no-delete",
+                "--timeout",
+                "1",
+                "--interval",
+                "1",
+                "--no-sync",
+            ],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge-when-ready failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+
+        // Find the PATCH request for PR #603 (c) — it should retarget to main.
+        let patch_603 = requests
+            .iter()
+            .find(|r| {
+                r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/603"
+            })
+            .expect("PR #603 should have been retargeted");
+        let payload_603: serde_json::Value = serde_json::from_slice(&patch_603.body).unwrap();
+        assert_eq!(
+            payload_603["base"], "main",
+            "PR #603 (branch c) must be retargeted to main"
+        );
+
+        // Find the PATCH request for PR #604 (d) — it must retarget to branch c,
+        // NOT to main (the regression #311 was flattening this to main).
+        let patch_604 = requests
+            .iter()
+            .find(|r| {
+                r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/604"
+            })
+            .expect("PR #604 should have been retargeted");
+        let payload_604: serde_json::Value = serde_json::from_slice(&patch_604.body).unwrap();
+        assert_eq!(
+            payload_604["base"], branch_c,
+            "PR #604 (branch d) must keep its base on branch c, not flatten to trunk"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
`merge --when-ready` rebased every remaining descendant onto trunk and updated each PR base to trunk, flattening stacks of the form `main <- a <- b <- c <- d` into `main <- c` + `main <- d` whenever `a` and `b` merged. The regular `merge` already walked the remaining list chain-wise; mirror that logic so the topology (and the PR diff size) of higher branches stays stable.

- Walk remaining branches chain-wise in `merge --when-ready` (first → trunk, then each onto previous remaining)
- Extract `rebase_and_finalize_remaining_branch` shared helper; both merge flows now share the full fetch + rebase + push + retarget sequence
- Add integration test asserting \`PR_d.base == branch_c\` (not flattened to trunk)

Fixes #311.

**Note:** stacked on top of #312 (#317). Rebase onto main once #312 merges.

## Test plan
- [x] `make test` — full suite passes (Docker Linux)
- [x] New test: `test_merge_when_ready_preserves_remaining_chain` builds a 4-branch stack, merges the lower two, and verifies remaining PRs retarget to their previous remaining branch rather than flattening onto trunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)