### PR TITLE
feat(refresh): support non-interactive submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ st ss
 
 # 4. After the bottom PR merges on GitHub…
 st refresh         # sync trunk, restack this stack, update PRs
+st refresh --yes --no-prompt  # run the full refresh flow non-interactively
 ```
 
 Picked the wrong trunk? Run `st trunk main` or `st init --trunk <branch>` to reconfigure.
@@ -252,6 +253,7 @@ st config --set-ai
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st refresh` | Sync trunk, restack current stack, then push/update PRs |
+| `st refresh --yes --no-prompt` | Run refresh without submit title/body/draft prompts |
 | `st refresh --verbose` | Include detailed sync/restack/submit timing |
 | `st restack` | Rebase current stack onto parents locally |
 | `st cascade` | Restack + push + open/update PRs |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ st ss
 
 # 4. After the bottom PR merges on GitHub…
 st refresh         # sync trunk, restack this stack, update PRs
-st refresh --yes --no-prompt  # run the full refresh flow non-interactively
+st refresh --force --yes --no-prompt  # same flow without prompts
 ```
 
 Picked the wrong trunk? Run `st trunk main` or `st init --trunk <branch>` to reconfigure.
@@ -253,7 +253,7 @@ st config --set-ai
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st refresh` | Sync trunk, restack current stack, then push/update PRs |
-| `st refresh --yes --no-prompt` | Run refresh without submit title/body/draft prompts |
+| `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |
 | `st refresh --verbose` | Include detailed sync/restack/submit timing |
 | `st restack` | Rebase current stack onto parents locally |
 | `st cascade` | Restack + push + open/update PRs |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -31,6 +31,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
 | `st refresh` | `sync --restack` **plus** push and update PRs |
+| `st refresh --yes --no-prompt` | Full refresh flow without submit title/body/draft prompts |
 | `st refresh --verbose` | Same as `st refresh`, with detailed sync/restack/submit timing |
 
 ## Navigation and recovery

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -31,7 +31,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
 | `st refresh` | `sync --restack` **plus** push and update PRs |
-| `st refresh --yes --no-prompt` | Full refresh flow without submit title/body/draft prompts |
+| `st refresh --force --yes --no-prompt` | Full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | Same as `st refresh`, with detailed sync/restack/submit timing |
 
 ## Navigation and recovery

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -16,6 +16,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
 | `st refresh` | | `sync --restack`, then push and create/update PRs for the current stack |
+| `st refresh --yes --no-prompt` | | Run the full refresh flow without submit title/body/draft prompts |
 | `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
 | `st restack` | | Rebase current stack locally — auto-normalizes missing/merged parents; `--stop-here` limits scope |
 | `st cascade` | | Restack from bottom and submit updates |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -16,7 +16,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
 | `st refresh` | | `sync --restack`, then push and create/update PRs for the current stack |
-| `st refresh --yes --no-prompt` | | Run the full refresh flow without submit title/body/draft prompts |
+| `st refresh --force --yes --no-prompt` | | Run the full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
 | `st restack` | | Rebase current stack locally — auto-normalizes missing/merged parents; `--stop-here` limits scope |
 | `st cascade` | | Restack from bottom and submit updates |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -45,7 +45,7 @@ st ss
 # After the bottom PR merges on GitHub, catch up in one shot:
 st rs --restack    # pull trunk, clean merged, rebase the rest
 # or: st refresh    # sync + restack + push/update PRs in one command
-# scripts: st refresh --yes --no-prompt
+# scripts: st refresh --force --yes --no-prompt
 ```
 
 Picked the wrong trunk? `st trunk main` or `st init --trunk <branch>` reconfigures.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -45,6 +45,7 @@ st ss
 # After the bottom PR merges on GitHub, catch up in one shot:
 st rs --restack    # pull trunk, clean merged, rebase the rest
 # or: st refresh    # sync + restack + push/update PRs in one command
+# scripts: st refresh --yes --no-prompt
 ```
 
 Picked the wrong trunk? `st trunk main` or `st init --trunk <branch>` reconfigures.

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -95,5 +95,5 @@ The "bottom PR merged, catch me up" command. Prints the plan up front, then runs
 | `st refresh --no-pr` | sync → restack → push |
 | `st refresh --no-submit` | sync → restack |
 | `st refresh --force` | force the sync step instead of prompting |
-| `st refresh --yes --no-prompt` | run the full sync/restack/submit flow without submit prompts |
+| `st refresh --force --yes --no-prompt` | run the full sync/restack/submit flow without prompts |
 | `st refresh --verbose` | show detailed sync/restack/submit timing |

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -95,4 +95,5 @@ The "bottom PR merged, catch me up" command. Prints the plan up front, then runs
 | `st refresh --no-pr` | sync → restack → push |
 | `st refresh --no-submit` | sync → restack |
 | `st refresh --force` | force the sync step instead of prompting |
+| `st refresh --yes --no-prompt` | run the full sync/restack/submit flow without submit prompts |
 | `st refresh --verbose` | show detailed sync/restack/submit timing |

--- a/skills.md
+++ b/skills.md
@@ -222,6 +222,7 @@ stax refresh                       # Sync, restack, then submit
 stax refresh --no-pr               # Push only after sync/restack
 stax refresh --no-submit           # Sync/restack only
 stax refresh --force               # Force sync without prompts first
+stax refresh --yes --no-prompt     # Full refresh without submit prompts
 stax refresh --verbose             # Show detailed sync/restack/submit timings
 
 stax restack                       # Restack current branch onto parent

--- a/skills.md
+++ b/skills.md
@@ -222,7 +222,7 @@ stax refresh                       # Sync, restack, then submit
 stax refresh --no-pr               # Push only after sync/restack
 stax refresh --no-submit           # Sync/restack only
 stax refresh --force               # Force sync without prompts first
-stax refresh --yes --no-prompt     # Full refresh without submit prompts
+stax refresh --force --yes --no-prompt # Full refresh without sync/submit prompts
 stax refresh --verbose             # Show detailed sync/restack/submit timings
 
 stax restack                       # Restack current branch onto parent

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -388,6 +388,12 @@ enum Commands {
         /// Show detailed sync/restack/submit timing
         #[arg(long)]
         verbose: bool,
+        /// Accept submit defaults without confirmation
+        #[arg(short, long)]
+        yes: bool,
+        /// Use submit defaults instead of prompting for PR details
+        #[arg(long)]
+        no_prompt: bool,
         /// Auto-stash and auto-pop dirty target worktrees during sync/restack
         #[arg(long)]
         auto_stash_pop: bool,
@@ -1764,8 +1770,19 @@ pub fn run() -> Result<()> {
             force,
             safe,
             verbose,
+            yes,
+            no_prompt,
             auto_stash_pop,
-        } => commands::refresh::run(no_pr, no_submit, force, safe, verbose, auto_stash_pop),
+        } => commands::refresh::run(
+            no_pr,
+            no_submit,
+            force,
+            safe,
+            verbose,
+            yes,
+            no_prompt,
+            auto_stash_pop,
+        ),
         Commands::Checkout {
             branch,
             pr,

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -9,6 +9,8 @@ pub fn run(
     force: bool,
     safe: bool,
     verbose: bool,
+    yes: bool,
+    no_prompt: bool,
     auto_stash_pop: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
@@ -50,13 +52,13 @@ pub fn run(
 
     commands::submit::run(
         commands::submit::SubmitScope::Stack,
-        false,  // draft
-        false,  // publish
-        no_pr,  // no_pr
-        false,  // no_fetch
-        false,  // force
-        false,  // yes
-        false,  // no_prompt
+        false, // draft
+        false, // publish
+        no_pr, // no_pr
+        false, // no_fetch
+        false, // force
+        yes,
+        no_prompt,
         vec![], // reviewers
         vec![], // labels
         vec![], // assignees

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -231,6 +231,8 @@ fn test_refresh_help() {
     assert!(stdout.contains("force"));
     assert!(stdout.contains("safe"));
     assert!(stdout.contains("verbose"));
+    assert!(stdout.contains("--yes"));
+    assert!(stdout.contains("--no-prompt"));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6808,10 +6808,14 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
-        let output = run_stax_with_env(&repo, home.path(), &["refresh", "--yes", "--no-prompt"]);
+        let output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["refresh", "--force", "--yes", "--no-prompt"],
+        );
         assert!(
             output.status.success(),
-            "refresh --yes --no-prompt failed\nstdout: {}\nstderr: {}",
+            "refresh --force --yes --no-prompt failed\nstdout: {}\nstderr: {}",
             TestRepo::stdout(&output),
             TestRepo::stderr(&output)
         );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6743,6 +6743,94 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
+    async fn test_refresh_yes_no_prompt_creates_pr_on_mock_github() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_submit(home.path(), &mock_server.uri(), Some("off"));
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "refresh-non-interactive"]);
+        assert!(
+            output.status.success(),
+            "Failed to create branch: {}",
+            TestRepo::stderr(&output)
+        );
+
+        repo.create_file("feature.txt", "content\n");
+        repo.commit("Feature commit");
+        let branch = repo.current_branch();
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/88",
+                "id": 88,
+                "number": 88,
+                "state": "open",
+                "title": "Feature commit",
+                "draft": true,
+                "body": "",
+                "head": { "ref": branch.clone(), "sha": "aaaa", "label": format!("test:{}", branch) },
+                "base": { "ref": "main", "sha": "bbbb", "label": "test:main" },
+                "html_url": "https://github.com/test/repo/pull/88"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/issues/88/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/88"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/88",
+                "id": 88,
+                "number": 88,
+                "state": "open",
+                "title": "Feature commit",
+                "draft": true,
+                "body": "",
+                "head": { "ref": branch.clone(), "sha": "aaaa", "label": format!("test:{}", branch) },
+                "base": { "ref": "main", "sha": "bbbb", "label": "test:main" },
+                "html_url": "https://github.com/test/repo/pull/88"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["refresh", "--yes", "--no-prompt"]);
+        assert!(
+            output.status.success(),
+            "refresh --yes --no-prompt failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let pr_create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path() == "/repos/test/repo/pulls"
+            })
+            .expect("missing PR create request");
+        let payload: serde_json::Value = serde_json::from_slice(&pr_create.body).unwrap();
+        assert_eq!(payload["head"], branch);
+        assert_eq!(payload["base"], "main");
+        assert_eq!(payload["title"], "Feature commit");
+        assert_eq!(payload["draft"], true);
+    }
+
+    #[tokio::test]
     async fn test_submit_persists_pr_info_for_existing_pr() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;


### PR DESCRIPTION
Closes #322.

## Summary
- add `st refresh --yes --no-prompt` and pass those flags into the submit step
- document `st refresh --force --yes --no-prompt` as the fully non-interactive sync/restack/submit path
- cover help output and mocked GitHub PR creation through refresh

## Tests
- cargo test --test cli_tests test_refresh_help
- cargo test --test integration_tests forge_mock_tests::test_refresh_yes_no_prompt_creates_pr_on_mock_github

## Re-review
- Kept the default refresh behavior unchanged and added explicit flags for scripts.
- Clarified docs/tests so `--force` covers sync prompts while `--no-prompt` covers submit prompts.
- Removed unrelated `cargo fmt` churn before commit.