### PR TITLE
feat(create): add --no-verify flag

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -185,6 +185,7 @@ st wt go ui-polish --run "cursor ." --tmux
 
 - `-m "msg"` set commit message (with nothing staged in a TTY: menu for stage all, `--patch`, empty branch, or abort)
 - `-am "msg"` stage all and commit
+- `-n`, `--no-verify` skip pre-commit and commit-msg hooks when creating a commit
 - `--insert` reparent children of the current branch onto the new branch
 - `--below` create from the current branch's parent and reparent the current branch onto the new branch; combines with `-m`/`-am` to commit on the new lower branch
 - `st branch create --message "msg" --prefix feature/`

--- a/skills.md
+++ b/skills.md
@@ -148,6 +148,7 @@ stax create <name>                 # Create branch stacked on current
 stax create -m "message"           # Use commit message (TTY menu if nothing staged)
 stax create -a                     # Stage all before creating
 stax create -am "message"          # Stage all + commit (bypasses menu)
+stax create -n -am "message"       # Stage all + commit, skipping hooks
 stax create --from <branch>        # Create from explicit base
 stax create --prefix feature/      # Override branch prefix
 stax create <name> --below         # Insert new branch below current

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -602,6 +602,9 @@ enum Commands {
         /// Insert below current branch (reparent current and descendants)
         #[arg(long, conflicts_with_all = ["insert", "from"])]
         below: bool,
+        /// Skip pre-commit and commit-msg hooks
+        #[arg(long = "no-verify", short = 'n')]
+        no_verify: bool,
     },
 
     /// Open the current branch PR or list repo pull requests
@@ -964,6 +967,9 @@ enum Commands {
         /// Insert below current branch (reparent current and descendants)
         #[arg(long, conflicts_with_all = ["insert", "from"])]
         below: bool,
+        /// Skip pre-commit and commit-msg hooks
+        #[arg(long = "no-verify", short = 'n')]
+        no_verify: bool,
     },
     #[command(hide = true)]
     Bu {
@@ -1134,6 +1140,9 @@ enum BranchCommands {
         /// Insert below current branch (reparent current and descendants)
         #[arg(long, conflicts_with_all = ["insert", "from"])]
         below: bool,
+        /// Skip pre-commit and commit-msg hooks
+        #[arg(long = "no-verify", short = 'n')]
+        no_verify: bool,
     },
 
     /// Checkout a branch in the stack
@@ -1842,7 +1851,10 @@ pub fn run() -> Result<()> {
             prefix,
             insert,
             below,
-        } => commands::branch::create::run(name, message, from, prefix, all, insert, below),
+            no_verify,
+        } => commands::branch::create::run(
+            name, message, from, prefix, all, insert, below, no_verify,
+        ),
         Commands::Pr { command } => match command.unwrap_or(PrCommands::Open) {
             PrCommands::Open => commands::pr::run_open(),
             PrCommands::List { limit, json } => commands::pr::run_list(limit, json),
@@ -1958,7 +1970,10 @@ pub fn run() -> Result<()> {
                 prefix,
                 insert,
                 below,
-            } => commands::branch::create::run(name, message, from, prefix, all, insert, below),
+                no_verify,
+            } => commands::branch::create::run(
+                name, message, from, prefix, all, insert, below, no_verify,
+            ),
             BranchCommands::Checkout {
                 branch,
                 pr,
@@ -2048,7 +2063,10 @@ pub fn run() -> Result<()> {
             prefix,
             insert,
             below,
-        } => commands::branch::create::run(name, message, from, prefix, all, insert, below),
+            no_verify,
+        } => commands::branch::create::run(
+            name, message, from, prefix, all, insert, below, no_verify,
+        ),
         Commands::Bu { count } => commands::navigate::up(count),
         Commands::Bd { count } => commands::navigate::down(count),
         Commands::Bs { submit } => run_submit(submit, commands::submit::SubmitScope::Branch),
@@ -2356,9 +2374,9 @@ fn print_worktree_help() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        check_interactive_terminal_with_probe, detect_interactive_stdio, has_interactive_terminal,
         Cli, CliSubcommand, CommandPolicy, Commands, InteractiveTerminalCheck, RestackSubmitAfter,
-        StackCommands, WorktreeCommands,
+        StackCommands, WorktreeCommands, check_interactive_terminal_with_probe,
+        detect_interactive_stdio, has_interactive_terminal,
     };
     use clap::Parser;
     use std::cell::Cell;

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -25,10 +25,10 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use crate::remote;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use console::Term;
-use dialoguer::{theme::ColorfulTheme, Input, Select};
+use dialoguer::{Input, Select, theme::ColorfulTheme};
 use std::path::Path;
 use std::process::Command;
 
@@ -56,6 +56,7 @@ pub fn run(
     all: bool,
     insert: bool,
     below: bool,
+    no_verify: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let config = Config::load()?;
@@ -174,6 +175,7 @@ pub fn run(
                 stage_mode,
                 needs_stage_all,
                 insert,
+                no_verify,
             );
         }
     }
@@ -221,6 +223,7 @@ pub fn run(
                     &current,
                     &branch_name,
                     below_current_meta.as_ref(),
+                    no_verify,
                 )?;
                 println!("Committed: {}", msg.cyan());
             }
@@ -240,6 +243,33 @@ pub fn run(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy)]
+struct GitCommitOptions {
+    quiet: bool,
+    no_verify: bool,
+}
+
+fn run_git_commit(
+    workdir: &Path,
+    message: &str,
+    options: GitCommitOptions,
+) -> Result<std::process::ExitStatus> {
+    let mut args = vec!["commit"];
+    if options.quiet {
+        args.push("--quiet");
+    }
+    if options.no_verify {
+        args.push("--no-verify");
+    }
+    args.extend(["-m", message]);
+
+    Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git commit")
+}
+
 /// Run `git commit -m <msg>` on the currently checked-out branch. On any
 /// failure (spawn error, non-zero exit, hook rejection), invoke
 /// `rollback_create` to clean up the partially-created branch before
@@ -252,11 +282,16 @@ fn commit_or_rollback(
     original: &str,
     new_branch: &str,
     restore_original_meta: Option<&BranchMetadata>,
+    no_verify: bool,
 ) -> Result<()> {
-    let status = Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(workdir)
-        .status();
+    let status = run_git_commit(
+        workdir,
+        message,
+        GitCommitOptions {
+            quiet: false,
+            no_verify,
+        },
+    );
     match status {
         Ok(s) if s.success() => Ok(()),
         Ok(_) => {
@@ -325,6 +360,7 @@ fn run_commit_first(
     stage_mode: StageMode,
     needs_stage_all: bool,
     insert: bool,
+    no_verify: bool,
 ) -> Result<()> {
     let workdir = repo.workdir()?;
 
@@ -351,11 +387,14 @@ fn run_commit_first(
     // "[<branch> <sha>] <msg>" summary that would otherwise show the commit
     // landing on the original branch — we move it off a few calls later and
     // print our own summary. Pre-commit hook output is not suppressed by -q.
-    let commit_status = Command::new("git")
-        .args(["commit", "--quiet", "-m", message])
-        .current_dir(workdir)
-        .status()
-        .context("Failed to run git commit")?;
+    let commit_status = run_git_commit(
+        workdir,
+        message,
+        GitCommitOptions {
+            quiet: true,
+            no_verify,
+        },
+    )?;
 
     if !commit_status.success() {
         bail!(
@@ -754,10 +793,7 @@ fn append_branch_suffix(branch_name: &str, suffix: usize) -> String {
 /// routes to the staging menu and the user picks `--patch`, we run
 /// `git add -p` inline so the caller sees the "staged manually" shape
 /// (`StageMode::ExistingOnly`, no auto-stage-all).
-fn run_wizard(
-    workdir: &Path,
-    parent_branch: &str,
-) -> Result<(String, Option<String>, StageMode)> {
+fn run_wizard(workdir: &Path, parent_branch: &str) -> Result<(String, Option<String>, StageMode)> {
     println!();
     println!("╭─ Create Stacked Branch ─────────────────────────────╮");
     println!(
@@ -825,11 +861,7 @@ fn run_wizard(
             .with_prompt("Commit message (Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
-        if m.is_empty() {
-            None
-        } else {
-            Some(m)
-        }
+        if m.is_empty() { None } else { Some(m) }
     } else {
         None
     };

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1055,6 +1055,8 @@ fn test_branch_create_help_flags() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("from"));
     assert!(stdout.contains("prefix"));
+    assert!(stdout.contains("-n"));
+    assert!(stdout.contains("--no-verify"));
 }
 
 #[test]
@@ -1124,6 +1126,7 @@ fn fp_parity_bc_branch_create() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("message")); // -m flag
     assert!(stdout.contains("from")); // --from flag
+    assert!(stdout.contains("no-verify")); // -n/--no-verify flag
 }
 
 #[test]
@@ -1314,6 +1317,8 @@ fn gt_parity_create_am_flags() {
     assert!(stdout.contains("--all"));
     assert!(stdout.contains("-m"));
     assert!(stdout.contains("--message"));
+    assert!(stdout.contains("-n"));
+    assert!(stdout.contains("--no-verify"));
 }
 
 #[test]

--- a/tests/create_below_tests.rs
+++ b/tests/create_below_tests.rs
@@ -214,6 +214,51 @@ fn test_create_below_restores_original_metadata_when_commit_fails() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_create_below_no_verify_skips_hook() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["below-no-verify-parent", "below-no-verify-current"]);
+    let current = &branches[1];
+    let current_before = repo.get_commit_sha(current);
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    repo.create_file("skip-below-hook.txt", "work that should commit\n");
+    install_failing_pre_commit_hook(&repo);
+
+    let output = repo.run_stax(&[
+        "create",
+        "-a",
+        "-m",
+        "Skip below hook",
+        "--below",
+        "--no-verify",
+    ]);
+    output.assert_success();
+    output.assert_stdout_contains("Committed: Skip below hook");
+
+    let new_branch = repo.current_branch();
+    assert!(
+        new_branch.to_lowercase().contains("skip-below-hook"),
+        "Expected generated skip-below-hook branch, got: {}",
+        new_branch
+    );
+
+    let subject = repo.git(&["log", "-1", "--pretty=%s"]);
+    assert!(subject.status.success(), "{}", TestRepo::stderr(&subject));
+    assert_eq!(TestRepo::stdout(&subject).trim(), "Skip below hook");
+    assert_eq!(
+        repo.get_commit_sha(current),
+        current_before,
+        "original branch should not advance when committing below it"
+    );
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    assert_current_parent_contains(&repo, "skip-below-hook");
+}
+
+#[test]
 fn test_create_below_rejects_from() {
     let repo = TestRepo::new();
     repo.run_stax(&["status"]).assert_success();

--- a/tests/create_rollback_tests.rs
+++ b/tests/create_rollback_tests.rs
@@ -117,6 +117,45 @@ fn create_with_successful_commit_still_works() {
     );
 }
 
+#[test]
+#[cfg(unix)]
+fn create_no_verify_skips_hook_in_commit_first_flow() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_file("test.txt", "hello");
+    install_failing_pre_commit_hook(&repo);
+
+    let output = repo.run_stax(&["create", "-a", "-m", "skip hook", "--no-verify"]);
+    output.assert_success();
+
+    assert!(
+        repo.current_branch().contains("skip-hook"),
+        "Should be on the created branch. Current: {}",
+        repo.current_branch()
+    );
+    let subject = repo.git(&["log", "-1", "--pretty=%s"]);
+    assert!(subject.status.success(), "{}", TestRepo::stderr(&subject));
+    assert_eq!(TestRepo::stdout(&subject).trim(), "skip hook");
+}
+
+#[test]
+#[cfg(unix)]
+fn create_no_verify_works_via_bc_alias() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_file("alias.txt", "hello");
+    install_failing_pre_commit_hook(&repo);
+
+    repo.run_stax(&["bc", "-a", "-m", "alias skip hook", "-n"])
+        .assert_success();
+
+    assert!(
+        repo.current_branch().contains("alias-skip-hook"),
+        "Should be on the created branch. Current: {}",
+        repo.current_branch()
+    );
+}
+
 /// Verifies the commit-first ordering: on success, the new commit lives only
 /// on the new branch and `main`'s HEAD does not advance.
 #[test]
@@ -318,4 +357,38 @@ fn create_from_other_branch_with_failing_hook_rolls_back() {
         repo.list_branches(),
     );
     output.assert_stderr_contains("rolled back");
+}
+
+#[test]
+#[cfg(unix)]
+fn branch_create_no_verify_skips_hook_in_branch_first_flow() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let branches = repo.create_stack(&["sibling"]);
+
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    install_failing_pre_commit_hook(&repo);
+    repo.create_file("wip.txt", "wip");
+
+    let output = repo.run_stax(&[
+        "branch",
+        "create",
+        "--from",
+        &branches[0],
+        "-a",
+        "-m",
+        "off sibling no verify",
+        "-n",
+    ]);
+    output.assert_success();
+
+    assert!(
+        repo.current_branch().contains("off-sibling-no-verify"),
+        "Should be on the created branch. Current: {}",
+        repo.current_branch()
+    );
+    let subject = repo.git(&["log", "-1", "--pretty=%s"]);
+    assert!(subject.status.success(), "{}", TestRepo::stderr(&subject));
+    assert_eq!(TestRepo::stdout(&subject).trim(), "off sibling no verify");
 }


### PR DESCRIPTION
## Summary
- add `-n` / `--no-verify` to `st create`, `st branch create`, and `bc`
- pass `--no-verify` through create commit paths, including commit-first, `--from`, and rebased `--below`
- centralize create `git commit` argument construction so `--quiet` and `--no-verify` are handled in one place
- document the flag in the command reference and skills.md
- assert the new flag appears in create help output for `create`, `branch create`, and `bc`
- add regression coverage for `create --below --no-verify` skipping hooks after rebasing onto `main`

Closes #336

## Tests
- `cargo test --test create_rollback_tests`
- `cargo test --test create_insert_tests`
- `cargo test --test create_below_tests`
- `cargo test --test cli_tests test_branch_create_help_flags`
- `cargo test --test cli_tests gt_parity_create_am_flags`
- `cargo test --test cli_tests fp_parity_bc_branch_create`
- `cargo run --quiet -- create --help`
- `cargo run --quiet -- branch create --help`

## Docs note
README not updated: the quick-start and core command table do not list per-command commit flags.