### PR TITLE
Style checkout picker rows with active background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "dirs",
+ "fuzzy-matcher",
  "git2",
  "indicatif",
  "octocrab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1"
 dialoguer = { version = "0.12", features = ["fuzzy-select", "editor"] }
 console = "0.16"
 colored = "3"
+fuzzy-matcher = "0.3"
 indicatif = "0.18"
 ratatui = "0.30"
 crossterm = "0.29"

--- a/learnings.md
+++ b/learnings.md
@@ -1,6 +1,7 @@
-# Lessons
+# learnings.md
 
 - When changing the `stax co` UI, match the `stax ls` visual language (colors, tree/indentation) and confirm it visually. Do not ship a redesign without verifying the output looks like the `ls` tree and that selection emphasis is obvious.
+- When using `dialoguer::FuzzySelect` with pre-colored ANSI rows, do not rely on `ColorfulTheme::active_item_style` while `highlight_matches(false)` is set. Use a custom `Theme` with explicit active/inactive row renderings so selected-row styling still applies without corrupting ANSI color output.
 - Stack tree lane colors must come from `src/commands/stack_palette.rs`; do not duplicate per-command color arrays or `st ls`/`st co` will drift.
 - Interactive prompts rendered on `stderr` must style item text against `stderr` and gate interactivity on `stdin` + `stderr`; shell integration can capture stdout for `--shell-output` while dialoguer prompts still run on stderr.
 - TUI changes must be checked at standard terminal widths (around 80 columns); keep one-line summaries and footers compact, and prefer a single contextual action over listing every shortcut.
@@ -36,7 +37,7 @@
 - Dirty-worktree removal must use the same force/blocker policy across `wt rm`, `wt cleanup`, and `sync`: if the user confirmed "remove anyway" or passed `--force`, the eventual `git worktree remove` call must also be forced, and prompts must not promise a removal path that still falls through to a non-forced Git command.
 - When routing to an existing worktree, preserve a unique selector such as the worktree path or checked-out branch; never round-trip through the display basename because different worktrees can share the same leaf directory name.
 - Branch-switching commands in very large repos must drop live libgit2 repository handles before spawning `git checkout` or writing prev-branch refs; use path-based `git` subprocesses for the final handoff so checkout still works under file-descriptor pressure.
-- When a command needs to reopen a repository after an FD-heavy libgit2 phase, reopen from a saved repo path (`git_dir`/worktree path) instead of rediscovering `.`; `Repository::discover(\".\")` can fail under `EMFILE` even when the repo path is already known.
+- When a command needs to reopen a repository after an FD-heavy libgit2 phase, reopen from a saved repo path (`git_dir`/worktree path) instead of rediscovering `.`; `Repository::discover(".")` can fail under `EMFILE` even when the repo path is already known.
 - Stack/branch graph traversal in user-facing commands must be iterative and cycle-safe; do not recurse over metadata graphs that can be deep or corrupted by local refs.
 - For stack-merge flows that delete merged branches, always rebase and retarget descendant branches/PR bases before cleanup; deleting a base branch first can auto-close descendant PRs on GitHub.
 - Any descendant-rebase path (`merge`, `merge --when-ready`, `restack`, `upstack restack`, `sync --restack`) must preserve provenance boundaries (`parent_branch_revision` / old parent tip) and use provenance-aware rebase logic; plain `git rebase <trunk>` will replay already-integrated parent history after squash merges.

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -22,6 +22,7 @@ const BRIGHT_BLUE: CheckoutColor = CheckoutColor::new(Color::Blue, true);
 const BRIGHT_CYAN: CheckoutColor = CheckoutColor::new(Color::Cyan, true);
 const CHECKOUT_PICKER_ITEM_SEPARATOR: char = '\u{1f}';
 const ACTIVE_ROW_BACKGROUND: &str = "\u{1b}[48;5;236m";
+const CHECKOUT_BRANCH_STYLE: &str = "\u{1b}[1;96m";
 const ANSI_RESET: &str = "\u{1b}[0m";
 
 #[derive(Clone, Copy)]
@@ -137,6 +138,14 @@ fn already_on_message(branch: &str) -> String {
         "Already on".yellow().bold(),
         branch.bright_cyan().bold()
     )
+}
+
+fn checkout_completion_shell_message(branch: &str) -> String {
+    format!("Checked out {CHECKOUT_BRANCH_STYLE}{branch}{ANSI_RESET}.")
+}
+
+fn already_on_shell_message(branch: &str) -> String {
+    format!("Already on {CHECKOUT_BRANCH_STYLE}{branch}{ANSI_RESET}.")
 }
 
 fn active_checkout_row(text: &str, min_width: usize) -> String {
@@ -334,7 +343,7 @@ pub fn run(
         )?;
     } else if target == current {
         if shell_output {
-            emit_shell_message(&format!("Already on {}.", target));
+            emit_shell_message(&already_on_shell_message(&target));
         } else {
             println!("{}", already_on_message(&target));
         }
@@ -344,7 +353,7 @@ pub fn run(
         }
         checkout_branch_in(&workdir, &target)?;
         if shell_output {
-            emit_shell_message(&format!("Checked out {}.", target));
+            emit_shell_message(&checkout_completion_shell_message(&target));
         } else {
             println!("{}", checkout_completion_message(&target));
         }

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -6,16 +6,23 @@ use crate::git::repo::WorktreeInfo;
 use crate::git::{checkout_branch_in, refs, GitRepo};
 use anyhow::Result;
 use colored::Colorize;
-use console::{truncate_str, Color, Style};
+use console::{colors_enabled_stderr, measure_text_width, truncate_str, Color, Style};
 use crossterm::terminal;
-use dialoguer::{theme::ColorfulTheme, FuzzySelect};
+use dialoguer::{
+    theme::{ColorfulTheme, Theme},
+    FuzzySelect,
+};
+use fuzzy_matcher::skim::SkimMatcherV2;
 use std::collections::HashSet;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::path::Path;
 
 const LINKED_WORKTREE_GLYPH: &str = "↳";
 const BRIGHT_BLUE: CheckoutColor = CheckoutColor::new(Color::Blue, true);
 const BRIGHT_CYAN: CheckoutColor = CheckoutColor::new(Color::Cyan, true);
+const CHECKOUT_PICKER_ITEM_SEPARATOR: char = '\u{1f}';
+const ACTIVE_ROW_BACKGROUND: &str = "\u{1b}[48;5;236m";
+const ANSI_RESET: &str = "\u{1b}[0m";
 
 #[derive(Clone, Copy)]
 struct CheckoutColor {
@@ -38,6 +45,47 @@ struct DisplayBranch {
 struct CheckoutRow {
     branch: String,
     display: String,
+    active_display: String,
+}
+
+struct CheckoutPickerTheme {
+    inner: ColorfulTheme,
+}
+
+impl Default for CheckoutPickerTheme {
+    fn default() -> Self {
+        Self {
+            inner: ColorfulTheme::default(),
+        }
+    }
+}
+
+impl Theme for CheckoutPickerTheme {
+    fn format_fuzzy_select_prompt_item(
+        &self,
+        f: &mut dyn fmt::Write,
+        text: &str,
+        active: bool,
+        _highlight_matches: bool,
+        _matcher: &SkimMatcherV2,
+        _search_term: &str,
+    ) -> fmt::Result {
+        if active {
+            write!(f, "{}", checkout_picker_item_display(text, true))
+        } else {
+            write!(f, "  {}", checkout_picker_item_display(text, false))
+        }
+    }
+
+    fn format_fuzzy_select_prompt(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        search_term: &str,
+        bytes_pos: usize,
+    ) -> fmt::Result {
+        Theme::format_fuzzy_select_prompt(&self.inner, f, prompt, search_term, bytes_pos)
+    }
 }
 
 fn checkout_style(spec: CheckoutColor) -> Style {
@@ -73,6 +121,67 @@ fn ahead_label(ahead: usize) -> String {
 
 fn render_stderr<T: Display>(value: T, style: Style) -> String {
     format!("{}", style.apply_to(value))
+}
+
+fn checkout_completion_message(branch: &str) -> String {
+    format!(
+        "{} {}.",
+        "Checked out".green().bold(),
+        branch.bright_cyan().bold()
+    )
+}
+
+fn already_on_message(branch: &str) -> String {
+    format!(
+        "{} {}.",
+        "Already on".yellow().bold(),
+        branch.bright_cyan().bold()
+    )
+}
+
+fn active_checkout_row(text: &str, min_width: usize) -> String {
+    let mut row = text.to_string();
+    let visible_width = measure_text_width(text);
+    if visible_width < min_width {
+        row.push_str(&" ".repeat(min_width - visible_width));
+    }
+
+    if !colors_enabled_stderr() {
+        return row;
+    }
+
+    let mut highlighted = String::with_capacity(row.len() + ACTIVE_ROW_BACKGROUND.len() * 4);
+    highlighted.push_str(ACTIVE_ROW_BACKGROUND);
+
+    let mut remaining = row.as_str();
+    while let Some(reset_index) = remaining.find(ANSI_RESET) {
+        let end = reset_index + ANSI_RESET.len();
+        highlighted.push_str(&remaining[..end]);
+        highlighted.push_str(ACTIVE_ROW_BACKGROUND);
+        remaining = &remaining[end..];
+    }
+    highlighted.push_str(remaining);
+    highlighted.push_str(ANSI_RESET);
+    highlighted
+}
+
+fn checkout_picker_item(branch: &str, display: &str, active_display: &str) -> String {
+    format!(
+        "{branch}{CHECKOUT_PICKER_ITEM_SEPARATOR}{display}{CHECKOUT_PICKER_ITEM_SEPARATOR}{active_display}"
+    )
+}
+
+fn checkout_picker_item_display(item: &str, active: bool) -> &str {
+    let mut parts = item.splitn(3, CHECKOUT_PICKER_ITEM_SEPARATOR);
+    let _search_text = parts.next();
+    let inactive_display = parts.next();
+    let active_display = parts.next();
+
+    match (inactive_display, active_display) {
+        (Some(_inactive), Some(active_item)) if active => active_item,
+        (Some(inactive), Some(_)) => inactive,
+        _ => item,
+    }
 }
 
 pub fn run(
@@ -160,19 +269,13 @@ pub fn run(
                     return Ok(());
                 }
 
-                let items: Vec<String> = rows.iter().map(|r| r.display.clone()).collect();
+                let items: Vec<String> = rows
+                    .iter()
+                    .map(|r| checkout_picker_item(&r.branch, &r.display, &r.active_display))
+                    .collect();
                 let branch_names: Vec<String> = rows.iter().map(|r| r.branch.clone()).collect();
 
-                let theme = ColorfulTheme {
-                    active_item_style: console::Style::new().for_stderr().black().on_white().bold(),
-                    active_item_prefix: console::style("▶".to_string())
-                        .for_stderr()
-                        .black()
-                        .on_white()
-                        .bold(),
-                    inactive_item_prefix: console::style(" ".to_string()).for_stderr(),
-                    ..ColorfulTheme::default()
-                };
+                let theme = CheckoutPickerTheme::default();
 
                 let term = console::Term::stderr();
                 if term.is_term() {
@@ -186,10 +289,11 @@ pub fn run(
                     .unwrap_or(0);
 
                 let selection = FuzzySelect::with_theme(&theme)
-                    .with_prompt("Checkout a branch (type to filter)")
+                    .with_prompt("Checkout a branch (autocomplete or arrow keys)")
                     .items(&items)
                     .default(default_index)
                     .highlight_matches(false) // Disabled - conflicts with ANSI colors
+                    .report(false)
                     .interact()?;
 
                 branch_names[selection].clone()
@@ -230,9 +334,9 @@ pub fn run(
         )?;
     } else if target == current {
         if shell_output {
-            emit_shell_message(&format!("Already on '{}'", target));
+            emit_shell_message(&format!("Already on {}.", target));
         } else {
-            println!("Already on '{}'", target);
+            println!("{}", already_on_message(&target));
         }
     } else {
         if let Err(e) = refs::write_prev_branch_at(&workdir, &current) {
@@ -240,9 +344,9 @@ pub fn run(
         }
         checkout_branch_in(&workdir, &target)?;
         if shell_output {
-            emit_shell_message(&format!("Switched to branch '{}'", target));
+            emit_shell_message(&format!("Checked out {}.", target));
         } else {
-            println!("Switched to branch '{}'", target);
+            println!("{}", checkout_completion_message(&target));
         }
     }
 
@@ -310,7 +414,8 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
     }
 
     let tree_target_width = (max_column + 1) * 2;
-    let max_width = terminal_width().saturating_sub(1);
+    let picker_row_width = terminal_width().saturating_sub(1);
+    let item_width = picker_row_width.saturating_sub(2);
     let mut rows = Vec::new();
 
     for (i, db) in display_branches.iter().enumerate() {
@@ -379,10 +484,19 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
             info_str.push_str(&format!(" {}", restack_label()));
         }
 
-        let display = truncate_display(&format!("{}{}", tree, info_str), max_width);
+        let display = truncate_display(&format!("{}{}", tree, info_str), item_width);
+        let active_display = active_checkout_row(
+            &format!(
+                "{} {}",
+                render_stderr("›", Style::new().for_stderr().cyan().bold()),
+                display
+            ),
+            picker_row_width,
+        );
         rows.push(CheckoutRow {
             branch: branch.clone(),
             display,
+            active_display,
         });
     }
 
@@ -447,10 +561,19 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
         }
     }
 
-    let trunk_display = truncate_display(&format!("{}{}", trunk_tree, trunk_info), max_width);
+    let trunk_display = truncate_display(&format!("{}{}", trunk_tree, trunk_info), item_width);
+    let active_trunk_display = active_checkout_row(
+        &format!(
+            "{} {}",
+            render_stderr("›", Style::new().for_stderr().cyan().bold()),
+            trunk_display
+        ),
+        picker_row_width,
+    );
     rows.push(CheckoutRow {
         branch: stack.trunk.clone(),
         display: trunk_display,
+        active_display: active_trunk_display,
     });
 
     Ok(rows)
@@ -816,5 +939,82 @@ mod tests {
         let (behind, ahead) = with_stderr_colors_enabled(|| (behind_label(4), ahead_label(6)));
         assert_eq!(behind, "\u{1b}[31m4 behind\u{1b}[0m");
         assert_eq!(ahead, "\u{1b}[32m6 ahead\u{1b}[0m");
+    }
+
+    #[test]
+    fn checkout_completion_message_colors_status_and_branch() {
+        colored::control::set_override(true);
+        let message = checkout_completion_message("feature/payments-api");
+        colored::control::unset_override();
+
+        assert_eq!(strip_ansi(&message), "Checked out feature/payments-api.");
+        assert!(
+            message.contains("\u{1b}[32m") || message.contains("\u{1b}[1;32m"),
+            "Expected success text to include green styling, got: {message:?}"
+        );
+        assert!(
+            message.contains("\u{1b}[96m") || message.contains("\u{1b}[1;96m"),
+            "Expected branch text to include bright cyan styling, got: {message:?}"
+        );
+    }
+
+    #[test]
+    fn checkout_picker_item_uses_active_display_for_selected_row() {
+        let item = checkout_picker_item("feature/auth", "inactive row", "active row");
+
+        assert_eq!(checkout_picker_item_display(&item, false), "inactive row");
+        assert_eq!(checkout_picker_item_display(&item, true), "active row");
+    }
+
+    #[test]
+    fn active_checkout_row_uses_background_instead_of_guide_line() {
+        let active = with_stderr_colors_enabled(|| active_checkout_row("○   feature/auth", 20));
+
+        assert_eq!(strip_ansi(&active), "○   feature/auth    ");
+        assert!(
+            active.contains("\u{1b}[48;5;236m"),
+            "Expected active row background styling, got: {active:?}"
+        );
+        assert!(
+            !strip_ansi(&active).contains("───"),
+            "Active row should not draw a guide line: {active:?}"
+        );
+    }
+
+    #[test]
+    fn active_checkout_row_pads_colored_text_by_visible_width() {
+        let active = with_stderr_colors_enabled(|| {
+            active_checkout_row(
+                &render_stderr("○", checkout_style(checkout_lane_color(0))),
+                4,
+            )
+        });
+
+        assert_eq!(strip_ansi(&active), "○   ");
+    }
+
+    #[test]
+    fn active_picker_row_keeps_prefix_inside_row_width() {
+        let theme = CheckoutPickerTheme::default();
+        let active_display =
+            with_stderr_colors_enabled(|| active_checkout_row("› ○ feature/auth", 16));
+        let item = checkout_picker_item("feature/auth", "○ feature/auth", &active_display);
+        let mut rendered = String::new();
+
+        with_stderr_colors_enabled(|| {
+            Theme::format_fuzzy_select_prompt_item(
+                &theme,
+                &mut rendered,
+                &item,
+                true,
+                false,
+                &SkimMatcherV2::default(),
+                "",
+            )
+        })
+        .expect("format active picker item");
+
+        assert_eq!(strip_ansi(&rendered).chars().count(), 16);
+        assert!(strip_ansi(&rendered).starts_with('›'));
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1019,6 +1019,34 @@ fn test_checkout_explicit_branch() {
 }
 
 #[test]
+fn test_checkout_explicit_branch_prints_clean_completion() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["bc", "feature-1"]);
+    let feature_branch = repo.current_branch();
+    repo.run_stax(&["t"]);
+
+    let output = repo.run_stax(&["checkout", &feature_branch]);
+    assert!(
+        output.status.success(),
+        "Failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains(&format!("Checked out {}.", feature_branch)),
+        "Expected clean checkout completion, got:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("Switched to branch"),
+        "Expected stax-native checkout wording, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn test_checkout_trunk_flag() {
     let repo = TestRepo::new();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1047,6 +1047,34 @@ fn test_checkout_explicit_branch_prints_clean_completion() {
 }
 
 #[test]
+fn test_checkout_shell_output_colors_branch_in_completion_message() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["bc", "feature-1"]);
+    let feature_branch = repo.current_branch();
+    repo.run_stax(&["t"]);
+
+    let output = repo.run_stax(&["checkout", &feature_branch, "--shell-output"]);
+    assert!(
+        output.status.success(),
+        "Failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains(&format!("STAX_SHELL_MESSAGE=Checked out ")),
+        "Expected shell completion message, got:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!("\u{1b}[1;96m{}\u{1b}[0m", feature_branch)),
+        "Expected colored branch in shell completion message, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn test_checkout_trunk_flag() {
     let repo = TestRepo::new();
 


### PR DESCRIPTION
## Summary

Polishes the `stax checkout` / `co` / `bco` interactive branch picker so it feels cleaner and closer to the existing stack visual language.

## What Changed

- Replaced the stock `dialoguer` active-row styling with a checkout-specific picker theme.
- Added a subtle dark background highlight for the selected branch row.
- Suppressed the noisy selected-row echo after pressing Enter.
- Changed checkout completion from git-style wording to cleaner stax wording:
  - `Checked out feature/profile-edit.`
- Styles checkout completion output:
  - success text is green/bold
  - branch name is bright cyan/bold
  - shell-integration messages now preserve branch color too
- Consolidated durable repo lessons into `learnings.md`.

## Notes

Docs were not updated because this changes checkout picker/output presentation only; command names, flags, and documented workflows are unchanged.

## Verification

- `cargo fmt --check`
- `cargo test --lib commands::checkout -- --nocapture`
- `cargo test --test integration_tests checkout -- --nocapture`
- Manual TTY smoke tests for:
  - active row background highlight
  - no selected-row echo
  - colored shell-integration checkout message
