### PR TITLE
fix(create): make --from and --below commits interruption-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "signal-hook",
  "tempfile",
  "termimad",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ termimad = "0.34"
 
 # Error handling
 anyhow = "1"
+signal-hook = "0.3"
 
 # Clipboard (text-only — skip image support to avoid pulling in the image crate)
 arboard = { version = "3", default-features = false }

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -186,6 +186,7 @@ st wt go ui-polish --run "cursor ." --tmux
 - `-m "msg"` set commit message (with nothing staged in a TTY: menu for stage all, `--patch`, empty branch, or abort)
 - `-am "msg"` stage all and commit
 - `-n`, `--no-verify` skip pre-commit and commit-msg hooks when creating a commit
+- `-m` / `-am` create the commit before creating the destination branch, including with `--from` and `--below`, so hook failures or interrupts do not leave orphan branches
 - `--insert` reparent children of the current branch onto the new branch
 - `--below` create from the current branch's parent and reparent the current branch onto the new branch; combines with `-m`/`-am` to commit on the new lower branch
 - `st branch create --message "msg" --prefix feature/`

--- a/skills.md
+++ b/skills.md
@@ -154,6 +154,8 @@ stax create --prefix feature/      # Override branch prefix
 stax create <name> --below         # Insert new branch below current
 stax create --below -am "message"  # Commit on new lower branch
 stax bc <name>                     # Hidden shortcut alias
+# create -m/-am commits before branch creation, including --from/--below,
+# so hook failures or interrupts do not leave orphan branches or -2 retries.
 
 stax m                             # Amend current commit (TTY menu if nothing staged)
 stax m -a                          # Stage all + amend (bypasses menu)

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -2,16 +2,16 @@
 //!
 //! Two flows live in this file:
 //!
-//! - **Commit-first** (the default when `-m "msg"` is used and the new branch
-//!   stacks on the current branch): `git commit` runs on the current branch
-//!   *before* any stax ref is created. On hook failure or Ctrl+C nothing is
-//!   touched — no orphan branch, no `mybranch-2` drift on retry. The new
-//!   commit is then split off to the new branch and the current branch ref is
-//!   moved back to its pre-commit SHA.
-//! - **Branch-first** (everything else: name-only `st create`, `--from
-//!   <other>`, no-op `-m` with a clean tree): create the branch and switch to
-//!   it first, then optionally commit. Failures here use the legacy
-//!   `rollback_create` cleanup.
+//! - **Commit-first** (`-m "msg"`): `git commit` runs *before* any destination
+//!   branch ref is created. When the requested parent is the current branch, the
+//!   commit is made on the current branch and then split off. For `--from` and
+//!   `--below`, the commit is made on a detached checkout of the requested
+//!   parent so the new commit has the right base without advancing that parent.
+//!   On hook failure or Ctrl+C no destination branch exists, so retries do not
+//!   drift to `mybranch-2`, `mybranch-3`, etc.
+//! - **Branch-first** (everything else: name-only `st create`, no-op `-m` with
+//!   a clean tree): create the branch and switch to it first. Failures here use
+//!   the legacy `rollback_create` cleanup.
 //!
 //! Both flows share `create_branch_with_banner` for the create → metadata →
 //! `--insert`/`--below` placement → checkout → summary sequence.
@@ -25,12 +25,16 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use crate::remote;
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use console::Term;
-use dialoguer::{Input, Select, theme::ColorfulTheme};
+use dialoguer::{theme::ColorfulTheme, Input, Select};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StageMode {
@@ -157,27 +161,26 @@ pub fn run(
 
     let commit_message = if skip_commit { None } else { commit_message };
 
-    // Commit-first path: when the user supplied -m and the new branch stacks on
-    // the current branch, run the commit on the current branch BEFORE creating
-    // or switching to the new branch. If pre-commit hooks fail (or the user
-    // hits Ctrl+C) we exit with no refs touched: no orphan branch, no name
-    // drift to `-2`/`-3`, and the user stays on their original branch with
-    // their working tree preserved. Only on a successful commit do we split
-    // it off to the new branch and move the parent ref back.
+    // Commit-first path: when the user supplied -m, run the commit BEFORE
+    // creating or switching to the destination branch. If pre-commit hooks fail
+    // (or the user hits Ctrl+C) we exit with no destination refs touched: no
+    // orphan branch, no name drift to `-2`/`-3`, and the user can retry the same
+    // command. Only after a successful commit do we create metadata and move
+    // into the requested placement.
     if let Some(msg) = commit_message.as_deref() {
-        if parent_branch == current {
-            return run_commit_first(
-                &repo,
-                &config,
-                &current,
-                &branch_name,
-                msg,
-                stage_mode,
-                needs_stage_all,
-                insert,
-                no_verify,
-            );
-        }
+        return run_commit_first(
+            &repo,
+            &config,
+            &current,
+            &parent_branch,
+            &branch_name,
+            msg,
+            stage_mode,
+            needs_stage_all,
+            insert,
+            below_current_meta.as_ref(),
+            no_verify,
+        );
     }
 
     create_branch_with_banner(
@@ -209,25 +212,7 @@ pub fn run(
             }
         }
 
-        // Only commit if -m was provided. This block only runs for the
-        // `--from <other>` + `-m` path; the common `-m` without `--from` case
-        // returns early via `run_commit_first`.
-        if let Some(msg) = commit_message {
-            if staging::is_staging_area_empty(workdir)? {
-                println!("{}", "No changes to commit".dimmed());
-            } else {
-                commit_or_rollback(
-                    workdir,
-                    &msg,
-                    &repo,
-                    &current,
-                    &branch_name,
-                    below_current_meta.as_ref(),
-                    no_verify,
-                )?;
-                println!("Committed: {}", msg.cyan());
-            }
-        } else if stage_mode == StageMode::All {
+        if stage_mode == StageMode::All {
             println!("{}", "Changes staged".dimmed());
         }
     }
@@ -241,71 +226,6 @@ pub fn run(
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy)]
-struct GitCommitOptions {
-    quiet: bool,
-    no_verify: bool,
-}
-
-fn run_git_commit(
-    workdir: &Path,
-    message: &str,
-    options: GitCommitOptions,
-) -> Result<std::process::ExitStatus> {
-    let mut args = vec!["commit"];
-    if options.quiet {
-        args.push("--quiet");
-    }
-    if options.no_verify {
-        args.push("--no-verify");
-    }
-    args.extend(["-m", message]);
-
-    Command::new("git")
-        .args(&args)
-        .current_dir(workdir)
-        .status()
-        .context("Failed to run git commit")
-}
-
-/// Run `git commit -m <msg>` on the currently checked-out branch. On any
-/// failure (spawn error, non-zero exit, hook rejection), invoke
-/// `rollback_create` to clean up the partially-created branch before
-/// returning the error. Used only by the branch-first path — commit-first
-/// runs its own bare `git commit` because there's nothing to roll back yet.
-fn commit_or_rollback(
-    workdir: &Path,
-    message: &str,
-    repo: &GitRepo,
-    original: &str,
-    new_branch: &str,
-    restore_original_meta: Option<&BranchMetadata>,
-    no_verify: bool,
-) -> Result<()> {
-    let status = run_git_commit(
-        workdir,
-        message,
-        GitCommitOptions {
-            quiet: false,
-            no_verify,
-        },
-    );
-    match status {
-        Ok(s) if s.success() => Ok(()),
-        Ok(_) => {
-            rollback_create_and_restore(repo, original, new_branch, restore_original_meta);
-            bail!(
-                "Commit failed (pre-commit hook or other error). \
-                 Branch rolled back. Fix the issue and retry."
-            );
-        }
-        Err(e) => {
-            rollback_create_and_restore(repo, original, new_branch, restore_original_meta);
-            Err(anyhow::Error::from(e).context("Failed to run git commit"))
-        }
-    }
 }
 
 /// Best-effort rollback: unstage changes, checkout the original branch,
@@ -340,112 +260,222 @@ fn rollback_create_and_restore(
     rollback_create(repo, original_branch, new_branch);
 }
 
-/// Graphite-style commit-first flow: commit on the current branch, then split
-/// the new commit off to a new branch and move the current branch ref back.
+/// Graphite-style commit-first flow: commit before creating the destination
+/// branch, then split the new commit off to a new branch.
 ///
 /// The key property: nothing observable changes until `git commit` returns
 /// successfully. If pre-commit hooks reject the commit, or the user hits
-/// Ctrl+C during the commit, no branch is created, no metadata is written,
-/// and HEAD is untouched — so retrying the exact same command is a clean
-/// operation that does not drift into `mybranch-2`, `mybranch-3`, etc.
+/// Ctrl+C during the commit, no destination branch is created and no metadata
+/// is written — so retrying the exact same command is a clean operation that
+/// does not drift into `mybranch-2`, `mybranch-3`, etc.
 ///
-/// Precondition: `parent_branch == current` (i.e. no explicit `--from`).
+/// When `parent_branch != current` (`--from` or `--below`), we check out the
+/// parent detached before committing. That makes the resulting commit's parent
+/// correct without advancing the requested parent branch.
 #[allow(clippy::too_many_arguments)]
 fn run_commit_first(
     repo: &GitRepo,
     config: &Config,
     current: &str,
+    parent_branch: &str,
     branch_name: &str,
     message: &str,
     stage_mode: StageMode,
     needs_stage_all: bool,
     insert: bool,
+    below_current_meta: Option<&BranchMetadata>,
     no_verify: bool,
 ) -> Result<()> {
     let workdir = repo.workdir()?;
+    let committing_on_current = parent_branch == current;
+    let parent_sha = repo.branch_commit(parent_branch)?;
+
+    if !committing_on_current {
+        checkout_detached_for_commit(workdir, parent_branch)?;
+    }
 
     // Stage (if requested) BEFORE the commit so hooks see the final tree.
     if stage_mode == StageMode::All || needs_stage_all {
-        staging::stage_all(workdir)?;
+        if let Err(e) = staging::stage_all(workdir) {
+            restore_after_failed_pre_branch_commit(repo, workdir, current, committing_on_current);
+            return Err(e);
+        }
     }
 
     // If nothing is staged by the time we reach here, there is no commit to
     // make. Fall back to creating an empty branch — same shape as the
     // branch-first path without the trailing commit.
-    if staging::is_staging_area_empty(workdir)? {
-        create_branch_with_banner(repo, config, current, current, branch_name, insert, None)?;
+    let staging_area_empty = match staging::is_staging_area_empty(workdir) {
+        Ok(empty) => empty,
+        Err(e) => {
+            restore_after_failed_pre_branch_commit(repo, workdir, current, committing_on_current);
+            return Err(e);
+        }
+    };
+
+    if staging_area_empty {
+        create_branch_with_banner(
+            repo,
+            config,
+            current,
+            parent_branch,
+            branch_name,
+            insert,
+            below_current_meta,
+        )?;
         println!("{}", "No changes to commit".dimmed());
         print_tips(config);
         return Ok(());
     }
 
-    // Capture the pre-commit SHA so we can move the current branch back to it
-    // after splitting the new commit off.
-    let old_parent_sha = repo.branch_commit(current)?;
+    // Run the commit before the destination branch exists. `--quiet`
+    // suppresses git's "[<branch> <sha>] <msg>" summary that would otherwise
+    // mention the temporary commit location; we print our own summary after
+    // the commit is split off. Pre-commit hook output is not suppressed by -q.
+    let commit = match run_git_commit(workdir, message, true, no_verify) {
+        Ok(commit) => commit,
+        Err(e) => {
+            restore_after_failed_pre_branch_commit(repo, workdir, current, committing_on_current);
+            return Err(e);
+        }
+    };
 
-    // Run the commit on the current branch. `--quiet` suppresses git's
-    // "[<branch> <sha>] <msg>" summary that would otherwise show the commit
-    // landing on the original branch — we move it off a few calls later and
-    // print our own summary. Pre-commit hook output is not suppressed by -q.
-    let commit_status = run_git_commit(
-        workdir,
-        message,
-        GitCommitOptions {
-            quiet: true,
-            no_verify,
-        },
-    )?;
+    if !commit.status.success() {
+        restore_after_failed_pre_branch_commit(repo, workdir, current, committing_on_current);
+        if commit.interrupted {
+            bail!(
+                "Commit interrupted. \
+                 No branch was created — fix the issue and retry with the same command."
+            );
+        } else {
+            bail!(
+                "Commit failed (pre-commit hook or other error). \
+                 No branch was created — fix the issue and retry with the same command."
+            );
+        }
+    }
 
-    if !commit_status.success() {
+    if commit.interrupted {
+        rollback_after_commit(
+            workdir,
+            current,
+            &parent_sha,
+            None,
+            repo,
+            committing_on_current,
+            below_current_meta,
+        );
         bail!(
-            "Commit failed (pre-commit hook or other error). \
+            "Commit interrupted. \
              No branch was created — fix the issue and retry with the same command."
         );
     }
 
-    // From here on the commit exists on the current branch. Any failure must
-    // undo the commit with a soft reset so the user's working tree and staged
-    // changes are preserved.
-    let new_sha = repo.branch_commit(current)?;
+    // From here on the commit exists either on the current branch or on a
+    // detached HEAD at `parent_branch`. Any failure must preserve the user's
+    // staged work and avoid leaving a destination branch behind.
+    let new_sha = match repo.rev_parse("HEAD") {
+        Ok(sha) => sha,
+        Err(e) => {
+            rollback_after_commit(
+                workdir,
+                current,
+                &parent_sha,
+                None,
+                repo,
+                committing_on_current,
+                below_current_meta,
+            );
+            return Err(e);
+        }
+    };
 
     if let Err(e) = repo.create_branch_at_commit(branch_name, &new_sha) {
-        rollback_after_commit(workdir, &old_parent_sha, None, repo);
+        rollback_after_commit(
+            workdir,
+            current,
+            &parent_sha,
+            None,
+            repo,
+            committing_on_current,
+            below_current_meta,
+        );
         return Err(e);
     }
 
-    let meta = BranchMetadata::new(current, &old_parent_sha);
+    let meta = BranchMetadata::new(parent_branch, &parent_sha);
     if let Err(e) = meta.write(repo.inner(), branch_name) {
-        rollback_after_commit(workdir, &old_parent_sha, Some(branch_name), repo);
+        rollback_after_commit(
+            workdir,
+            current,
+            &parent_sha,
+            Some(branch_name),
+            repo,
+            committing_on_current,
+            below_current_meta,
+        );
         return Err(e);
     }
 
     if insert {
-        if let Err(e) = apply_insert_reparenting(repo, current, branch_name) {
-            rollback_after_commit(workdir, &old_parent_sha, Some(branch_name), repo);
+        if let Err(e) = apply_insert_reparenting(repo, parent_branch, branch_name) {
+            rollback_after_commit(
+                workdir,
+                current,
+                &parent_sha,
+                Some(branch_name),
+                repo,
+                committing_on_current,
+                below_current_meta,
+            );
             return Err(e);
         }
     }
 
-    // Move the current branch ref back to the pre-commit SHA. The new commit
-    // now lives only on `branch_name`.
-    let current_ref = format!("refs/heads/{}", current);
-    if let Err(e) = repo.update_ref(&current_ref, &old_parent_sha) {
-        rollback_after_commit(workdir, &old_parent_sha, Some(branch_name), repo);
-        return Err(e);
+    if let Some(current_meta) = below_current_meta {
+        if let Err(e) = apply_below_reparenting(repo, current, branch_name, current_meta) {
+            rollback_after_commit(
+                workdir,
+                current,
+                &parent_sha,
+                Some(branch_name),
+                repo,
+                committing_on_current,
+                below_current_meta,
+            );
+            return Err(e);
+        }
     }
 
-    // Switch to the new branch. HEAD still points at `current` (now at the old
-    // SHA) while the working tree matches the new commit; `git checkout` moves
-    // HEAD without touching the working tree since it's already correct. If
-    // this fails there's nothing to undo — the commit lives on the new branch,
-    // `current` is reset — the user just needs `git checkout <new>` manually.
+    if committing_on_current {
+        // Move the current branch ref back to the pre-commit SHA. The new commit
+        // now lives only on `branch_name`.
+        let current_ref = format!("refs/heads/{}", current);
+        if let Err(e) = repo.update_ref(&current_ref, &parent_sha) {
+            rollback_after_commit(
+                workdir,
+                current,
+                &parent_sha,
+                Some(branch_name),
+                repo,
+                committing_on_current,
+                below_current_meta,
+            );
+            return Err(e);
+        }
+    }
+
+    // Switch to the new branch. In the current-parent case HEAD still points at
+    // `current` (now at the old SHA) while the working tree matches the new
+    // commit; in the detached-parent case HEAD already points at the new commit.
+    // `git checkout` only moves HEAD in both cases.
     repo.checkout(branch_name)?;
 
-    print_remote_parent_warning(repo, config, current);
+    print_remote_parent_warning(repo, config, parent_branch);
     println!(
         "Created and switched to branch '{}' (stacked on {})",
         branch_name.green(),
-        current.blue()
+        parent_branch.blue()
     );
     println!("Committed: {}", message.cyan());
     print_tips(config);
@@ -453,12 +483,136 @@ fn run_commit_first(
     Ok(())
 }
 
+struct GitCommitResult {
+    status: ExitStatus,
+    interrupted: bool,
+}
+
+struct CommitSignalGuard {
+    interrupted: Arc<AtomicBool>,
+    registrations: Vec<signal_hook::SigId>,
+}
+
+impl CommitSignalGuard {
+    fn install() -> Result<Self> {
+        let interrupted = Arc::new(AtomicBool::new(false));
+        let sigint = signal_hook::flag::register(
+            signal_hook::consts::signal::SIGINT,
+            Arc::clone(&interrupted),
+        )
+        .context("Failed to install SIGINT handler")?;
+        let sigterm = match signal_hook::flag::register(
+            signal_hook::consts::signal::SIGTERM,
+            Arc::clone(&interrupted),
+        ) {
+            Ok(registration) => registration,
+            Err(e) => {
+                let _ = signal_hook::low_level::unregister(sigint);
+                return Err(anyhow::Error::from(e).context("Failed to install SIGTERM handler"));
+            }
+        };
+
+        Ok(Self {
+            interrupted,
+            registrations: vec![sigint, sigterm],
+        })
+    }
+
+    fn interrupted(&self) -> bool {
+        self.interrupted.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for CommitSignalGuard {
+    fn drop(&mut self) {
+        for registration in self.registrations.drain(..) {
+            let _ = signal_hook::low_level::unregister(registration);
+        }
+    }
+}
+
+fn run_git_commit(
+    workdir: &Path,
+    message: &str,
+    quiet: bool,
+    no_verify: bool,
+) -> Result<GitCommitResult> {
+    let guard = CommitSignalGuard::install()?;
+    let mut args = vec!["commit"];
+    if quiet {
+        args.push("--quiet");
+    }
+    if no_verify {
+        args.push("--no-verify");
+    }
+    args.extend(["-m", message]);
+
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .status()
+        .context("Failed to run git commit")?;
+    let interrupted = guard.interrupted();
+
+    Ok(GitCommitResult {
+        status,
+        interrupted,
+    })
+}
+
+fn checkout_detached_for_commit(workdir: &Path, parent_branch: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["checkout", "--detach", parent_branch])
+        .current_dir(workdir)
+        .output()
+        .context("Failed to run git checkout --detach")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "Failed to prepare commit on '{}': {}",
+            parent_branch,
+            stderr
+        );
+    }
+
+    Ok(())
+}
+
+fn restore_after_failed_pre_branch_commit(
+    repo: &GitRepo,
+    workdir: &Path,
+    original_branch: &str,
+    committing_on_current: bool,
+) {
+    if committing_on_current {
+        return;
+    }
+
+    let _ = Command::new("git")
+        .args(["reset"])
+        .current_dir(workdir)
+        .status();
+    let _ = repo.checkout(original_branch);
+}
+
 /// Undo the partial state left by `run_commit_first` when a step after
 /// `git commit` (branch creation, metadata write, ref update) fails.
 ///
 /// `--soft` keeps the working tree and index exactly as git left them after
 /// the successful commit, so the user can retry without re-staging.
-fn rollback_after_commit(workdir: &Path, old_sha: &str, new_branch: Option<&str>, repo: &GitRepo) {
+fn rollback_after_commit(
+    workdir: &Path,
+    original_branch: &str,
+    old_sha: &str,
+    new_branch: Option<&str>,
+    repo: &GitRepo,
+    committing_on_current: bool,
+    restore_original_meta: Option<&BranchMetadata>,
+) {
+    if let Some(meta) = restore_original_meta {
+        let _ = meta.write(repo.inner(), original_branch);
+    }
     if let Some(name) = new_branch {
         let _ = BranchMetadata::delete(repo.inner(), name);
         let _ = repo.delete_branch(name, true);
@@ -467,6 +621,10 @@ fn rollback_after_commit(workdir: &Path, old_sha: &str, new_branch: Option<&str>
         .args(["reset", "--soft", old_sha])
         .current_dir(workdir)
         .status();
+
+    if !committing_on_current {
+        let _ = repo.checkout(original_branch);
+    }
 }
 
 /// Create `branch_name` stacked on `parent_branch`, write stax metadata,
@@ -861,7 +1019,11 @@ fn run_wizard(workdir: &Path, parent_branch: &str) -> Result<(String, Option<Str
             .with_prompt("Commit message (Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
-        if m.is_empty() { None } else { Some(m) }
+        if m.is_empty() {
+            None
+        } else {
+            Some(m)
+        }
     } else {
         None
     };

--- a/tests/create_below_tests.rs
+++ b/tests/create_below_tests.rs
@@ -137,7 +137,9 @@ fn test_create_below_with_message_commits_on_new_branch() {
     repo.run_stax(&["status"]).assert_success();
 
     let branches = repo.create_stack(&["below-message-parent", "below-message-current"]);
+    let parent = &branches[0];
     let current = &branches[1];
+    let parent_before = repo.get_commit_sha(parent);
     let current_before = repo.get_commit_sha(current);
 
     repo.run_stax(&["checkout", current]).assert_success();
@@ -157,6 +159,17 @@ fn test_create_below_with_message_commits_on_new_branch() {
     let subject = repo.git(&["log", "-1", "--pretty=%s"]);
     assert!(subject.status.success(), "{}", TestRepo::stderr(&subject));
     assert_eq!(TestRepo::stdout(&subject).trim(), "Prep below");
+    let commit_parent = repo.git(&["rev-parse", "HEAD^"]);
+    assert!(
+        commit_parent.status.success(),
+        "{}",
+        TestRepo::stderr(&commit_parent)
+    );
+    assert_eq!(
+        TestRepo::stdout(&commit_parent).trim(),
+        parent_before,
+        "below commit should be based on the original parent"
+    );
     assert_eq!(
         repo.get_commit_sha(current),
         current_before,
@@ -188,6 +201,7 @@ fn test_create_below_restores_original_metadata_when_commit_fails() {
 
     let output = repo.run_stax(&["create", "-a", "-m", "Fail below", "--below"]);
     output.assert_failure();
+    output.assert_stderr_contains("No branch was created");
 
     assert_eq!(
         repo.current_branch(),
@@ -210,6 +224,16 @@ fn test_create_below_restores_original_metadata_when_commit_fails() {
     assert!(
         repo.path().join("fail-below.txt").exists(),
         "rollback should preserve the user's working-tree file"
+    );
+
+    repo.run_stax(&["create", "-a", "-m", "Fail below", "--below"])
+        .assert_failure();
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|branch| branch.to_lowercase().contains("fail-below-2")),
+        "retry should not drift into a suffixed branch"
     );
 }
 

--- a/tests/create_rollback_tests.rs
+++ b/tests/create_rollback_tests.rs
@@ -7,18 +7,27 @@
 //! retrying with the same message does not drift into `mybranch-2`,
 //! `mybranch-3`, etc.
 //!
-//! A legacy rollback path still exists for the less common branch-first flow
-//! (e.g. `st create -m "msg" --from <other>`); this file covers both.
+//! The same safety property applies when `-m` commits from a non-current
+//! parent (`--from <other>` / `--below`): stax commits before creating the
+//! destination branch, then writes refs and metadata only after success.
 //!
 //! Most tests require Unix (pre-commit hooks use `#!/bin/sh` and chmod).
 
 mod common;
 
+#[cfg(unix)]
+use common::stax_bin;
 use common::{OutputAssertions, TestRepo};
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::process::{Command, Stdio};
+#[cfg(unix)]
+use std::thread;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 
 /// Install a pre-commit hook that always fails.
 #[cfg(unix)]
@@ -30,11 +39,82 @@ fn install_failing_pre_commit_hook(repo: &TestRepo) {
     fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
 }
 
+#[cfg(unix)]
+fn install_waiting_pre_commit_hook(repo: &TestRepo) {
+    let hooks_dir = repo.path().join(".git").join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    let hook_path = hooks_dir.join("pre-commit");
+    fs::write(
+        &hook_path,
+        "#!/bin/sh\n\
+         touch .git/hooks/pre-commit-started\n\
+         while [ ! -f .git/hooks/pre-commit-release ]; do sleep 1; done\n",
+    )
+    .unwrap();
+    fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
 /// Remove the pre-commit hook.
 #[cfg(unix)]
 fn remove_pre_commit_hook(repo: &TestRepo) {
     let hook_path = repo.path().join(".git").join("hooks").join("pre-commit");
     let _ = std::fs::remove_file(hook_path);
+}
+
+#[cfg(unix)]
+fn wait_for_hook_start(repo: &TestRepo) {
+    let marker = repo
+        .path()
+        .join(".git")
+        .join("hooks")
+        .join("pre-commit-started");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if marker.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("pre-commit hook did not start");
+}
+
+#[cfg(unix)]
+fn run_stax_until_hook_then_interrupt(repo: &TestRepo, args: &[&str]) -> std::process::Output {
+    let null_path = if cfg!(windows) { "NUL" } else { "/dev/null" };
+    let child = Command::new(stax_bin())
+        .args(args)
+        .current_dir(repo.path())
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("STAX_GITHUB_TOKEN")
+        .env_remove("STAX_SHELL_INTEGRATION")
+        .env_remove("GH_TOKEN")
+        .env("GIT_CONFIG_GLOBAL", null_path)
+        .env("GIT_CONFIG_SYSTEM", null_path)
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn stax");
+
+    wait_for_hook_start(repo);
+
+    let pid = child.id().to_string();
+    let status = Command::new("kill")
+        .args(["-INT", &pid])
+        .status()
+        .expect("send SIGINT to stax process");
+    assert!(status.success(), "failed to interrupt stax process {pid}");
+
+    fs::write(
+        repo.path()
+            .join(".git")
+            .join("hooks")
+            .join("pre-commit-release"),
+        "",
+    )
+    .expect("release waiting pre-commit hook");
+
+    child.wait_with_output().expect("wait for interrupted stax")
 }
 
 #[test]
@@ -313,17 +393,12 @@ fn create_rollback_then_succeed_after_hook_removed() {
     );
 }
 
-/// The `--from <other> -m "msg"` path still uses branch-first + the
-/// `rollback_create` fallback (commit-first only applies when the new branch
-/// stacks on the current branch). Guard that path: a failing hook must roll
-/// back the branch so retry is clean, just like the commit-first path.
-///
 /// `-m` is passed without a positional name so the branch name is derived
 /// from the message — when both are given, stax uses the positional name and
 /// discards the message, which would suppress the commit entirely.
 #[test]
 #[cfg(unix)]
-fn create_from_other_branch_with_failing_hook_rolls_back() {
+fn create_from_other_branch_with_failing_hook_leaves_no_branch() {
     let repo = TestRepo::new();
     repo.run_stax(&["init"]).assert_success();
 
@@ -346,8 +421,8 @@ fn create_from_other_branch_with_failing_hook_rolls_back() {
     ]);
     output.assert_failure();
 
-    // The branch must have been rolled back — no orphan, and the error must
-    // name the rollback so users know what happened.
+    // The branch must never be created — no orphan, and retries do not drift
+    // into a suffixed name.
     assert!(
         !repo
             .list_branches()
@@ -356,7 +431,201 @@ fn create_from_other_branch_with_failing_hook_rolls_back() {
         "new branch must be rolled back after hook failure. Branches: {:?}",
         repo.list_branches(),
     );
-    output.assert_stderr_contains("rolled back");
+    output.assert_stderr_contains("No branch was created");
+
+    repo.run_stax(&[
+        "create",
+        "--from",
+        &branches[0],
+        "-a",
+        "-m",
+        "off sibling feature",
+    ])
+    .assert_failure();
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|b| b.contains("off-sibling-feature-2")),
+        "retry must not drift into a suffixed branch. Branches: {:?}",
+        repo.list_branches(),
+    );
+}
+
+#[test]
+fn create_from_other_branch_with_message_commits_on_requested_parent() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let branches = repo.create_stack(&["sibling-parent"]);
+    let parent = &branches[0];
+    let parent_before = repo.get_commit_sha(parent);
+
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    let main_before = repo.get_commit_sha("main");
+    repo.create_file("from-parent.txt", "work for explicit parent\n");
+
+    let output = repo.run_stax(&["create", "--from", parent, "-a", "-m", "off sibling parent"]);
+    output.assert_success();
+    output.assert_stdout_contains("Committed: off sibling parent");
+
+    assert_eq!(
+        repo.get_commit_sha("main"),
+        main_before,
+        "original branch should not advance when creating from another parent"
+    );
+
+    let commit_parent = repo.git(&["rev-parse", "HEAD^"]);
+    assert!(
+        commit_parent.status.success(),
+        "{}",
+        TestRepo::stderr(&commit_parent)
+    );
+    assert_eq!(TestRepo::stdout(&commit_parent).trim(), parent_before);
+
+    let stax_parent = repo.get_current_parent();
+    assert!(
+        stax_parent.as_deref().is_some_and(|p| p == parent),
+        "new branch metadata should point at requested parent, got: {:?}",
+        stax_parent
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn create_from_other_branch_interrupted_commit_leaves_no_branch_and_retries_cleanly() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let branches = repo.create_stack(&["interrupt-parent"]);
+    let parent = &branches[0];
+
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    repo.create_file("interrupt.txt", "work interrupted during commit\n");
+    install_waiting_pre_commit_hook(&repo);
+
+    let output = run_stax_until_hook_then_interrupt(
+        &repo,
+        &[
+            "create",
+            "--from",
+            parent,
+            "-a",
+            "-m",
+            "interrupted from parent",
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "interrupted create should fail\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    assert_eq!(
+        repo.current_branch(),
+        "main",
+        "interrupted create should restore the original branch"
+    );
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|b| b.contains("interrupted-from-parent")),
+        "interrupted create must not leave a destination branch. Branches: {:?}",
+        repo.list_branches(),
+    );
+
+    remove_pre_commit_hook(&repo);
+    repo.run_stax(&[
+        "create",
+        "--from",
+        parent,
+        "-a",
+        "-m",
+        "interrupted from parent",
+    ])
+    .assert_success();
+
+    let branch = repo.current_branch();
+    assert!(
+        branch.contains("interrupted-from-parent") && !branch.contains("interrupted-from-parent-2"),
+        "retry should use the original branch name, got: {}",
+        branch
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn create_below_interrupted_commit_leaves_no_branch_and_retries_cleanly() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["interrupt-below-parent", "interrupt-below-current"]);
+    let parent = &branches[0];
+    let current = &branches[1];
+    let current_before = repo.get_commit_sha(current);
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    repo.create_file(
+        "interrupt-below.txt",
+        "work interrupted during below commit\n",
+    );
+    install_waiting_pre_commit_hook(&repo);
+
+    let output = run_stax_until_hook_then_interrupt(
+        &repo,
+        &["create", "--below", "-a", "-m", "interrupted below parent"],
+    );
+    assert!(
+        !output.status.success(),
+        "interrupted create --below should fail\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    assert_eq!(
+        repo.current_branch(),
+        *current,
+        "interrupted create --below should restore the original branch"
+    );
+    assert_eq!(
+        repo.get_commit_sha(current),
+        current_before,
+        "interrupted create --below should not advance the original branch"
+    );
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|b| b.contains("interrupted-below-parent")),
+        "interrupted create --below must not leave a destination branch. Branches: {:?}",
+        repo.list_branches(),
+    );
+
+    remove_pre_commit_hook(&repo);
+    repo.run_stax(&["create", "--below", "-a", "-m", "interrupted below parent"])
+        .assert_success();
+
+    let branch = repo.current_branch();
+    assert!(
+        branch.contains("interrupted-below-parent")
+            && !branch.contains("interrupted-below-parent-2"),
+        "retry should use the original branch name, got: {}",
+        branch
+    );
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    let stax_parent = repo.get_current_parent();
+    assert!(
+        stax_parent
+            .as_deref()
+            .is_some_and(|p| p.contains("interrupted-below-parent")),
+        "original branch should be reparented onto retry branch, got: {:?}",
+        stax_parent
+    );
+
+    repo.run_stax(&["checkout", parent]).assert_success();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend create commit-first behavior to `--from <branch>` and `--below` when `-m` / `-am` is used
- commit on a detached checkout of the requested parent before creating the destination branch, so failed hooks or interrupts cannot leave orphan destination branches
- handle SIGINT/SIGTERM during `git commit` so stax can restore the original branch before returning
- preserve `-n` / `--no-verify` support from #337 through the interruption-safe create path
- document the safer create behavior in the command reference and skills.md

Closes #338

## Tests
- `cargo test --test create_rollback_tests`
- `cargo nextest run --test create_rollback_tests`
- `cargo test --test create_below_tests`
- `cargo test --test create_insert_tests`
- `cargo test --test cli_tests test_branch_create_help_flags`
- `cargo test --test cli_tests gt_parity_create_am_flags`
- `cargo test --test cli_tests fp_parity_bc_branch_create`
- `cargo test --test additional_coverage_tests test_branch_create_from_different_parent`
- `cargo test --test command_coverage_tests test_branch_create_from_trunk`
- `git diff --check`

## Docs note
README not updated: the quick-start/core command table only lists create commands and does not describe commit failure semantics.