### PR TITLE
feat(submit): add --no-verify for push hooks

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -197,7 +197,8 @@ st wt go ui-polish --run "cursor ." --tmux
 
 ### `st submit`
 
-- `--draft` / `--publish` / `--no-pr` / `--no-fetch` / `--open` / `--quiet` / `--verbose`
+- `--draft` / `--publish` / `--no-pr` / `--no-fetch` / `--no-verify` / `--open` / `--quiet` / `--verbose`
+- `--no-verify` (`-n`) skips pre-push hooks while pushing branches
 - `--reviewers alice,bob --labels bug,urgent --assignees alice`
 - `--squash` squash commits on each branch before pushing
 - `--ai-body` generate PR body with AI

--- a/skills.md
+++ b/skills.md
@@ -183,6 +183,8 @@ stax ss                            # Alias for submit
 stax submit --draft                # Create draft PRs
 stax submit --no-pr                # Push only (no PR create/update)
 stax submit --no-fetch             # Skip git fetch
+stax submit --no-verify            # Skip pre-push hooks while pushing
+stax submit -n                     # Short for --no-verify
 stax submit --open                 # Open current PR after submit
 stax submit --reviewers a,b        # Set reviewers
 stax submit --labels bug,urgent    # Set labels

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,9 @@ struct SubmitOptions {
     /// Skip git fetch and use cached remote-tracking refs
     #[arg(long = "no-fetch", action = clap::ArgAction::SetTrue)]
     no_fetch: bool,
+    /// Skip pre-push hooks when pushing branches
+    #[arg(long = "no-verify", short = 'n')]
+    no_verify: bool,
     /// Deprecated: kept for CLI compatibility (currently a no-op)
     #[arg(long, hide = true)]
     force: bool,
@@ -76,6 +79,34 @@ struct SubmitOptions {
     /// Update existing PR titles when the tip commit subject has changed
     #[arg(long)]
     update_title: bool,
+}
+
+impl From<SubmitOptions> for commands::submit::SubmitOptions {
+    fn from(submit: SubmitOptions) -> Self {
+        Self {
+            draft: submit.draft,
+            publish: submit.publish,
+            no_pr: submit.no_pr,
+            no_fetch: submit.no_fetch,
+            no_verify: submit.no_verify,
+            force: submit.force,
+            yes: submit.yes,
+            no_prompt: submit.no_prompt,
+            reviewers: submit.reviewers,
+            labels: submit.labels,
+            assignees: submit.assignees,
+            quiet: submit.quiet,
+            open: submit.open,
+            verbose: submit.verbose,
+            template: submit.template,
+            no_template: submit.no_template,
+            edit: submit.edit,
+            ai_body: submit.ai_body,
+            rerequest_review: submit.rerequest_review,
+            squash: submit.squash,
+            update_title: submit.update_title,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -1441,29 +1472,7 @@ enum IssueCommands {
 }
 
 fn run_submit(submit: SubmitOptions, scope: commands::submit::SubmitScope) -> Result<()> {
-    commands::submit::run(
-        scope,
-        submit.draft,
-        submit.publish,
-        submit.no_pr,
-        submit.no_fetch,
-        submit.force,
-        submit.yes,
-        submit.no_prompt,
-        submit.reviewers,
-        submit.labels,
-        submit.assignees,
-        submit.quiet,
-        submit.open,
-        submit.verbose,
-        submit.template,
-        submit.no_template,
-        submit.edit,
-        submit.ai_body,
-        submit.rerequest_review,
-        submit.squash,
-        submit.update_title,
-    )
+    commands::submit::run(scope, submit.into())
 }
 
 fn print_subcommand_help(name: &str) -> Result<()> {

--- a/src/commands/cascade.rs
+++ b/src/commands/cascade.rs
@@ -40,26 +40,12 @@ pub fn run(no_pr: bool, no_submit: bool, auto_stash_pop: bool) -> Result<()> {
     } else {
         commands::submit::run(
             commands::submit::SubmitScope::Stack,
-            false,  // draft
-            false,  // publish
-            no_pr,  // no_pr (push but skip PR creation/updates)
-            false,  // no_fetch
-            false,  // force
-            true,   // yes
-            true,   // no_prompt
-            vec![], // reviewers
-            vec![], // labels
-            vec![], // assignees
-            false,  // quiet
-            false,  // open
-            false,  // verbose
-            None,   // template
-            false,  // no_template
-            false,  // edit
-            false,  // ai_body
-            false,  // rerequest_review
-            false,  // squash
-            false,  // update_title
+            commands::submit::SubmitOptions {
+                no_pr,
+                yes: true,
+                no_prompt: true,
+                ..Default::default()
+            },
         )?;
     }
 

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -52,26 +52,13 @@ pub fn run(
 
     commands::submit::run(
         commands::submit::SubmitScope::Stack,
-        false, // draft
-        false, // publish
-        no_pr, // no_pr
-        false, // no_fetch
-        false, // force
-        yes,
-        no_prompt,
-        vec![], // reviewers
-        vec![], // labels
-        vec![], // assignees
-        false,  // quiet
-        false,  // open
-        verbose,
-        None,  // template
-        false, // no_template
-        false, // edit
-        false, // ai_body
-        false, // rerequest_review
-        false, // squash
-        false, // update_title
+        commands::submit::SubmitOptions {
+            no_pr,
+            yes,
+            no_prompt,
+            verbose,
+            ..Default::default()
+        },
     )?;
 
     restore_original_branch(&repo, &workdir, &original)

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -767,26 +767,12 @@ fn submit_after_restack(quiet: bool) -> Result<()> {
 
     crate::commands::submit::run(
         crate::commands::submit::SubmitScope::Stack,
-        false,  // draft
-        false,  // publish
-        false,  // no_pr
-        false,  // no_fetch
-        false,  // force
-        true,   // yes
-        true,   // no_prompt
-        vec![], // reviewers
-        vec![], // labels
-        vec![], // assignees
-        quiet,
-        false, // open
-        false, // verbose
-        None,  // template
-        false, // no_template
-        false, // edit
-        false, // ai_body
-        false, // rerequest_review
-        false, // squash
-        false, // update_title
+        crate::commands::submit::SubmitOptions {
+            yes: true,
+            no_prompt: true,
+            quiet,
+            ..Default::default()
+        },
     )?;
 
     Ok(())

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -40,6 +40,32 @@ impl SubmitScope {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct SubmitOptions {
+    pub draft: bool,
+    pub publish: bool,
+    pub no_pr: bool,
+    pub no_fetch: bool,
+    pub no_verify: bool,
+    /// Deprecated; kept for CLI compatibility (currently a no-op).
+    pub force: bool,
+    pub yes: bool,
+    pub no_prompt: bool,
+    pub reviewers: Vec<String>,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+    pub quiet: bool,
+    pub open: bool,
+    pub verbose: bool,
+    pub template: Option<String>,
+    pub no_template: bool,
+    pub edit: bool,
+    pub ai_body: bool,
+    pub rerequest_review: bool,
+    pub squash: bool,
+    pub update_title: bool,
+}
+
 struct PrPlan {
     branch: String,
     parent: String,
@@ -88,30 +114,31 @@ fn resolve_is_draft_without_prompt(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn run(
-    scope: SubmitScope,
-    draft: bool,
-    publish: bool,
-    no_pr: bool,
-    no_fetch: bool,
-    force: bool, // deprecated; kept for CLI compatibility — see issue #222
-    yes: bool,
-    no_prompt: bool,
-    reviewers: Vec<String>,
-    labels: Vec<String>,
-    assignees: Vec<String>,
-    quiet: bool,
-    open: bool,
-    verbose: bool,
-    template: Option<String>,
-    no_template: bool,
-    edit: bool,
-    ai_body: bool,
-    rerequest_review: bool,
-    squash: bool,
-    update_title: bool,
-) -> Result<()> {
+pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
+    let SubmitOptions {
+        draft,
+        publish,
+        no_pr,
+        no_fetch,
+        no_verify,
+        force,
+        yes,
+        no_prompt,
+        reviewers,
+        labels,
+        assignees,
+        quiet,
+        open,
+        verbose,
+        template,
+        no_template,
+        edit,
+        ai_body,
+        rerequest_review,
+        squash,
+        update_title,
+    } = options;
+
     if force && !quiet {
         eprintln!(
             "  {} --force is deprecated and has no effect (see issue #222)",
@@ -928,7 +955,7 @@ pub fn run(
             // Get local OID before push (this is what we're pushing)
             let local_oid = repo.branch_commit(&plan.branch).ok();
 
-            match push_branch(repo.workdir()?, &remote_info.name, &plan.branch) {
+            match push_branch(repo.workdir()?, &remote_info.name, &plan.branch, no_verify) {
                 Ok(()) => {
                     // Record after-OIDs
                     if let Some(ref mut tx) = tx {
@@ -1424,9 +1451,20 @@ fn squash_branch_commits(workdir: &Path, branch: &str, base: &str) -> Result<()>
     Ok(())
 }
 
-fn push_branch(workdir: &std::path::Path, remote: &str, branch: &str) -> Result<()> {
+fn push_branch(
+    workdir: &std::path::Path,
+    remote: &str,
+    branch: &str,
+    no_verify: bool,
+) -> Result<()> {
+    let mut args = vec!["push", "--force-with-lease"];
+    if no_verify {
+        args.push("--no-verify");
+    }
+    args.extend(["-u", remote, branch]);
+
     let status = Command::new("git")
-        .args(["push", "--force-with-lease", "-u", remote, branch])
+        .args(args)
         .current_dir(workdir)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -204,6 +204,7 @@ fn test_submit_alias_ss() {
     assert!(stdout.contains("reviewers"));
     assert!(stdout.contains("labels"));
     assert!(stdout.contains("assignees"));
+    assert!(stdout.contains("no-verify"));
     assert!(stdout.contains("no-prompt"));
     assert!(stdout.contains("yes"));
 }
@@ -421,6 +422,11 @@ fn test_scoped_submit_subcommand_help_flags() {
         assert!(
             stdout.contains("--no-fetch"),
             "Expected --no-fetch in {:?}",
+            args
+        );
+        assert!(
+            stdout.contains("--no-verify"),
+            "Expected --no-verify in {:?}",
             args
         );
         assert!(stdout.contains("--open"), "Expected --open in {:?}", args);

--- a/tests/submit_no_verify_tests.rs
+++ b/tests/submit_no_verify_tests.rs
@@ -1,0 +1,146 @@
+mod common;
+
+#[cfg(unix)]
+mod unix {
+    use super::common::{OutputAssertions, TestRepo};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn configure_submit_remote(repo: &TestRepo) {
+        let remote_path = repo
+            .remote_path()
+            .expect("Expected remote path for repository with origin");
+        let remote_path_str = remote_path.to_string_lossy().to_string();
+
+        let out = repo.git(&[
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ]);
+        assert!(
+            out.status.success(),
+            "set-url failed: {}",
+            TestRepo::stderr(&out)
+        );
+
+        let out = repo.git(&["remote", "set-url", "--push", "origin", &remote_path_str]);
+        assert!(
+            out.status.success(),
+            "set-url --push failed: {}",
+            TestRepo::stderr(&out)
+        );
+
+        let file_url = format!("file://{}", remote_path_str);
+        let instead_of_key = format!("url.{}.insteadOf", file_url.trim_end_matches('/'));
+        let out = repo.git(&[
+            "config",
+            "--local",
+            &instead_of_key,
+            "https://github.com/test-owner/test-repo.git",
+        ]);
+        assert!(
+            out.status.success(),
+            "insteadOf config failed: {}",
+            TestRepo::stderr(&out)
+        );
+    }
+
+    fn install_failing_pre_push_hook(repo: &TestRepo) {
+        let hook = repo.path().join(".git/hooks/pre-push");
+        fs::write(
+            &hook,
+            "#!/bin/sh\necho 'pre-push hook blocked submit' >&2\nexit 1\n",
+        )
+        .expect("write pre-push hook");
+        fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).expect("chmod pre-push hook");
+    }
+
+    fn repo_with_failing_pre_push_hook(branch_name: &str) -> (TestRepo, String) {
+        let repo = TestRepo::new_with_remote();
+        configure_submit_remote(&repo);
+
+        repo.run_stax(&["bc", branch_name]).assert_success();
+        repo.create_file(
+            &format!("{branch_name}.txt"),
+            &format!("content for {branch_name}"),
+        );
+        repo.commit(&format!("Commit for {branch_name}"));
+        let branch = repo.current_branch();
+
+        install_failing_pre_push_hook(&repo);
+        (repo, branch)
+    }
+
+    fn remote_has_branch(repo: &TestRepo, branch: &str) -> bool {
+        let out = repo.git(&["ls-remote", "--heads", "origin", branch]);
+        assert!(
+            out.status.success(),
+            "ls-remote failed: {}",
+            TestRepo::stderr(&out)
+        );
+
+        let expected_ref = format!("refs/heads/{branch}");
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .any(|line| line.ends_with(&expected_ref))
+    }
+
+    #[test]
+    fn submit_no_verify_skips_pre_push_hook() {
+        let (repo, branch) = repo_with_failing_pre_push_hook("submit-no-verify");
+
+        repo.run_stax(&["ss", "--no-fetch", "--no-pr", "--no-prompt", "--yes"])
+            .assert_failure();
+        assert!(
+            !remote_has_branch(&repo, &branch),
+            "branch should not exist after hook-blocked push"
+        );
+
+        repo.run_stax(&[
+            "ss",
+            "--no-fetch",
+            "--no-pr",
+            "--no-prompt",
+            "--yes",
+            "--no-verify",
+        ])
+        .assert_success();
+        assert!(
+            remote_has_branch(&repo, &branch),
+            "branch should be pushed when --no-verify bypasses the hook"
+        );
+    }
+
+    #[test]
+    fn branch_submit_alias_no_verify_skips_pre_push_hook() {
+        let (repo, branch) = repo_with_failing_pre_push_hook("bs-no-verify");
+
+        repo.run_stax(&["bs", "--no-fetch", "--no-pr", "--no-prompt", "--yes", "-n"])
+            .assert_success();
+        assert!(
+            remote_has_branch(&repo, &branch),
+            "bs -n should bypass the pre-push hook"
+        );
+    }
+
+    #[test]
+    fn upstack_submit_no_verify_skips_pre_push_hook() {
+        let (repo, branch) = repo_with_failing_pre_push_hook("upstack-no-verify");
+
+        repo.run_stax(&[
+            "upstack",
+            "submit",
+            "--no-fetch",
+            "--no-pr",
+            "--no-prompt",
+            "--yes",
+            "--no-verify",
+        ])
+        .assert_success();
+        assert!(
+            remote_has_branch(&repo, &branch),
+            "upstack submit --no-verify should bypass the pre-push hook"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add shared submit `--no-verify` / `-n` support for `submit`, `ss`, `bs`, and scoped submit commands
- pass the flag through to `git push --no-verify` while replacing fragile internal positional submit calls with a typed options struct
- document the new submit flag in command reference and skills.md

Closes #335

## Tests
- `cargo test --test submit_no_verify_tests`
- `cargo test --test cli_tests test_submit_alias_ss`
- `cargo test --test cli_tests test_scoped_submit_subcommand_help_flags`
- `git diff --check`

README unchanged: the new flag is documented in the command reference, but it does not change the quick-start or core command table.