### PR TITLE
feat(create): add --below placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ st config --set-ai
 | `st` | Launch interactive TUI |
 | `st ls` / `st ll` | Show stack (with PR status / with PR URLs and details) |
 | `st create <name>` | Create a branch stacked on current |
+| `st create <name> --below` | Insert a new branch below current |
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -10,6 +10,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st ls` | Show stack with PR and rebase status |
 | `st ll` | Like `st ls` plus PR URLs and detail |
 | `st create <name>` | Create a branch stacked on current |
+| `st create <name> --below` | Insert a new branch below current |
 
 ## Submit and merge
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -49,6 +49,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | Command | Alias | Description |
 |---|---|---|
 | `st create <name>` | `c`, `bc` | Create stacked branch (TTY menu when nothing staged and `-m`) |
+| `st create <name> --below` | | Insert a new branch below current |
 | `st modify` | `m` | Amend staged changes into current commit (`-a` stages all, `-r` restacks after) |
 | `st rename` | | Rename current branch |
 | `st branch track` | | Track an existing branch |
@@ -185,6 +186,7 @@ st wt go ui-polish --run "cursor ." --tmux
 - `-m "msg"` set commit message (with nothing staged in a TTY: menu for stage all, `--patch`, empty branch, or abort)
 - `-am "msg"` stage all and commit
 - `--insert` reparent children of the current branch onto the new branch
+- `--below` create from the current branch's parent and reparent the current branch onto the new branch; combines with `-m`/`-am` to commit on the new lower branch
 - `st branch create --message "msg" --prefix feature/`
 
 ### `st status` / `st ll` / `st log`

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -23,6 +23,7 @@ st status   # your existing stack appears immediately
 | `fp rs` | `gt sync` | `st sync` · `st rs` |
 | `fp bc` | `gt create` | `st create` · `st bc` |
 | — | `gt create --insert` | `st create --insert` |
+| — | — | `st create --below` |
 | `fp bco` | `gt checkout` | `st checkout` · `st co` |
 | `fp bu` | `gt up` | `st up` · `st bu` |
 | `fp bd` | `gt down` | `st down` · `st bd` |

--- a/skills.md
+++ b/skills.md
@@ -57,7 +57,7 @@ stax branch ...|b              # Branch subcommands
 stax upstack ...|us            # Descendant-scope commands
 stax downstack ...|ds          # Ancestor-scope commands
 
-stax create|c                  # Create stacked branch (menu when nothing staged)
+stax create|c                  # Create stacked branch (--below inserts under current)
 stax modify|m                  # Amend current commit (menu when nothing staged)
 stax rename                    # Rename current branch
 stax detach                    # Remove branch from stack, reparent children
@@ -150,6 +150,8 @@ stax create -a                     # Stage all before creating
 stax create -am "message"          # Stage all + commit (bypasses menu)
 stax create --from <branch>        # Create from explicit base
 stax create --prefix feature/      # Override branch prefix
+stax create <name> --below         # Insert new branch below current
+stax create --below -am "message"  # Commit on new lower branch
 stax bc <name>                     # Hidden shortcut alias
 
 stax m                             # Amend current commit (TTY menu if nothing staged)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -597,8 +597,11 @@ enum Commands {
         #[arg(long)]
         prefix: Option<String>,
         /// Insert between current branch and its children (reparent children)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "below")]
         insert: bool,
+        /// Insert below current branch (reparent current and descendants)
+        #[arg(long, conflicts_with_all = ["insert", "from"])]
+        below: bool,
     },
 
     /// Open the current branch PR or list repo pull requests
@@ -956,8 +959,11 @@ enum Commands {
         #[arg(long)]
         prefix: Option<String>,
         /// Insert between current branch and its children (reparent children)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "below")]
         insert: bool,
+        /// Insert below current branch (reparent current and descendants)
+        #[arg(long, conflicts_with_all = ["insert", "from"])]
+        below: bool,
     },
     #[command(hide = true)]
     Bu {
@@ -1123,8 +1129,11 @@ enum BranchCommands {
         #[arg(long)]
         prefix: Option<String>,
         /// Insert between current branch and its children (reparent children)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "below")]
         insert: bool,
+        /// Insert below current branch (reparent current and descendants)
+        #[arg(long, conflicts_with_all = ["insert", "from"])]
+        below: bool,
     },
 
     /// Checkout a branch in the stack
@@ -1832,7 +1841,8 @@ pub fn run() -> Result<()> {
             from,
             prefix,
             insert,
-        } => commands::branch::create::run(name, message, from, prefix, all, insert),
+            below,
+        } => commands::branch::create::run(name, message, from, prefix, all, insert, below),
         Commands::Pr { command } => match command.unwrap_or(PrCommands::Open) {
             PrCommands::Open => commands::pr::run_open(),
             PrCommands::List { limit, json } => commands::pr::run_list(limit, json),
@@ -1947,7 +1957,8 @@ pub fn run() -> Result<()> {
                 from,
                 prefix,
                 insert,
-            } => commands::branch::create::run(name, message, from, prefix, all, insert),
+                below,
+            } => commands::branch::create::run(name, message, from, prefix, all, insert, below),
             BranchCommands::Checkout {
                 branch,
                 pr,
@@ -2036,7 +2047,8 @@ pub fn run() -> Result<()> {
             from,
             prefix,
             insert,
-        } => commands::branch::create::run(name, message, from, prefix, all, insert),
+            below,
+        } => commands::branch::create::run(name, message, from, prefix, all, insert, below),
         Commands::Bu { count } => commands::navigate::up(count),
         Commands::Bd { count } => commands::navigate::down(count),
         Commands::Bs { submit } => run_submit(submit, commands::submit::SubmitScope::Branch),

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -14,7 +14,7 @@
 //!   `rollback_create` cleanup.
 //!
 //! Both flows share `create_branch_with_banner` for the create → metadata →
-//! `--insert` → checkout → summary sequence.
+//! `--insert`/`--below` placement → checkout → summary sequence.
 //!
 //! When the user passes `-m` but nothing is staged and `-a` wasn't supplied,
 //! `stax create` offers the shared staging menu (see
@@ -43,6 +43,11 @@ enum StageMode {
     All,
 }
 
+struct CreatePlacement {
+    parent_branch: String,
+    below_current_meta: Option<BranchMetadata>,
+}
+
 pub fn run(
     name: Option<String>,
     message: Option<String>,
@@ -50,11 +55,14 @@ pub fn run(
     prefix: Option<String>,
     all: bool,
     insert: bool,
+    below: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let config = Config::load()?;
     let current = repo.current_branch()?;
-    let parent_branch = from.unwrap_or_else(|| current.clone());
+    let placement = resolve_create_placement(&repo, &current, from, insert, below)?;
+    let parent_branch = placement.parent_branch;
+    let below_current_meta = placement.below_current_meta;
     let generated_from_message = name.is_none() && message.is_some();
 
     if repo.branch_commit(&parent_branch).is_err() {
@@ -177,6 +185,7 @@ pub fn run(
         &parent_branch,
         &branch_name,
         insert,
+        below_current_meta.as_ref(),
     )?;
 
     // Stage/commit behavior:
@@ -188,7 +197,12 @@ pub fn run(
 
         if stage_mode == StageMode::All || needs_stage_all {
             if let Err(e) = staging::stage_all(workdir) {
-                rollback_create(&repo, &current, &branch_name);
+                rollback_create_and_restore(
+                    &repo,
+                    &current,
+                    &branch_name,
+                    below_current_meta.as_ref(),
+                );
                 return Err(e);
             }
         }
@@ -200,7 +214,14 @@ pub fn run(
             if staging::is_staging_area_empty(workdir)? {
                 println!("{}", "No changes to commit".dimmed());
             } else {
-                commit_or_rollback(workdir, &msg, &repo, &current, &branch_name)?;
+                commit_or_rollback(
+                    workdir,
+                    &msg,
+                    &repo,
+                    &current,
+                    &branch_name,
+                    below_current_meta.as_ref(),
+                )?;
                 println!("Committed: {}", msg.cyan());
             }
         } else if stage_mode == StageMode::All {
@@ -230,6 +251,7 @@ fn commit_or_rollback(
     repo: &GitRepo,
     original: &str,
     new_branch: &str,
+    restore_original_meta: Option<&BranchMetadata>,
 ) -> Result<()> {
     let status = Command::new("git")
         .args(["commit", "-m", message])
@@ -238,14 +260,14 @@ fn commit_or_rollback(
     match status {
         Ok(s) if s.success() => Ok(()),
         Ok(_) => {
-            rollback_create(repo, original, new_branch);
+            rollback_create_and_restore(repo, original, new_branch, restore_original_meta);
             bail!(
                 "Commit failed (pre-commit hook or other error). \
                  Branch rolled back. Fix the issue and retry."
             );
         }
         Err(e) => {
-            rollback_create(repo, original, new_branch);
+            rollback_create_and_restore(repo, original, new_branch, restore_original_meta);
             Err(anyhow::Error::from(e).context("Failed to run git commit"))
         }
     }
@@ -269,6 +291,18 @@ fn rollback_create(repo: &GitRepo, original_branch: &str, new_branch: &str) {
     }
     let _ = repo.delete_branch(new_branch, true);
     let _ = BranchMetadata::delete(repo.inner(), new_branch);
+}
+
+fn rollback_create_and_restore(
+    repo: &GitRepo,
+    original_branch: &str,
+    new_branch: &str,
+    restore_original_meta: Option<&BranchMetadata>,
+) {
+    if let Some(meta) = restore_original_meta {
+        let _ = meta.write(repo.inner(), original_branch);
+    }
+    rollback_create(repo, original_branch, new_branch);
 }
 
 /// Graphite-style commit-first flow: commit on the current branch, then split
@@ -303,7 +337,7 @@ fn run_commit_first(
     // make. Fall back to creating an empty branch — same shape as the
     // branch-first path without the trailing commit.
     if staging::is_staging_area_empty(workdir)? {
-        create_branch_with_banner(repo, config, current, current, branch_name, insert)?;
+        create_branch_with_banner(repo, config, current, current, branch_name, insert, None)?;
         println!("{}", "No changes to commit".dimmed());
         print_tips(config);
         return Ok(());
@@ -397,7 +431,7 @@ fn rollback_after_commit(workdir: &Path, old_sha: &str, new_branch: Option<&str>
 }
 
 /// Create `branch_name` stacked on `parent_branch`, write stax metadata,
-/// apply `--insert` reparenting, check out the new branch, and print the
+/// apply `--insert`/`--below` reparenting, check out the new branch, and print the
 /// "Created and switched…" banner. On any failure, undo all of it with
 /// `rollback_create` so the caller sees a clean failure.
 ///
@@ -405,7 +439,7 @@ fn rollback_after_commit(workdir: &Path, old_sha: &str, new_branch: Option<&str>
 /// where `rollback_create` checks out on failure. For the commit-first
 /// no-changes fallback `original == parent_branch == current`; for the
 /// branch-first flow `original == current`, and `parent_branch` may or may not
-/// equal it (the `--from` case).
+/// equal it (the `--from` and `--below` cases).
 ///
 /// The caller owns whatever comes next — the trailing "No changes to commit"
 /// note, the stage/commit block, or the tips line.
@@ -416,6 +450,7 @@ fn create_branch_with_banner(
     parent_branch: &str,
     branch_name: &str,
     insert: bool,
+    below_current_meta: Option<&BranchMetadata>,
 ) -> Result<()> {
     if parent_branch == original {
         repo.create_branch(branch_name)?;
@@ -437,8 +472,15 @@ fn create_branch_with_banner(
         }
     }
 
+    if let Some(current_meta) = below_current_meta {
+        if let Err(e) = apply_below_reparenting(repo, original, branch_name, current_meta) {
+            rollback_create_and_restore(repo, original, branch_name, below_current_meta);
+            return Err(e);
+        }
+    }
+
     if let Err(e) = repo.checkout(branch_name) {
-        rollback_create(repo, original, branch_name);
+        rollback_create_and_restore(repo, original, branch_name, below_current_meta);
         return Err(e);
     }
 
@@ -450,6 +492,57 @@ fn create_branch_with_banner(
     );
 
     Ok(())
+}
+
+fn resolve_create_placement(
+    repo: &GitRepo,
+    current: &str,
+    from: Option<String>,
+    insert: bool,
+    below: bool,
+) -> Result<CreatePlacement> {
+    if insert && below {
+        bail!("`--insert` and `--below` cannot be used together");
+    }
+    if below && from.is_some() {
+        bail!("`--below` cannot be used with `--from`");
+    }
+
+    if below {
+        let meta = resolve_below_current_metadata(repo, current)?;
+        return Ok(CreatePlacement {
+            parent_branch: meta.parent_branch_name.clone(),
+            below_current_meta: Some(meta),
+        });
+    }
+
+    Ok(CreatePlacement {
+        parent_branch: from.unwrap_or_else(|| current.to_string()),
+        below_current_meta: None,
+    })
+}
+
+fn resolve_below_current_metadata(repo: &GitRepo, current: &str) -> Result<BranchMetadata> {
+    let trunk = repo.trunk_branch()?;
+    if current == trunk {
+        bail!("Cannot create a branch below trunk. Checkout a stacked branch first.");
+    }
+
+    let meta = BranchMetadata::read(repo.inner(), current)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Branch '{}' is not tracked by stax. Run `st branch track` first.",
+            current
+        )
+    })?;
+
+    if meta.parent_branch_name == current {
+        bail!(
+            "Cannot create a branch below '{}': branch metadata points to itself as parent.",
+            current
+        );
+    }
+
+    Ok(meta)
 }
 
 /// Reparent children of `parent_branch` onto `new_branch` and print the usual
@@ -494,6 +587,50 @@ fn apply_insert_reparenting(repo: &GitRepo, parent_branch: &str, new_branch: &st
     println!(
         "{}",
         "Run `stax restack --all` to rebase the reparented branches.".yellow()
+    );
+
+    Ok(())
+}
+
+/// Insert `new_branch` between `current_branch` and its current parent.
+/// Descendant metadata stays untouched: moving the subtree root makes all
+/// descendants follow it while preserving their relative structure.
+fn apply_below_reparenting(
+    repo: &GitRepo,
+    current_branch: &str,
+    new_branch: &str,
+    current_meta: &BranchMetadata,
+) -> Result<()> {
+    let new_parent_rev = repo.branch_commit(new_branch)?;
+    let parent_revision = repo
+        .merge_base(new_branch, current_branch)
+        .unwrap_or(new_parent_rev);
+    let updated = BranchMetadata {
+        parent_branch_name: new_branch.to_string(),
+        parent_branch_revision: parent_revision,
+        ..current_meta.clone()
+    };
+    updated.write(repo.inner(), current_branch)?;
+
+    let descendants = Stack::load(repo)?.descendants(current_branch);
+
+    println!(
+        "Reparented '{}' onto '{}'",
+        current_branch.green(),
+        new_branch.green()
+    );
+    if !descendants.is_empty() {
+        println!(
+            "  {} descendant branch(es) moved with it:",
+            descendants.len().to_string().cyan()
+        );
+        for descendant in &descendants {
+            println!("    {}", descendant.dimmed());
+        }
+    }
+    println!(
+        "{}",
+        "Run `stax restack` to rebase the moved branches onto their new parent.".yellow()
     );
 
     Ok(())

--- a/tests/create_below_tests.rs
+++ b/tests/create_below_tests.rs
@@ -1,0 +1,281 @@
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+
+#[cfg(unix)]
+fn install_failing_pre_commit_hook(repo: &TestRepo) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let hooks_dir = repo.path().join(".git").join("hooks");
+    std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+    let hook = hooks_dir.join("pre-commit");
+    std::fs::write(&hook, "#!/bin/sh\necho hook failed >&2\nexit 1\n").expect("write failing hook");
+    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod failing hook");
+}
+
+fn assert_current_parent_contains(repo: &TestRepo, expected: &str) {
+    let parent = repo.get_current_parent();
+    let expected_lower = expected.to_lowercase();
+    assert!(
+        parent
+            .as_ref()
+            .is_some_and(|p| p.to_lowercase().contains(&expected_lower)),
+        "Expected current parent to contain '{}', got: {:?}",
+        expected,
+        parent
+    );
+}
+
+fn branch_needs_restack(repo: &TestRepo, branch: &str) -> bool {
+    repo.get_status_json()["branches"]
+        .as_array()
+        .and_then(|branches| {
+            branches
+                .iter()
+                .find(|entry| entry["name"].as_str() == Some(branch))
+        })
+        .and_then(|entry| entry["needs_restack"].as_bool())
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_create_below_reparents_current_branch_and_preserves_descendants() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    // main -> below-parent -> below-current -> below-child
+    let branches = repo.create_stack(&["below-parent", "below-current", "below-child"]);
+    let parent = &branches[0];
+    let current = &branches[1];
+    let child = &branches[2];
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    let output = repo.run_stax(&["create", "below-mid", "--below"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("Reparented") && stdout.contains("restack"),
+        "Expected reparent summary and restack hint, got: {}",
+        stdout
+    );
+
+    let below_mid = repo.current_branch();
+    assert!(
+        below_mid.contains("below-mid"),
+        "Expected to switch to new below branch, got: {}",
+        below_mid
+    );
+    assert_current_parent_contains(&repo, "below-parent");
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    assert_current_parent_contains(&repo, "below-mid");
+
+    repo.run_stax(&["checkout", child]).assert_success();
+    assert_current_parent_contains(&repo, "below-current");
+
+    repo.run_stax(&["checkout", parent]).assert_success();
+    let children = repo.get_children(parent);
+    assert!(
+        children.iter().any(|name| name.contains("below-mid")),
+        "Expected parent to have below-mid as a direct child, got: {:?}",
+        children
+    );
+}
+
+#[test]
+fn test_create_below_works_for_direct_child_of_trunk_via_bc_alias() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["below-root"]);
+    let original = &branches[0];
+
+    repo.run_stax(&["checkout", original]).assert_success();
+    repo.run_stax(&["bc", "below-root-mid", "--below"])
+        .assert_success();
+
+    let below_root_mid = repo.current_branch();
+    assert!(
+        below_root_mid.contains("below-root-mid"),
+        "Expected to switch to new below branch, got: {}",
+        below_root_mid
+    );
+    assert_current_parent_contains(&repo, "main");
+
+    repo.run_stax(&["checkout", original]).assert_success();
+    assert_current_parent_contains(&repo, "below-root-mid");
+}
+
+#[test]
+fn test_create_below_works_via_branch_create() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["below-branch-create"]);
+    let original = &branches[0];
+
+    repo.run_stax(&["branch", "create", "below-via-branch", "--below"])
+        .assert_success();
+
+    let new_branch = repo.current_branch();
+    assert!(
+        new_branch.contains("below-via-branch"),
+        "Expected branch create --below to switch to new branch, got: {}",
+        new_branch
+    );
+    assert_current_parent_contains(&repo, "main");
+
+    repo.run_stax(&["checkout", original]).assert_success();
+    assert_current_parent_contains(&repo, "below-via-branch");
+}
+
+#[test]
+fn test_create_below_with_message_commits_on_new_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["below-message-parent", "below-message-current"]);
+    let current = &branches[1];
+    let current_before = repo.get_commit_sha(current);
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    repo.create_file("prep.txt", "prep work\n");
+
+    let output = repo.run_stax(&["create", "-a", "-m", "Prep below", "--below"]);
+    output.assert_success();
+    output.assert_stdout_contains("Committed: Prep below");
+
+    let prep_branch = repo.current_branch();
+    assert!(
+        prep_branch.to_lowercase().contains("prep-below"),
+        "Expected generated prep-below branch, got: {}",
+        prep_branch
+    );
+
+    let subject = repo.git(&["log", "-1", "--pretty=%s"]);
+    assert!(subject.status.success(), "{}", TestRepo::stderr(&subject));
+    assert_eq!(TestRepo::stdout(&subject).trim(), "Prep below");
+    assert_eq!(
+        repo.get_commit_sha(current),
+        current_before,
+        "original branch should not advance when committing below it"
+    );
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    assert_current_parent_contains(&repo, "prep-below");
+    assert!(
+        branch_needs_restack(&repo, current),
+        "original branch should need restack after the below branch gets a commit"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_create_below_restores_original_metadata_when_commit_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["below-fail-parent", "below-fail-current"]);
+    let parent = &branches[0];
+    let current = &branches[1];
+    let current_before = repo.get_commit_sha(current);
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    repo.create_file("fail-below.txt", "work that should stay\n");
+    install_failing_pre_commit_hook(&repo);
+
+    let output = repo.run_stax(&["create", "-a", "-m", "Fail below", "--below"]);
+    output.assert_failure();
+
+    assert_eq!(
+        repo.current_branch(),
+        *current,
+        "rollback should return to the original branch"
+    );
+    assert_eq!(
+        repo.get_commit_sha(current),
+        current_before,
+        "original branch should not advance after failed below commit"
+    );
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|branch| branch.to_lowercase().contains("fail-below")),
+        "failed below branch should be deleted"
+    );
+    assert_current_parent_contains(&repo, parent);
+    assert!(
+        repo.path().join("fail-below.txt").exists(),
+        "rollback should preserve the user's working-tree file"
+    );
+}
+
+#[test]
+fn test_create_below_rejects_from() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+    repo.create_stack(&["below-from-conflict"]);
+
+    let output = repo.run_stax(&["create", "bad", "--below", "--from", "main"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("cannot be used") || stderr.contains("conflict"),
+        "Expected conflicting --from error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_create_below_untracked_branch_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    repo.git(&["checkout", "-b", "manual-untracked"]);
+    let output = repo.run_stax(&["create", "bad", "--below"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("not tracked") || stderr.contains("branch track"),
+        "Expected untracked branch guidance, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_create_below_from_trunk_fails() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let output = repo.run_stax(&["create", "below-main", "--below"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("below trunk") || stderr.contains("Checkout a stacked branch"),
+        "Expected below-trunk guidance, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_create_below_rejects_conflicting_placement_flags() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+    repo.create_stack(&["below-conflict"]);
+
+    let output = repo.run_stax(&["create", "bad", "--below", "--insert"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("cannot be used") || stderr.contains("conflict"),
+        "Expected conflicting flag error, got: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary
- add `st create <name> --below` to insert a new branch between the current branch and its parent
- reparent the original current branch onto the new branch while preserving descendants
- document the new flag in README, command docs, compatibility docs, and skills.md

Closes #332

## Tests
- `cargo test --test create_below_tests`
- `cargo test --test create_insert_tests`
- `cargo test --test create_rollback_tests`