### PR TITLE
[codex] Add verbose refresh/restack timing diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ st config --set-ai
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st refresh` | Sync trunk, restack current stack, then push/update PRs |
+| `st refresh --verbose` | Include detailed sync/restack/submit timing |
 | `st restack` | Rebase current stack onto parents locally |
 | `st cascade` | Restack + push + open/update PRs |
 | `st split` | Split a branch into stacked branches (by commit or `--hunk`) |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -31,6 +31,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
 | `st refresh` | `sync --restack` **plus** push and update PRs |
+| `st refresh --verbose` | Same as `st refresh`, with detailed sync/restack/submit timing |
 
 ## Navigation and recovery
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -16,6 +16,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
 | `st refresh` | | `sync --restack`, then push and create/update PRs for the current stack |
+| `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
 | `st restack` | | Rebase current stack locally — auto-normalizes missing/merged parents; `--stop-here` limits scope |
 | `st cascade` | | Restack from bottom and submit updates |
 | `st diff` | | Show per-branch diffs vs parent |

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -95,3 +95,4 @@ The "bottom PR merged, catch me up" command. Prints the plan up front, then runs
 | `st refresh --no-pr` | sync → restack → push |
 | `st refresh --no-submit` | sync → restack |
 | `st refresh --force` | force the sync step instead of prompting |
+| `st refresh --verbose` | show detailed sync/restack/submit timing |

--- a/skills.md
+++ b/skills.md
@@ -222,6 +222,7 @@ stax refresh                       # Sync, restack, then submit
 stax refresh --no-pr               # Push only after sync/restack
 stax refresh --no-submit           # Sync/restack only
 stax refresh --force               # Force sync without prompts first
+stax refresh --verbose             # Show detailed sync/restack/submit timings
 
 stax restack                       # Restack current branch onto parent
 stax restack --all                 # Restack whole stack

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -385,6 +385,9 @@ enum Commands {
         /// Avoid hard reset when updating trunk
         #[arg(long)]
         safe: bool,
+        /// Show detailed sync/restack/submit timing
+        #[arg(long)]
+        verbose: bool,
         /// Auto-stash and auto-pop dirty target worktrees during sync/restack
         #[arg(long)]
         auto_stash_pop: bool,
@@ -1760,8 +1763,9 @@ pub fn run() -> Result<()> {
             no_submit,
             force,
             safe,
+            verbose,
             auto_stash_pop,
-        } => commands::refresh::run(no_pr, no_submit, force, safe, auto_stash_pop),
+        } => commands::refresh::run(no_pr, no_submit, force, safe, verbose, auto_stash_pop),
         Commands::Checkout {
             branch,
             pr,

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -8,6 +8,7 @@ pub fn run(
     no_submit: bool,
     force: bool,
     safe: bool,
+    verbose: bool,
     auto_stash_pop: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
@@ -35,7 +36,7 @@ pub fn run(
         safe,
         false, // continue
         false, // quiet
-        false, // verbose
+        verbose,
         auto_stash_pop,
     )?;
 
@@ -61,14 +62,14 @@ pub fn run(
         vec![], // assignees
         false,  // quiet
         false,  // open
-        false,  // verbose
-        None,   // template
-        false,  // no_template
-        false,  // edit
-        false,  // ai_body
-        false,  // rerequest_review
-        false,  // squash
-        false,  // update_title
+        verbose,
+        None,  // template
+        false, // no_template
+        false, // edit
+        false, // ai_body
+        false, // rerequest_review
+        false, // squash
+        false, // update_title
     )?;
 
     restore_original_branch(&repo, &workdir, &original)

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -10,7 +10,7 @@ use crate::engine::{BranchMetadata, Stack};
 use crate::errors::ConflictStopped;
 use crate::forge::ForgeClient;
 use crate::git::repo::BranchDeleteResolution;
-use crate::git::{GitRepo, RebaseResult};
+use crate::git::{GitRepo, RebaseResult, RebaseTimings};
 use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
@@ -28,6 +28,19 @@ struct SyncStats {
     trunk: Option<TrunkSummary>,
     merged_branches_cleaned: usize,
     restacked_branches: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RestackBranchTiming {
+    branch: String,
+    rebase_timings: RebaseTimings,
+    metadata_update: Duration,
+}
+
+impl RestackBranchTiming {
+    fn total(&self) -> Duration {
+        self.rebase_timings.total() + self.metadata_update
+    }
 }
 
 #[derive(Debug)]
@@ -113,6 +126,7 @@ pub fn run(
 ) -> Result<()> {
     let sync_started_at = Instant::now();
     let mut step_timings: Vec<(String, Duration)> = Vec::new();
+    let mut restack_branch_timings: Vec<RestackBranchTiming> = Vec::new();
     let mut stats = SyncStats::default();
 
     let repo = GitRepo::open()?;
@@ -1220,29 +1234,49 @@ pub fn run(
                     None => continue,
                 };
 
-                match repo.rebase_branch_onto_with_provenance(
+                let rebase = repo.rebase_branch_onto_with_provenance_timing(
                     branch,
                     &meta.parent_branch_name,
                     &meta.parent_branch_revision,
                     auto_stash_pop,
-                )? {
+                )?;
+
+                match rebase.result {
                     RebaseResult::Success => {
+                        let metadata_update_started_at = Instant::now();
                         let parent_commit = repo.branch_commit(&meta.parent_branch_name)?;
                         let updated_meta = BranchMetadata {
                             parent_branch_revision: parent_commit,
                             ..meta
                         };
                         updated_meta.write(repo.inner(), branch)?;
+                        let metadata_update = metadata_update_started_at.elapsed();
 
                         // Record after-OID
                         tx.record_after(&repo, branch)?;
                         tx.push_completed_branch(branch);
+
+                        if verbose {
+                            restack_branch_timings.push(RestackBranchTiming {
+                                branch: branch.clone(),
+                                rebase_timings: rebase.timings,
+                                metadata_update,
+                            });
+                        }
 
                         LiveTimer::maybe_finish_timed(restack_timer);
                         restacked_branches += 1;
                         summary.push((branch.clone(), "ok".to_string()));
                     }
                     RebaseResult::Conflict => {
+                        if verbose {
+                            restack_branch_timings.push(RestackBranchTiming {
+                                branch: branch.clone(),
+                                rebase_timings: rebase.timings,
+                                metadata_update: Duration::ZERO,
+                            });
+                        }
+
                         LiveTimer::maybe_finish_warn(restack_timer, "conflict");
                         let completed_branches: Vec<String> = summary
                             .iter()
@@ -1319,6 +1353,7 @@ pub fn run(
         for (step, duration) in &step_timings {
             println!("  {:<35} {}", step, format_duration(*duration).dimmed());
         }
+        print_restack_branch_timings(&restack_branch_timings);
         println!(
             "  {:<35} {}",
             "total",
@@ -2117,6 +2152,61 @@ fn record_ci_history_for_merged(
 
 fn format_duration(duration: Duration) -> String {
     format!("{:.3}s", duration.as_secs_f64())
+}
+
+fn print_restack_branch_timings(restack_branch_timings: &[RestackBranchTiming]) {
+    for timing in restack_branch_timings {
+        println!(
+            "  {}",
+            format!("restack branch {}", timing.branch).bright_cyan()
+        );
+        println!(
+            "    {:<31} {}",
+            "worktree prep",
+            format_duration(timing.rebase_timings.prepare_context).dimmed()
+        );
+        println!(
+            "    {:<31} {}",
+            "dirty check",
+            format_duration(timing.rebase_timings.dirty_check).dimmed()
+        );
+        if !timing.rebase_timings.auto_stash_push.is_zero() {
+            println!(
+                "    {:<31} {}",
+                "auto-stash push",
+                format_duration(timing.rebase_timings.auto_stash_push).dimmed()
+            );
+        }
+        println!(
+            "    {:<31} {}",
+            "provenance scan",
+            format_duration(timing.rebase_timings.provenance_scan).dimmed()
+        );
+        println!(
+            "    {:<31} {}",
+            "git rebase",
+            format_duration(timing.rebase_timings.git_rebase).dimmed()
+        );
+        if !timing.rebase_timings.auto_stash_pop.is_zero() {
+            println!(
+                "    {:<31} {}",
+                "auto-stash pop",
+                format_duration(timing.rebase_timings.auto_stash_pop).dimmed()
+            );
+        }
+        if !timing.metadata_update.is_zero() {
+            println!(
+                "    {:<31} {}",
+                "metadata update",
+                format_duration(timing.metadata_update).dimmed()
+            );
+        }
+        println!(
+            "    {:<31} {}",
+            "branch total",
+            format_duration(timing.total()).dimmed()
+        );
+    }
 }
 
 fn render_sync_footer(stats: &SyncStats, total_duration: Duration) -> String {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,4 @@
 pub mod refs;
 pub mod repo;
 
-pub use repo::{checkout_branch_in, local_branch_exists_in, GitRepo, RebaseResult};
+pub use repo::{checkout_branch_in, local_branch_exists_in, GitRepo, RebaseResult, RebaseTimings};

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output};
+use std::time::{Duration, Instant};
 
 pub struct GitRepo {
     repo: Repository,
@@ -1138,10 +1139,34 @@ impl GitRepo {
         fallback_upstream: &str,
         auto_stash_pop: bool,
     ) -> Result<RebaseResult> {
+        Ok(self
+            .rebase_branch_onto_with_provenance_timing(
+                branch,
+                onto,
+                fallback_upstream,
+                auto_stash_pop,
+            )?
+            .result)
+    }
+
+    pub fn rebase_branch_onto_with_provenance_timing(
+        &self,
+        branch: &str,
+        onto: &str,
+        fallback_upstream: &str,
+        auto_stash_pop: bool,
+    ) -> Result<RebaseOutcome> {
+        let mut timings = RebaseTimings::default();
+
+        let prepare_started_at = Instant::now();
         let (_current_workdir, target_workdir) = self.prepare_branch_rebase_context(branch)?;
+        timings.prepare_context = prepare_started_at.elapsed();
 
         let mut stashed = false;
-        if self.is_dirty_at(&target_workdir)? {
+        let dirty_check_started_at = Instant::now();
+        let target_is_dirty = self.is_dirty_at(&target_workdir)?;
+        timings.dirty_check = dirty_check_started_at.elapsed();
+        if target_is_dirty {
             if !auto_stash_pop {
                 anyhow::bail!(
                     "Cannot restack '{}': worktree '{}' has uncommitted changes. \
@@ -1150,9 +1175,12 @@ Use --auto-stash-pop or stash/commit changes first.",
                     target_workdir.display()
                 );
             }
+            let auto_stash_push_started_at = Instant::now();
             stashed = self.stash_push_at(&target_workdir)?;
+            timings.auto_stash_push = auto_stash_push_started_at.elapsed();
         }
 
+        let provenance_started_at = Instant::now();
         let can_use_fallback_upstream = !fallback_upstream.trim().is_empty()
             && self.is_ancestor(fallback_upstream, branch).unwrap_or(false);
         let inferred_upstream = self
@@ -1163,7 +1191,9 @@ Use --auto-stash-pop or stash/commit changes first.",
         } else {
             None
         };
+        timings.provenance_scan = provenance_started_at.elapsed();
 
+        let git_rebase_started_at = Instant::now();
         let rebase_result = if let Some(upstream) = upstream_for_rebase.as_deref() {
             self.rebase_onto_upstream_in_path(&target_workdir, onto, upstream)
                 .with_context(|| {
@@ -1185,6 +1215,7 @@ Use --auto-stash-pop or stash/commit changes first.",
                 )
             })
         };
+        timings.git_rebase = git_rebase_started_at.elapsed();
 
         let result = match rebase_result {
             Ok(result) => result,
@@ -1200,6 +1231,7 @@ Use --auto-stash-pop or stash/commit changes first.",
         };
 
         if stashed && result == RebaseResult::Success {
+            let auto_stash_pop_started_at = Instant::now();
             self.stash_pop_at(&target_workdir).with_context(|| {
                 format!(
                     "Rebased '{}' successfully, but failed to auto-pop stash in '{}'",
@@ -1207,9 +1239,10 @@ Use --auto-stash-pop or stash/commit changes first.",
                     target_workdir.display()
                 )
             })?;
+            timings.auto_stash_pop = auto_stash_pop_started_at.elapsed();
         }
 
-        Ok(result)
+        Ok(RebaseOutcome { result, timings })
     }
 
     /// Rebase current branch onto target
@@ -2042,10 +2075,37 @@ Use --auto-stash-pop or stash/commit changes first.",
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RebaseResult {
     Success,
     Conflict,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RebaseTimings {
+    pub prepare_context: Duration,
+    pub dirty_check: Duration,
+    pub auto_stash_push: Duration,
+    pub provenance_scan: Duration,
+    pub git_rebase: Duration,
+    pub auto_stash_pop: Duration,
+}
+
+impl RebaseTimings {
+    pub fn total(&self) -> Duration {
+        self.prepare_context
+            + self.dirty_check
+            + self.auto_stash_push
+            + self.provenance_scan
+            + self.git_rebase
+            + self.auto_stash_pop
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RebaseOutcome {
+    pub result: RebaseResult,
+    pub timings: RebaseTimings,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -230,6 +230,7 @@ fn test_refresh_help() {
     assert!(stdout.contains("no-submit"));
     assert!(stdout.contains("force"));
     assert!(stdout.contains("safe"));
+    assert!(stdout.contains("verbose"));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2362,6 +2362,44 @@ fn test_refresh_no_submit_keeps_original_branch_and_restacks_stack() {
 }
 
 #[test]
+fn test_refresh_verbose_shows_restack_timing_breakdown() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "refresh-verbose"]);
+    let branch = repo.current_branch();
+    repo.create_file("refresh.txt", "refresh");
+    repo.commit("refresh commit");
+    repo.git(&["push", "-u", "origin", &branch]);
+
+    repo.simulate_remote_commit("main-update.txt", "main update", "main update");
+
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force", "--verbose"]);
+    assert!(
+        output.status.success(),
+        "refresh --verbose failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Sync timing summary:"),
+        "Expected sync timing summary, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("restack branch {}", branch)),
+        "Expected restack branch timing breakdown, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("git rebase"),
+        "Expected git rebase timing detail, got: {}",
+        stdout
+    );
+}
+
+#[test]
 fn test_refresh_no_pr_pushes_current_stack() {
     let repo = TestRepo::new_with_remote();
     configure_submit_remote(&repo);
@@ -2945,6 +2983,43 @@ fn test_sync_with_restack_flag() {
     // Remote file should be accessible (after restack onto updated main)
     repo.run_stax(&["checkout", &feature_branch]);
     // The remote.txt should be in our history now
+}
+
+#[test]
+fn test_sync_verbose_restack_shows_branch_timing_breakdown() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-restack-verbose"]);
+    let feature_branch = repo.current_branch();
+    repo.create_file("feature.txt", "feature");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", &feature_branch]);
+
+    repo.simulate_remote_commit("remote.txt", "content", "Remote update");
+
+    let output = repo.run_stax(&["sync", "--restack", "--force", "--verbose"]);
+    assert!(
+        output.status.success(),
+        "Failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains(&format!("restack branch {}", feature_branch)),
+        "Expected verbose restack branch timing header, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("provenance scan"),
+        "Expected provenance timing in verbose restack output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("git rebase"),
+        "Expected git rebase timing in verbose restack output, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -9811,7 +9886,8 @@ mod forge_mock_tests {
             })
             .count();
         assert_eq!(
-            patch_402_calls, 0,
+            patch_402_calls,
+            0,
             "Expected PR #402 base NOT to be retargeted when push failed. Requests: {:?}",
             requests
                 .iter()
@@ -9979,7 +10055,8 @@ mod forge_mock_tests {
             })
             .count();
         assert_eq!(
-            patch_502_calls, 0,
+            patch_502_calls,
+            0,
             "Expected PR #502 base NOT to be retargeted when push failed. Requests: {:?}",
             requests
                 .iter()


### PR DESCRIPTION
## Summary
- add per-branch restack timing diagnostics to `sync --restack --verbose`, including worktree prep, provenance scan, `git rebase`, metadata update, and branch totals
- add `st refresh --verbose` and forward verbose output through both the sync and submit phases so the same diagnostics are available from the higher-level workflow
- document the new `refresh --verbose` entrypoint in the README, command docs, workflow guide, and `skills.md`

## Why
A recent user report showed `st refresh` spending 13 minutes in restack with no way to tell whether the time was going into stax preflight or the underlying `git rebase`. The follow-up trace showed the need more clearly: users need first-class timing breakdowns from the normal `refresh` path, not just from `sync`.

## User Impact
Users can now run `st sync --restack --verbose` or `st refresh --verbose` and immediately see whether a slow restack is dominated by provenance scanning, the actual rebase, or smaller setup work.

## Test Plan
- `cargo test test_refresh_help --test cli_tests`
- `cargo test test_refresh_verbose_shows_restack_timing_breakdown --test integration_tests`
- `cargo test test_refresh_no_submit_keeps_original_branch_and_restacks_stack --test integration_tests`
- `cargo test test_refresh_no_pr_pushes_current_stack --test integration_tests`
- `cargo test test_sync_verbose_restack_shows_branch_timing_breakdown --test integration_tests`
- `cargo test test_sync_verbose_shows_step_timing_summary --test integration_tests`
