### PR TITLE
feat(fold): match `gt fold` semantics — preserve commits, reparent descendants, fix `--keep`

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -58,7 +58,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st branch reparent` | | Change parent |
 | `st branch submit` | `bs` | Submit current branch only |
 | `st branch delete` | | Delete branch |
-| `st branch fold` | | Fold branch into parent |
+| `st fold` / `st branch fold` | `b f` | Fold current branch into its parent (preserves commits, reparents descendants, rebases siblings; `--keep` keeps current name) |
 | `st branch squash` | | Squash commits |
 | `st detach` | | Remove branch from stack, reparent children |
 | `st reorder` | | Interactively reorder branches in stack |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -726,6 +726,23 @@ enum Commands {
         yes: bool,
     },
 
+    /// Fold the current branch into its parent (collapse a branch boundary).
+    ///
+    /// Top-level alias of `stax branch fold`, mirroring `gt fold`. Commits are
+    /// preserved (not squashed); descendants of the current branch are
+    /// reparented onto the parent; siblings are rebased onto the new parent
+    /// tip. With `--keep`, the surviving branch keeps the *current* name and
+    /// the parent ref is deleted instead.
+    Fold {
+        /// Keep the current branch's name as the surviving ref (delete the
+        /// parent ref instead)
+        #[arg(short, long)]
+        keep: bool,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+
     /// Move the current branch (and its descendants) onto a new parent.
     ///
     /// Equivalent to `stax upstack onto`; kept as a top-level alias for
@@ -1898,6 +1915,7 @@ pub fn run() -> Result<()> {
             commands::copy::run(target)
         }
         Commands::Detach { branch, yes } => commands::detach::run(branch, yes),
+        Commands::Fold { keep, yes } => commands::branch::fold::run(keep, yes),
         Commands::Reorder { yes } => commands::reorder::run(yes),
         Commands::Edit { yes, no_verify } => commands::edit::run(yes, no_verify),
         Commands::Validate => commands::stack_cmd::run_validate(),

--- a/src/commands/branch/fold.rs
+++ b/src/commands/branch/fold.rs
@@ -1,204 +1,288 @@
+//! Fold the current branch into its parent (`gt fold` parity).
+//!
+//! Default mode collapses the *current* branch into the *parent* branch:
+//! the parent ref is force-updated to the current branch's tip (commits are
+//! preserved, not squashed), the current branch ref is deleted, descendants
+//! of the current branch are re-parented onto the parent, and any
+//! "siblings" (other children of the parent) are rebased onto the new
+//! parent tip.
+//!
+//! `--keep` mode keeps the *current* branch's name as the surviving ref;
+//! the parent ref is deleted instead, and the current branch's metadata is
+//! updated to point at the grandparent.
+//!
+//! In both modes the surviving ref ends up at the same SHA (the current
+//! branch's tip), so descendants of the current branch only need a metadata
+//! re-parent. Siblings need an actual rebase because their previous base
+//! (the old parent tip) is no longer the tip of any tracked branch.
+
 use crate::engine::{BranchMetadata, Stack};
-use crate::git::GitRepo;
-use anyhow::{Context, Result};
+use crate::git::{GitRepo, RebaseResult};
+use crate::ops::receipt::OpKind;
+use crate::ops::tx::Transaction;
+use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
-use std::process::Command;
 
-/// Fold the current branch into its parent (merge commits into parent)
 pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
     let repo = GitRepo::open()?;
-    let current = repo.current_branch()?;
     let stack = Stack::load(&repo)?;
-    let workdir = repo.workdir()?;
+    let current = repo.current_branch()?;
 
-    // Check if current branch is tracked
-    let meta = BranchMetadata::read(repo.inner(), &current)?
-        .context("Current branch is not tracked. Use 'stax branch track' first.")?;
+    if current == stack.trunk {
+        bail!("Cannot fold trunk. Checkout a stacked branch first.");
+    }
 
-    let parent = &meta.parent_branch_name;
+    if repo.is_dirty()? {
+        bail!("Working tree has uncommitted changes. Commit or stash them before folding.");
+    }
 
-    // Don't fold into trunk
-    if parent == &stack.trunk {
+    if repo.rebase_in_progress()? {
+        bail!("A rebase is in progress. Run `stax continue` or `stax abort` first.");
+    }
+
+    let current_meta = BranchMetadata::read(repo.inner(), &current)?.with_context(|| {
+        format!(
+            "Branch '{}' is not tracked. Run `stax branch track` first.",
+            current
+        )
+    })?;
+    let parent = current_meta.parent_branch_name.clone();
+
+    if parent == stack.trunk {
         println!(
             "{}",
-            "Cannot fold into trunk. Use 'stax submit' to merge into trunk via PR.".yellow()
+            "Cannot fold into trunk. Use `stax submit` to merge the branch into trunk via a PR."
+                .yellow()
         );
         return Ok(());
     }
 
-    // Check if current branch has children
-    if let Some(branch_info) = stack.branches.get(&current) {
-        if !branch_info.children.is_empty() {
-            println!("{}", "Cannot fold: this branch has children.".red());
-            println!("Children: {}", branch_info.children.join(", ").cyan());
-            println!();
-            println!("Please fold or delete child branches first.");
-            return Ok(());
-        }
-    }
+    let parent_meta = BranchMetadata::read(repo.inner(), &parent)?.with_context(|| {
+        format!(
+            "Parent branch '{}' is not tracked, so its parent cannot be determined.",
+            parent
+        )
+    })?;
+    let grandparent = parent_meta.parent_branch_name.clone();
+    let grandparent_revision = parent_meta.parent_branch_revision.clone();
 
-    // Count commits to fold
-    let output = Command::new("git")
-        .args(["rev-list", "--count", &format!("{}..HEAD", parent)])
-        .current_dir(workdir)
-        .output()
-        .context("Failed to count commits")?;
+    let kids: Vec<String> = stack.children(&current);
+    let siblings: Vec<String> = stack
+        .children(&parent)
+        .into_iter()
+        .filter(|name| name != &current)
+        .collect();
 
-    let commit_count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap_or(0);
+    let current_tip = repo
+        .branch_commit(&current)
+        .with_context(|| format!("Could not resolve commit for '{}'", current))?;
+    let old_parent_tip = repo
+        .branch_commit(&parent)
+        .with_context(|| format!("Could not resolve commit for '{}'", parent))?;
 
-    if commit_count == 0 {
-        println!("{}", "No commits to fold.".yellow());
+    let (commits_folded_in, _) = repo
+        .commits_ahead_behind(&parent, &current)
+        .unwrap_or((0, 0));
+
+    if commits_folded_in == 0 && kids.is_empty() && siblings.is_empty() {
+        println!(
+            "{}",
+            "Nothing to fold: branch has no commits ahead of parent and no descendants/siblings."
+                .yellow()
+        );
         return Ok(());
     }
 
+    let (survivor, discarded) = if keep_branch {
+        (current.clone(), parent.clone())
+    } else {
+        (parent.clone(), current.clone())
+    };
+
     println!(
-        "Folding '{}' ({} commit(s)) into '{}'",
+        "Fold plan: collapse '{}' into '{}'",
         current.cyan(),
-        commit_count.to_string().cyan(),
-        parent.green()
+        parent.cyan()
     );
-
-    // Show the commits
-    let log_output = Command::new("git")
-        .args(["log", "--oneline", &format!("{}..HEAD", parent)])
-        .current_dir(workdir)
-        .output()
-        .context("Failed to show commits")?;
-
-    println!();
-    println!("{}", "Commits to fold:".bold());
-    for line in String::from_utf8_lossy(&log_output.stdout).lines() {
-        println!("  {}", line.dimmed());
+    println!(
+        "  {} {} commit(s) preserved on '{}'",
+        "▸".dimmed(),
+        commits_folded_in.to_string().cyan(),
+        survivor.green()
+    );
+    println!(
+        "  {} '{}' will be deleted",
+        "▸".dimmed(),
+        discarded.red()
+    );
+    if !kids.is_empty() {
+        println!(
+            "  {} {} child branch(es) re-parented onto '{}': {}",
+            "▸".dimmed(),
+            kids.len().to_string().cyan(),
+            survivor.green(),
+            kids.join(", ").dimmed()
+        );
+    }
+    if !siblings.is_empty() {
+        println!(
+            "  {} {} sibling branch(es) will be rebased onto '{}': {}",
+            "▸".dimmed(),
+            siblings.len().to_string().cyan(),
+            survivor.green(),
+            siblings.join(", ").dimmed()
+        );
     }
     println!();
 
-    // Confirm (unless --yes flag)
-    let action = if keep_branch {
-        "fold"
-    } else {
-        "fold and delete"
-    };
     if !skip_confirm {
-        let confirm = Confirm::with_theme(&ColorfulTheme::default())
-            .with_prompt(format!("{}  '{}' into '{}'?", action, current, parent))
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!("Fold '{}' into '{}'?", current, parent))
             .default(true)
             .interact()?;
-
-        if !confirm {
+        if !confirmed {
             println!("{}", "Aborted.".red());
             return Ok(());
         }
     }
 
-    // Checkout parent
-    print!("Checking out {}... ", parent.cyan());
-    let checkout_status = Command::new("git")
-        .args(["checkout", parent])
-        .current_dir(workdir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .context("Failed to checkout parent")?;
-
-    if !checkout_status.success() {
-        println!("{}", "failed".red());
-        anyhow::bail!("Failed to checkout parent branch");
+    let mut tx = Transaction::begin(OpKind::Fold, &repo, false)?;
+    tx.plan_branch(&repo, &parent)?;
+    tx.plan_branch(&repo, &current)?;
+    for sibling in &siblings {
+        tx.plan_branch(&repo, sibling)?;
     }
-    println!("{}", "done".green());
-
-    // Merge current branch into parent
-    print!("Merging {}... ", current.cyan());
-    let merge_status = Command::new("git")
-        .args(["merge", "--squash", &current])
-        .current_dir(workdir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .context("Failed to merge")?;
-
-    if !merge_status.success() {
-        println!("{}", "failed".red());
-
-        // Abort merge and reset working tree
-        let _ = Command::new("git")
-            .args(["merge", "--abort"])
-            .current_dir(workdir)
-            .status();
-
-        // Reset any staged changes from the failed squash merge
-        let _ = Command::new("git")
-            .args(["reset", "--hard", "HEAD"])
-            .current_dir(workdir)
-            .status();
-
-        // Restore original branch
-        let _ = Command::new("git")
-            .args(["checkout", &current])
-            .current_dir(workdir)
-            .status();
-
-        anyhow::bail!(
-            "Failed to merge branch. There may be conflicts.\n\
-             Restored to branch '{}'.",
-            current
-        );
+    tx.plan_metadata_ref(&repo, &parent)?;
+    tx.plan_metadata_ref(&repo, &current)?;
+    for kid in &kids {
+        tx.plan_metadata_ref(&repo, kid)?;
     }
-    println!("{}", "done".green());
+    for sibling in &siblings {
+        tx.plan_metadata_ref(&repo, sibling)?;
+    }
+    tx.snapshot()?;
 
-    // Commit the merge
-    print!("Committing... ");
-    let commit_msg = format!("Fold {} into {}", current, parent);
-    let commit_status = Command::new("git")
-        .args(["commit", "-m", &commit_msg])
-        .current_dir(workdir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .context("Failed to commit")?;
-
-    if !commit_status.success() {
-        // Maybe nothing to commit
-        println!("{}", "no changes".yellow());
+    if keep_branch {
+        // Survivor = current. The current ref already has the right SHA; just
+        // delete the parent ref and re-parent current onto grandparent.
+        repo.delete_ref(&format!("refs/heads/{}", parent))
+            .with_context(|| format!("Failed to delete parent branch '{}'", parent))?;
     } else {
-        println!("{}", "done".green());
+        // Survivor = parent. Switch to parent (so we can delete current),
+        // force-update the parent ref to current's tip, then delete current.
+        repo.checkout(&parent)
+            .with_context(|| format!("Failed to checkout '{}'", parent))?;
+        repo.update_ref(&format!("refs/heads/{}", parent), &current_tip)
+            .with_context(|| format!("Failed to fast-forward '{}' to {}", parent, current_tip))?;
+        repo.reset_hard(&current_tip)
+            .with_context(|| format!("Failed to reset working tree to {}", current_tip))?;
+        repo.delete_ref(&format!("refs/heads/{}", current))
+            .with_context(|| format!("Failed to delete '{}'", current))?;
     }
+    tx.record_after(&repo, &parent).ok();
+    tx.record_after(&repo, &current).ok();
 
-    // Delete the old branch unless --keep
     if !keep_branch {
-        print!("Deleting {}... ", current.cyan());
-        let delete_status = Command::new("git")
-            .args(["branch", "-D", &current])
-            .current_dir(workdir)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .context("Failed to delete branch")?;
-
-        if delete_status.success() {
-            // Also delete metadata
-            let _ = BranchMetadata::delete(repo.inner(), &current);
-            println!("{}", "done".green());
-        } else {
-            println!("{}", "failed".yellow());
+        for kid in &kids {
+            let meta = BranchMetadata::read(repo.inner(), kid)?.with_context(|| {
+                format!(
+                    "Child branch '{}' is missing metadata; cannot reparent.",
+                    kid
+                )
+            })?;
+            let updated = BranchMetadata {
+                parent_branch_name: parent.clone(),
+                ..meta
+            };
+            updated.write(repo.inner(), kid)?;
+            tx.record_metadata_ref_after(&repo, kid)?;
         }
     }
 
-    // Update parent's metadata (it may need restack now)
-    if let Some(parent_meta) = BranchMetadata::read(repo.inner(), parent)? {
-        let parent_commit = repo.branch_commit(&parent_meta.parent_branch_name)?;
-        let updated_parent = BranchMetadata {
-            parent_branch_revision: parent_commit,
-            ..parent_meta
+    if keep_branch {
+        let updated = BranchMetadata {
+            parent_branch_name: grandparent.clone(),
+            parent_branch_revision: grandparent_revision.clone(),
+            ..current_meta.clone()
         };
-        updated_parent.write(repo.inner(), parent)?;
+        updated.write(repo.inner(), &current)?;
+        tx.record_metadata_ref_after(&repo, &current)?;
+    }
+
+    BranchMetadata::delete(repo.inner(), &discarded)
+        .with_context(|| format!("Failed to delete metadata for '{}'", discarded))?;
+    tx.record_metadata_ref_after(&repo, &discarded)?;
+
+    let mut completed_siblings: Vec<String> = Vec::new();
+    for sibling in &siblings {
+        let result = repo
+            .rebase_branch_onto_with_provenance(sibling, &survivor, &old_parent_tip, false)
+            .with_context(|| format!("Failed to rebase sibling '{}'", sibling))?;
+
+        match result {
+            RebaseResult::Success => {
+                tx.push_completed_branch(sibling);
+                tx.record_after(&repo, sibling)?;
+                let new_parent_revision = repo.branch_commit(&survivor)?;
+                if let Some(meta) = BranchMetadata::read(repo.inner(), sibling)? {
+                    let updated = BranchMetadata {
+                        parent_branch_name: survivor.clone(),
+                        parent_branch_revision: new_parent_revision,
+                        ..meta
+                    };
+                    updated.write(repo.inner(), sibling)?;
+                }
+                tx.record_metadata_ref_after(&repo, sibling)?;
+                completed_siblings.push(sibling.clone());
+            }
+            RebaseResult::Conflict => {
+                let _ = repo.rebase_abort();
+                let msg = format!(
+                    "Conflict while rebasing sibling '{}' onto '{}'. The fold's structural \
+                     changes are applied (refs and child metadata updated). {} sibling(s) \
+                     rebased before the conflict. Run `stax undo` to roll back the entire \
+                     fold, or rebase the remaining siblings manually.",
+                    sibling,
+                    survivor,
+                    completed_siblings.len()
+                );
+                tx.finish_err(&msg, Some("rebase"), Some(sibling))?;
+                bail!(msg);
+            }
+        }
+    }
+
+    tx.finish_ok()?;
+
+    if repo.current_branch()? != survivor {
+        let _ = repo.checkout(&survivor);
     }
 
     println!();
-    println!("{} Folded '{}' into '{}'", "✓".green(), current, parent);
+    println!(
+        "{} Folded '{}' into '{}'.",
+        "✓".green().bold(),
+        current.cyan(),
+        parent.cyan()
+    );
+    println!("  Surviving branch: {}", survivor.green().bold());
+
+    let discarded_pr = if keep_branch {
+        parent_meta.pr_info.as_ref().map(|p| p.number)
+    } else {
+        current_meta.pr_info.as_ref().map(|p| p.number)
+    };
+    if let Some(pr_number) = discarded_pr {
+        println!();
+        println!(
+            "{} '{}' had PR #{}. Close it manually with: {}",
+            "ⓘ".blue(),
+            discarded.dimmed(),
+            pr_number,
+            format!("gh pr close {}", pr_number).cyan()
+        );
+    }
 
     Ok(())
 }

--- a/src/commands/branch/fold.rs
+++ b/src/commands/branch/fold.rs
@@ -66,6 +66,10 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
     })?;
     let grandparent = parent_meta.parent_branch_name.clone();
     let grandparent_revision = parent_meta.parent_branch_revision.clone();
+    // Capture PR numbers up front so the orphaned-PR hint at the end of the
+    // function doesn't need to outlive the metadata moves below.
+    let current_pr = current_meta.pr_info.as_ref().map(|p| p.number);
+    let parent_pr = parent_meta.pr_info.as_ref().map(|p| p.number);
 
     let kids: Vec<String> = stack.children(&current);
     let siblings: Vec<String> = stack
@@ -111,11 +115,7 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
         commits_folded_in.to_string().cyan(),
         survivor.green()
     );
-    println!(
-        "  {} '{}' will be deleted",
-        "▸".dimmed(),
-        discarded.red()
-    );
+    println!("  {} '{}' will be deleted", "▸".dimmed(), discarded.red());
     if !kids.is_empty() {
         println!(
             "  {} {} child branch(es) re-parented onto '{}': {}",
@@ -164,22 +164,23 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
     tx.snapshot()?;
 
     if keep_branch {
-        // Survivor = current. The current ref already has the right SHA; just
-        // delete the parent ref and re-parent current onto grandparent.
-        repo.delete_ref(&format!("refs/heads/{}", parent))
+        // delete_branch (vs raw delete_ref) carries the worktree-checkout
+        // safety check, which matters if `parent` is checked out elsewhere.
+        repo.delete_branch(&parent, true)
             .with_context(|| format!("Failed to delete parent branch '{}'", parent))?;
     } else {
-        // Survivor = parent. Switch to parent (so we can delete current),
-        // force-update the parent ref to current's tip, then delete current.
         repo.checkout(&parent)
             .with_context(|| format!("Failed to checkout '{}'", parent))?;
         repo.update_ref(&format!("refs/heads/{}", parent), &current_tip)
             .with_context(|| format!("Failed to fast-forward '{}' to {}", parent, current_tip))?;
         repo.reset_hard(&current_tip)
             .with_context(|| format!("Failed to reset working tree to {}", current_tip))?;
-        repo.delete_ref(&format!("refs/heads/{}", current))
+        repo.delete_branch(&current, true)
             .with_context(|| format!("Failed to delete '{}'", current))?;
     }
+    // After deletion, `branch_commit(discarded)` errors — record_after surfaces
+    // that as Err which we intentionally swallow; the receipt entry stays at
+    // oid_after=None, which is exactly what undo needs to recreate the ref.
     tx.record_after(&repo, &parent).ok();
     tx.record_after(&repo, &current).ok();
 
@@ -198,13 +199,11 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
             updated.write(repo.inner(), kid)?;
             tx.record_metadata_ref_after(&repo, kid)?;
         }
-    }
-
-    if keep_branch {
+    } else {
         let updated = BranchMetadata {
             parent_branch_name: grandparent.clone(),
             parent_branch_revision: grandparent_revision.clone(),
-            ..current_meta.clone()
+            ..current_meta
         };
         updated.write(repo.inner(), &current)?;
         tx.record_metadata_ref_after(&repo, &current)?;
@@ -224,11 +223,12 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
             RebaseResult::Success => {
                 tx.push_completed_branch(sibling);
                 tx.record_after(&repo, sibling)?;
-                let new_parent_revision = repo.branch_commit(&survivor)?;
                 if let Some(meta) = BranchMetadata::read(repo.inner(), sibling)? {
                     let updated = BranchMetadata {
                         parent_branch_name: survivor.clone(),
-                        parent_branch_revision: new_parent_revision,
+                        // Survivor's tip equals current_tip (we either force-
+                        // updated parent → current_tip, or kept current as-is).
+                        parent_branch_revision: current_tip.clone(),
                         ..meta
                     };
                     updated.write(repo.inner(), sibling)?;
@@ -238,17 +238,16 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
             }
             RebaseResult::Conflict => {
                 let _ = repo.rebase_abort();
+                // Don't repeat the "stax undo" hint — tx.finish_err prints it.
                 let msg = format!(
-                    "Conflict while rebasing sibling '{}' onto '{}'. The fold's structural \
-                     changes are applied (refs and child metadata updated). {} sibling(s) \
-                     rebased before the conflict. Run `stax undo` to roll back the entire \
-                     fold, or rebase the remaining siblings manually.",
+                    "Conflict rebasing sibling '{}' onto '{}'. The fold's structural \
+                     changes are applied; {} sibling(s) rebased before the conflict.",
                     sibling,
                     survivor,
                     completed_siblings.len()
                 );
                 tx.finish_err(&msg, Some("rebase"), Some(sibling))?;
-                bail!(msg);
+                bail!("{}", msg);
             }
         }
     }
@@ -268,11 +267,7 @@ pub fn run(keep_branch: bool, skip_confirm: bool) -> Result<()> {
     );
     println!("  Surviving branch: {}", survivor.green().bold());
 
-    let discarded_pr = if keep_branch {
-        parent_meta.pr_info.as_ref().map(|p| p.number)
-    } else {
-        current_meta.pr_info.as_ref().map(|p| p.number)
-    };
+    let discarded_pr = if keep_branch { parent_pr } else { current_pr };
     if let Some(pr_number) = discarded_pr {
         println!();
         println!(

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -3,13 +3,28 @@ use git2::Repository;
 use std::path::Path;
 use std::process::Command;
 
-const METADATA_REF_PREFIX: &str = "refs/branch-metadata/";
+pub(crate) const METADATA_REF_PREFIX: &str = "refs/branch-metadata/";
+
+/// Build the full ref name for a branch's stax metadata blob.
+pub(crate) fn metadata_refname(branch: &str) -> String {
+    format!("{}{}", METADATA_REF_PREFIX, branch)
+}
+
+/// Resolve a branch's metadata-ref OID via libgit2 (no subprocess).
+/// Returns `None` if the ref is missing.
+pub(crate) fn metadata_ref_oid(repo: &Repository, branch: &str) -> Option<String> {
+    let refname = metadata_refname(branch);
+    repo.find_reference(&refname)
+        .ok()
+        .and_then(|r| r.target())
+        .map(|oid| oid.to_string())
+}
 const STAX_TRUNK_REF: &str = "refs/stax/trunk";
 const STAX_PREV_BRANCH_REF: &str = "refs/stax/prev-branch";
 
 /// Read metadata JSON for a branch from git refs
 pub fn read_metadata(repo: &Repository, branch: &str) -> Result<Option<String>> {
-    let ref_name = format!("{}{}", METADATA_REF_PREFIX, branch);
+    let ref_name = metadata_refname(branch);
 
     match repo.find_reference(&ref_name) {
         Ok(reference) => {
@@ -46,7 +61,7 @@ pub fn write_metadata(repo: &Repository, branch: &str, json: &str) -> Result<()>
     let hash = String::from_utf8(output.stdout)?.trim().to_string();
 
     // Update the ref to point to the blob
-    let ref_name = format!("{}{}", METADATA_REF_PREFIX, branch);
+    let ref_name = metadata_refname(branch);
     let status = Command::new("git")
         .args(["update-ref", &ref_name, &hash])
         .current_dir(workdir)
@@ -62,7 +77,7 @@ pub fn write_metadata(repo: &Repository, branch: &str, json: &str) -> Result<()>
 
 /// Delete metadata ref for a branch
 pub fn delete_metadata(repo: &Repository, branch: &str) -> Result<()> {
-    let ref_name = format!("{}{}", METADATA_REF_PREFIX, branch);
+    let ref_name = metadata_refname(branch);
     let workdir = repo
         .workdir()
         .context("Repository has no working directory")?;

--- a/src/ops/receipt.rs
+++ b/src/ops/receipt.rs
@@ -173,6 +173,29 @@ impl OpReceipt {
         });
     }
 
+    /// Add a branch-metadata ref (`refs/branch-metadata/<branch>`) to track.
+    ///
+    /// The label gets a `@meta` suffix so it doesn't collide with the
+    /// matching `add_local_ref(branch, ...)` entry — both can coexist for
+    /// one branch, which `fold` relies on.
+    pub fn add_metadata_ref(&mut self, branch: &str, oid_before: Option<&str>) {
+        self.local_refs.push(LocalRefEntry {
+            branch: format!("{}{}", branch, super::tx::METADATA_REF_LABEL_SUFFIX),
+            refname: crate::git::refs::metadata_refname(branch),
+            existed_before: oid_before.is_some(),
+            oid_before: oid_before.map(|s| s.to_string()),
+            oid_after: None,
+        });
+    }
+
+    /// Update the after-OID for a branch-metadata ref entry.
+    pub fn update_metadata_ref_after(&mut self, branch: &str, oid_after: Option<&str>) {
+        let label = format!("{}{}", branch, super::tx::METADATA_REF_LABEL_SUFFIX);
+        if let Some(entry) = self.local_refs.iter_mut().find(|e| e.branch == label) {
+            entry.oid_after = oid_after.map(|s| s.to_string());
+        }
+    }
+
     /// Add a remote ref to track
     pub fn add_remote_ref(&mut self, remote: &str, branch: &str, oid_before: Option<&str>) {
         self.remote_refs.push(RemoteRefEntry {

--- a/src/ops/receipt.rs
+++ b/src/ops/receipt.rs
@@ -29,6 +29,7 @@ pub enum OpKind {
     Detach,
     Fix,
     Edit,
+    Fold,
 }
 
 impl OpKind {
@@ -44,6 +45,7 @@ impl OpKind {
             OpKind::Detach => "detach",
             OpKind::Fix => "stack fix",
             OpKind::Edit => "edit",
+            OpKind::Fold => "fold",
         }
     }
 }

--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -14,8 +14,8 @@
 //! tx.finish_ok()?;  // Or tx.finish_err("message")?;
 //! ```
 
-use super::receipt::{LocalRefEntry, OpKind, OpReceipt, PlanSummary};
-use crate::git::GitRepo;
+use super::receipt::{OpKind, OpReceipt, PlanSummary};
+use crate::git::{refs, GitRepo};
 use anyhow::Result;
 use colored::Colorize;
 use std::path::PathBuf;
@@ -24,8 +24,6 @@ use std::path::PathBuf;
 /// they don't collide with the `refs/heads/<branch>` entry for the same
 /// branch in the receipt.
 pub const METADATA_REF_LABEL_SUFFIX: &str = "@meta";
-
-const METADATA_REF_PREFIX: &str = "refs/branch-metadata/";
 
 /// A transaction wrapper for history-rewriting operations
 pub struct Transaction {
@@ -92,18 +90,11 @@ impl Transaction {
     ///
     /// Used by operations like `fold` that mutate or delete stax metadata. The
     /// metadata blob's OID is captured so that `stax undo` can restore it via
-    /// the same `update-ref`-based mechanism it uses for branch heads.
+    /// the same `update-ref`-based mechanism it uses for branch heads. Uses
+    /// libgit2 (no subprocess) since fold may invoke this in a per-branch loop.
     pub fn plan_metadata_ref(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
-        let refname = format!("{}{}", METADATA_REF_PREFIX, branch);
-        let oid = repo.rev_parse(&refname).ok();
-        let label = format!("{}{}", branch, METADATA_REF_LABEL_SUFFIX);
-        self.receipt.local_refs.push(LocalRefEntry {
-            branch: label,
-            refname,
-            existed_before: oid.is_some(),
-            oid_before: oid,
-            oid_after: None,
-        });
+        let oid = refs::metadata_ref_oid(repo.inner(), branch);
+        self.receipt.add_metadata_ref(branch, oid.as_deref());
         Ok(())
     }
 
@@ -182,19 +173,14 @@ impl Transaction {
     }
 
     /// Record the after-OID for a branch-metadata ref. Pass `branch` (not the
-    /// `@meta` label); the lookup re-derives the label internally.
+    /// `@meta` label); the lookup re-derives the label internally. The ref
+    /// may be absent (e.g., metadata was deleted) — that's recorded as
+    /// `oid_after = None`, which `stax undo` handles by re-creating the ref
+    /// from `oid_before`.
     pub fn record_metadata_ref_after(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
-        let refname = format!("{}{}", METADATA_REF_PREFIX, branch);
-        let oid = repo.rev_parse(&refname).ok();
-        let label = format!("{}{}", branch, METADATA_REF_LABEL_SUFFIX);
-        if let Some(entry) = self
-            .receipt
-            .local_refs
-            .iter_mut()
-            .find(|e| e.branch == label)
-        {
-            entry.oid_after = oid;
-        }
+        let oid = refs::metadata_ref_oid(repo.inner(), branch);
+        self.receipt
+            .update_metadata_ref_after(branch, oid.as_deref());
         Ok(())
     }
 

--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -14,11 +14,18 @@
 //! tx.finish_ok()?;  // Or tx.finish_err("message")?;
 //! ```
 
-use super::receipt::{OpKind, OpReceipt, PlanSummary};
+use super::receipt::{LocalRefEntry, OpKind, OpReceipt, PlanSummary};
 use crate::git::GitRepo;
 use anyhow::Result;
 use colored::Colorize;
 use std::path::PathBuf;
+
+/// Suffix appended to the entry label for branch-metadata ref backups so
+/// they don't collide with the `refs/heads/<branch>` entry for the same
+/// branch in the receipt.
+pub const METADATA_REF_LABEL_SUFFIX: &str = "@meta";
+
+const METADATA_REF_PREFIX: &str = "refs/branch-metadata/";
 
 /// A transaction wrapper for history-rewriting operations
 pub struct Transaction {
@@ -78,6 +85,25 @@ impl Transaction {
         for branch in branches {
             self.plan_branch(repo, branch)?;
         }
+        Ok(())
+    }
+
+    /// Plan a branch-metadata ref to be modified (under `refs/branch-metadata/`).
+    ///
+    /// Used by operations like `fold` that mutate or delete stax metadata. The
+    /// metadata blob's OID is captured so that `stax undo` can restore it via
+    /// the same `update-ref`-based mechanism it uses for branch heads.
+    pub fn plan_metadata_ref(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
+        let refname = format!("{}{}", METADATA_REF_PREFIX, branch);
+        let oid = repo.rev_parse(&refname).ok();
+        let label = format!("{}{}", branch, METADATA_REF_LABEL_SUFFIX);
+        self.receipt.local_refs.push(LocalRefEntry {
+            branch: label,
+            refname,
+            existed_before: oid.is_some(),
+            oid_before: oid,
+            oid_after: None,
+        });
         Ok(())
     }
 
@@ -152,6 +178,23 @@ impl Transaction {
     pub fn record_after(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
         let oid = repo.branch_commit(branch)?;
         self.receipt.update_local_ref_after(branch, &oid);
+        Ok(())
+    }
+
+    /// Record the after-OID for a branch-metadata ref. Pass `branch` (not the
+    /// `@meta` label); the lookup re-derives the label internally.
+    pub fn record_metadata_ref_after(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
+        let refname = format!("{}{}", METADATA_REF_PREFIX, branch);
+        let oid = repo.rev_parse(&refname).ok();
+        let label = format!("{}{}", branch, METADATA_REF_LABEL_SUFFIX);
+        if let Some(entry) = self
+            .receipt
+            .local_refs
+            .iter_mut()
+            .find(|e| e.branch == label)
+        {
+            entry.oid_after = oid;
+        }
         Ok(())
     }
 

--- a/tests/fold_tests.rs
+++ b/tests/fold_tests.rs
@@ -1,33 +1,31 @@
-//! Branch fold command integration tests
+//! Branch fold command integration tests.
 //!
-//! Tests for the `branch fold` command that merges a branch into its parent.
-//! Note: The fold command is interactive (requires confirmation), so we test
-//! error cases that exit before the confirmation prompt.
+//! Covers the post-graphite-parity rewrite: commits are preserved (not
+//! squashed), descendants of the folded branch are reparented onto the
+//! surviving branch, and `--keep` lets the current branch's name survive
+//! while the parent ref is deleted.
 
 mod common;
 
 use common::{OutputAssertions, TestRepo};
 
 // =============================================================================
-// Error Case Tests (these don't require confirmation)
+// Error / precondition tests (no confirmation required — fold bails early)
 // =============================================================================
 
 #[test]
 fn test_fold_into_trunk_not_allowed() {
     let repo = TestRepo::new();
-
-    // Create a branch directly from main
     repo.create_stack(&["feature-1"]);
     assert!(repo.current_branch_contains("feature-1"));
 
-    // Try to fold into trunk - should fail before confirmation
     let output = repo.run_stax(&["branch", "fold"]);
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
 
-    let stdout = TestRepo::stdout(&output);
-    let stderr = TestRepo::stderr(&output);
-    let combined = format!("{}{}", stdout, stderr);
-
-    // Should indicate we can't fold into trunk
     assert!(
         combined.contains("trunk")
             || combined.contains("Cannot fold")
@@ -38,50 +36,20 @@ fn test_fold_into_trunk_not_allowed() {
 }
 
 #[test]
-fn test_fold_with_children_not_allowed() {
-    let repo = TestRepo::new();
-
-    // Create a stack: main -> feature-1 -> feature-2
-    let branches = repo.create_stack(&["feature-1", "feature-2"]);
-
-    // Go to feature-1 (which has feature-2 as child)
-    repo.run_stax(&["checkout", &branches[0]]);
-    assert!(repo.current_branch_contains("feature-1"));
-
-    // Try to fold - should fail because it has children
-    let output = repo.run_stax(&["branch", "fold"]);
-
-    let stdout = TestRepo::stdout(&output);
-    let stderr = TestRepo::stderr(&output);
-    let combined = format!("{}{}", stdout, stderr);
-
-    // Should indicate we can't fold due to children
-    assert!(
-        combined.contains("children")
-            || combined.contains("child")
-            || combined.contains("Cannot fold"),
-        "Expected message about children, got: {}",
-        combined
-    );
-}
-
-#[test]
 fn test_fold_untracked_branch_fails() {
     let repo = TestRepo::new();
 
-    // Create an untracked branch directly with git
     repo.git(&["checkout", "-b", "untracked-branch"]);
     repo.create_file("test.txt", "content");
     repo.commit("Untracked commit");
 
-    // Try to fold - should fail because branch is not tracked
     let output = repo.run_stax(&["branch", "fold"]);
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
 
-    let stdout = TestRepo::stdout(&output);
-    let stderr = TestRepo::stderr(&output);
-    let combined = format!("{}{}", stdout, stderr);
-
-    // Should indicate branch is not tracked
     assert!(
         combined.contains("not tracked") || combined.contains("track") || !output.status.success(),
         "Expected message about tracking or failure, got: {}",
@@ -93,21 +61,17 @@ fn test_fold_untracked_branch_fails() {
 fn test_fold_on_trunk_not_allowed() {
     let repo = TestRepo::new();
 
-    // Create a branch so stax is initialized
     repo.create_stack(&["feature-1"]);
-
-    // Go back to trunk
     repo.run_stax(&["t"]);
     assert_eq!(repo.current_branch(), "main");
 
-    // Try to fold on trunk - should fail
     let output = repo.run_stax(&["branch", "fold"]);
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
 
-    let stdout = TestRepo::stdout(&output);
-    let stderr = TestRepo::stderr(&output);
-    let combined = format!("{}{}", stdout, stderr);
-
-    // Should indicate can't fold on trunk (not tracked or similar)
     assert!(
         combined.contains("trunk") || combined.contains("not tracked") || !output.status.success(),
         "Expected failure on trunk, got: {}",
@@ -119,50 +83,64 @@ fn test_fold_on_trunk_not_allowed() {
 fn test_fold_no_commits_to_fold() {
     let repo = TestRepo::new();
 
-    // Create a branch chain but with same commit as parent
+    // main → feature-1 (with commit) → empty-branch (same SHA as feature-1)
     repo.run_stax(&["bc", "feature-1"]);
     let feature1 = repo.current_branch();
     repo.create_file("f1.txt", "content");
     repo.commit("Feature 1");
 
-    // Create child without additional commits
-    repo.run_stax(&["bc", "feature-2"]);
-    // No commit here - same as parent
-
-    // Delete child's branch so feature-1 has no children
-    let feature2 = repo.current_branch();
-    repo.run_stax(&["checkout", &feature1]);
-    repo.run_stax(&["branch", "delete", &feature2, "--force"]);
-
-    // Now create a new branch from feature-1 without any new commits
-    // Actually, the branch creation itself creates a commit in our helper
-    // So we need a different approach
-
-    // Create a branch that points to the same commit as parent
     repo.git(&["checkout", "-b", "empty-branch"]);
-
-    // Track it with stax
     repo.run_stax(&["branch", "track", "--parent", &feature1]);
 
-    // Now try to fold - should say no commits to fold
-    let output = repo.run_stax(&["branch", "fold"]);
+    let output = repo.run_stax(&["branch", "fold", "--yes"]);
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
 
-    let stdout = TestRepo::stdout(&output);
-    let stderr = TestRepo::stderr(&output);
-    let combined = format!("{}{}", stdout, stderr);
-
-    // Should indicate no commits to fold
     assert!(
-        combined.contains("No commits")
-            || combined.contains("no commits")
-            || combined.contains("0 commit"),
-        "Expected 'no commits' message, got: {}",
+        combined.to_lowercase().contains("no commits")
+            || combined.contains("0 commit")
+            || combined.contains("Nothing to fold"),
+        "Expected 'no commits' / 'Nothing to fold' message, got: {}",
+        combined
+    );
+}
+
+#[test]
+fn test_fold_with_dirty_working_tree_refused() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["bc", "feature-1"]);
+    repo.create_file("f1.txt", "content");
+    repo.commit("Feature 1");
+
+    repo.run_stax(&["bc", "feature-2"]);
+    repo.create_file("f2.txt", "content");
+    repo.commit("Feature 2");
+
+    // Make the working tree dirty
+    repo.create_file("dirty.txt", "uncommitted");
+
+    let output = repo.run_stax(&["branch", "fold", "--yes"]);
+    let combined = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    assert!(!output.status.success(), "Fold should refuse a dirty tree");
+    assert!(
+        combined.to_lowercase().contains("uncommitted")
+            || combined.to_lowercase().contains("dirty"),
+        "Expected dirty-tree error, got: {}",
         combined
     );
 }
 
 // =============================================================================
-// Help and Alias Tests
+// Help / alias tests
 // =============================================================================
 
 #[test]
@@ -171,7 +149,6 @@ fn test_fold_help() {
 
     let output = repo.run_stax(&["branch", "fold", "--help"]);
     output.assert_success();
-
     let stdout = TestRepo::stdout(&output);
     assert!(
         stdout.contains("--keep") || stdout.contains("-k"),
@@ -186,10 +163,7 @@ fn test_fold_help() {
 #[test]
 fn test_fold_alias_f() {
     let repo = TestRepo::new();
-
-    // b f should work as alias for branch fold
-    let output = repo.run_stax(&["b", "f", "--help"]);
-    output.assert_success();
+    repo.run_stax(&["b", "f", "--help"]).assert_success();
 }
 
 #[test]
@@ -198,7 +172,6 @@ fn test_fold_keep_flag_in_help() {
 
     let output = repo.run_stax(&["branch", "fold", "--help"]);
     output.assert_success();
-
     let stdout = TestRepo::stdout(&output);
     assert!(
         stdout.contains("keep") || stdout.contains("Keep"),
@@ -207,95 +180,213 @@ fn test_fold_keep_flag_in_help() {
     );
 }
 
+#[test]
+fn test_fold_top_level_alias_help() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["fold", "--help"]);
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    assert!(stdout.contains("Fold") || stdout.contains("fold"));
+}
+
 // =============================================================================
-// Fold Scenario Setup Tests
-// These test the preconditions for fold without running interactive fold
+// Behavioural tests (post-rewrite)
 // =============================================================================
 
 #[test]
-fn test_fold_scenario_valid_setup() {
+fn test_fold_default_mode_basic_collapses_leaf() {
     let repo = TestRepo::new();
 
-    // Create: main -> feature-1 -> feature-2 (no children)
-    repo.run_stax(&["bc", "feature-1"]);
-    repo.create_file("f1.txt", "content 1");
-    repo.commit("Feature 1 commit");
+    // main → A (commits a-file) → B (commits b-file)
+    repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
 
-    repo.run_stax(&["bc", "feature-2"]);
-    repo.create_file("f2.txt", "content 2");
-    repo.commit("Feature 2 commit");
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
 
-    // feature-2 has no children, so fold should be possible
-    // (would require confirmation in real scenario)
+    // Fold leaf B into A
+    let output = repo.run_stax(&["branch", "fold", "--yes"]);
+    output.assert_success();
 
-    // Verify the setup is correct for fold
-    let json = repo.get_status_json();
-    let branches = json["branches"].as_array().unwrap();
+    // B no longer exists
+    assert!(
+        !repo.list_branches().iter().any(|name| name == &b),
+        "Folded branch '{}' should be deleted, branches: {:?}",
+        b,
+        repo.list_branches()
+    );
 
-    let f2_branch = branches
+    // We are checked out on the survivor (A)
+    assert_eq!(repo.current_branch(), a, "Should end up on A");
+
+    // Both files are present (commits preserved, not squashed away)
+    assert!(repo.path().join("a.txt").exists(), "a.txt should be on A");
+    assert!(
+        repo.path().join("b.txt").exists(),
+        "b.txt (from B) should now live on A after fold"
+    );
+}
+
+#[test]
+fn test_fold_keep_mode_basic_keeps_current_name() {
+    let repo = TestRepo::new();
+
+    // main → A → B (leaf)
+    repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
+
+    // Fold with --keep: B's name survives, A is deleted
+    let output = repo.run_stax(&["branch", "fold", "--keep", "--yes"]);
+    output.assert_success();
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.iter().any(|name| name == &a),
+        "--keep should delete the parent ref '{}', branches: {:?}",
+        a,
+        branches
+    );
+    assert!(
+        branches.iter().any(|name| name == &b),
+        "--keep should preserve the current branch '{}', branches: {:?}",
+        b,
+        branches
+    );
+
+    assert_eq!(repo.current_branch(), b, "Should still be on B");
+
+    // B is now reparented onto trunk (since A — its old parent — was the
+    // only intermediate branch and trunk is A's parent).
+    assert_eq!(
+        repo.get_current_parent().as_deref(),
+        Some("main"),
+        "B's parent should now be the grandparent (main)"
+    );
+
+    assert!(repo.path().join("a.txt").exists());
+    assert!(repo.path().join("b.txt").exists());
+}
+
+#[test]
+fn test_fold_with_descendants_reparents_them() {
+    let repo = TestRepo::new();
+
+    // main → A → B → C
+    repo.run_stax(&["bc", "A"]);
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
+
+    repo.run_stax(&["bc", "C"]);
+    let c = repo.current_branch();
+    repo.create_file("c.txt", "from C");
+    repo.commit("C commit");
+
+    // Move to B and fold it (B has child C)
+    repo.run_stax(&["checkout", &b]);
+
+    let output = repo.run_stax(&["branch", "fold", "--yes"]);
+    output.assert_success();
+
+    // B is gone
+    assert!(
+        !repo.list_branches().iter().any(|name| name == &b),
+        "B should be deleted after fold"
+    );
+
+    // C is now a child of A (the survivor)
+    let parent_of_c_json = repo.get_status_json();
+    let c_branch = parent_of_c_json["branches"]
+        .as_array()
+        .unwrap()
         .iter()
-        .find(|b| b["name"].as_str().unwrap_or("").contains("feature-2"))
-        .expect("Should find feature-2");
-
-    // feature-2 should have feature-1 as parent (not trunk)
+        .find(|b| b["name"].as_str() == Some(&c))
+        .expect("C should still be tracked");
+    let c_parent = c_branch["parent"].as_str().unwrap_or("");
     assert!(
-        f2_branch["parent"]
-            .as_str()
-            .unwrap_or("")
-            .contains("feature-1"),
-        "feature-2 should have feature-1 as parent"
-    );
-
-    // feature-2 should have commits ahead of its parent
-    let ahead = f2_branch["ahead"].as_i64().unwrap_or(0);
-    assert!(ahead > 0, "feature-2 should have commits ahead: {}", ahead);
-}
-
-#[test]
-fn test_fold_scenario_branch_with_children_detected() {
-    let repo = TestRepo::new();
-
-    // Create: main -> feature-1 -> feature-2
-    repo.run_stax(&["bc", "feature-1"]);
-    let feature1 = repo.current_branch();
-    repo.create_file("f1.txt", "content 1");
-    repo.commit("Feature 1 commit");
-
-    repo.run_stax(&["bc", "feature-2"]);
-    repo.create_file("f2.txt", "content 2");
-    repo.commit("Feature 2 commit");
-
-    // feature-1 has feature-2 as child
-    let children = repo.get_children(&feature1);
-    assert!(
-        !children.is_empty(),
-        "feature-1 should have children: {:?}",
-        children
-    );
-    assert!(
-        children.iter().any(|c| c.contains("feature-2")),
-        "feature-1 should have feature-2 as child"
+        c_parent.ends_with('A') || c_parent == "A",
+        "C's parent should be A after fold, got '{}'",
+        c_parent
     );
 }
 
 #[test]
-fn test_fold_scenario_parent_is_not_trunk() {
+fn test_fold_top_level_alias_works() {
     let repo = TestRepo::new();
 
-    // Create: main -> feature-1 -> feature-2
-    repo.run_stax(&["bc", "feature-1"]);
-    repo.create_file("f1.txt", "content");
-    repo.commit("Feature 1");
+    repo.run_stax(&["bc", "A"]);
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
 
-    repo.run_stax(&["bc", "feature-2"]);
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
 
-    // Check parent is feature-1, not trunk
-    let parent = repo.get_current_parent();
-    assert!(parent.is_some(), "feature-2 should have a parent");
+    // `stax fold` (no `branch` prefix) should match `gt fold`'s ergonomics
+    let output = repo.run_stax(&["fold", "--yes"]);
+    output.assert_success();
+
     assert!(
-        parent.unwrap().contains("feature-1"),
-        "feature-2's parent should be feature-1"
+        !repo.list_branches().iter().any(|name| name == &b),
+        "B should be deleted via top-level fold"
     );
+}
 
-    // This means fold would work (parent is not trunk)
+#[test]
+fn test_fold_undo_restores_state() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
+
+    let b_sha_before = repo.get_commit_sha(&b);
+    let a_sha_before = repo.get_commit_sha(&a);
+
+    repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
+
+    // Undo
+    let undo = repo.run_stax(&["undo", "--yes"]);
+    undo.assert_success();
+
+    // B exists again, both at original SHAs
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|name| name == &b),
+        "Undo should restore '{}', branches: {:?}",
+        b,
+        branches
+    );
+    assert_eq!(
+        repo.get_commit_sha(&b),
+        b_sha_before,
+        "B should be at original SHA after undo"
+    );
+    assert_eq!(
+        repo.get_commit_sha(&a),
+        a_sha_before,
+        "A should be at original SHA after undo"
+    );
 }

--- a/tests/fold_tests.rs
+++ b/tests/fold_tests.rs
@@ -2,36 +2,31 @@
 //!
 //! Covers the post-graphite-parity rewrite: commits are preserved (not
 //! squashed), descendants of the folded branch are reparented onto the
-//! surviving branch, and `--keep` lets the current branch's name survive
-//! while the parent ref is deleted.
+//! surviving branch, siblings are rebased, and `--keep` lets the current
+//! branch's name survive while the parent ref is deleted.
 
 mod common;
 
 use common::{OutputAssertions, TestRepo};
 
+fn combined(output: &std::process::Output) -> String {
+    format!("{}{}", TestRepo::stdout(output), TestRepo::stderr(output))
+}
+
 // =============================================================================
-// Error / precondition tests (no confirmation required — fold bails early)
+// Preconditions — fold bails before the confirmation prompt
 // =============================================================================
 
 #[test]
 fn test_fold_into_trunk_not_allowed() {
     let repo = TestRepo::new();
     repo.create_stack(&["feature-1"]);
-    assert!(repo.current_branch_contains("feature-1"));
 
     let output = repo.run_stax(&["branch", "fold"]);
-    let combined = format!(
-        "{}{}",
-        TestRepo::stdout(&output),
-        TestRepo::stderr(&output)
-    );
-
     assert!(
-        combined.contains("trunk")
-            || combined.contains("Cannot fold")
-            || combined.contains("submit"),
-        "Expected message about trunk, got: {}",
-        combined
+        combined(&output).contains("Cannot fold into trunk"),
+        "expected 'Cannot fold into trunk' message, got: {}",
+        combined(&output)
     );
 }
 
@@ -44,67 +39,49 @@ fn test_fold_untracked_branch_fails() {
     repo.commit("Untracked commit");
 
     let output = repo.run_stax(&["branch", "fold"]);
-    let combined = format!(
-        "{}{}",
-        TestRepo::stdout(&output),
-        TestRepo::stderr(&output)
-    );
-
+    output.assert_failure();
     assert!(
-        combined.contains("not tracked") || combined.contains("track") || !output.status.success(),
-        "Expected message about tracking or failure, got: {}",
-        combined
+        combined(&output).contains("not tracked"),
+        "expected 'not tracked' in: {}",
+        combined(&output)
     );
 }
 
 #[test]
-fn test_fold_on_trunk_not_allowed() {
+fn test_fold_when_on_trunk_bails() {
     let repo = TestRepo::new();
-
     repo.create_stack(&["feature-1"]);
     repo.run_stax(&["t"]);
     assert_eq!(repo.current_branch(), "main");
 
     let output = repo.run_stax(&["branch", "fold"]);
-    let combined = format!(
-        "{}{}",
-        TestRepo::stdout(&output),
-        TestRepo::stderr(&output)
-    );
-
+    output.assert_failure();
     assert!(
-        combined.contains("trunk") || combined.contains("not tracked") || !output.status.success(),
-        "Expected failure on trunk, got: {}",
-        combined
+        combined(&output).contains("Cannot fold trunk"),
+        "expected 'Cannot fold trunk' in: {}",
+        combined(&output)
     );
 }
 
 #[test]
-fn test_fold_no_commits_to_fold() {
+fn test_fold_with_no_changes_is_a_noop() {
     let repo = TestRepo::new();
 
-    // main → feature-1 (with commit) → empty-branch (same SHA as feature-1)
     repo.run_stax(&["bc", "feature-1"]);
     let feature1 = repo.current_branch();
     repo.create_file("f1.txt", "content");
     repo.commit("Feature 1");
 
+    // Empty branch off feature-1 (same SHA, no kids, no siblings)
     repo.git(&["checkout", "-b", "empty-branch"]);
     repo.run_stax(&["branch", "track", "--parent", &feature1]);
 
     let output = repo.run_stax(&["branch", "fold", "--yes"]);
-    let combined = format!(
-        "{}{}",
-        TestRepo::stdout(&output),
-        TestRepo::stderr(&output)
-    );
-
+    output.assert_success();
     assert!(
-        combined.to_lowercase().contains("no commits")
-            || combined.contains("0 commit")
-            || combined.contains("Nothing to fold"),
-        "Expected 'no commits' / 'Nothing to fold' message, got: {}",
-        combined
+        combined(&output).contains("Nothing to fold"),
+        "expected 'Nothing to fold' in: {}",
+        combined(&output)
     );
 }
 
@@ -120,84 +97,50 @@ fn test_fold_with_dirty_working_tree_refused() {
     repo.create_file("f2.txt", "content");
     repo.commit("Feature 2");
 
-    // Make the working tree dirty
     repo.create_file("dirty.txt", "uncommitted");
 
     let output = repo.run_stax(&["branch", "fold", "--yes"]);
-    let combined = format!(
-        "{}{}",
-        TestRepo::stdout(&output),
-        TestRepo::stderr(&output)
-    );
-
-    assert!(!output.status.success(), "Fold should refuse a dirty tree");
+    output.assert_failure();
     assert!(
-        combined.to_lowercase().contains("uncommitted")
-            || combined.to_lowercase().contains("dirty"),
-        "Expected dirty-tree error, got: {}",
-        combined
+        combined(&output).contains("uncommitted"),
+        "expected 'uncommitted' in: {}",
+        combined(&output)
     );
 }
 
 // =============================================================================
-// Help / alias tests
+// Help / alias surface
 // =============================================================================
 
 #[test]
-fn test_fold_help() {
+fn test_fold_help_surfaces() {
     let repo = TestRepo::new();
 
-    let output = repo.run_stax(&["branch", "fold", "--help"]);
-    output.assert_success();
-    let stdout = TestRepo::stdout(&output);
-    assert!(
-        stdout.contains("--keep") || stdout.contains("-k"),
-        "Expected --keep flag in help"
-    );
-    assert!(
-        stdout.contains("fold") || stdout.contains("Fold"),
-        "Expected 'fold' in help"
-    );
-}
-
-#[test]
-fn test_fold_alias_f() {
-    let repo = TestRepo::new();
-    repo.run_stax(&["b", "f", "--help"]).assert_success();
-}
-
-#[test]
-fn test_fold_keep_flag_in_help() {
-    let repo = TestRepo::new();
-
-    let output = repo.run_stax(&["branch", "fold", "--help"]);
-    output.assert_success();
-    let stdout = TestRepo::stdout(&output);
-    assert!(
-        stdout.contains("keep") || stdout.contains("Keep"),
-        "Expected 'keep' in fold help: {}",
-        stdout
-    );
-}
-
-#[test]
-fn test_fold_top_level_alias_help() {
-    let repo = TestRepo::new();
-    let output = repo.run_stax(&["fold", "--help"]);
-    output.assert_success();
-    let stdout = TestRepo::stdout(&output);
-    assert!(stdout.contains("Fold") || stdout.contains("fold"));
+    for args in [
+        &["branch", "fold", "--help"][..],
+        &["b", "f", "--help"][..],
+        &["fold", "--help"][..],
+    ] {
+        let output = repo.run_stax(args);
+        output.assert_success();
+        let stdout = TestRepo::stdout(&output);
+        assert!(
+            stdout.contains("--keep") || stdout.contains("-k"),
+            "expected --keep in `{:?}` help: {}",
+            args,
+            stdout
+        );
+    }
 }
 
 // =============================================================================
-// Behavioural tests (post-rewrite)
+// Behaviour
 // =============================================================================
 
 #[test]
 fn test_fold_default_mode_basic_collapses_leaf() {
     let repo = TestRepo::new();
 
-    // main → A (commits a-file) → B (commits b-file)
     repo.run_stax(&["bc", "A"]);
     let a = repo.current_branch();
     repo.create_file("a.txt", "from A");
@@ -208,26 +151,19 @@ fn test_fold_default_mode_basic_collapses_leaf() {
     repo.create_file("b.txt", "from B");
     repo.commit("B commit");
 
-    // Fold leaf B into A
-    let output = repo.run_stax(&["branch", "fold", "--yes"]);
-    output.assert_success();
+    repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
 
-    // B no longer exists
+    let branches = repo.list_branches();
     assert!(
-        !repo.list_branches().iter().any(|name| name == &b),
-        "Folded branch '{}' should be deleted, branches: {:?}",
-        b,
-        repo.list_branches()
+        !branches.iter().any(|n| n == &b),
+        "B should be deleted, branches: {:?}",
+        branches
     );
-
-    // We are checked out on the survivor (A)
-    assert_eq!(repo.current_branch(), a, "Should end up on A");
-
-    // Both files are present (commits preserved, not squashed away)
+    assert_eq!(repo.current_branch(), a, "should end up on A");
     assert!(repo.path().join("a.txt").exists(), "a.txt should be on A");
     assert!(
         repo.path().join("b.txt").exists(),
-        "b.txt (from B) should now live on A after fold"
+        "b.txt (from B) should now live on A — commits preserved, not squashed"
     );
 }
 
@@ -235,7 +171,6 @@ fn test_fold_default_mode_basic_collapses_leaf() {
 fn test_fold_keep_mode_basic_keeps_current_name() {
     let repo = TestRepo::new();
 
-    // main → A → B (leaf)
     repo.run_stax(&["bc", "A"]);
     let a = repo.current_branch();
     repo.create_file("a.txt", "from A");
@@ -246,36 +181,28 @@ fn test_fold_keep_mode_basic_keeps_current_name() {
     repo.create_file("b.txt", "from B");
     repo.commit("B commit");
 
-    // Fold with --keep: B's name survives, A is deleted
-    let output = repo.run_stax(&["branch", "fold", "--keep", "--yes"]);
-    output.assert_success();
+    repo.run_stax(&["branch", "fold", "--keep", "--yes"])
+        .assert_success();
 
     let branches = repo.list_branches();
     assert!(
-        !branches.iter().any(|name| name == &a),
+        !branches.iter().any(|n| n == &a),
         "--keep should delete the parent ref '{}', branches: {:?}",
         a,
         branches
     );
     assert!(
-        branches.iter().any(|name| name == &b),
-        "--keep should preserve the current branch '{}', branches: {:?}",
+        branches.iter().any(|n| n == &b),
+        "--keep should preserve '{}', branches: {:?}",
         b,
         branches
     );
-
-    assert_eq!(repo.current_branch(), b, "Should still be on B");
-
-    // B is now reparented onto trunk (since A — its old parent — was the
-    // only intermediate branch and trunk is A's parent).
+    assert_eq!(repo.current_branch(), b);
     assert_eq!(
         repo.get_current_parent().as_deref(),
         Some("main"),
         "B's parent should now be the grandparent (main)"
     );
-
-    assert!(repo.path().join("a.txt").exists());
-    assert!(repo.path().join("b.txt").exists());
 }
 
 #[test]
@@ -284,6 +211,7 @@ fn test_fold_with_descendants_reparents_them() {
 
     // main → A → B → C
     repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
     repo.create_file("a.txt", "from A");
     repo.commit("A commit");
 
@@ -297,32 +225,128 @@ fn test_fold_with_descendants_reparents_them() {
     repo.create_file("c.txt", "from C");
     repo.commit("C commit");
 
-    // Move to B and fold it (B has child C)
     repo.run_stax(&["checkout", &b]);
+    repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
 
-    let output = repo.run_stax(&["branch", "fold", "--yes"]);
-    output.assert_success();
-
-    // B is gone
     assert!(
-        !repo.list_branches().iter().any(|name| name == &b),
-        "B should be deleted after fold"
+        !repo.list_branches().iter().any(|n| n == &b),
+        "B should be deleted"
     );
 
-    // C is now a child of A (the survivor)
-    let parent_of_c_json = repo.get_status_json();
-    let c_branch = parent_of_c_json["branches"]
+    let json = repo.get_status_json();
+    let c_parent = json["branches"]
         .as_array()
         .unwrap()
         .iter()
-        .find(|b| b["name"].as_str() == Some(&c))
-        .expect("C should still be tracked");
-    let c_parent = c_branch["parent"].as_str().unwrap_or("");
+        .find(|br| br["name"].as_str() == Some(&c))
+        .expect("C should still be tracked")["parent"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(c_parent, a, "C's parent should be A after fold");
+}
+
+#[test]
+fn test_fold_keep_mode_with_descendants_keeps_kid_pointing_at_survivor() {
+    let repo = TestRepo::new();
+
+    // main → A → B → C, then `fold --keep` from B.
+    // Survivor=B; A is deleted. C's parent_branch_name was B (now survivor)
+    // and stays B — kids of `current` need no metadata change in --keep mode.
+    repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
+
+    repo.run_stax(&["bc", "C"]);
+    let c = repo.current_branch();
+    repo.create_file("c.txt", "from C");
+    repo.commit("C commit");
+
+    repo.run_stax(&["checkout", &b]);
+    repo.run_stax(&["branch", "fold", "--keep", "--yes"])
+        .assert_success();
+
+    let branches = repo.list_branches();
+    assert!(branches.iter().any(|n| n == &b), "B should survive --keep");
     assert!(
-        c_parent.ends_with('A') || c_parent == "A",
-        "C's parent should be A after fold, got '{}'",
-        c_parent
+        !branches.iter().any(|n| n == &a),
+        "A ('{}') should be deleted, branches: {:?}",
+        a,
+        branches
     );
+
+    let json = repo.get_status_json();
+    let c_parent = json["branches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|br| br["name"].as_str() == Some(&c))
+        .expect("C should still be tracked")["parent"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(c_parent, b, "C's parent should still be B (the survivor)");
+}
+
+#[test]
+fn test_fold_with_sibling_rebases_it_onto_survivor() {
+    let repo = TestRepo::new();
+
+    // main → A → B  (target of fold)
+    //          → S  (sibling — touches different files so rebase is conflict-free)
+    repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
+
+    repo.run_stax(&["checkout", &a]);
+    repo.run_stax(&["bc", "S"]);
+    let s = repo.current_branch();
+    repo.create_file("s.txt", "from S");
+    repo.commit("S commit");
+
+    repo.run_stax(&["checkout", &b]);
+    repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|n| n == &s),
+        "sibling S should survive, branches: {:?}",
+        branches
+    );
+
+    repo.run_stax(&["checkout", &s]);
+    assert!(
+        repo.path().join("s.txt").exists(),
+        "S's own file should remain"
+    );
+    assert!(
+        repo.path().join("b.txt").exists(),
+        "S should now have B's commits underneath (rebased onto survivor)"
+    );
+
+    let json = repo.get_status_json();
+    let s_parent = json["branches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|br| br["name"].as_str() == Some(&s))
+        .expect("S should be tracked")["parent"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(s_parent, a, "S's parent should be the survivor (A)");
 }
 
 #[test]
@@ -338,12 +362,9 @@ fn test_fold_top_level_alias_works() {
     repo.create_file("b.txt", "from B");
     repo.commit("B commit");
 
-    // `stax fold` (no `branch` prefix) should match `gt fold`'s ergonomics
-    let output = repo.run_stax(&["fold", "--yes"]);
-    output.assert_success();
-
+    repo.run_stax(&["fold", "--yes"]).assert_success();
     assert!(
-        !repo.list_branches().iter().any(|name| name == &b),
+        !repo.list_branches().iter().any(|n| n == &b),
         "B should be deleted via top-level fold"
     );
 }
@@ -362,31 +383,74 @@ fn test_fold_undo_restores_state() {
     repo.create_file("b.txt", "from B");
     repo.commit("B commit");
 
-    let b_sha_before = repo.get_commit_sha(&b);
-    let a_sha_before = repo.get_commit_sha(&a);
+    let b_sha = repo.get_commit_sha(&b);
+    let a_sha = repo.get_commit_sha(&a);
 
     repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
+    repo.run_stax(&["undo", "--yes"]).assert_success();
 
-    // Undo
-    let undo = repo.run_stax(&["undo", "--yes"]);
-    undo.assert_success();
-
-    // B exists again, both at original SHAs
-    let branches = repo.list_branches();
     assert!(
-        branches.iter().any(|name| name == &b),
-        "Undo should restore '{}', branches: {:?}",
-        b,
-        branches
+        repo.list_branches().iter().any(|n| n == &b),
+        "undo should restore B"
     );
-    assert_eq!(
-        repo.get_commit_sha(&b),
-        b_sha_before,
-        "B should be at original SHA after undo"
+    assert_eq!(repo.get_commit_sha(&b), b_sha, "B back to original SHA");
+    assert_eq!(repo.get_commit_sha(&a), a_sha, "A back to original SHA");
+}
+
+#[test]
+fn test_fold_orphaned_pr_hint_when_pr_info_present() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["bc", "A"]);
+    let a = repo.current_branch();
+    repo.create_file("a.txt", "from A");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "B"]);
+    let b = repo.current_branch();
+    repo.create_file("b.txt", "from B");
+    repo.commit("B commit");
+
+    // Inject pr_info onto B by writing a metadata blob directly. Avoids
+    // needing a real GitHub remote in the test.
+    let pr_json = format!(
+        r#"{{"parentBranchName":"{}","parentBranchRevision":"{}","prInfo":{{"number":4242,"state":"OPEN","isDraft":false}}}}"#,
+        a,
+        repo.get_commit_sha(&a)
     );
-    assert_eq!(
-        repo.get_commit_sha(&a),
-        a_sha_before,
-        "A should be at original SHA after undo"
+    let mut child = std::process::Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    use std::io::Write;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(pr_json.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    let blob_hash = String::from_utf8(out.stdout).unwrap().trim().to_string();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{}", b),
+        &blob_hash,
+    ]);
+
+    let output = repo.run_stax(&["branch", "fold", "--yes"]);
+    output.assert_success();
+    let out = combined(&output);
+    assert!(
+        out.contains("PR #4242"),
+        "expected orphaned-PR hint to mention PR #4242, got: {}",
+        out
+    );
+    assert!(
+        out.contains("gh pr close 4242"),
+        "expected gh pr close hint, got: {}",
+        out
     );
 }


### PR DESCRIPTION
## Motivation

Closes (in spirit) #343. `stax branch fold` exists today but diverges from `gt fold` in ways that limit its usefulness — most importantly, it refuses to fold a branch that has children, which is the most common reason to want to fold (collapsing an over-decomposed middle of a stack). It also squash-merges instead of preserving commits, and `--keep` doesn't do what `gt --keep` does.

## Description of changes / notes for reviewers

- Rewrite `commands/branch/fold.rs` to match `gt fold`:
  - **Commits preserved** (no longer squash-merge). The surviving branch ends up at the current branch's tip SHA, keeping both the parent's and the current branch's commits.
  - **Descendants of the folded branch reparented** onto the surviving branch (metadata-only since the SHAs match).
  - **Siblings** (other children of the parent) rebased onto the new tip via `rebase_branch_onto_with_provenance`. Conflicts surface with the standard `stax undo` recovery hint and the in-progress rebase is aborted so the working tree stays clean.
  - **`--keep` semantics fixed**: the surviving branch keeps the *current* name and the parent ref is deleted — matches `gt fold --keep`.
  - **Refuses** on dirty working tree / in-progress rebase (the old impl was missing these guards).
- Wrap in a `Transaction` with new `OpKind::Fold` so the operation is fully recoverable via `stax undo`. Extended `Transaction` with `plan_metadata_ref` / `record_metadata_ref_after` helpers so `refs/branch-metadata/*` are also captured in the receipt — without this, undo restores the branch ref but leaves the metadata gone.
- Add **top-level `stax fold`** alias (mirrors `gt fold`'s discoverability without forcing `stax branch fold`).
- Hint at the orphaned PR with a `gh pr close <num>` suggestion. `--close` (auto-close via the GitHub API) deferred to a follow-up since it would touch the forge layer.
- Tests cover: default-mode leaf fold, `--keep` leaf fold, fold-with-descendants, top-level alias, dirty-tree refusal, undo restoration, plus all the existing precondition tests (preserved).

### Behavioral comparison

| Aspect | Before | After |
|---|---|---|
| Commits | Squashed into one (\`Fold X into Y\`) | Preserved (linear concat) |
| Branch with children | Refused | Reparents children onto survivor |
| `--keep` | Keeps folded branch + still merges into parent | Surviving branch takes current's name; parent ref deleted |
| Top-level alias | None | `stax fold` |
| Undo | Not wrapped in Transaction | `OpKind::Fold` + metadata-ref backups |
| Dirty tree | Allowed | Refused |
| Rebase in progress | Allowed | Refused |

### Out of scope (intentional follow-ups)

- `--close` flag to auto-close the orphaned PR via the forge API.
- `--stack` flag to fold an entire stack into one branch (per gt v1.8.4).
- Additional safety check for branches checked out in linked worktrees during the ref movement step.

## Test plan

- [x] Existing fold tests continue to pass (preconditions, help, alias).
- [x] New: `test_fold_default_mode_basic_collapses_leaf` — verifies leaf branch is deleted, survivor is parent, both files preserved.
- [x] New: `test_fold_keep_mode_basic_keeps_current_name` — verifies parent is deleted, survivor keeps current's name, parent reparented to grandparent.
- [x] New: `test_fold_with_descendants_reparents_them` — verifies child of folded branch becomes child of survivor.
- [x] New: `test_fold_top_level_alias_works` — `stax fold --yes` works.
- [x] New: `test_fold_with_dirty_working_tree_refused` — fold refuses dirty tree.
- [x] New: `test_fold_undo_restores_state` — `stax undo` restores branch refs.
- [x] `cargo test` full suite green (modulo two pre-existing `cli_tests` failures around shell-setup / gh-auth import that fail identically on origin/main).