### PR TITLE
Fix redundant merge PR base retargets

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -17,6 +17,9 @@ use std::io::Write;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+const DUPLICATE_PR_BASE_RECHECK_TIMEOUT: Duration = Duration::from_secs(2);
+const DUPLICATE_PR_BASE_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
+
 /// Information about a branch in the merge scope
 #[derive(Debug, Clone)]
 struct MergeBranchInfo {
@@ -35,6 +38,12 @@ struct MergeScope {
     remaining: Vec<MergeBranchInfo>,
     /// The trunk branch name
     trunk: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrBaseUpdate {
+    Updated,
+    AlreadyTargeted,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -291,9 +300,18 @@ pub fn run(
                     &format!("Retargeting #{} to {}...", next_pr, scope.trunk),
                 );
 
-                match rt.block_on(async { client.update_pr_base(next_pr, &scope.trunk).await }) {
-                    Ok(()) => {
+                match update_pr_base_unless_current(
+                    &rt,
+                    &client,
+                    next_pr,
+                    &scope.trunk,
+                    &next_branch.branch,
+                ) {
+                    Ok(PrBaseUpdate::Updated) => {
                         LiveTimer::maybe_finish_ok(update_base_timer, "done");
+                    }
+                    Ok(PrBaseUpdate::AlreadyTargeted) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "already on base");
                     }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
@@ -681,12 +699,12 @@ fn print_merge_preview(scope: &MergeScope, method: &MergeMethod) {
     println!();
 
     // Print branches to merge
-    print_branch_box(&scope.to_merge, true);
+    print_branch_box(&scope.to_merge, true, &scope.trunk);
 
     // Print remaining branches if any
     if !scope.remaining.is_empty() {
         println!();
-        print_branch_box(&scope.remaining, false);
+        print_branch_box(&scope.remaining, false, &scope.trunk);
     }
 
     println!();
@@ -698,7 +716,7 @@ fn print_merge_preview(scope: &MergeScope, method: &MergeMethod) {
 }
 
 /// Print branch info as a checklist
-fn print_branch_box(branches: &[MergeBranchInfo], included: bool) {
+fn print_branch_box(branches: &[MergeBranchInfo], included: bool, trunk: &str) {
     println!();
 
     for (idx, branch) in branches.iter().enumerate() {
@@ -750,18 +768,18 @@ fn print_branch_box(branches: &[MergeBranchInfo], included: bool) {
                 println!("{}", mergeable_check);
 
                 // Merge target
-                let merge_into = if branch.position == 1 {
-                    "main".to_string()
-                } else {
-                    "main (after rebase)".to_string()
-                };
+                let merge_into = merge_target_label(branch.position, trunk);
                 println!("  {} Merge into {}", "→".dimmed(), merge_into);
             } else {
                 println!("  {} Fetching status...", "○".yellow());
             }
         } else {
             println!("  {} Not included in this merge", "·".dimmed());
-            println!("  {} Will be rebased onto main", "→".dimmed());
+            println!(
+                "  {} Will be rebased onto {}",
+                "→".dimmed(),
+                remaining_rebase_target_label(idx, branches, trunk)
+            );
         }
 
         // Add spacing between branches
@@ -771,6 +789,26 @@ fn print_branch_box(branches: &[MergeBranchInfo], included: bool) {
     }
 
     println!();
+}
+
+fn merge_target_label(position: usize, trunk: &str) -> String {
+    if position == 1 {
+        trunk.to_string()
+    } else {
+        format!("{trunk} (after rebase)")
+    }
+}
+
+fn remaining_rebase_target_label<'a>(
+    idx: usize,
+    branches: &'a [MergeBranchInfo],
+    trunk: &'a str,
+) -> &'a str {
+    if idx == 0 {
+        trunk
+    } else {
+        &branches[idx - 1].branch
+    }
 }
 
 /// Strip ANSI codes for length calculation
@@ -972,6 +1010,93 @@ fn summarize_git_stderr(stderr: &[u8]) -> String {
         .to_string()
 }
 
+/// Retarget a PR base unless the forge already reports the desired base.
+///
+/// The preflight read validates that the PR number still belongs to the
+/// expected stack branch when that read succeeds. GitHub can sometimes return a
+/// duplicate base/head validation after the retarget has effectively applied, so
+/// that specific error is treated as idempotent only after a follow-up read
+/// confirms the intended base.
+pub(crate) fn update_pr_base_unless_current(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    pr_number: u64,
+    new_base: &str,
+    expected_head: &str,
+) -> Result<PrBaseUpdate> {
+    // Best-effort read: if this fails, let PATCH run and surface the real forge error.
+    if let Ok(current_pr) = rt.block_on(async { client.get_pr_with_head(pr_number).await }) {
+        ensure_pr_head_matches(pr_number, &current_pr.head, expected_head)?;
+
+        if current_pr.info.base == new_base {
+            return Ok(PrBaseUpdate::AlreadyTargeted);
+        }
+    }
+
+    let update_result = rt.block_on(async { client.update_pr_base(pr_number, new_base).await });
+    match update_result {
+        Ok(()) => Ok(PrBaseUpdate::Updated),
+        Err(e) => {
+            if is_duplicate_pr_base_error(&e, new_base, expected_head)
+                && pr_base_matches_after_duplicate_error(rt, client, pr_number, new_base)
+            {
+                return Ok(PrBaseUpdate::AlreadyTargeted);
+            }
+
+            Err(e).with_context(|| format!("failed to retarget PR #{} to {}", pr_number, new_base))
+        }
+    }
+}
+
+fn ensure_pr_head_matches(pr_number: u64, actual_head: &str, expected_head: &str) -> Result<()> {
+    if actual_head != expected_head {
+        anyhow::bail!(
+            "PR #{} is for head branch '{}', expected '{}'",
+            pr_number,
+            actual_head,
+            expected_head
+        );
+    }
+
+    Ok(())
+}
+
+/// Re-read a PR briefly after GitHub reports a duplicate base/head pair.
+///
+/// This covers a stale-response race: the update endpoint can reject a retarget
+/// as a duplicate even though subsequent PR reads show the same PR now targets
+/// the requested base.
+fn pr_base_matches_after_duplicate_error(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    pr_number: u64,
+    new_base: &str,
+) -> bool {
+    let deadline = Instant::now() + DUPLICATE_PR_BASE_RECHECK_TIMEOUT;
+
+    loop {
+        if let Ok(pr) = rt.block_on(async { client.get_pr(pr_number).await }) {
+            if pr.base == new_base {
+                return true;
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return false;
+        }
+
+        std::thread::sleep(DUPLICATE_PR_BASE_RECHECK_INTERVAL);
+    }
+}
+
+/// Detect GitHub's duplicate base/head validation for the exact target pair.
+fn is_duplicate_pr_base_error(error: &anyhow::Error, new_base: &str, expected_head: &str) -> bool {
+    let message = format!("{:#}", error);
+    message.contains("A pull request already exists")
+        && message.contains(&format!("base branch '{}'", new_base))
+        && message.contains(&format!("head branch '{}'", expected_head))
+}
+
 /// Push a rebased remaining-stack branch and — only on success — retarget its
 /// PR base. Surfaces push or retarget failures via the supplied `LiveTimer`;
 /// on any failure the PR base is left pointing at the previous parent so the
@@ -1007,9 +1132,7 @@ fn finalize_remaining_branch_push(
     }
 
     if let Some(pr_num) = pr_number {
-        if let Err(e) =
-            rt.block_on(async { client.update_pr_base(pr_num, new_base).await })
-        {
+        if let Err(e) = update_pr_base_unless_current(rt, client, pr_num, new_base, branch) {
             LiveTimer::maybe_finish_err(timer, &format!("retarget failed: {:#}", e));
             return Ok(());
         }
@@ -1251,6 +1374,62 @@ mod tests {
         assert_eq!(scope.to_merge.len(), 2);
         assert_eq!(scope.remaining.len(), 1);
         assert_eq!(scope.trunk, "main");
+    }
+
+    #[test]
+    fn test_merge_target_label_uses_configured_trunk() {
+        assert_eq!(merge_target_label(1, "master"), "master");
+        assert_eq!(merge_target_label(2, "master"), "master (after rebase)");
+    }
+
+    #[test]
+    fn test_remaining_rebase_target_label_preserves_remaining_chain() {
+        let branches = vec![
+            MergeBranchInfo {
+                branch: "feature-b".to_string(),
+                pr_number: Some(2),
+                pr_status: None,
+                is_current: false,
+                position: 2,
+            },
+            MergeBranchInfo {
+                branch: "feature-c".to_string(),
+                pr_number: Some(3),
+                pr_status: None,
+                is_current: false,
+                position: 3,
+            },
+        ];
+
+        assert_eq!(
+            remaining_rebase_target_label(0, &branches, "master"),
+            "master"
+        );
+        assert_eq!(
+            remaining_rebase_target_label(1, &branches, "master"),
+            "feature-b"
+        );
+    }
+
+    #[test]
+    fn test_duplicate_pr_base_error_matches_requested_base_and_head() {
+        let err = anyhow::anyhow!(
+            "GitHub: Validation Failed\nErrors:\n- {{\"message\":\"A pull request already exists for base branch 'master' and head branch 'jonny/feature'\"}}"
+        );
+
+        assert!(is_duplicate_pr_base_error(&err, "master", "jonny/feature"));
+        assert!(!is_duplicate_pr_base_error(&err, "main", "jonny/feature"));
+        assert!(!is_duplicate_pr_base_error(&err, "master", "other/feature"));
+    }
+
+    #[test]
+    fn test_pr_head_mismatch_bails() {
+        let err = ensure_pr_head_matches(42, "wrong-head", "expected-head")
+            .expect_err("head mismatch should fail");
+        let message = format!("{:#}", err);
+
+        assert!(message.contains("PR #42 is for head branch 'wrong-head'"));
+        assert!(message.contains("expected 'expected-head'"));
     }
 
     #[test]

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -5,6 +5,7 @@
 //! polls until all PRs are merged.  Finishes with auto-sync and a desktop
 //! notification — the same "land and walk away" experience as Graphite.
 
+use crate::commands::merge::{update_pr_base_unless_current, PrBaseUpdate};
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
@@ -73,6 +74,9 @@ pub fn run(
         );
     }
 
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+
     let client = ForgeClient::new(&remote_info).context(
         "Failed to connect to the configured forge. Check your token and remote configuration.",
     )?;
@@ -81,9 +85,6 @@ pub fn run(
         ForgeType::GitLab => "merge train",
         _ => "merge queue",
     };
-
-    let rt = tokio::runtime::Runtime::new()?;
-    let _enter = rt.enter();
 
     let (to_queue, trunk) = calculate_queue_scope(&stack, &current, all);
 
@@ -224,14 +225,19 @@ pub fn run(
             &format!("Retargeting #{} to {}...", branch.pr_number, trunk),
         );
 
-        match rt.block_on(async { client.update_pr_base(branch.pr_number, &trunk).await }) {
-            Ok(()) => LiveTimer::maybe_finish_ok(retarget_timer, "done"),
+        let retarget_result =
+            update_pr_base_unless_current(&rt, &client, branch.pr_number, &trunk, &branch.branch);
+        match retarget_result {
+            Ok(PrBaseUpdate::Updated) => LiveTimer::maybe_finish_ok(retarget_timer, "done"),
+            Ok(PrBaseUpdate::AlreadyTargeted) => {
+                LiveTimer::maybe_finish_ok(retarget_timer, "already on base")
+            }
             Err(e) => {
                 LiveTimer::maybe_finish_err(retarget_timer, "failed");
                 failed = Some((
                     branch.branch.clone(),
                     branch.pr_number,
-                    format!("Failed to retarget PR: {}", e),
+                    format!("Failed to retarget PR: {:#}", e),
                 ));
                 break;
             }
@@ -265,17 +271,24 @@ pub fn run(
                             branch.pr_number, branch.original_base
                         ),
                     );
-                    match rt.block_on(async {
-                        client
-                            .update_pr_base(branch.pr_number, &branch.original_base)
-                            .await
-                    }) {
-                        Ok(()) => LiveTimer::maybe_finish_ok(rollback_timer, "restored"),
+                    match update_pr_base_unless_current(
+                        &rt,
+                        &client,
+                        branch.pr_number,
+                        &branch.original_base,
+                        &branch.branch,
+                    ) {
+                        Ok(PrBaseUpdate::Updated) => {
+                            LiveTimer::maybe_finish_ok(rollback_timer, "restored")
+                        }
+                        Ok(PrBaseUpdate::AlreadyTargeted) => {
+                            LiveTimer::maybe_finish_ok(rollback_timer, "already restored")
+                        }
                         Err(rb_err) => {
                             LiveTimer::maybe_finish_err(rollback_timer, "rollback failed");
                             if !quiet {
                                 println!(
-                                    "      {} Could not restore original base: {}",
+                                    "      {} Could not restore original base: {:#}",
                                     "⚠".yellow(),
                                     rb_err
                                 );

--- a/src/commands/merge_remote.rs
+++ b/src/commands/merge_remote.rs
@@ -3,6 +3,7 @@
 //! Dependent PR branches are updated via GitHub's "Update branch" endpoint (`PUT .../update-branch`).
 
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
+use crate::commands::merge::{update_pr_base_unless_current, PrBaseUpdate};
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
@@ -224,19 +225,26 @@ pub fn run(
                     ),
                 );
 
-                match rt.block_on(async {
-                    client
-                        .update_pr_base(next_branch.pr_number, &scope.trunk)
-                        .await
-                }) {
-                    Ok(()) => LiveTimer::maybe_finish_ok(update_base_timer, "done"),
+                match update_pr_base_unless_current(
+                    &rt,
+                    &client,
+                    next_branch.pr_number,
+                    &scope.trunk,
+                    &next_branch.branch,
+                ) {
+                    Ok(PrBaseUpdate::Updated) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "done")
+                    }
+                    Ok(PrBaseUpdate::AlreadyTargeted) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "already on base")
+                    }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
                         failed_pr = Some((
                             branch_name,
                             pr_number,
                             format!(
-                                "Failed to retarget dependent PR #{}: {}",
+                                "Failed to retarget dependent PR #{}: {:#}",
                                 next_branch.pr_number, e
                             ),
                         ));
@@ -284,19 +292,26 @@ pub fn run(
                     ),
                 );
 
-                match rt.block_on(async {
-                    client
-                        .update_pr_base(next_branch.pr_number, &scope.trunk)
-                        .await
-                }) {
-                    Ok(()) => LiveTimer::maybe_finish_ok(update_base_timer, "done"),
+                match update_pr_base_unless_current(
+                    &rt,
+                    &client,
+                    next_branch.pr_number,
+                    &scope.trunk,
+                    &next_branch.branch,
+                ) {
+                    Ok(PrBaseUpdate::Updated) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "done")
+                    }
+                    Ok(PrBaseUpdate::AlreadyTargeted) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "already on base")
+                    }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
                         failed_pr = Some((
                             branch_name,
                             pr_number,
                             format!(
-                                "Failed to retarget dependent PR #{}: {}",
+                                "Failed to retarget dependent PR #{}: {:#}",
                                 next_branch.pr_number, e
                             ),
                         ));
@@ -351,14 +366,23 @@ pub fn run(
                 !quiet,
                 &format!("Retargeting #{} to {}...", pr_num, scope.trunk),
             );
-            match rt.block_on(async { client.update_pr_base(pr_num, &scope.trunk).await }) {
-                Ok(()) => LiveTimer::maybe_finish_ok(base_timer, "done"),
+            match update_pr_base_unless_current(
+                &rt,
+                &client,
+                pr_num,
+                &scope.trunk,
+                &remaining.branch,
+            ) {
+                Ok(PrBaseUpdate::Updated) => LiveTimer::maybe_finish_ok(base_timer, "done"),
+                Ok(PrBaseUpdate::AlreadyTargeted) => {
+                    LiveTimer::maybe_finish_ok(base_timer, "already on base")
+                }
                 Err(e) => {
                     LiveTimer::maybe_finish_err(base_timer, "failed");
                     failed_pr = Some((
                         remaining.branch.clone(),
                         pr_num,
-                        format!("Failed to retarget PR #{}: {}", pr_num, e),
+                        format!("Failed to retarget PR #{}: {:#}", pr_num, e),
                     ));
                     break;
                 }

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -1,5 +1,8 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
-use crate::commands::merge::{rebase_and_finalize_remaining_branch, sync_head_after_push};
+use crate::commands::merge::{
+    rebase_and_finalize_remaining_branch, sync_head_after_push, update_pr_base_unless_current,
+    PrBaseUpdate,
+};
 use crate::commands::merge_rebase::{
     fetch_remote_for_descendant_rebase, rebase_descendant_onto_remote_trunk_with_provenance,
 };
@@ -324,18 +327,23 @@ pub fn run(
                     ),
                 );
 
-                match rt.block_on(async {
-                    client
-                        .update_pr_base(next_branch.pr_number, &scope.trunk)
-                        .await
-                }) {
-                    Ok(()) => {
+                match update_pr_base_unless_current(
+                    &rt,
+                    &client,
+                    next_branch.pr_number,
+                    &scope.trunk,
+                    &next_branch.branch,
+                ) {
+                    Ok(PrBaseUpdate::Updated) => {
                         LiveTimer::maybe_finish_ok(update_base_timer, "done");
+                    }
+                    Ok(PrBaseUpdate::AlreadyTargeted) => {
+                        LiveTimer::maybe_finish_ok(update_base_timer, "already on base");
                     }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
                         let reason = format!(
-                            "Failed to retarget dependent PR #{}: {}",
+                            "Failed to retarget dependent PR #{}: {:#}",
                             next_branch.pr_number, e
                         );
                         branches[idx].status = LandStatus::Failed(reason.clone());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2407,7 +2407,11 @@ fn test_refresh_auto_stash_pop_restores_dirty_linked_worktree() {
         TestRepo::stderr(&output)
     );
 
-    assert_eq!(repo.current_branch(), tip, "refresh should restore original branch");
+    assert_eq!(
+        repo.current_branch(),
+        tip,
+        "refresh should restore original branch"
+    );
 
     let status = repo.git_in(&base_worktree, &["status", "--porcelain"]);
     assert!(
@@ -6366,6 +6370,33 @@ mod forge_mock_tests {
         })
     }
 
+    fn github_pull_fixture(
+        number: u64,
+        head_branch: &str,
+        base_branch: &str,
+        head_sha: &str,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "url": format!("https://api.github.com/repos/test/repo/pulls/{}", number),
+            "id": number,
+            "number": number,
+            "state": "open",
+            "draft": false,
+            "merged_at": null,
+            "mergeable": true,
+            "mergeable_state": "clean",
+            "head": {
+                "ref": head_branch,
+                "sha": head_sha,
+                "label": format!("test:{}", head_branch)
+            },
+            "base": {
+                "ref": base_branch,
+                "sha": format!("{}-sha", base_branch)
+            }
+        })
+    }
+
     fn gitlab_mr_fixture(
         iid: u64,
         title: &str,
@@ -7720,6 +7751,345 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
+    async fn test_merge_skips_retarget_when_next_pr_already_targets_trunk() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-skip-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-skip-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(101, &branch_a, "main", "sha-a"),
+                github_pull_fixture(102, &branch_b, "main", "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(101, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, "main", "sha-b")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/101/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/102/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        assert!(
+            requests.iter().all(|request| {
+                request.method.as_str() != "PATCH"
+                    || request.url.path() != "/repos/test/repo/pulls/102"
+            }),
+            "Expected already-retargeted PR to skip PATCH, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_treats_duplicate_retarget_error_as_done_after_confirming_base() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-dupe-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-dupe-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(101, &branch_a, "main", "sha-a"),
+                github_pull_fixture(102, &branch_b, &branch_a, "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(101, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, &branch_a, "sha-b")),
+            )
+            .with_priority(1)
+            .up_to_n_times(2)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, "main", "sha-b")),
+            )
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Validation Failed",
+                "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+                "errors": [{
+                    "resource": "PullRequest",
+                    "field": "base",
+                    "code": "invalid",
+                    "message": format!(
+                        "A pull request already exists for base branch 'main' and head branch '{}'",
+                        branch_b
+                    )
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/101/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/102/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let stdout = TestRepo::stdout(&merge_output);
+        assert!(
+            stdout.contains("already on base"),
+            "Expected duplicate retarget to be treated as already applied. Output:\n{}",
+            stdout
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/102");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/101/merge");
+        assert!(
+            patch_idx > merge_idx,
+            "Expected duplicate retarget response after parent merge, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_surfaces_duplicate_retarget_error_when_base_does_not_change() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-dupe-fail-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "merge-dupe-fail-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(101, &branch_a, "main", "sha-a"),
+                github_pull_fixture(102, &branch_b, &branch_a, "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(101, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, &branch_a, "sha-b")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Validation Failed",
+                "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+                "errors": [{
+                    "resource": "PullRequest",
+                    "field": "base",
+                    "code": "invalid",
+                    "message": format!(
+                        "A pull request already exists for base branch 'main' and head branch '{}'",
+                        branch_b
+                    )
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/101/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        let combined = format!(
+            "{}{}",
+            TestRepo::stdout(&merge_output),
+            TestRepo::stderr(&merge_output)
+        );
+        assert!(
+            combined.contains("A pull request already exists for base branch 'main'")
+                && combined.contains("Merge Stopped"),
+            "Expected duplicate PR base error to surface. Output:\n{}",
+            combined
+        );
+    }
+
+    #[tokio::test]
     async fn test_merge_when_ready_already_merged_pr_still_rebases_next_branch_and_reparents_metadata(
     ) {
         ensure_crypto_provider();
@@ -8252,6 +8622,305 @@ mod forge_mock_tests {
             update_idx < merge2_idx,
             "Expected update-branch before child merge"
         );
+    }
+
+    #[tokio::test]
+    async fn test_merge_remote_treats_duplicate_retarget_error_as_done_after_confirming_base() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mremote-dupe-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "mremote-dupe-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(301, &branch_a, "main", "sha-a"),
+                github_pull_fixture(302, &branch_b, &branch_a, "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/301"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(301, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/302"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(302, &branch_b, &branch_a, "sha-b")),
+            )
+            .with_priority(1)
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/302"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(302, &branch_b, "main", "sha-b")),
+            )
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/302"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Validation Failed",
+                "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+                "errors": [{
+                    "resource": "PullRequest",
+                    "field": "base",
+                    "code": "invalid",
+                    "message": format!(
+                        "A pull request already exists for base branch 'main' and head branch '{}'",
+                        branch_b
+                    )
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/301/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/302/update-branch"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "message": "Updating pull request branch.",
+                "url": "https://api.github.com/repos/test/repo/pulls/302"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/302/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &[
+                "merge",
+                "--remote",
+                "--yes",
+                "--no-delete",
+                "--timeout",
+                "1",
+                "--interval",
+                "1",
+                "--no-sync",
+            ],
+        );
+        assert!(
+            merge_output.status.success(),
+            "merge --remote failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let stdout = TestRepo::stdout(&merge_output);
+        assert!(
+            stdout.contains("already on base"),
+            "Expected duplicate retarget to be treated as already applied. Output:\n{}",
+            stdout
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/302");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/301/merge");
+        assert!(
+            patch_idx > merge_idx,
+            "Expected duplicate retarget response after parent merge, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_queue_uses_idempotent_retarget_and_rollback() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "queue-dupe-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "queue-dupe-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        let mut merged_parent = github_pull_fixture(401, &branch_a, "main", "sha-a");
+        merged_parent["merged_at"] = serde_json::json!("2026-04-23T00:00:00Z");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                merged_parent,
+                github_pull_fixture(402, &branch_b, &branch_a, "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let mut merged_parent_get = github_pull_fixture(401, &branch_a, "main", "sha-a");
+        merged_parent_get["merged_at"] = serde_json::json!("2026-04-23T00:00:00Z");
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/401"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(merged_parent_get))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/402"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(402, &branch_b, &branch_a, "sha-b")),
+            )
+            .with_priority(1)
+            .up_to_n_times(2)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/402"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(402, &branch_b, "main", "sha-b")),
+            )
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/402"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Validation Failed",
+                "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+                "errors": [{
+                    "resource": "PullRequest",
+                    "field": "base",
+                    "code": "invalid",
+                    "message": format!(
+                        "A pull request already exists for base branch 'main' and head branch '{}'",
+                        branch_b
+                    )
+                }]
+            })))
+            .with_priority(1)
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/402"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(402, &branch_b, &branch_a, "sha-b")),
+            )
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        let queue_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &[
+                "merge",
+                "--queue",
+                "--yes",
+                "--timeout",
+                "1",
+                "--interval",
+                "1",
+                "--no-sync",
+            ],
+        );
+        assert!(
+            queue_output.status.success(),
+            "merge --queue failed unexpectedly: {}\n{}",
+            TestRepo::stderr(&queue_output),
+            TestRepo::stdout(&queue_output)
+        );
+
+        let stdout = TestRepo::stdout(&queue_output);
+        assert!(
+            stdout.contains("already on base")
+                && stdout.contains("Rolling back #402 base")
+                && stdout.contains("restored")
+                && stdout.contains("Failed to enqueue"),
+            "Expected queue retarget to be idempotent and rollback to restore base. Output:\n{}",
+            stdout
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_count = requests
+            .iter()
+            .filter(|request| {
+                request.method.as_str() == "PATCH"
+                    && request.url.path() == "/repos/test/repo/pulls/402"
+            })
+            .count();
+        assert_eq!(patch_count, 2, "Expected retarget and rollback PATCHes");
     }
 
     #[tokio::test]
@@ -10347,8 +11016,9 @@ mod forge_mock_tests {
                 .await;
         }
 
-        // Accept PATCH retargets on any of the remaining PRs — the assertion
-        // below inspects the body to verify each got the correct new base.
+        // Accept PATCH retargets on any PR whose base needs to change. Branch d
+        // may already point at branch c and therefore legitimately skip PATCH
+        // once retargeting becomes idempotent.
         for pr_id in [602u64, 603, 604] {
             Mock::given(method("PATCH"))
                 .and(path(format!("/repos/test/repo/pulls/{}", pr_id)))
@@ -10407,9 +11077,7 @@ mod forge_mock_tests {
         // Find the PATCH request for PR #603 (c) — it should retarget to main.
         let patch_603 = requests
             .iter()
-            .find(|r| {
-                r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/603"
-            })
+            .find(|r| r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/603")
             .expect("PR #603 should have been retargeted");
         let payload_603: serde_json::Value = serde_json::from_slice(&patch_603.body).unwrap();
         assert_eq!(
@@ -10417,18 +11085,18 @@ mod forge_mock_tests {
             "PR #603 (branch c) must be retargeted to main"
         );
 
-        // Find the PATCH request for PR #604 (d) — it must retarget to branch c,
-        // NOT to main (the regression #311 was flattening this to main).
+        // PR #604 (branch d) must keep its base on branch c, not flatten to
+        // trunk. With idempotent retargeting it may skip PATCH entirely when
+        // the forge already reports branch c as the base.
         let patch_604 = requests
             .iter()
-            .find(|r| {
-                r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/604"
-            })
-            .expect("PR #604 should have been retargeted");
-        let payload_604: serde_json::Value = serde_json::from_slice(&patch_604.body).unwrap();
-        assert_eq!(
-            payload_604["base"], branch_c,
-            "PR #604 (branch d) must keep its base on branch c, not flatten to trunk"
-        );
+            .find(|r| r.method.as_str() == "PATCH" && r.url.path() == "/repos/test/repo/pulls/604");
+        if let Some(patch_604) = patch_604 {
+            let payload_604: serde_json::Value = serde_json::from_slice(&patch_604.body).unwrap();
+            assert_eq!(
+                payload_604["base"], branch_c,
+                "PR #604 (branch d) must keep its base on branch c, not flatten to trunk"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Make the merge preview use the configured trunk branch instead of hard-coded main.
- Route merge, merge-when-ready, merge --remote, and merge --queue PR retargets through a shared idempotent helper.
- Skip PR base updates when the dependent PR already targets the desired base, with head-branch validation to avoid retargeting stale PR metadata.
- Treat GitHub duplicate base/head validation as already applied only after a follow-up read confirms the PR now targets the desired base.
- Add helper documentation, named duplicate-recheck timing constants, and a unit test for head mismatches.
- Show chained rebase targets for remaining stack branches instead of saying every branch rebases onto trunk.

## Tests
- cargo test --lib commands::merge::tests::
- cargo test --test integration_tests forge_mock_tests::test_merge_treats_duplicate_retarget_error_as_done_after_confirming_base -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_surfaces_duplicate_retarget_error_when_base_does_not_change -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_skips_retarget_when_next_pr_already_targets_trunk -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_retargets_next_pr_after_merging_parent_pr -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_when_ready_retargets_next_pr_after_merging_parent_pr -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_preserves_remaining_pr_base_when_push_fails -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_when_ready_preserves_remaining_pr_base_when_push_fails -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_remote_treats_duplicate_retarget_error_as_done_after_confirming_base -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_remote_retargets_and_updates_branch_after_merging -- --exact
- cargo test --test integration_tests forge_mock_tests::test_merge_queue_uses_idempotent_retarget_and_rollback -- --exact
- rustfmt --edition 2021 --check src/commands/merge.rs src/commands/merge_remote.rs src/commands/merge_queue.rs tests/integration_tests.rs
- git diff --check

Refs #302 and https://github.com/cesarferreira/stax/issues/302#issuecomment-4304075114.

Docs not updated: this is a bug fix for existing merge output and retarget behavior; it does not add or change commands, flags, defaults, or documented workflows.