### PR TITLE
Add AI-assisted branch creation and PR drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,10 @@ Bare `st` launches a full-screen TUI for browsing stacks, inspecting branch summ
 
 → [TUI guide](docs/interface/tui.md)
 
-### AI PR bodies and standups
+### AI PR details and standups
 
 ```bash
+st ss --ai --yes          # generate PR titles/bodies during submit
 st generate --pr-body      # draft/refresh PR body from branch diff + context
 st standup --summary       # spoken-style daily engineering summary
 st standup --summary --style slack  # Slack-ready Yesterday/Today bullets
@@ -264,6 +265,7 @@ st config --set-ai
 | `st wt` | Open the worktree dashboard |
 | `st resolve` | AI-resolve an in-progress rebase conflict |
 | `st generate --pr-body` | Draft/refresh PR body with AI |
+| `st ss --ai` | Submit with AI-generated PR title/body suggestions |
 | `st standup` | Summarize recent engineering activity |
 | `st undo` / `st redo` | Recover / reapply risky operations |
 | `st run <cmd>` | Run a command on each branch in the stack |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ One giant PR is slow to review and risky to merge. A stack of small PRs is the a
 
 - **Stack, don't wait.** Keep shipping on top of in-review PRs. `st create`, `st ss`, done.
 - **Native-fast.** A single Rust binary that starts in ~25ms. `st ls` benches ~70× faster than Graphite and ~215× faster than Freephite on this repo.
-- **Agent-native.** Run parallel AI agents on isolated branches (`st lane`), auto-resolve rebase conflicts (`st resolve`), and generate PR bodies from real diffs.
+- **Agent-native.** Run parallel AI agents on isolated branches (`st lane`), auto-resolve rebase conflicts (`st resolve`), and generate branch names, commit messages, and PR details from real diffs.
 - **Undo-first.** Every destructive op snapshots state. `st undo` / `st redo` rescue risky rebases instantly.
 - **Batteries-included TUI.** Run bare `st` to browse the stack, inspect diffs, and watch CI hydrate live.
 
@@ -226,16 +226,17 @@ Bare `st` launches a full-screen TUI for browsing stacks, inspecting branch summ
 
 → [TUI guide](docs/interface/tui.md)
 
-### AI PR details and standups
+### AI branch names, PR details, and standups
 
 ```bash
+st create --ai -a --yes   # generate branch name + first commit message
 st ss --ai --yes          # generate PR titles/bodies during submit
 st generate --pr-body      # draft/refresh PR body from branch diff + context
 st standup --summary       # spoken-style daily engineering summary
 st standup --summary --style slack  # Slack-ready Yesterday/Today bullets
 ```
 
-Each AI feature (`generate`, `standup`, `resolve`, `lane`) can use a different agent/model. Configure with:
+Each AI feature (`generate`, `standup`, `resolve`, `lane`) can use a different agent/model. `st create --ai`, `st submit --ai`, and `st generate --pr-body` share the `generate` setting. Configure with:
 
 ```bash
 st config --set-ai
@@ -251,6 +252,7 @@ st config --set-ai
 | `st` | Launch interactive TUI |
 | `st ls` / `st ll` | Show stack health and PR status (`st ll` adds PR URLs/details) |
 | `st create <name>` | Create a branch stacked on current |
+| `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current |
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
@@ -264,6 +266,7 @@ st config --set-ai
 | `st lane <name> "<task>"` | Spawn an AI agent on a new lane |
 | `st wt` | Open the worktree dashboard |
 | `st resolve` | AI-resolve an in-progress rebase conflict |
+| `st create --ai` | Generate a branch name from local changes |
 | `st generate --pr-body` | Draft/refresh PR body with AI |
 | `st ss --ai` | Submit with AI-generated PR title/body suggestions |
 | `st standup` | Summarize recent engineering activity |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -10,6 +10,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st ls` | Show stack with PR, rebase, and metadata-repair status |
 | `st ll` | Like `st ls` plus PR URLs and detail |
 | `st create <name>` | Create a branch stacked on current |
+| `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current |
 
 ## Submit and merge

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -117,6 +117,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st standup` | Recent activity (`--summary` for AI spoken version; `--jit` for Jira context) |
 | `st changelog [from] [to]` | Generate changelog (auto-resolves last tag when `from` omitted) |
 | `st generate --pr-body` | Generate PR body with AI |
+| `st ss --ai` | Submit with AI-generated PR title/body suggestions |
 
 ## Utilities
 
@@ -201,7 +202,7 @@ st wt go ui-polish --run "cursor ." --tmux
 - `--no-verify` (`-n`) skips pre-push hooks while pushing branches
 - `--reviewers alice,bob --labels bug,urgent --assignees alice`
 - `--squash` squash commits on each branch before pushing
-- `--ai-body` generate PR body with AI
+- `--ai` generate PR title and body with AI; narrow with `--title` or `--body`
 - `--template <name>` / `--no-template` / `--edit`
 - `--rerequest-review` / `--update-title`
 - `--yes` / `--no-prompt`

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -49,6 +49,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | Command | Alias | Description |
 |---|---|---|
 | `st create <name>` | `c`, `bc` | Create stacked branch (TTY menu when nothing staged and `-m`) |
+| `st create --ai` | | Generate a branch name from local changes (`-a` also generates a first commit message) |
 | `st create <name> --below` | | Insert a new branch below current |
 | `st modify` | `m` | Amend staged changes into current commit (`-a` stages all, `-r` restacks after) |
 | `st rename` | | Rename current branch |
@@ -186,6 +187,10 @@ st wt go ui-polish --run "cursor ." --tmux
 
 - `-m "msg"` set commit message (with nothing staged in a TTY: menu for stage all, `--patch`, empty branch, or abort)
 - `-am "msg"` stage all and commit
+- `--ai` generate missing branch name and/or first commit message from local changes
+- `--ai -a --yes` stage all changes, generate branch name + commit message, and skip AI value review prompts
+- `st create <name> --ai -a` keeps `<name>` and generates the first commit message
+- `st create --ai -m "msg"` keeps the commit message and generates the branch name
 - `-n`, `--no-verify` skip pre-commit and commit-msg hooks when creating a commit
 - `-m` / `-am` create the commit before creating the destination branch, including with `--from` and `--below`, so hook failures or interrupts do not leave orphan branches
 - `--insert` reparent children of the current branch onto the new branch

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -40,7 +40,7 @@ Main config path: `~/.config/stax/config.toml`.
 # model = "claude-sonnet-4-5-20250929"
 
 # Per-feature overrides — optional, fall back to [ai] above
-[ai.generate]   # st generate --pr-body, st submit --ai
+[ai.generate]   # st create --ai, st generate --pr-body, st submit --ai
 # agent = "codex"
 # model = "o4-mini"
 
@@ -89,11 +89,11 @@ The first time you run an AI-powered command without a configured agent (e.g. `s
 
 ### Resolution order
 
-For every AI-powered command, agent and model are resolved in this order:
+For AI-powered commands, agent and model are resolved in this order:
 
 | Priority | Source |
 |---|---|
-| 1 | CLI flag (`--agent`, `--model`) |
+| 1 | CLI flag (`--agent`, `--model`) where the command exposes one |
 | 2 | Per-feature config (`[ai.generate]`, `[ai.standup]`, …) |
 | 3 | Global config (`[ai]`) |
 | 4 | Interactive first-use prompt (persisted) |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -40,7 +40,7 @@ Main config path: `~/.config/stax/config.toml`.
 # model = "claude-sonnet-4-5-20250929"
 
 # Per-feature overrides — optional, fall back to [ai] above
-[ai.generate]   # st generate --pr-body
+[ai.generate]   # st generate --pr-body, st submit --ai
 # agent = "codex"
 # model = "o4-mini"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 | Understand worktree-aware behavior | [Multi-worktree behavior](workflows/multi-worktree.md) |
 | Recover from a bad rewrite | [Undo and redo](safety/undo-redo.md) |
 | Validate or repair stack metadata | [Stack health](commands/stack-health.md) |
-| Generate PR bodies / standup summaries | [Reporting](workflows/reporting.md) · [PR templates + AI](integrations/pr-templates-and-ai.md) |
+| Generate branch names, PR bodies, or standup summaries | [Reporting](workflows/reporting.md) · [PR templates + AI](integrations/pr-templates-and-ai.md) |
 | Configure auth, naming, or AI agents | [Configuration](configuration/index.md) |
 | Cut a release with auto-generated changelog | [Release workflow](workflows/releasing.md) |
 | Use stax alongside a specific AI tool | [Integrations](integrations/claude-code.md) |

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -9,9 +9,10 @@ curl -o ~/.claude/skills/stax.md https://raw.githubusercontent.com/cesarferreira
 
 Enables workflow assistance for stacked branch creation, submit flows, and related operations.
 
-## Use Claude with AI PR generation
+## Use Claude with AI create/PR generation
 
 ```bash
+st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent claude
 st generate --pr-body --agent claude --model claude-opus-4-5

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -9,9 +9,10 @@ curl -o ~/.claude/skills/stax.md https://raw.githubusercontent.com/cesarferreira
 
 Enables workflow assistance for stacked branch creation, submit flows, and related operations.
 
-## Use Claude with AI PR body generation
+## Use Claude with AI PR generation
 
 ```bash
+st submit --ai
 st generate --pr-body --agent claude
 st generate --pr-body --agent claude --model claude-opus-4-5
 ```

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -9,9 +9,10 @@ curl -o "${CODEX_HOME:-$HOME/.codex}/skills/stax/SKILL.md" https://raw.githubuse
 
 Enables workflow assistance for stacked branch creation, submit flows, and related operations.
 
-## Use Codex with AI PR generation
+## Use Codex with AI create/PR generation
 
 ```bash
+st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent codex
 st generate --pr-body --agent codex --model gpt-5.3-codex

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -9,9 +9,10 @@ curl -o "${CODEX_HOME:-$HOME/.codex}/skills/stax/SKILL.md" https://raw.githubuse
 
 Enables workflow assistance for stacked branch creation, submit flows, and related operations.
 
-## Use Codex with AI PR body generation
+## Use Codex with AI PR generation
 
 ```bash
+st submit --ai
 st generate --pr-body --agent codex
 st generate --pr-body --agent codex --model gpt-5.3-codex
 ```

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -18,9 +18,10 @@ curl -o GEMINI.md https://raw.githubusercontent.com/cesarferreira/stax/main/skil
 
 Gemini CLI loads hierarchical instructions from `GEMINI.md`, which gives it stax-aware workflow guidance.
 
-## 3. Use Gemini with AI PR body generation
+## 3. Use Gemini with AI PR generation
 
 ```bash
+st submit --ai
 st generate --pr-body --agent gemini
 st generate --pr-body --agent gemini --model gemini-2.5-flash
 ```

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -18,9 +18,10 @@ curl -o GEMINI.md https://raw.githubusercontent.com/cesarferreira/stax/main/skil
 
 Gemini CLI loads hierarchical instructions from `GEMINI.md`, which gives it stax-aware workflow guidance.
 
-## 3. Use Gemini with AI PR generation
+## 3. Use Gemini with AI create/PR generation
 
 ```bash
+st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent gemini
 st generate --pr-body --agent gemini --model gemini-2.5-flash

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -17,9 +17,10 @@ curl -o ~/.config/opencode/skills/stax/SKILL.md https://raw.githubusercontent.co
 
 OpenCode loads skills from `~/.config/opencode/skills/<name>/SKILL.md`.
 
-## 3. Use OpenCode with AI PR body generation
+## 3. Use OpenCode with AI PR generation
 
 ```bash
+st submit --ai
 st generate --pr-body --agent opencode
 st generate --pr-body --agent opencode --model opencode/gpt-5.1-codex
 ```

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -17,9 +17,10 @@ curl -o ~/.config/opencode/skills/stax/SKILL.md https://raw.githubusercontent.co
 
 OpenCode loads skills from `~/.config/opencode/skills/<name>/SKILL.md`.
 
-## 3. Use OpenCode with AI PR generation
+## 3. Use OpenCode with AI create/PR generation
 
 ```bash
+st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent opencode
 st generate --pr-body --agent opencode --model opencode/gpt-5.1-codex

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -1,4 +1,4 @@
-# PR templates and AI PR bodies
+# PR templates and AI PR details
 
 ## PR templates
 
@@ -30,7 +30,22 @@ Use `.github/PULL_REQUEST_TEMPLATE/` with one file per template:
 | `--no-template` | Skip template entirely |
 | `--edit` | Always open the editor |
 
-## AI PR body generation
+## AI PR details during submit
+
+Generate PR titles and bodies while submitting:
+
+```bash
+st ss --ai                  # suggest title/body and prompt before updating
+st bs --ai --body           # current branch only, body generation only
+st ss --ai --yes            # accept generated details for new PRs
+st ss --ai --body --yes     # refresh existing PR bodies automatically
+```
+
+`--title` and `--body` narrow what AI generates. Without either modifier, `--ai` targets both title and body.
+
+For existing PRs, interactive `--ai` asks whether to update title, body, both, or skip. With `--yes`, plain `--ai` leaves existing PR content alone; explicit `--title` and/or `--body` updates those fields automatically.
+
+## AI PR body refresh
 
 Generate or update a PR body using diff, commits, and template:
 
@@ -88,12 +103,6 @@ To forget the saved AI pairing and re-prompt:
 ```bash
 st config --reset-ai
 st config --reset-ai --no-prompt   # clear without opening picker
-```
-
-You can also generate during submit:
-
-```bash
-st submit --ai-body
 ```
 
 ### Stack graph placement

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -30,6 +30,19 @@ Use `.github/PULL_REQUEST_TEMPLATE/` with one file per template:
 | `--no-template` | Skip template entirely |
 | `--edit` | Always open the editor |
 
+## AI branch names and first commits
+
+Generate the missing `st create` inputs from local changes:
+
+```bash
+st create --ai                  # branch name from local changes
+st create --ai -a --yes         # branch name + first commit message, stage all
+st create api-work --ai -a      # keep branch name, generate commit message
+st create --ai -m "Add API"     # keep commit message, generate branch name
+```
+
+`--yes` accepts generated values without the review prompts. It does not stage files by itself; use `-a` or pre-stage changes when you want `st create --ai` to create the first commit.
+
 ## AI PR details during submit
 
 Generate PR titles and bodies while submitting:

--- a/docs/reference/windows.md
+++ b/docs/reference/windows.md
@@ -15,7 +15,7 @@ All core stax features work on Windows without modification:
 - Sync and cleanup: `st rs`, `st sync`
 - Undo/redo: `st undo`, `st redo`
 - Interactive TUI: bare `st`
-- AI generation: `st generate --pr-body`, `st standup --summary`
+- AI generation: `st create --ai`, `st generate --pr-body`, `st standup --summary`
 - Worktree commands: `st wt c/go/ls/ll/cleanup/rm <name>/prune/restack`
 - Browser opening: `st pr`, `st open` (uses `cmd /c start`)
 - Auth: `st auth`, `st auth --from-gh`, `STAX_GITHUB_TOKEN`

--- a/skills.md
+++ b/skills.md
@@ -193,7 +193,10 @@ stax submit --assignees alice      # Set assignees
 stax submit --template backend     # Use named PR template
 stax submit --no-template          # Skip template picker
 stax submit --edit                 # Always edit PR body
-stax submit --ai-body              # Generate PR body with AI
+stax submit --ai                   # Generate PR title/body with AI
+stax submit --ai --title           # Generate/update PR title only
+stax submit --ai --body            # Generate/update PR body only
+stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
 
 # ~/.config/stax/config.toml

--- a/skills.md
+++ b/skills.md
@@ -57,7 +57,7 @@ stax branch ...|b              # Branch subcommands
 stax upstack ...|us            # Descendant-scope commands
 stax downstack ...|ds          # Ancestor-scope commands
 
-stax create|c                  # Create stacked branch (--below inserts under current)
+stax create|c                  # Create stacked branch (--ai can name it from changes)
 stax modify|m                  # Amend current commit (menu when nothing staged)
 stax rename                    # Rename current branch
 stax detach                    # Remove branch from stack, reparent children
@@ -149,6 +149,10 @@ stax create <name>                 # Create branch stacked on current
 stax create -m "message"           # Use commit message (TTY menu if nothing staged)
 stax create -a                     # Stage all before creating
 stax create -am "message"          # Stage all + commit (bypasses menu)
+stax create --ai                   # Generate a branch name from local changes
+stax create --ai -a --yes          # Generate branch name + first commit message, stage all
+stax create <name> --ai -a         # Keep branch name, generate first commit message
+stax create --ai -m "message"      # Keep message, generate branch name
 stax create -n -am "message"       # Stage all + commit, skipping hooks
 stax create --from <branch>        # Create from explicit base
 stax create --prefix feature/      # Override branch prefix

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,9 +67,15 @@ struct SubmitOptions {
     /// Always open editor for PR body
     #[arg(long)]
     edit: bool,
-    /// Generate PR body using AI (claude, codex, or gemini)
+    /// Generate PR title and body using AI
     #[arg(long)]
-    ai_body: bool,
+    ai: bool,
+    /// With --ai, generate/update PR title only
+    #[arg(long, requires = "ai")]
+    title: bool,
+    /// With --ai, generate/update PR body only
+    #[arg(long, requires = "ai")]
+    body: bool,
     /// Re-request review from existing reviewers when updating PRs
     #[arg(long)]
     rerequest_review: bool,
@@ -101,7 +107,9 @@ impl From<SubmitOptions> for commands::submit::SubmitOptions {
             template: submit.template,
             no_template: submit.no_template,
             edit: submit.edit,
-            ai_body: submit.ai_body,
+            ai: submit.ai,
+            title: submit.title,
+            body: submit.body,
             rerequest_review: submit.rerequest_review,
             squash: submit.squash,
             update_title: submit.update_title,
@@ -2664,6 +2672,39 @@ mod tests {
     fn ss_still_parses_as_top_level_submit() {
         let cli = parse_cli(&["stax", "ss"]);
         assert!(matches!(cli.command, Some(Commands::Submit { .. })));
+    }
+
+    #[test]
+    fn submit_ai_flags_parse_for_full_title_and_body_generation() {
+        let cli = parse_cli(&["stax", "ss", "--ai", "--title", "--body", "--yes"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Submit { submit }) if submit.ai
+                && submit.title
+                && submit.body
+                && submit.yes
+        ));
+    }
+
+    #[test]
+    fn branch_submit_body_scope_modifier_parses() {
+        let cli = parse_cli(&["stax", "bs", "--ai", "--body"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Bs { submit }) if submit.ai && !submit.title && submit.body
+        ));
+    }
+
+    #[test]
+    fn title_and_body_modifiers_require_ai() {
+        assert!(try_parse_cli(&["stax", "submit", "--title"]).is_err());
+        assert!(try_parse_cli(&["stax", "submit", "--body"]).is_err());
+    }
+
+    #[test]
+    fn removed_legacy_body_flag_is_rejected() {
+        let removed_flag = ["--ai", "-body"].concat();
+        assert!(try_parse_cli(&["stax", "submit", &removed_flag]).is_err());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -644,6 +644,12 @@ enum Commands {
         /// Commit message (also used as branch name if no name provided)
         #[arg(short, long)]
         message: Option<String>,
+        /// Generate missing branch name and/or first commit message with AI
+        #[arg(long)]
+        ai: bool,
+        /// Accept generated AI values without prompting
+        #[arg(short, long)]
+        yes: bool,
         /// Base branch to create from (defaults to current)
         #[arg(long)]
         from: Option<String>,
@@ -1029,6 +1035,12 @@ enum Commands {
         all: bool,
         #[arg(short, long)]
         message: Option<String>,
+        /// Generate missing branch name and/or first commit message with AI
+        #[arg(long)]
+        ai: bool,
+        /// Accept generated AI values without prompting
+        #[arg(short, long)]
+        yes: bool,
         /// Base branch to create from (defaults to current)
         #[arg(long)]
         from: Option<String>,
@@ -1202,6 +1214,12 @@ enum BranchCommands {
         /// Commit message (also used as branch name if no name provided)
         #[arg(short, long)]
         message: Option<String>,
+        /// Generate missing branch name and/or first commit message with AI
+        #[arg(long)]
+        ai: bool,
+        /// Accept generated AI values without prompting
+        #[arg(short, long)]
+        yes: bool,
         /// Base branch to create from (defaults to current)
         #[arg(long)]
         from: Option<String>,
@@ -1899,13 +1917,15 @@ pub fn run() -> Result<()> {
             name,
             all,
             message,
+            ai,
+            yes,
             from,
             prefix,
             insert,
             below,
             no_verify,
         } => commands::branch::create::run(
-            name, message, from, prefix, all, insert, below, no_verify,
+            name, message, from, prefix, all, insert, below, no_verify, ai, yes,
         ),
         Commands::Pr { command } => match command.unwrap_or(PrCommands::Open) {
             PrCommands::Open => commands::pr::run_open(),
@@ -2030,13 +2050,15 @@ pub fn run() -> Result<()> {
                 name,
                 all,
                 message,
+                ai,
+                yes,
                 from,
                 prefix,
                 insert,
                 below,
                 no_verify,
             } => commands::branch::create::run(
-                name, message, from, prefix, all, insert, below, no_verify,
+                name, message, from, prefix, all, insert, below, no_verify, ai, yes,
             ),
             BranchCommands::Checkout {
                 branch,
@@ -2123,13 +2145,15 @@ pub fn run() -> Result<()> {
             name,
             all,
             message,
+            ai,
+            yes,
             from,
             prefix,
             insert,
             below,
             no_verify,
         } => commands::branch::create::run(
-            name, message, from, prefix, all, insert, below, no_verify,
+            name, message, from, prefix, all, insert, below, no_verify, ai, yes,
         ),
         Commands::Bu { count } => commands::navigate::up(count),
         Commands::Bd { count } => commands::navigate::down(count),
@@ -2683,6 +2707,45 @@ mod tests {
                 && submit.title
                 && submit.body
                 && submit.yes
+        ));
+    }
+
+    #[test]
+    fn create_ai_flags_parse_for_generated_branch_details() {
+        let cli = parse_cli(&["stax", "create", "--ai", "--yes"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Create {
+                ai: true,
+                yes: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn branch_create_ai_flags_parse() {
+        let cli = parse_cli(&["stax", "branch", "create", "--ai", "-a"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Branch(super::BranchCommands::Create {
+                ai: true,
+                all: true,
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn hidden_bc_ai_flags_parse() {
+        let cli = parse_cli(&["stax", "bc", "--ai", "--yes"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Bc {
+                ai: true,
+                yes: true,
+                ..
+            })
         ));
     }
 

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -24,11 +24,14 @@ use crate::commands::staging::{self, ContinueLabel, StagingAction};
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
+use crate::progress::LiveTimer;
 use crate::remote;
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Input, Select};
+use serde::Deserialize;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process::{Command, ExitStatus};
 use std::sync::{
@@ -52,6 +55,318 @@ struct CreatePlacement {
     below_current_meta: Option<BranchMetadata>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AiCreateTargets {
+    branch: bool,
+    message: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AiCreateDetails {
+    branch: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAiCreateDetails {
+    branch: Option<String>,
+    branch_name: Option<String>,
+    message: Option<String>,
+    commit_message: Option<String>,
+}
+
+const MAX_AI_CREATE_DIFF_BYTES: usize = 80_000;
+
+fn resolve_ai_create_targets(
+    ai: bool,
+    name: Option<&str>,
+    message: Option<&str>,
+    all: bool,
+    has_staged_changes: bool,
+    has_uncommitted_changes: bool,
+    can_prompt_for_staging: bool,
+) -> Result<Option<AiCreateTargets>> {
+    if !ai {
+        return Ok(None);
+    }
+
+    let targets = AiCreateTargets {
+        branch: name.is_none(),
+        message: message.is_none()
+            && (all || has_staged_changes || (has_uncommitted_changes && can_prompt_for_staging)),
+    };
+
+    Ok((targets.branch || targets.message).then_some(targets))
+}
+
+fn generate_ai_create_details(
+    workdir: &Path,
+    config: &mut Config,
+    targets: AiCreateTargets,
+    stage_all: bool,
+    non_interactive: bool,
+) -> Result<AiCreateDetails> {
+    use crate::commands::generate;
+
+    let (agent, model) = if non_interactive {
+        let agent = generate::resolve_agent_non_interactive(None, config, "generate")?;
+        let model = generate::resolve_model(None, config, &agent, "generate")?;
+        (agent, model)
+    } else if config.ai.generate.agent.is_some() {
+        let agent = config
+            .ai
+            .agent_for("generate")
+            .context("No AI agent configured for create generation")?
+            .to_string();
+        let model = generate::resolve_model(None, config, &agent, "generate")?;
+        (agent, model)
+    } else {
+        generate::prompt_for_feature_ai(config, "generate")?
+    };
+
+    generate::print_using_agent(&agent, model.as_deref());
+
+    let context_timer = LiveTimer::maybe_new(true, "Collecting branch context...");
+    let status = git_stdout(workdir, &["status", "--short", "--untracked-files=all"]);
+    let staged_diff = git_stdout(workdir, &["diff", "--cached"]);
+    let unstaged_diff = git_stdout(workdir, &["diff"]);
+    LiveTimer::maybe_finish_ok(context_timer, "done");
+
+    let prompt =
+        build_ai_create_details_prompt(&status, &staged_diff, &unstaged_diff, targets, stage_all);
+
+    let generation_timer = LiveTimer::maybe_new(true, "Generating AI create details...");
+    let raw = match generate::invoke_ai_agent(&agent, model.as_deref(), &prompt) {
+        Ok(raw) => raw,
+        Err(err) => {
+            LiveTimer::maybe_finish_warn(generation_timer, "failed");
+            return Err(err);
+        }
+    };
+
+    match parse_ai_create_details(&raw, targets) {
+        Ok(details) => {
+            LiveTimer::maybe_finish_ok(generation_timer, "done");
+            Ok(details)
+        }
+        Err(err) => {
+            LiveTimer::maybe_finish_warn(generation_timer, "failed");
+            Err(err)
+        }
+    }
+}
+
+fn resolve_ai_create_details_for_use(
+    mut details: AiCreateDetails,
+    targets: AiCreateTargets,
+    auto_accept: bool,
+) -> Result<AiCreateDetails> {
+    if auto_accept {
+        return Ok(details);
+    }
+
+    if targets.branch {
+        let suggested = details
+            .branch
+            .clone()
+            .context("AI agent did not return a branch")?;
+        let branch: String = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Branch name")
+            .default(suggested)
+            .interact_text()?;
+        details.branch = Some(require_non_empty(branch, "branch")?);
+    }
+
+    if targets.message {
+        let suggested = details
+            .message
+            .clone()
+            .context("AI agent did not return a commit message")?;
+        let message: String = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Commit message")
+            .default(suggested)
+            .interact_text()?;
+        details.message = Some(require_non_empty(message, "commit message")?);
+    }
+
+    Ok(details)
+}
+
+fn parse_ai_create_details(raw: &str, targets: AiCreateTargets) -> Result<AiCreateDetails> {
+    let json = extract_ai_json(raw);
+    let parsed: RawAiCreateDetails = serde_json::from_str(&json)
+        .context("AI agent did not return JSON create details with branch/message fields")?;
+
+    let branch = parsed
+        .branch
+        .or(parsed.branch_name)
+        .and_then(non_empty_trimmed);
+    let message = parsed
+        .message
+        .or(parsed.commit_message)
+        .and_then(non_empty_trimmed);
+
+    if targets.branch && branch.is_none() {
+        bail!("AI agent did not return a non-empty branch");
+    }
+    if targets.message && message.is_none() {
+        bail!("AI agent did not return a non-empty commit message");
+    }
+
+    Ok(AiCreateDetails {
+        branch: targets.branch.then_some(branch).flatten(),
+        message: targets.message.then_some(message).flatten(),
+    })
+}
+
+fn build_ai_create_details_prompt(
+    status: &str,
+    staged_diff: &str,
+    unstaged_diff: &str,
+    targets: AiCreateTargets,
+    stage_all: bool,
+) -> String {
+    let mut prompt = String::new();
+
+    match (targets.branch, targets.message) {
+        (true, true) => prompt
+            .push_str("Generate a branch name and first commit message for these changes.\n\n"),
+        (true, false) => prompt.push_str("Generate a branch name for these changes.\n\n"),
+        (false, true) => prompt.push_str("Generate a first commit message for these changes.\n\n"),
+        (false, false) => prompt.push_str("Summarize these changes.\n\n"),
+    }
+
+    prompt.push_str("Return only a compact JSON object with these string fields: ");
+    match (targets.branch, targets.message) {
+        (true, true) => prompt.push_str("\"branch\" and \"message\""),
+        (true, false) => prompt.push_str("\"branch\""),
+        (false, true) => prompt.push_str("\"message\""),
+        (false, false) => prompt.push_str(""),
+    }
+    prompt.push_str(". Do not include markdown fences or explanatory text.\n\n");
+
+    if targets.branch {
+        prompt.push_str(
+            "Branch requirements:\n- Short lowercase slug suitable for a Git branch\n- No spaces\n- No prefix like feature/ unless the change clearly needs a nested branch name\n\n",
+        );
+    }
+
+    if targets.message {
+        prompt.push_str(
+            "Commit message requirements:\n- Imperative mood\n- Concise subject line\n- No trailing period\n\n",
+        );
+    }
+
+    if stage_all {
+        prompt.push_str("The command will stage all changes before committing.\n\n");
+    } else {
+        prompt.push_str(
+            "Only already-staged changes are guaranteed to be committed; unstaged changes may be used for naming context.\n\n",
+        );
+    }
+
+    if !status.is_empty() {
+        prompt.push_str("Git status:\n```\n");
+        prompt.push_str(status);
+        prompt.push_str("\n```\n\n");
+    }
+
+    if !staged_diff.is_empty() {
+        prompt.push_str("Staged diff:\n```diff\n");
+        prompt.push_str(&truncate_ai_create_diff(staged_diff));
+        prompt.push_str("\n```\n\n");
+    }
+
+    if !unstaged_diff.is_empty() {
+        prompt.push_str("Unstaged diff:\n```diff\n");
+        prompt.push_str(&truncate_ai_create_diff(unstaged_diff));
+        prompt.push_str("\n```\n\n");
+    }
+
+    prompt
+}
+
+fn git_stdout(workdir: &Path, args: &[&str]) -> String {
+    Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_default()
+}
+
+fn truncate_ai_create_diff(diff: &str) -> String {
+    if diff.len() <= MAX_AI_CREATE_DIFF_BYTES {
+        return diff.to_string();
+    }
+
+    let safe_end = safe_char_boundary(diff, MAX_AI_CREATE_DIFF_BYTES);
+    let safe = &diff[..safe_end];
+    let cut = safe.rfind('\n').unwrap_or(safe.len());
+    format!(
+        "{}\n\n... (diff truncated, showing first ~80KB of {} total) ...",
+        &safe[..cut],
+        format_ai_bytes(diff.len())
+    )
+}
+
+fn safe_char_boundary(value: &str, max: usize) -> usize {
+    let mut end = max.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+fn format_ai_bytes(bytes: usize) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1}MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1}KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{}B", bytes)
+    }
+}
+
+fn extract_ai_json(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let unfenced = if trimmed.starts_with("```") {
+        let without_opening = trimmed.lines().skip(1).collect::<Vec<_>>().join("\n");
+        without_opening
+            .trim()
+            .strip_suffix("```")
+            .unwrap_or(without_opening.trim())
+            .trim()
+            .to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    if unfenced.starts_with('{') && unfenced.ends_with('}') {
+        return unfenced;
+    }
+
+    match (unfenced.find('{'), unfenced.rfind('}')) {
+        (Some(start), Some(end)) if start < end => unfenced[start..=end].to_string(),
+        _ => unfenced,
+    }
+}
+
+fn non_empty_trimmed(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn require_non_empty(value: String, field: &str) -> Result<String> {
+    non_empty_trimmed(value).with_context(|| format!("{} cannot be empty", field))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     name: Option<String>,
@@ -62,18 +377,53 @@ pub fn run(
     insert: bool,
     below: bool,
     no_verify: bool,
+    ai: bool,
+    yes: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
-    let config = Config::load()?;
+    let mut config = Config::load()?;
     let current = repo.current_branch()?;
     let placement = resolve_create_placement(&repo, &current, from, insert, below)?;
     let parent_branch = placement.parent_branch;
     let below_current_meta = placement.below_current_meta;
-    let generated_from_message = name.is_none() && message.is_some();
 
     if repo.branch_commit(&parent_branch).is_err() {
         anyhow::bail!("Branch '{}' does not exist", parent_branch);
     }
+
+    let workdir = repo.workdir()?;
+    let has_staged_changes = !staging::is_staging_area_empty(workdir)?;
+    let has_uncommitted_changes = staging::has_uncommitted_changes(workdir);
+    let non_interactive =
+        yes || !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal();
+    let can_prompt_for_staging = !non_interactive;
+    let ai_targets = resolve_ai_create_targets(
+        ai,
+        name.as_deref(),
+        message.as_deref(),
+        all,
+        has_staged_changes,
+        has_uncommitted_changes,
+        can_prompt_for_staging,
+    )?;
+    let ai_details = match ai_targets {
+        Some(targets) => {
+            let details =
+                generate_ai_create_details(workdir, &mut config, targets, all, non_interactive)?;
+            Some(resolve_ai_create_details_for_use(
+                details,
+                targets,
+                non_interactive,
+            )?)
+        }
+        None => None,
+    };
+    let ai_branch = ai_details
+        .as_ref()
+        .and_then(|details| details.branch.clone());
+    let ai_message = ai_details
+        .as_ref()
+        .and_then(|details| details.message.clone());
 
     // Get the branch name from either name or message
     // When using -m, the message is used for both branch name and commit message.
@@ -81,13 +431,36 @@ pub fn run(
     // it offers an interactive menu (or bails in non-TTY). Use -a/--all to
     // skip the menu and force-stage.
     // When neither name nor message is provided, launch interactive wizard.
-    let (input, commit_message, stage_mode) = match (&name, &message) {
-        (Some(n), _) => (
-            n.clone(),
-            None,
-            if all { StageMode::All } else { StageMode::None },
-        ),
-        (None, Some(m)) => (
+    let (input, commit_message, stage_mode, generated_from_message) = if let Some(n) = &name {
+        let commit_message = ai_message;
+        let stage_mode = if commit_message.is_some() {
+            if all {
+                StageMode::All
+            } else {
+                StageMode::ExistingOnly
+            }
+        } else if all {
+            StageMode::All
+        } else {
+            StageMode::None
+        };
+        (n.clone(), commit_message, stage_mode, false)
+    } else if let Some(generated_branch) = ai_branch {
+        let commit_message = message.clone().or(ai_message);
+        let stage_mode = if commit_message.is_some() {
+            if all {
+                StageMode::All
+            } else {
+                StageMode::ExistingOnly
+            }
+        } else if all {
+            StageMode::All
+        } else {
+            StageMode::None
+        };
+        (generated_branch, commit_message, stage_mode, true)
+    } else if let Some(m) = &message {
+        (
             m.clone(),
             Some(m.clone()),
             if all {
@@ -95,18 +468,15 @@ pub fn run(
             } else {
                 StageMode::ExistingOnly
             },
-        ),
-        (None, None) => {
-            if !Term::stderr().is_term() {
-                bail!(
-                    "Branch name required. Use: stax create <name> or stax create -m \"message\""
-                );
-            }
-            // Launch interactive wizard
-            let (wizard_name, wizard_msg, wizard_stage) =
-                run_wizard(repo.workdir()?, &parent_branch)?;
-            (wizard_name, wizard_msg, wizard_stage)
+            true,
+        )
+    } else {
+        if !Term::stderr().is_term() {
+            bail!("Branch name required. Use: stax create <name> or stax create -m \"message\"");
         }
+        // Launch interactive wizard
+        let (wizard_name, wizard_msg, wizard_stage) = run_wizard(repo.workdir()?, &parent_branch)?;
+        (wizard_name, wizard_msg, wizard_stage, false)
     };
 
     // Format the branch name according to config
@@ -1031,4 +1401,109 @@ fn run_wizard(workdir: &Path, parent_branch: &str) -> Result<(String, Option<Str
 
     println!();
     Ok((name, msg, stage_mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn targets(branch: bool, message: bool) -> AiCreateTargets {
+        AiCreateTargets { branch, message }
+    }
+
+    #[test]
+    fn ai_create_targets_plain_ai_generates_branch_and_message_for_all_changes() {
+        let resolved =
+            resolve_ai_create_targets(true, None, None, true, false, true, false).unwrap();
+
+        assert_eq!(resolved, Some(targets(true, true)));
+    }
+
+    #[test]
+    fn ai_create_targets_named_branch_generates_commit_message_only() {
+        let resolved =
+            resolve_ai_create_targets(true, Some("manual-branch"), None, false, true, true, false)
+                .unwrap();
+
+        assert_eq!(resolved, Some(targets(false, true)));
+    }
+
+    #[test]
+    fn ai_create_targets_manual_message_generates_branch_only() {
+        let resolved = resolve_ai_create_targets(
+            true,
+            None,
+            Some("Manual commit message"),
+            true,
+            false,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(resolved, Some(targets(true, false)));
+    }
+
+    #[test]
+    fn ai_create_targets_skips_ai_when_no_field_needs_generation() {
+        let resolved = resolve_ai_create_targets(
+            true,
+            Some("manual-branch"),
+            None,
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn ai_create_targets_do_not_generate_message_without_commit_path() {
+        let resolved =
+            resolve_ai_create_targets(true, None, None, false, false, true, false).unwrap();
+
+        assert_eq!(resolved, Some(targets(true, false)));
+    }
+
+    #[test]
+    fn parse_ai_create_details_accepts_fenced_json() {
+        let parsed = parse_ai_create_details(
+            "```json\n{\"branch\":\"add-ai-create\",\"message\":\"Add AI create\"}\n```",
+            targets(true, true),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.branch.as_deref(), Some("add-ai-create"));
+        assert_eq!(parsed.message.as_deref(), Some("Add AI create"));
+    }
+
+    #[test]
+    fn parse_ai_create_details_requires_requested_fields() {
+        let err = parse_ai_create_details(r#"{"message":"Only a message"}"#, targets(true, false))
+            .unwrap_err();
+        assert!(err.to_string().contains("non-empty branch"));
+
+        let err = parse_ai_create_details(r#"{"branch":"only-branch"}"#, targets(false, true))
+            .unwrap_err();
+        assert!(err.to_string().contains("non-empty commit message"));
+    }
+
+    #[test]
+    fn build_ai_create_prompt_mentions_only_requested_fields() {
+        let prompt = build_ai_create_details_prompt(
+            " M src/lib.rs",
+            "diff --git a/src/lib.rs b/src/lib.rs",
+            "",
+            targets(false, true),
+            true,
+        );
+
+        assert!(prompt.contains("\"message\""));
+        assert!(!prompt.contains("\"branch\" and \"message\""));
+        assert!(prompt.contains("The command will stage all changes before committing."));
+        assert!(prompt.contains("diff --git"));
+    }
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -36,7 +36,9 @@ pub fn run(reset_ai: bool, no_prompt: bool, yes: bool, set_ai: bool) -> Result<(
 
     println!();
     println!("{}", "Per-feature AI overrides:".blue().bold());
-    println!(r#"  [ai.generate]  # PR generation (stax generate, stax submit --ai)"#);
+    println!(
+        r#"  [ai.generate]  # create/PR generation (stax create --ai, stax generate, stax submit --ai)"#
+    );
     println!(r#"  [ai.standup]   # standup summaries (stax standup --summary)"#);
     println!(r#"  [ai.resolve]   # conflict resolution (stax resolve)"#);
     println!(r#"  [ai.lane]      # interactive AI lanes (stax lane)"#);
@@ -54,7 +56,7 @@ fn set_ai_interactive() -> Result<()> {
         ),
         (
             "generate",
-            "generate        (PR details — stax generate, stax submit --ai)",
+            "generate        (create/PR details — stax create --ai, stax generate, stax submit --ai)",
         ),
         (
             "standup",

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -36,7 +36,7 @@ pub fn run(reset_ai: bool, no_prompt: bool, yes: bool, set_ai: bool) -> Result<(
 
     println!();
     println!("{}", "Per-feature AI overrides:".blue().bold());
-    println!(r#"  [ai.generate]  # PR body generation (stax generate, stax submit --ai-body)"#);
+    println!(r#"  [ai.generate]  # PR generation (stax generate, stax submit --ai)"#);
     println!(r#"  [ai.standup]   # standup summaries (stax standup --summary)"#);
     println!(r#"  [ai.resolve]   # conflict resolution (stax resolve)"#);
     println!(r#"  [ai.lane]      # interactive AI lanes (stax lane)"#);
@@ -54,7 +54,7 @@ fn set_ai_interactive() -> Result<()> {
         ),
         (
             "generate",
-            "generate        (PR body — stax generate, stax submit --ai-body)",
+            "generate        (PR details — stax generate, stax submit --ai)",
         ),
         (
             "standup",

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -296,7 +296,7 @@ fn which_exists(command: &str) -> bool {
 // Model resolution
 // ---------------------------------------------------------------------------
 
-fn resolve_model(
+pub(crate) fn resolve_model(
     cli_flag: Option<&str>,
     config: &Config,
     agent: &str,

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -15,6 +15,7 @@ use crate::remote::{self, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Editor, Input, Select};
+use serde::Deserialize;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
@@ -60,7 +61,9 @@ pub struct SubmitOptions {
     pub template: Option<String>,
     pub no_template: bool,
     pub edit: bool,
-    pub ai_body: bool,
+    pub ai: bool,
+    pub title: bool,
+    pub body: bool,
     pub rerequest_review: bool,
     pub squash: bool,
     pub update_title: bool,
@@ -75,9 +78,12 @@ struct PrPlan {
     tip_commit_subject: Option<String>,
     /// Whether the tip commit subject differs from the existing PR title.
     needs_title_update: bool,
+    existing_pr_title: Option<String>,
     // For new PRs, we'll collect these upfront
     title: Option<String>,
     body: Option<String>,
+    ai_title_update: Option<String>,
+    generated_body_update: Option<String>,
     is_draft: Option<bool>,
     // Track if this is a no-op (already synced)
     needs_push: bool,
@@ -96,6 +102,120 @@ struct SubmitPhaseTimings {
 
 const PR_TYPE_OPTIONS: [&str; 2] = ["Create as draft", "Publish immediately"];
 const PR_TYPE_DEFAULT_INDEX: usize = 0;
+const MAX_AI_DIFF_BYTES: usize = 80_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AiPrTargets {
+    title: bool,
+    body: bool,
+    explicit_scope: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AiPrDetails {
+    title: Option<String>,
+    body: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct AiAgentSelection {
+    agent: String,
+    model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAiPrDetails {
+    title: Option<String>,
+    body: Option<String>,
+}
+
+fn resolve_ai_targets(
+    ai: bool,
+    title: bool,
+    body: bool,
+    update_title: bool,
+) -> Result<Option<AiPrTargets>> {
+    if !ai {
+        if title {
+            anyhow::bail!("--title requires --ai");
+        }
+        if body {
+            anyhow::bail!("--body requires --ai");
+        }
+        return Ok(None);
+    }
+
+    let explicit_scope = title || body;
+    let targets = AiPrTargets {
+        title: if explicit_scope { title } else { true },
+        body: if explicit_scope { body } else { true },
+        explicit_scope,
+    };
+
+    if update_title && targets.title {
+        anyhow::bail!("--update-title cannot be combined with AI title generation");
+    }
+
+    Ok(Some(targets))
+}
+
+fn existing_ai_targets_for_auto_accept(targets: AiPrTargets) -> Option<AiPrTargets> {
+    targets.explicit_scope.then_some(targets)
+}
+
+fn parse_ai_pr_details(raw: &str, targets: AiPrTargets) -> Result<AiPrDetails> {
+    let json = extract_ai_json(raw);
+    let parsed: RawAiPrDetails = serde_json::from_str(&json)
+        .context("AI agent did not return JSON PR details with title/body fields")?;
+
+    let title = parsed.title.and_then(non_empty_trimmed);
+    let body = parsed.body.and_then(non_empty_trimmed);
+
+    if targets.title && title.is_none() {
+        anyhow::bail!("AI agent did not return a non-empty title");
+    }
+    if targets.body && body.is_none() {
+        anyhow::bail!("AI agent did not return a non-empty body");
+    }
+
+    Ok(AiPrDetails {
+        title: targets.title.then_some(title).flatten(),
+        body: targets.body.then_some(body).flatten(),
+    })
+}
+
+fn non_empty_trimmed(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn extract_ai_json(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let unfenced = if trimmed.starts_with("```") {
+        let without_opening = trimmed.lines().skip(1).collect::<Vec<_>>().join("\n");
+        without_opening
+            .trim()
+            .strip_suffix("```")
+            .unwrap_or(without_opening.trim())
+            .trim()
+            .to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    if unfenced.starts_with('{') && unfenced.ends_with('}') {
+        return unfenced;
+    }
+
+    match (unfenced.find('{'), unfenced.rfind('}')) {
+        (Some(start), Some(end)) if start < end => unfenced[start..=end].to_string(),
+        _ => unfenced,
+    }
+}
 
 fn resolve_is_draft_without_prompt(
     draft_flag_set: bool,
@@ -133,11 +253,16 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         template,
         no_template,
         edit,
-        ai_body,
+        ai,
+        title: ai_title,
+        body: body_scope,
         rerequest_review,
         squash,
         update_title,
     } = options;
+
+    let ai_targets = resolve_ai_targets(ai, ai_title, body_scope, update_title)?;
+    let auto_accept_prompts = yes || no_prompt;
 
     if force && !quiet {
         eprintln!(
@@ -150,7 +275,6 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let stack = Stack::load(&repo)?;
     let config = Config::load()?;
     let stack_links_mode = config.submit.stack_links;
-    let _ = yes; // Used for future auto-confirm features
 
     // Track if --draft was explicitly passed (we'll ask interactively if not)
     let draft_flag_set = draft;
@@ -503,8 +627,11 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 existing_pr_is_draft: None,
                 tip_commit_subject: None,
                 needs_title_update: false,
+                existing_pr_title: None,
                 title: None,
                 body: None,
+                ai_title_update: None,
+                generated_body_update: None,
                 is_draft: None,
                 needs_push,
                 needs_pr_update: false,
@@ -687,8 +814,11 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 existing_pr_is_draft: existing_pr.as_ref().map(|pr| pr.info.is_draft),
                 tip_commit_subject,
                 needs_title_update,
+                existing_pr_title: existing_pr.as_ref().map(|pr| pr.title.clone()),
                 title: None,
                 body: None,
+                ai_title_update: None,
+                generated_body_update: None,
                 is_draft: None,
                 needs_push,
                 needs_pr_update,
@@ -743,7 +873,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         }
     }
 
-    // Collect PR details for new PRs BEFORE pushing (skip empty branches)
+    // Collect PR details and AI update choices BEFORE pushing (skip empty branches).
     if !no_pr {
         // Discover all available PR templates
         let discovered_templates = if no_template {
@@ -751,6 +881,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         } else {
             discover_pr_templates(repo.workdir()?).unwrap_or_default()
         };
+        let mut ai_agent_selection: Option<AiAgentSelection> = None;
         let new_prs: Vec<_> = plans
             .iter()
             .filter(|p| p.existing_pr.is_none() && !p.is_empty)
@@ -783,8 +914,8 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     );
                 }
                 found
-            } else if no_prompt {
-                // --no-prompt: use first template if exactly one exists
+            } else if auto_accept_prompts {
+                // Non-interactive/auto-accept: use first template if exactly one exists
                 if discovered_templates.len() == 1 {
                     Some(discovered_templates[0].clone())
                 } else {
@@ -808,53 +939,76 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 println!("  {}", plan.branch.cyan());
             }
 
-            let title = if no_prompt {
-                default_title
-            } else {
-                Input::with_theme(&ColorfulTheme::default())
-                    .with_prompt("  Title")
-                    .default(default_title)
-                    .interact_text()?
-            };
-
-            let body = if ai_body {
-                // --ai-body flag: generate body using AI agent
-                if !quiet {
-                    println!("    {}", "Generating PR body with AI...".dimmed());
-                }
-                let ai_body_result = generate_ai_body(
+            let ai_details = if let Some(targets) = ai_targets {
+                match generate_ai_pr_details(
                     repo.workdir()?,
                     &plan.parent,
                     &plan.branch,
                     template_content,
-                );
-                match ai_body_result {
-                    Ok(generated) => {
-                        if edit {
-                            Editor::new().edit(&generated)?.unwrap_or(generated)
-                        } else {
-                            generated
-                        }
-                    }
+                    targets,
+                    &mut ai_agent_selection,
+                    auto_accept_prompts,
+                    quiet,
+                ) {
+                    Ok(details) => Some(details),
                     Err(e) => {
                         if !quiet {
                             eprintln!(
-                                "    {} AI generation failed: {}. Falling back to default.",
+                                "    {} AI generation failed: {}. Falling back to defaults.",
                                 "⚠".yellow(),
                                 e
                             );
                         }
-                        default_body
+                        finish_default_pr_detail_progress(
+                            quiet,
+                            &plan.branch,
+                            "PR details",
+                            "fallback",
+                        );
+                        None
                     }
                 }
-            } else if no_prompt {
-                default_body
+            } else {
+                None
+            };
+
+            if let Some(targets) = ai_targets {
+                if !targets.title {
+                    finish_default_pr_detail_progress(quiet, &plan.branch, "PR title", "done");
+                }
+                if !targets.body {
+                    finish_default_pr_detail_progress(quiet, &plan.branch, "PR body", "done");
+                }
+            }
+
+            let suggested_title = ai_details
+                .as_ref()
+                .and_then(|details| details.title.clone())
+                .unwrap_or(default_title);
+            let suggested_body = ai_details
+                .as_ref()
+                .and_then(|details| details.body.clone())
+                .unwrap_or(default_body);
+
+            let title = if auto_accept_prompts {
+                suggested_title
+            } else {
+                Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("  Title")
+                    .default(suggested_title)
+                    .interact_text()?
+            };
+
+            let body = if auto_accept_prompts {
+                suggested_body
             } else if edit {
                 // --edit flag: always open editor
-                Editor::new().edit(&default_body)?.unwrap_or(default_body)
+                Editor::new()
+                    .edit(&suggested_body)?
+                    .unwrap_or(suggested_body)
             } else {
                 // Interactive prompt
-                let options = if default_body.trim().is_empty() {
+                let options = if suggested_body.trim().is_empty() {
                     vec!["Edit", "Skip (leave empty)"]
                 } else {
                     vec!["Use default", "Edit", "Skip (leave empty)"]
@@ -867,15 +1021,17 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     .interact()?;
 
                 match options[choice] {
-                    "Use default" => default_body,
-                    "Edit" => Editor::new().edit(&default_body)?.unwrap_or(default_body),
+                    "Use default" => suggested_body,
+                    "Edit" => Editor::new()
+                        .edit(&suggested_body)?
+                        .unwrap_or(suggested_body),
                     _ => String::new(),
                 }
             };
 
             // Ask about draft vs publish (only if --draft/--publish wasn't explicitly set)
             let is_draft = if let Some(is_draft) =
-                resolve_is_draft_without_prompt(draft_flag_set, publish, draft, no_prompt)
+                resolve_is_draft_without_prompt(draft_flag_set, publish, draft, auto_accept_prompts)
             {
                 is_draft
             } else {
@@ -890,6 +1046,112 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             plan.title = Some(title);
             plan.body = Some(body);
             plan.is_draft = Some(is_draft);
+        }
+
+        if let Some(targets) = ai_targets {
+            let should_consider_existing_ai =
+                !auto_accept_prompts || existing_ai_targets_for_auto_accept(targets).is_some();
+            if should_consider_existing_ai {
+                let existing_prs: Vec<_> = plans
+                    .iter()
+                    .filter(|p| p.existing_pr.is_some() && !p.is_empty)
+                    .collect();
+                if !existing_prs.is_empty() && !quiet {
+                    println!();
+                    println!("{}", "Existing PR AI updates:".bold());
+                }
+
+                for plan in &mut plans {
+                    let Some(pr_number) = plan.existing_pr else {
+                        continue;
+                    };
+                    if plan.is_empty {
+                        continue;
+                    }
+
+                    let selected_targets = if auto_accept_prompts {
+                        existing_ai_targets_for_auto_accept(targets)
+                    } else {
+                        if !quiet {
+                            println!("  {} #{}", plan.branch.cyan(), pr_number);
+                        }
+                        prompt_existing_ai_targets(targets, &plan.branch, pr_number)?
+                    };
+
+                    let Some(selected_targets) = selected_targets else {
+                        if !quiet && !auto_accept_prompts {
+                            println!("    {}", "Skipping AI content update".dimmed());
+                        }
+                        continue;
+                    };
+
+                    let selected_template = if !selected_targets.body || no_template {
+                        None
+                    } else if let Some(ref template_name) = template {
+                        let found = discovered_templates
+                            .iter()
+                            .find(|t| t.name == *template_name)
+                            .cloned();
+
+                        if found.is_none() && !quiet {
+                            eprintln!(
+                                "  {} Template '{}' not found, using no template",
+                                "!".yellow(),
+                                template_name
+                            );
+                        }
+                        found
+                    } else if auto_accept_prompts {
+                        if discovered_templates.len() == 1 {
+                            Some(discovered_templates[0].clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        select_template_interactive(&discovered_templates)?
+                    };
+                    let template_content = selected_template.as_ref().map(|t| t.content.as_str());
+
+                    match generate_ai_pr_details(
+                        repo.workdir()?,
+                        &plan.parent,
+                        &plan.branch,
+                        template_content,
+                        selected_targets,
+                        &mut ai_agent_selection,
+                        auto_accept_prompts,
+                        quiet,
+                    ) {
+                        Ok(details) => {
+                            if let Some(title) = details.title {
+                                if plan.existing_pr_title.as_deref() == Some(title.as_str()) {
+                                    if !quiet {
+                                        println!(
+                                            "    {}",
+                                            "AI title matches existing title".dimmed()
+                                        );
+                                    }
+                                } else {
+                                    plan.ai_title_update = Some(title);
+                                }
+                            }
+                            if let Some(body) = details.body {
+                                plan.generated_body_update = Some(body);
+                            }
+                        }
+                        Err(e) => {
+                            if !quiet {
+                                eprintln!(
+                                    "    {} AI generation failed for existing PR #{}: {}",
+                                    "⚠".yellow(),
+                                    pr_number,
+                                    e
+                                );
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -1003,9 +1265,13 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     }
 
     // Check if anything needs to be done (exclude empty branches)
-    let any_pr_work = plans
-        .iter()
-        .any(|p| !p.is_empty && (p.existing_pr.is_none() || p.needs_pr_update));
+    let any_pr_work = plans.iter().any(|p| {
+        !p.is_empty
+            && (p.existing_pr.is_none()
+                || p.needs_pr_update
+                || p.ai_title_update.is_some()
+                || p.generated_body_update.is_some())
+    });
 
     let any_existing_prs = plans.iter().any(|p| !p.is_empty && p.existing_pr.is_some());
 
@@ -1079,6 +1345,16 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                                 .await?;
                         }
                     }
+
+                    apply_ai_pr_content_updates(
+                        &client,
+                        existing_pr_number,
+                        &plan.branch,
+                        plan.ai_title_update.as_deref(),
+                        plan.generated_body_update.as_deref(),
+                        quiet,
+                    )
+                    .await?;
 
                     apply_pr_metadata(&client, existing_pr_number, &reviewers, &labels, &assignees)
                         .await?;
@@ -1193,6 +1469,16 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                         }
                         LiveTimer::maybe_finish_ok(title_timer, "done");
                     }
+
+                    apply_ai_pr_content_updates(
+                        &client,
+                        existing_pr_number,
+                        &plan.branch,
+                        plan.ai_title_update.as_deref(),
+                        plan.generated_body_update.as_deref(),
+                        quiet,
+                    )
+                    .await?;
 
                     // No-op - just add to pr_infos for summary
                     pr_infos.push(StackPrInfo {
@@ -1746,6 +2032,259 @@ fn render_commit_list(commit_messages: &[String]) -> String {
         .join("\n")
 }
 
+fn prompt_existing_ai_targets(
+    targets: AiPrTargets,
+    branch: &str,
+    pr_number: u64,
+) -> Result<Option<AiPrTargets>> {
+    let items = existing_ai_prompt_items(targets);
+    let labels: Vec<_> = items.iter().map(|(label, _)| *label).collect();
+    let choice = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("  AI update for {} #{}", branch, pr_number))
+        .items(&labels)
+        .default(0)
+        .interact()?;
+
+    Ok(items[choice].1)
+}
+
+fn existing_ai_prompt_items(targets: AiPrTargets) -> Vec<(&'static str, Option<AiPrTargets>)> {
+    let mut items: Vec<(&str, Option<AiPrTargets>)> = vec![("Skip", None)];
+
+    match (targets.title, targets.body) {
+        (true, true) => {
+            items.push((
+                "Update title",
+                Some(AiPrTargets {
+                    title: true,
+                    body: false,
+                    explicit_scope: true,
+                }),
+            ));
+            items.push((
+                "Update body",
+                Some(AiPrTargets {
+                    title: false,
+                    body: true,
+                    explicit_scope: true,
+                }),
+            ));
+            items.push((
+                "Update title and body",
+                Some(AiPrTargets {
+                    title: true,
+                    body: true,
+                    explicit_scope: true,
+                }),
+            ));
+        }
+        (true, false) => items.push(("Update title", Some(targets))),
+        (false, true) => items.push(("Update body", Some(targets))),
+        (false, false) => {}
+    }
+
+    items
+}
+
+fn finish_default_pr_detail_progress(quiet: bool, branch: &str, field: &str, suffix: &str) {
+    let timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!("    Using default {} for {}...", field, branch),
+    );
+    if suffix == "fallback" {
+        LiveTimer::maybe_finish_warn(timer, suffix);
+    } else {
+        LiveTimer::maybe_finish_ok(timer, suffix);
+    }
+}
+
+fn resolve_ai_agent_selection(
+    cache: &mut Option<AiAgentSelection>,
+    non_interactive: bool,
+) -> Result<AiAgentSelection> {
+    if let Some(selection) = cache {
+        return Ok(selection.clone());
+    }
+
+    use super::generate;
+
+    let mut config = Config::load()?;
+    let (agent, model) = if non_interactive {
+        let agent = generate::resolve_agent_non_interactive(None, &config, "generate")?;
+        let model = generate::resolve_model(None, &config, &agent, "generate")?;
+        (agent, model)
+    } else if config.ai.generate.agent.is_some() {
+        let agent = config
+            .ai
+            .agent_for("generate")
+            .context("No AI agent configured for PR generation")?
+            .to_string();
+        let model = generate::resolve_model(None, &config, &agent, "generate")?;
+        (agent, model)
+    } else {
+        generate::prompt_for_feature_ai(&mut config, "generate")?
+    };
+
+    let selection = AiAgentSelection { agent, model };
+    *cache = Some(selection.clone());
+    Ok(selection)
+}
+
+fn generate_ai_pr_details(
+    workdir: &Path,
+    parent: &str,
+    branch: &str,
+    template: Option<&str>,
+    targets: AiPrTargets,
+    selection_cache: &mut Option<AiAgentSelection>,
+    non_interactive: bool,
+    quiet: bool,
+) -> Result<AiPrDetails> {
+    use super::generate;
+
+    let selection = resolve_ai_agent_selection(selection_cache, non_interactive)?;
+    if !quiet {
+        generate::print_using_agent(&selection.agent, selection.model.as_deref());
+    }
+
+    let context_timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!("    Collecting PR context for {}...", branch),
+    );
+    let diff_stat = generate::get_diff_stat(workdir, parent, branch);
+    let diff = generate::get_full_diff(workdir, parent, branch);
+    let commits = collect_commit_messages(workdir, parent, branch);
+    LiveTimer::maybe_finish_ok(context_timer, "done");
+
+    let prompt = build_ai_pr_details_prompt(&diff_stat, &diff, &commits, template, targets);
+
+    let generation_timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!("    Generating AI PR details for {}...", branch),
+    );
+    let raw = match generate::invoke_ai_agent(&selection.agent, selection.model.as_deref(), &prompt)
+    {
+        Ok(raw) => raw,
+        Err(err) => {
+            LiveTimer::maybe_finish_warn(generation_timer, "failed");
+            return Err(err);
+        }
+    };
+
+    match parse_ai_pr_details(&raw, targets) {
+        Ok(details) => {
+            LiveTimer::maybe_finish_ok(generation_timer, "done");
+            Ok(details)
+        }
+        Err(err) => {
+            LiveTimer::maybe_finish_warn(generation_timer, "failed");
+            Err(err)
+        }
+    }
+}
+
+fn build_ai_pr_details_prompt(
+    diff_stat: &str,
+    diff: &str,
+    commits: &[String],
+    template: Option<&str>,
+    targets: AiPrTargets,
+) -> String {
+    let mut prompt = String::new();
+
+    match (targets.title, targets.body) {
+        (true, true) => {
+            prompt.push_str("Generate a pull request title and body for the following changes.\n\n")
+        }
+        (true, false) => {
+            prompt.push_str("Generate a pull request title for the following changes.\n\n")
+        }
+        (false, true) => {
+            prompt.push_str("Generate a pull request body for the following changes.\n\n")
+        }
+        (false, false) => prompt.push_str("Summarize the following changes.\n\n"),
+    }
+
+    prompt.push_str("Return only a compact JSON object with these string fields: ");
+    let fields = match (targets.title, targets.body) {
+        (true, true) => "\"title\" and \"body\"",
+        (true, false) => "\"title\"",
+        (false, true) => "\"body\"",
+        (false, false) => "",
+    };
+    prompt.push_str(fields);
+    prompt.push_str(". Do not include markdown fences or explanatory text.\n\n");
+
+    if targets.title {
+        prompt.push_str("Title requirements:\n- Concise PR title, no trailing period\n- Describe the user-visible change, not the implementation mechanics\n\n");
+    }
+
+    if targets.body {
+        if let Some(tmpl) = template {
+            prompt.push_str("Use this PR template as the body structure. Fill in each section based on the changes:\n\n");
+            prompt.push_str(tmpl);
+            prompt.push_str("\n\n");
+        } else {
+            prompt.push_str("Body requirements:\n- Markdown\n- Include a clear Summary section\n- Mention important tests or validation only when supported by the diff or commits\n\n");
+        }
+    }
+
+    if !commits.is_empty() {
+        prompt.push_str("Commit messages:\n");
+        for msg in commits {
+            prompt.push_str(&format!("- {}\n", msg));
+        }
+        prompt.push('\n');
+    }
+
+    if !diff_stat.is_empty() {
+        prompt.push_str("Diff stat:\n```\n");
+        prompt.push_str(diff_stat);
+        prompt.push_str("\n```\n\n");
+    }
+
+    if !diff.is_empty() {
+        prompt.push_str("Full diff:\n```diff\n");
+        prompt.push_str(&truncate_ai_diff(diff));
+        prompt.push_str("\n```\n\n");
+    }
+
+    prompt
+}
+
+fn truncate_ai_diff(diff: &str) -> String {
+    if diff.len() <= MAX_AI_DIFF_BYTES {
+        return diff.to_string();
+    }
+
+    let safe_end = safe_char_boundary(diff, MAX_AI_DIFF_BYTES);
+    let safe = &diff[..safe_end];
+    let cut = safe.rfind('\n').unwrap_or(safe.len());
+    format!(
+        "{}\n\n... (diff truncated, showing first ~80KB of {} total) ...",
+        &safe[..cut],
+        format_ai_bytes(diff.len())
+    )
+}
+
+fn safe_char_boundary(value: &str, max: usize) -> usize {
+    let mut end = max.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+fn format_ai_bytes(bytes: usize) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1}MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1}KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{}B", bytes)
+    }
+}
+
 // Deprecated: Use github::pr_template::discover_pr_templates instead
 #[allow(dead_code)]
 fn load_pr_template(workdir: &Path) -> Option<String> {
@@ -1806,6 +2345,35 @@ async fn apply_pr_metadata(
 
     if !assignees.is_empty() {
         client.add_assignees(pr_number, assignees).await?;
+    }
+
+    Ok(())
+}
+
+async fn apply_ai_pr_content_updates(
+    client: &ForgeClient,
+    pr_number: u64,
+    branch: &str,
+    title: Option<&str>,
+    body: Option<&str>,
+    quiet: bool,
+) -> Result<()> {
+    if let Some(title) = title {
+        let timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!("Updating AI title for {} #{}...", branch, pr_number),
+        );
+        client.update_pr_title(pr_number, title).await?;
+        LiveTimer::maybe_finish_ok(timer, "done");
+    }
+
+    if let Some(body) = body {
+        let timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!("Updating AI body for {} #{}...", branch, pr_number),
+        );
+        client.update_pr_body(pr_number, body).await?;
+        LiveTimer::maybe_finish_ok(timer, "done");
     }
 
     Ok(())
@@ -1877,41 +2445,13 @@ fn format_duration(duration: Duration) -> String {
     }
 }
 
-/// Generate a PR body using an AI agent (for --ai-body flag).
-/// Loads agent/model from config, collects diff and commits, invokes the AI CLI.
-fn generate_ai_body(
-    workdir: &Path,
-    parent: &str,
-    branch: &str,
-    template: Option<&str>,
-) -> Result<String> {
-    use super::generate;
-
-    let config = Config::load()?;
-    let agent = config
-        .ai
-        .agent_for("generate")
-        .context(
-            "No AI agent configured. Run `stax generate --pr-body` first to set up, \
-             or add [ai] agent = \"claude\" (or \"codex\" / \"gemini\" / \"opencode\") to ~/.config/stax/config.toml",
-        )?
-        .to_string();
-
-    let model = config.ai.model_for("generate").map(String::from);
-
-    generate::print_using_agent(&agent, model.as_deref());
-
-    let diff_stat = generate::get_diff_stat(workdir, parent, branch);
-    let diff = generate::get_full_diff(workdir, parent, branch);
-    let commits = collect_commit_messages(workdir, parent, branch);
-    let prompt = generate::build_ai_prompt(&diff_stat, &diff, &commits, template);
-
-    generate::invoke_ai_agent(&agent, model.as_deref(), &prompt)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{resolve_is_draft_without_prompt, PR_TYPE_DEFAULT_INDEX, PR_TYPE_OPTIONS};
+    use super::{
+        build_ai_pr_details_prompt, existing_ai_prompt_items, existing_ai_targets_for_auto_accept,
+        parse_ai_pr_details, resolve_ai_targets, resolve_is_draft_without_prompt, truncate_ai_diff,
+        AiPrTargets, MAX_AI_DIFF_BYTES, PR_TYPE_DEFAULT_INDEX, PR_TYPE_OPTIONS,
+    };
 
     #[test]
     fn no_prompt_defaults_to_draft() {
@@ -1957,5 +2497,287 @@ mod tests {
     fn interactive_default_option_is_draft() {
         assert_eq!(PR_TYPE_DEFAULT_INDEX, 0);
         assert_eq!(PR_TYPE_OPTIONS[PR_TYPE_DEFAULT_INDEX], "Create as draft");
+    }
+
+    #[test]
+    fn ai_without_modifiers_targets_title_and_body() {
+        assert_eq!(
+            resolve_ai_targets(true, false, false, false).unwrap(),
+            Some(AiPrTargets {
+                title: true,
+                body: true,
+                explicit_scope: false,
+            })
+        );
+    }
+
+    #[test]
+    fn body_scope_targets_body_only() {
+        assert_eq!(
+            resolve_ai_targets(true, false, true, false).unwrap(),
+            Some(AiPrTargets {
+                title: false,
+                body: true,
+                explicit_scope: true,
+            })
+        );
+    }
+
+    #[test]
+    fn title_scope_targets_title_only() {
+        assert_eq!(
+            resolve_ai_targets(true, true, false, false).unwrap(),
+            Some(AiPrTargets {
+                title: true,
+                body: false,
+                explicit_scope: true,
+            })
+        );
+    }
+
+    #[test]
+    fn title_and_body_scope_targets_both_explicitly() {
+        assert_eq!(
+            resolve_ai_targets(true, true, true, false).unwrap(),
+            Some(AiPrTargets {
+                title: true,
+                body: true,
+                explicit_scope: true,
+            })
+        );
+    }
+
+    #[test]
+    fn title_and_body_modifiers_require_ai() {
+        let err = resolve_ai_targets(false, true, false, false).unwrap_err();
+        assert!(err.to_string().contains("--title requires --ai"));
+
+        let err = resolve_ai_targets(false, false, true, false).unwrap_err();
+        assert!(err.to_string().contains("--body requires --ai"));
+    }
+
+    #[test]
+    fn update_title_conflicts_when_ai_generates_title() {
+        let err = resolve_ai_targets(true, false, false, true).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("--update-title cannot be combined"));
+
+        let err = resolve_ai_targets(true, true, false, true).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("--update-title cannot be combined"));
+
+        assert!(resolve_ai_targets(true, false, true, true).is_ok());
+    }
+
+    #[test]
+    fn auto_accept_plain_ai_skips_existing_pr_content_updates() {
+        let targets = resolve_ai_targets(true, false, false, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(existing_ai_targets_for_auto_accept(targets), None);
+    }
+
+    #[test]
+    fn auto_accept_explicit_title_updates_existing_pr_title() {
+        let targets = resolve_ai_targets(true, true, false, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            existing_ai_targets_for_auto_accept(targets),
+            Some(AiPrTargets {
+                title: true,
+                body: false,
+                explicit_scope: true,
+            })
+        );
+    }
+
+    #[test]
+    fn auto_accept_explicit_body_updates_existing_pr_body() {
+        let targets = resolve_ai_targets(true, false, true, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            existing_ai_targets_for_auto_accept(targets),
+            Some(AiPrTargets {
+                title: false,
+                body: true,
+                explicit_scope: true,
+            })
+        );
+    }
+
+    #[test]
+    fn auto_accept_explicit_title_and_body_updates_existing_pr_both() {
+        let targets = resolve_ai_targets(true, true, true, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            existing_ai_targets_for_auto_accept(targets),
+            Some(AiPrTargets {
+                title: true,
+                body: true,
+                explicit_scope: true,
+            })
+        );
+    }
+
+    #[test]
+    fn existing_ai_prompt_choices_match_requested_scope() {
+        let full = AiPrTargets {
+            title: true,
+            body: true,
+            explicit_scope: false,
+        };
+        let labels: Vec<_> = existing_ai_prompt_items(full)
+            .into_iter()
+            .map(|(label, _)| label)
+            .collect();
+        assert_eq!(
+            labels,
+            vec![
+                "Skip",
+                "Update title",
+                "Update body",
+                "Update title and body"
+            ]
+        );
+
+        let title_only = AiPrTargets {
+            title: true,
+            body: false,
+            explicit_scope: true,
+        };
+        let labels: Vec<_> = existing_ai_prompt_items(title_only)
+            .into_iter()
+            .map(|(label, _)| label)
+            .collect();
+        assert_eq!(labels, vec!["Skip", "Update title"]);
+
+        let body_only = AiPrTargets {
+            title: false,
+            body: true,
+            explicit_scope: true,
+        };
+        let labels: Vec<_> = existing_ai_prompt_items(body_only)
+            .into_iter()
+            .map(|(label, _)| label)
+            .collect();
+        assert_eq!(labels, vec!["Skip", "Update body"]);
+    }
+
+    #[test]
+    fn parses_ai_pr_details_json() {
+        let targets = AiPrTargets {
+            title: true,
+            body: true,
+            explicit_scope: false,
+        };
+
+        let details = parse_ai_pr_details(
+            r###"{"title":"Improve submit AI","body":"## Summary\n\nAdds AI PR details."}"###,
+            targets,
+        )
+        .unwrap();
+
+        assert_eq!(details.title.as_deref(), Some("Improve submit AI"));
+        assert_eq!(
+            details.body.as_deref(),
+            Some("## Summary\n\nAdds AI PR details.")
+        );
+    }
+
+    #[test]
+    fn parses_ai_pr_details_from_json_fence() {
+        let targets = AiPrTargets {
+            title: false,
+            body: true,
+            explicit_scope: true,
+        };
+
+        let details =
+            parse_ai_pr_details("```json\n{\"body\":\"Only update the body\"}\n```", targets)
+                .unwrap();
+
+        assert_eq!(details.title, None);
+        assert_eq!(details.body.as_deref(), Some("Only update the body"));
+    }
+
+    #[test]
+    fn parse_ai_pr_details_requires_requested_fields() {
+        let targets = AiPrTargets {
+            title: true,
+            body: false,
+            explicit_scope: true,
+        };
+        let err = parse_ai_pr_details(r###"{"body":"Body only"}"###, targets).unwrap_err();
+        assert!(err.to_string().contains("non-empty title"));
+
+        let targets = AiPrTargets {
+            title: false,
+            body: true,
+            explicit_scope: true,
+        };
+        let err = parse_ai_pr_details(r###"{"title":"Title only"}"###, targets).unwrap_err();
+        assert!(err.to_string().contains("non-empty body"));
+    }
+
+    #[test]
+    fn ai_prompt_for_title_only_requests_title_json_without_body_rules() {
+        let prompt = build_ai_pr_details_prompt(
+            "src/lib.rs | 1 +",
+            "diff --git a/src/lib.rs b/src/lib.rs",
+            &["Add scoped submit AI".to_string()],
+            Some("## Summary\n{{COMMITS}}"),
+            AiPrTargets {
+                title: true,
+                body: false,
+                explicit_scope: true,
+            },
+        );
+
+        assert!(prompt.contains("Generate a pull request title"));
+        assert!(prompt.contains("\"title\""));
+        assert!(!prompt.contains("\"body\""));
+        assert!(prompt.contains("Title requirements:"));
+        assert!(!prompt.contains("Use this PR template"));
+    }
+
+    #[test]
+    fn ai_prompt_for_body_only_uses_template_and_body_json() {
+        let prompt = build_ai_pr_details_prompt(
+            "",
+            "",
+            &[],
+            Some("## Summary\n{{COMMITS}}"),
+            AiPrTargets {
+                title: false,
+                body: true,
+                explicit_scope: true,
+            },
+        );
+
+        assert!(prompt.contains("Generate a pull request body"));
+        assert!(prompt.contains("\"body\""));
+        assert!(!prompt.contains("\"title\""));
+        assert!(prompt.contains("Use this PR template as the body structure"));
+        assert!(prompt.contains("## Summary"));
+    }
+
+    #[test]
+    fn truncate_ai_diff_does_not_split_utf8() {
+        let mut diff = "a".repeat(MAX_AI_DIFF_BYTES - 1);
+        diff.push('é');
+        diff.push_str("\nrest");
+
+        let truncated = truncate_ai_diff(&diff);
+        assert!(truncated.contains("diff truncated"));
+        assert!(truncated.is_char_boundary(truncated.len()));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -114,7 +114,7 @@ pub struct AiConfig {
     /// Model to use with the AI agent (default: agent's own default)
     #[serde(default)]
     pub model: Option<String>,
-    /// Per-feature overrides for PR body generation (`stax generate`, `stax submit --ai-body`)
+    /// Per-feature overrides for PR generation (`stax generate`, `stax submit --ai`)
     #[serde(default, skip_serializing_if = "AiFeatureConfig::is_empty")]
     pub generate: AiFeatureConfig,
     /// Per-feature overrides for standup summaries (`stax standup --summary`)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -114,7 +114,7 @@ pub struct AiConfig {
     /// Model to use with the AI agent (default: agent's own default)
     #[serde(default)]
     pub model: Option<String>,
-    /// Per-feature overrides for PR generation (`stax generate`, `stax submit --ai`)
+    /// Per-feature overrides for create/PR generation (`stax create --ai`, `stax generate`, `stax submit --ai`)
     #[serde(default, skip_serializing_if = "AiFeatureConfig::is_empty")]
     pub generate: AiFeatureConfig,
     /// Per-feature overrides for standup summaries (`stax standup --summary`)

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1364,6 +1364,8 @@ fn gt_parity_create_am_flags() {
     assert!(stdout.contains("--message"));
     assert!(stdout.contains("-n"));
     assert!(stdout.contains("--no-verify"));
+    assert!(stdout.contains("--ai"));
+    assert!(stdout.contains("--yes"));
 }
 
 #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -467,6 +467,9 @@ fn test_scoped_submit_subcommand_help_flags() {
         );
         assert!(stdout.contains("--open"), "Expected --open in {:?}", args);
         assert!(stdout.contains("--yes"), "Expected --yes in {:?}", args);
+        assert!(stdout.contains("--ai"), "Expected --ai in {:?}", args);
+        assert!(stdout.contains("--title"), "Expected --title in {:?}", args);
+        assert!(stdout.contains("--body"), "Expected --body in {:?}", args);
         assert!(
             stdout.contains("--no-prompt"),
             "Expected --no-prompt in {:?}",

--- a/tests/create_ai_tests.rs
+++ b/tests/create_ai_tests.rs
@@ -1,0 +1,202 @@
+mod common;
+
+use common::TestRepo;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn write_test_config_with_ai(home: &Path) {
+    let config_dir = home.join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+[ai.generate]
+agent = "claude"
+"#,
+    )
+    .expect("write config");
+}
+
+fn write_fake_claude(home: &Path, response: &str, prompt_log: &Path) -> PathBuf {
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+
+    let claude = bin_dir.join("claude");
+    fs::write(
+        &claude,
+        format!(
+            "#!/bin/sh\ncat > \"{}\"\nprintf '%s\\n' '{}'\n",
+            prompt_log.display(),
+            response.replace('\'', "'\"'\"'")
+        ),
+    )
+    .expect("write fake claude");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&claude, fs::Permissions::from_mode(0o755)).expect("chmod fake claude");
+    }
+
+    bin_dir
+}
+
+fn path_with_bin(bin_dir: &Path) -> String {
+    let current = std::env::var("PATH").unwrap_or_default();
+    if current.is_empty() {
+        bin_dir.display().to_string()
+    } else {
+        format!("{}:{}", bin_dir.display(), current)
+    }
+}
+
+fn ai_env(home: &Path, bin_dir: &Path) -> Vec<(String, String)> {
+    vec![
+        ("HOME".to_string(), home.display().to_string()),
+        ("PATH".to_string(), path_with_bin(bin_dir)),
+    ]
+}
+
+fn env_refs(env: &[(String, String)]) -> Vec<(&str, &str)> {
+    env.iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect()
+}
+
+fn current_subject(repo: &TestRepo) -> String {
+    let output = repo.git(&["log", "-1", "--format=%s"]);
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn create_ai_all_yes_uses_generated_branch_and_commit_message() {
+    let repo = TestRepo::new();
+    repo.create_file("src/lib.rs", "pub fn answer() -> i32 { 42 }\n");
+
+    let home = TempDir::new().expect("create home");
+    write_test_config_with_ai(home.path());
+    let prompt_log = home.path().join("prompt.txt");
+    let bin_dir = write_fake_claude(
+        home.path(),
+        r#"{"branch":"add-answer-helper","message":"Add answer helper"}"#,
+        &prompt_log,
+    );
+    let env = ai_env(home.path(), &bin_dir);
+    let env = env_refs(&env);
+
+    let output = repo.run_stax_with_env(&["create", "--ai", "-a", "--yes"], &env);
+
+    assert!(
+        output.status.success(),
+        "create failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert_eq!(repo.current_branch(), "add-answer-helper");
+    assert_eq!(current_subject(&repo), "Add answer helper");
+
+    let prompt = fs::read_to_string(prompt_log).expect("read prompt");
+    assert!(prompt.contains("\"branch\" and \"message\""));
+    assert!(prompt.contains("src/lib.rs"));
+}
+
+#[test]
+fn create_named_ai_all_yes_uses_name_and_generated_commit_message() {
+    let repo = TestRepo::new();
+    repo.create_file("src/lib.rs", "pub fn feature() {}\n");
+
+    let home = TempDir::new().expect("create home");
+    write_test_config_with_ai(home.path());
+    let prompt_log = home.path().join("prompt.txt");
+    let bin_dir = write_fake_claude(
+        home.path(),
+        r#"{"message":"Add named feature"}"#,
+        &prompt_log,
+    );
+    let env = ai_env(home.path(), &bin_dir);
+    let env = env_refs(&env);
+
+    let output = repo.run_stax_with_env(&["create", "manual-feature", "--ai", "-a", "--yes"], &env);
+
+    assert!(
+        output.status.success(),
+        "create failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert_eq!(repo.current_branch(), "manual-feature");
+    assert_eq!(current_subject(&repo), "Add named feature");
+
+    let prompt = fs::read_to_string(prompt_log).expect("read prompt");
+    assert!(prompt.contains("\"message\""));
+    assert!(!prompt.contains("\"branch\" and \"message\""));
+}
+
+#[test]
+fn create_ai_manual_message_yes_uses_generated_branch_and_manual_commit_message() {
+    let repo = TestRepo::new();
+    repo.create_file("src/lib.rs", "pub fn manual_message() {}\n");
+
+    let home = TempDir::new().expect("create home");
+    write_test_config_with_ai(home.path());
+    let prompt_log = home.path().join("prompt.txt");
+    let bin_dir = write_fake_claude(
+        home.path(),
+        r#"{"branch":"manual-message-branch"}"#,
+        &prompt_log,
+    );
+    let env = ai_env(home.path(), &bin_dir);
+    let env = env_refs(&env);
+
+    let output = repo.run_stax_with_env(
+        &["create", "--ai", "-a", "-m", "Keep manual message", "--yes"],
+        &env,
+    );
+
+    assert!(
+        output.status.success(),
+        "create failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert_eq!(repo.current_branch(), "manual-message-branch");
+    assert_eq!(current_subject(&repo), "Keep manual message");
+
+    let prompt = fs::read_to_string(prompt_log).expect("read prompt");
+    assert!(prompt.contains("\"branch\""));
+    assert!(!prompt.contains("\"branch\" and \"message\""));
+}
+
+#[test]
+fn create_ai_yes_without_staging_generates_branch_only() {
+    let repo = TestRepo::new();
+    let original_head = repo.head_sha();
+    repo.create_file("src/lib.rs", "pub fn uncommitted() {}\n");
+
+    let home = TempDir::new().expect("create home");
+    write_test_config_with_ai(home.path());
+    let prompt_log = home.path().join("prompt.txt");
+    let bin_dir = write_fake_claude(home.path(), r#"{"branch":"branch-only-ai"}"#, &prompt_log);
+    let env = ai_env(home.path(), &bin_dir);
+    let env = env_refs(&env);
+
+    let output = repo.run_stax_with_env(&["create", "--ai", "--yes"], &env);
+
+    assert!(
+        output.status.success(),
+        "create failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert_eq!(repo.current_branch(), "branch-only-ai");
+    assert_eq!(repo.head_sha(), original_head);
+
+    let status = repo.git(&["status", "--short", "--untracked-files=all"]);
+    let status = String::from_utf8_lossy(&status.stdout);
+    assert!(status.contains("src/lib.rs"));
+
+    let prompt = fs::read_to_string(prompt_log).expect("read prompt");
+    assert!(prompt.contains("\"branch\""));
+    assert!(!prompt.contains("\"message\""));
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6099,6 +6099,41 @@ mod forge_mock_tests {
         fs::write(&config_path, config).expect("Failed to write config");
     }
 
+    fn write_test_config_with_ai(home: &Path, api_base_url: &str, stack_links: Option<&str>) {
+        let config_dir = home.join(".config").join("stax");
+        std::fs::create_dir_all(&config_dir).expect("Failed to create config dir");
+        let config_path = config_dir.join("config.toml");
+        let mut config = format!("[remote]\napi_base_url = \"{}\"\n", api_base_url);
+        if let Some(mode) = stack_links {
+            config.push_str(&format!("\n[submit]\nstack_links = \"{}\"\n", mode));
+        }
+        config.push_str("\n[ai.generate]\nagent = \"claude\"\n");
+        fs::write(&config_path, config).expect("Failed to write config");
+    }
+
+    fn write_fake_claude(home: &Path, response: &str) -> PathBuf {
+        let bin_dir = home.join("bin");
+        fs::create_dir_all(&bin_dir).expect("Failed to create fake AI bin dir");
+        let path = bin_dir.join("claude");
+        fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\ncat >/dev/null\ncat <<'JSON'\n{}\nJSON\n",
+                response
+            ),
+        )
+        .expect("Failed to write fake claude");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+                .expect("Failed to chmod fake claude");
+        }
+
+        bin_dir
+    }
+
     fn ensure_empty_gitconfig(home: &Path) -> std::path::PathBuf {
         let path = home.join("gitconfig");
         if !path.exists() {
@@ -6300,6 +6335,103 @@ mod forge_mock_tests {
         })
     }
 
+    fn github_pull_fixture_with_details(
+        number: u64,
+        head_branch: &str,
+        base_branch: &str,
+        title: &str,
+        body: &str,
+    ) -> serde_json::Value {
+        let mut pr = github_pull_fixture(number, head_branch, base_branch, "aaaa");
+        pr["title"] = serde_json::json!(title);
+        pr["body"] = serde_json::json!(body);
+        pr["html_url"] = serde_json::json!(format!("https://github.com/test/repo/pull/{}", number));
+        pr
+    }
+
+    async fn mount_github_new_pr_flow(
+        mock_server: &MockServer,
+        number: u64,
+        branch: &str,
+        title: &str,
+        body: &str,
+    ) {
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "url": format!("https://api.github.com/repos/test/repo/pulls/{}", number),
+                "id": number,
+                "number": number,
+                "state": "open",
+                "title": title,
+                "body": body,
+                "draft": true,
+                "head": { "ref": branch, "sha": "aaaa", "label": format!("test:{}", branch) },
+                "base": { "ref": "main", "sha": "bbbb" },
+                "html_url": format!("https://github.com/test/repo/pull/{}", number)
+            })))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/issues/{}/comments", number)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/pulls/{}", number)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(number, branch, "main", title, body),
+            ))
+            .mount(mock_server)
+            .await;
+    }
+
+    async fn mount_github_existing_pr(
+        mock_server: &MockServer,
+        number: u64,
+        branch: &str,
+        title: &str,
+        body: &str,
+    ) {
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture_with_details(number, branch, "main", title, body)
+            ])))
+            .mount(mock_server)
+            .await;
+    }
+
+    async fn mount_github_stack_links_off_sync(
+        mock_server: &MockServer,
+        number: u64,
+        branch: &str,
+        title: &str,
+        body: &str,
+    ) {
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/issues/{}/comments", number)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/pulls/{}", number)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(number, branch, "main", title, body),
+            ))
+            .mount(mock_server)
+            .await;
+    }
+
     fn gitlab_mr_fixture(
         iid: u64,
         title: &str,
@@ -6434,6 +6566,33 @@ mod forge_mock_tests {
             .env("GIT_CONFIG_GLOBAL", &gitconfig)
             .env("GIT_CONFIG_SYSTEM", &gitconfig)
             .env(token_env, "mock-token")
+            .env("STAX_DISABLE_UPDATE_CHECK", "1");
+        command.output().expect("Failed to execute stax")
+    }
+
+    fn run_stax_with_token_env_and_path(
+        repo: &TestRepo,
+        home: &Path,
+        token_env: &str,
+        path_prefix: &Path,
+        args: &[&str],
+    ) -> Output {
+        let gitconfig = ensure_empty_gitconfig(home);
+        let path = match std::env::var("PATH") {
+            Ok(current) if !current.is_empty() => {
+                format!("{}:{}", path_prefix.display(), current)
+            }
+            _ => path_prefix.display().to_string(),
+        };
+        let mut command = Command::new(stax_bin());
+        command
+            .args(args)
+            .current_dir(repo.path())
+            .env("HOME", home)
+            .env("GIT_CONFIG_GLOBAL", &gitconfig)
+            .env("GIT_CONFIG_SYSTEM", &gitconfig)
+            .env(token_env, "mock-token")
+            .env("PATH", path)
             .env("STAX_DISABLE_UPDATE_CHECK", "1");
         command.output().expect("Failed to execute stax")
     }
@@ -6760,6 +6919,342 @@ mod forge_mock_tests {
             "Expected lane PR number in metadata, got: {}",
             metadata
         );
+    }
+
+    #[tokio::test]
+    async fn test_submit_ai_yes_uses_generated_title_and_body_for_new_pr() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_ai(home.path(), &mock_server.uri(), Some("off"));
+        let ai_bin = write_fake_claude(
+            home.path(),
+            r###"{"title":"AI submit title","body":"## Summary\n\nAI generated body."}"###,
+        );
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &["bc", "feature-ai-submit"],
+        );
+        assert!(
+            output.status.success(),
+            "Failed to create branch: {}",
+            TestRepo::stderr(&output)
+        );
+        let branch = repo.current_branch();
+        repo.create_file("ai-submit.txt", "ai submit\n");
+        repo.commit("Add AI submit flow");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "title": "AI submit title",
+                "body": "## Summary\n\nAI generated body.",
+                "draft": true,
+                "head": { "ref": branch.clone(), "sha": "aaaa", "label": format!("test:{}", branch) },
+                "base": { "ref": "main", "sha": "bbbb" },
+                "html_url": "https://github.com/test/repo/pull/42"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "title": "AI submit title",
+                "body": "## Summary\n\nAI generated body.",
+                "draft": true,
+                "head": { "ref": branch.clone(), "sha": "aaaa", "label": format!("test:{}", branch) },
+                "base": { "ref": "main", "sha": "bbbb" },
+                "html_url": "https://github.com/test/repo/pull/42"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &["submit", "--ai", "--yes", "--no-prompt"],
+        );
+        assert!(
+            output.status.success(),
+            "submit --ai failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let pr_create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path() == "/repos/test/repo/pulls"
+            })
+            .expect("missing PR create request");
+        let payload: serde_json::Value = serde_json::from_slice(&pr_create.body).unwrap();
+        assert_eq!(payload["title"], "AI submit title");
+        assert_eq!(payload["body"], "## Summary\n\nAI generated body.");
+        assert_eq!(payload["head"], branch);
+        assert_eq!(payload["draft"], true);
+    }
+
+    #[tokio::test]
+    async fn test_submit_body_scope_yes_uses_default_title_for_new_pr() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_ai(home.path(), &mock_server.uri(), Some("off"));
+        let ai_bin = write_fake_claude(home.path(), r###"{"body":"AI body only"}"###);
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &["bc", "feature-body-scope"],
+        );
+        assert!(
+            output.status.success(),
+            "Failed to create branch: {}",
+            TestRepo::stderr(&output)
+        );
+        let branch = repo.current_branch();
+        repo.create_file("body-scope.txt", "body scope\n");
+        repo.commit("Add AI body scope");
+
+        mount_github_new_pr_flow(
+            &mock_server,
+            43,
+            &branch,
+            "Add AI body scope",
+            "AI body only",
+        )
+        .await;
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &["submit", "--ai", "--body", "--yes", "--no-prompt"],
+        );
+        assert!(
+            output.status.success(),
+            "submit --ai --body failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let pr_create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path() == "/repos/test/repo/pulls"
+            })
+            .expect("missing PR create request");
+        let payload: serde_json::Value = serde_json::from_slice(&pr_create.body).unwrap();
+        assert_eq!(payload["title"], "Add AI body scope");
+        assert_eq!(payload["body"], "AI body only");
+    }
+
+    #[tokio::test]
+    async fn test_submit_ai_yes_falls_back_to_default_new_pr_details() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_ai(home.path(), &mock_server.uri(), Some("off"));
+        let ai_bin = write_fake_claude(home.path(), "not json");
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &["bc", "feature-ai-fallback"],
+        );
+        assert!(
+            output.status.success(),
+            "Failed to create branch: {}",
+            TestRepo::stderr(&output)
+        );
+        let branch = repo.current_branch();
+        repo.create_file("ai-fallback.txt", "ai fallback\n");
+        repo.commit("Add AI fallback");
+        let default_body = "## Summary\n\n- Add AI fallback";
+
+        mount_github_new_pr_flow(&mock_server, 44, &branch, "Add AI fallback", default_body).await;
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &["submit", "--ai", "--yes", "--no-prompt"],
+        );
+        assert!(
+            output.status.success(),
+            "submit --ai fallback failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let pr_create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path() == "/repos/test/repo/pulls"
+            })
+            .expect("missing PR create request");
+        let payload: serde_json::Value = serde_json::from_slice(&pr_create.body).unwrap();
+        assert_eq!(payload["title"], "Add AI fallback");
+        assert_eq!(payload["body"], default_body);
+    }
+
+    #[tokio::test]
+    async fn test_submit_plain_ai_yes_skips_existing_pr_content_updates() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_submit(home.path(), &mock_server.uri(), Some("off"));
+        let repo = setup_branch_with_remote(home.path(), "feature-ai-existing-skip");
+        let branch = repo.current_branch();
+
+        mount_github_existing_pr(&mock_server, 45, &branch, "Existing title", "Existing body")
+            .await;
+        mount_github_stack_links_off_sync(
+            &mock_server,
+            45,
+            &branch,
+            "Existing title",
+            "Existing body",
+        )
+        .await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["submit", "--ai", "--yes"]);
+        assert!(
+            output.status.success(),
+            "submit --ai --yes existing skip failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert!(
+            !requests.iter().any(|request| {
+                request.method.as_str() == "PATCH"
+                    && request.url.path() == "/repos/test/repo/pulls/45"
+            }),
+            "plain --ai --yes should not patch existing PR content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_submit_ai_title_body_yes_updates_existing_pr_content() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_ai(home.path(), &mock_server.uri(), Some("off"));
+        let ai_bin = write_fake_claude(
+            home.path(),
+            r###"{"title":"AI refreshed title","body":"AI refreshed body"}"###,
+        );
+        let repo = setup_branch_with_remote(home.path(), "feature-ai-existing-update");
+        let branch = repo.current_branch();
+
+        mount_github_existing_pr(&mock_server, 46, &branch, "Existing title", "Existing body")
+            .await;
+        mount_github_stack_links_off_sync(
+            &mock_server,
+            46,
+            &branch,
+            "AI refreshed title",
+            "AI refreshed body",
+        )
+        .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/46"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(
+                    46,
+                    &branch,
+                    "main",
+                    "AI refreshed title",
+                    "AI refreshed body",
+                ),
+            ))
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_token_env_and_path(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &ai_bin,
+            &[
+                "submit",
+                "--ai",
+                "--title",
+                "--body",
+                "--yes",
+                "--no-prompt",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "submit existing --ai --title --body failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let title_patch = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "PATCH"
+                    && request.url.path() == "/repos/test/repo/pulls/46"
+                    && serde_json::from_slice::<serde_json::Value>(&request.body)
+                        .ok()
+                        .and_then(|payload| payload.get("title").cloned())
+                        .is_some()
+            })
+            .expect("missing existing PR title patch");
+        let title_payload: serde_json::Value = serde_json::from_slice(&title_patch.body).unwrap();
+        assert_eq!(title_payload["title"], "AI refreshed title");
+
+        let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/46");
+        let body_payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
+        assert_eq!(body_payload["body"], "AI refreshed body");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Make branch creation and PR submission faster by letting stax draft branch names, first commit messages, and PR details from local changes.

## Description of changes / notes for reviewers

- `st create --ai` now generates a branch name from local changes, and `-a --yes` can also generate the first commit message.
- `st submit --ai` replaces `--ai-body`, generates PR titles and bodies with optional `--title` / `--body` scoping, and can update existing PRs; docs, config help text, and tests were updated to match.