### PR TITLE
Track branches from the merge-base for safer restacks

### DIFF
--- a/src/commands/branch/track.rs
+++ b/src/commands/branch/track.rs
@@ -85,7 +85,13 @@ pub fn run(parent: Option<String>, all_prs: bool) -> Result<()> {
         }
     };
 
-    let parent_rev = repo.branch_commit(&parent_branch)?;
+    // Use the divergence point (merge-base) rather than the parent's current tip.
+    // This matches freephite's `trackBranch` which stores `getMergeBase(branch, parent)`.
+    // Storing the tip would make the stored revision a non-ancestor of `current`,
+    // which causes `git rebase --onto` to scope the replay incorrectly.
+    let parent_rev = repo
+        .merge_base(&parent_branch, &current)
+        .or_else(|_| repo.branch_commit(&parent_branch))?;
 
     // Create metadata
     let meta = BranchMetadata::new(&parent_branch, &parent_rev);
@@ -205,7 +211,13 @@ fn run_track_all_prs() -> Result<()> {
             trunk.clone()
         };
 
-        let parent_rev = match repo.branch_commit(&parent_branch) {
+        // Use the divergence point (merge-base) rather than the parent's current tip.
+        // Matches freephite's `trackBranch`: store `getMergeBase(branch, parent)` so
+        // that `git rebase --onto` scopes the replay to only the branch's own commits.
+        let parent_rev = match repo
+            .merge_base(&parent_branch, &pr.head_branch)
+            .or_else(|_| repo.branch_commit(&parent_branch))
+        {
             Ok(rev) => rev,
             Err(_) => {
                 eprintln!(

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1178,9 +1178,13 @@ impl GitRepo {
 
     /// Rebase a branch onto `onto` using the stored parent revision as upstream.
     ///
-    /// Runs `git rebase --onto <onto> <fallback_upstream> <branch>` when
-    /// `fallback_upstream` is a valid ancestor of `branch` (the normal case).
-    /// This matches freephite's restack strategy: fast, simple, no patch-id scanning.
+    /// When `fallback_upstream` is non-empty, always runs:
+    ///   `git rebase --onto <onto> <fallback_upstream> <branch>`
+    /// This is exactly freephite's restack strategy: replay only the commits that
+    /// sit between the stored divergence point and the branch tip, regardless of
+    /// whether that point is still a reachable ancestor.  Falling back to plain
+    /// `git rebase <onto>` (no `--onto`) recomputes the merge-base from scratch
+    /// and can replay hundreds of unrelated commits, causing spurious conflicts.
     pub fn rebase_branch_onto_with_provenance(
         &self,
         branch: &str,
@@ -1257,24 +1261,18 @@ Use --auto-stash-pop or stash/commit changes first.",
             });
         }
 
-        // Use the stored parent revision as upstream when it is a valid ancestor
-        // of the branch.  This is the same strategy freephite uses:
-        //   git rebase --onto <onto> <parent_branch_revision> <branch>
-        // No patch-id scanning; the old provenance path was the main source of
-        // slowness (O(N) `git log -p` per branch) and spurious conflicts.
-        let upstream_for_rebase = (!fallback_upstream.trim().is_empty()
-            && self.is_ancestor(fallback_upstream, branch).unwrap_or(false))
-        .then(|| fallback_upstream.to_string());
-
-        let rebase_result = if let Some(upstream) = upstream_for_rebase.as_deref() {
-            self.rebase_onto_upstream_in_path(&target_workdir, onto, upstream)
+        // Always prefer `git rebase --onto <onto> <upstream> <branch>` when the
+        // caller supplies a stored upstream (parent_branch_revision).  This
+        // confines the replay to the branch's own commits and avoids re-applying
+        // thousands of trunk commits when the stored revision is no longer a
+        // reachable ancestor (e.g. after squash-merges or metadata drift).
+        // Only fall back to plain `git rebase <onto>` when no upstream is provided.
+        let rebase_result = if !fallback_upstream.trim().is_empty() {
+            self.rebase_onto_upstream_in_path(&target_workdir, onto, fallback_upstream)
                 .with_context(|| {
                     format!(
                         "Failed to rebase '{}' onto '{}' with upstream '{}' in '{}'",
-                        branch,
-                        onto,
-                        upstream,
-                        target_workdir.display()
+                        branch, onto, fallback_upstream, target_workdir.display()
                     )
                 })
         } else {

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -169,6 +169,121 @@ fn test_stack_restack_with_drifted_revisions_succeeds() {
 }
 
 // =============================================================================
+// sync --restack path (the actual command the user hit: `st rs --restack`)
+// =============================================================================
+
+/// `stax sync --restack` goes through a different code path in sync.rs than
+/// plain `stax restack`.  Verify it succeeds even when parentBranchRevision
+/// is drifted to a non-ancestor SHA.
+#[test]
+fn test_sync_restack_with_drifted_revision_succeeds() {
+    let repo = TestRepo::new_with_remote();
+
+    // Create a feature branch via stax and push it
+    repo.git(&["checkout", "-b", "sync-feature"]);
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", "sync-feature"]);
+
+    // Advance remote main (simulating another developer's push)
+    repo.simulate_remote_commit("main-remote.txt", "remote content", "Remote main commit");
+
+    // Fetch so local main can advance
+    repo.git(&["fetch", "origin"]);
+    repo.git(&["checkout", "main"]);
+    repo.git(&["merge", "--ff-only", "origin/main"]);
+
+    let new_main_sha = repo.get_commit_sha("HEAD");
+
+    // Corrupt metadata: point stored revision to new main HEAD (not in feature ancestry)
+    write_branch_metadata_raw(&repo, "sync-feature", "main", &new_main_sha);
+
+    repo.git(&["checkout", "sync-feature"]);
+
+    // Run sync --restack — this is the exact command the user runs as `st rs --restack`
+    let output = repo.run_stax(&["sync", "--restack", "--quiet"]);
+    output.assert_success();
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Rebase should not be in progress after successful sync --restack"
+    );
+}
+
+// =============================================================================
+// Behavioral proof: restack with drifted revision preserves only feature commits
+// =============================================================================
+
+/// When stored revision is not in feature's ancestry (triggering the old is_ancestor=FALSE
+/// path), restack must still apply ONLY the feature's own commits on top of the new
+/// parent — not replay any main history.
+///
+/// Setup: feature branches at M1. Main adds M2, M3.
+/// Stored parentBranchRevision = M2 (a main-only commit NOT in feature's history).
+///   → needs_restack: M2 ≠ M3 (current main) → TRUE → restack fires
+///   → old code: is_ancestor(M2, feature) = FALSE → falls back to plain `git rebase main`
+///   → new code: always `git rebase --onto main M2 feature`
+/// Both replay only {F1, F2}. We verify the outcome: exactly 2 commits atop main.
+#[test]
+fn test_restack_with_non_ancestor_revision_preserves_only_feature_commits() {
+    let repo = TestRepo::new();
+
+    // Create feature with exactly 2 commits, branched at initial commit
+    repo.git(&["checkout", "-b", "count-feature"]);
+    repo.create_file("f1.txt", "file one");
+    repo.commit("Feature commit 1");
+    repo.create_file("f2.txt", "file two");
+    repo.commit("Feature commit 2");
+
+    // Advance main: add M2 first, capture its SHA, then add M3
+    repo.git(&["checkout", "main"]);
+    repo.create_file("m1.txt", "main one");
+    repo.commit("Main commit 1");
+    let mid_main_sha = repo.get_commit_sha("HEAD"); // M2 — NOT in feature's history
+
+    repo.create_file("m2.txt", "main two");
+    repo.commit("Main commit 2"); // M3 — current main HEAD
+
+    // Store parentBranchRevision = M2 (not in feature history, not equal to current main)
+    // This triggers needs_restack (M2 ≠ M3) and hits the non-ancestor path.
+    write_branch_metadata_raw(&repo, "count-feature", "main", &mid_main_sha);
+    repo.run_stax(&["set-trunk", "main"]);
+
+    repo.git(&["checkout", "count-feature"]);
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_success();
+    assert!(!repo.has_rebase_in_progress());
+
+    // Verify: feature must be exactly 2 commits ahead of main (its own commits only)
+    let log_out = repo.git(&["log", "--oneline", "main..count-feature"]);
+    let log_str = String::from_utf8_lossy(&log_out.stdout).to_string();
+    let feature_only: Vec<&str> = log_str
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    assert_eq!(
+        feature_only.len(),
+        2,
+        "After restack, feature should have exactly 2 commits on top of main \
+         (no extra main commits replayed).\nGot {} commit(s):\n{}",
+        feature_only.len(),
+        feature_only.join("\n")
+    );
+
+    // Verify feature is 0 commits behind main (fully rebased)
+    let behind_out = repo.git(&["rev-list", "--count", "count-feature..main"]);
+    let behind = String::from_utf8_lossy(&behind_out.stdout)
+        .trim()
+        .parse::<usize>()
+        .unwrap_or(99);
+    assert_eq!(
+        behind, 0,
+        "Feature should be 0 commits behind main after restack, got {} behind",
+        behind
+    );
+}
+
+// =============================================================================
 // Genuine conflict is still reported correctly (no regression)
 // =============================================================================
 

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -1,0 +1,209 @@
+//! Tests for restack provenance: stax should always use `git rebase --onto <onto> <stored_upstream>`
+//! rather than falling back to plain `git rebase <onto>`.
+//!
+//! Regression tests for the scenario where a user's branch had its stored
+//! `parentBranchRevision` pointing to a commit that is not in the branch's ancestry
+//! (e.g. because `stax branch track` stored the parent's current tip instead of the
+//! merge-base). Previously, stax fell back to plain `git rebase <parent>` which
+//! could replay unrelated trunk commits and cause spurious conflicts.
+//!
+//! freephite reference: it always runs
+//!   `git rebase --onto <parentBranchName> <parentBranchRevision> <branch>`
+//! without any ancestor check.
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+// ---------------------------------------------------------------------------
+// Helper: write stax metadata directly into git refs.
+// This lets tests set up "bad" or "drifted" parentBranchRevision values without
+// going through stax commands.
+// ---------------------------------------------------------------------------
+
+fn write_branch_metadata_raw(repo: &TestRepo, branch: &str, parent_name: &str, parent_revision: &str) {
+    let json = format!(
+        r#"{{"parentBranchName":"{}","parentBranchRevision":"{}"}}"#,
+        parent_name, parent_revision
+    );
+
+    // Write the JSON as a git blob object
+    let mut child = Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .spawn()
+        .expect("Failed to spawn git hash-object");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin missing")
+        .write_all(json.as_bytes())
+        .expect("Failed to write metadata JSON to stdin");
+
+    let out = child.wait_with_output().expect("git hash-object failed");
+    assert!(out.status.success(), "git hash-object exited non-zero");
+
+    let hash = String::from_utf8(out.stdout)
+        .expect("non-utf8 hash output")
+        .trim()
+        .to_string();
+
+    let ref_name = format!("refs/branch-metadata/{}", branch);
+    let status = Command::new("git")
+        .args(["update-ref", &ref_name, &hash])
+        .current_dir(repo.path())
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .status()
+        .expect("Failed to spawn git update-ref");
+    assert!(status.success(), "git update-ref exited non-zero");
+}
+
+// =============================================================================
+// Happy path: stored revision is the correct merge-base
+// =============================================================================
+
+/// Standard case: branch created via stax, parent advances, restack cleans it up.
+#[test]
+fn test_restack_with_correct_stored_revision_succeeds() {
+    let repo = TestRepo::new();
+
+    let branches = repo.create_stack(&["feature"]);
+    let feature = &branches[0];
+
+    // Advance main with a non-conflicting change
+    repo.git(&["checkout", "main"]);
+    repo.create_file("main-extra.txt", "extra main content");
+    repo.commit("Extra main commit");
+
+    repo.git(&["checkout", feature]);
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_success();
+    assert!(!repo.has_rebase_in_progress());
+}
+
+// =============================================================================
+// Key regression: stored revision is NOT in the branch's ancestry
+// (simulates the bug where `stax branch track` stored parent's current tip)
+// =============================================================================
+
+/// When parentBranchRevision is set to main's current HEAD (which is NOT in the
+/// feature branch's commit history), restack should still succeed.
+///
+/// With the fix: `git rebase --onto main <main_head> feature`
+///   → git log <main_head>..feature = only the feature's own commits
+///   → replays feature commits cleanly onto new main.
+#[test]
+fn test_restack_with_non_ancestor_stored_revision_succeeds() {
+    let repo = TestRepo::new();
+
+    // Create a feature branch manually (bypassing stax bc) so we control metadata
+    repo.git(&["checkout", "-b", "my-feature"]);
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit");
+
+    // Advance main with non-conflicting changes
+    repo.git(&["checkout", "main"]);
+    repo.create_file("main-a.txt", "main-a content");
+    repo.commit("Main commit A");
+    repo.create_file("main-b.txt", "main-b content");
+    repo.commit("Main commit B");
+
+    let current_main_sha = repo.get_commit_sha("HEAD");
+
+    // Write metadata with parentBranchRevision = current main HEAD.
+    // This is NOT in feature's history (feature branched before these commits).
+    write_branch_metadata_raw(&repo, "my-feature", "main", &current_main_sha);
+
+    // Initialize stax trunk
+    repo.run_stax(&["set-trunk", "main"]);
+
+    repo.git(&["checkout", "my-feature"]);
+
+    // Restack must succeed — the stored revision, though not a direct ancestor of
+    // my-feature, still scopes the replay correctly because git computes:
+    //   git log <current_main_sha>..my-feature = "Feature commit" only
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_success();
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Rebase should not be in progress after successful restack"
+    );
+}
+
+// =============================================================================
+// Stack of two branches with drifted revisions
+// =============================================================================
+
+/// Both branches in a stack have their stored revisions overwritten to a
+/// non-ancestor SHA. Restack should still complete cleanly.
+#[test]
+fn test_stack_restack_with_drifted_revisions_succeeds() {
+    let repo = TestRepo::new();
+
+    let branches = repo.create_stack(&["branch-a", "branch-b"]);
+    let branch_a = &branches[0];
+    let branch_b = &branches[1];
+
+    // Advance main
+    repo.git(&["checkout", "main"]);
+    repo.create_file("main-extra.txt", "main-extra content");
+    repo.commit("Main extra commit");
+    let new_main_sha = repo.get_commit_sha("HEAD");
+
+    // Simulate metadata drift by overwriting stored revisions
+    write_branch_metadata_raw(&repo, branch_a, "main", &new_main_sha);
+    write_branch_metadata_raw(&repo, branch_b, branch_a, &new_main_sha);
+
+    repo.git(&["checkout", branch_b]);
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_success();
+    assert!(!repo.has_rebase_in_progress());
+}
+
+// =============================================================================
+// Genuine conflict is still reported correctly (no regression)
+// =============================================================================
+
+/// Verify that an actual content conflict still causes restack to stop and
+/// report a failure — the provenance fix must not silently swallow real conflicts.
+#[test]
+fn test_genuine_conflict_still_fails_after_fix() {
+    let repo = TestRepo::new();
+
+    // Record main SHA before the conflict commit
+    let pre_conflict_sha = repo.get_commit_sha("HEAD");
+
+    // Create feature with a change to shared.txt
+    repo.git(&["checkout", "-b", "conflict-feature"]);
+    repo.create_file("shared.txt", "feature version\n");
+    repo.commit("Feature changes shared.txt");
+
+    // Advance main with a conflicting change to the same file
+    repo.git(&["checkout", "main"]);
+    repo.create_file("shared.txt", "main version\n");
+    repo.commit("Main changes shared.txt");
+
+    // Write metadata with the pre-conflict main SHA as parentBranchRevision
+    // (this is the correct merge-base — we want a real conflict, not metadata drift)
+    write_branch_metadata_raw(&repo, "conflict-feature", "main", &pre_conflict_sha);
+    repo.run_stax(&["set-trunk", "main"]);
+
+    repo.git(&["checkout", "conflict-feature"]);
+
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_failure();
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Rebase should be in progress after a genuine conflict"
+    );
+
+    repo.abort_rebase();
+}

--- a/tests/track_merge_base_tests.rs
+++ b/tests/track_merge_base_tests.rs
@@ -1,0 +1,179 @@
+//! Tests for `stax branch track` storing the merge-base as `parentBranchRevision`.
+//!
+//! freephite reference: `engine.trackBranch` stores `git.getMergeBase(branch, parent)`,
+//! not the parent's current HEAD.  Storing the tip as the revision causes
+//! `git rebase --onto` to scope the replay incorrectly when the branch was created
+//! from an older parent commit.
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+
+// ---------------------------------------------------------------------------
+// Helper: read parentBranchRevision from stax metadata
+// ---------------------------------------------------------------------------
+
+fn read_parent_revision(repo: &TestRepo, branch: &str) -> String {
+    let ref_name = format!("refs/branch-metadata/{}", branch);
+    let out = repo.git(&["cat-file", "blob", &ref_name]);
+    assert!(
+        out.status.success(),
+        "Could not read metadata ref for '{}': {}",
+        branch,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = String::from_utf8(out.stdout).expect("non-utf8 metadata");
+    // Parse parentBranchRevision from the JSON (simple substring extraction)
+    let key = r#""parentBranchRevision":""#;
+    let start = json
+        .find(key)
+        .expect("parentBranchRevision key missing")
+        + key.len();
+    let end = json[start..].find('"').expect("closing quote missing") + start;
+    json[start..end].to_string()
+}
+
+fn get_merge_base(repo: &TestRepo, a: &str, b: &str) -> String {
+    let out = repo.git(&["merge-base", a, b]);
+    assert!(out.status.success(), "git merge-base failed");
+    String::from_utf8(out.stdout)
+        .expect("non-utf8")
+        .trim()
+        .to_string()
+}
+
+// =============================================================================
+// Interactive `stax branch track --parent <p>` stores merge-base
+// =============================================================================
+
+/// When tracking a branch that diverged from main at an older commit, the stored
+/// parentBranchRevision must be the merge-base (divergence point), NOT main's
+/// current HEAD.
+#[test]
+fn test_branch_track_stores_merge_base_not_parent_tip() {
+    let repo = TestRepo::new();
+
+    // Record main SHA before adding any feature commits
+    let divergence_sha = repo.get_commit_sha("HEAD");
+
+    // Create a feature branch manually and add a commit
+    repo.git(&["checkout", "-b", "my-feature"]);
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit");
+
+    // Advance main PAST the divergence point (so tip ≠ merge-base)
+    repo.git(&["checkout", "main"]);
+    repo.create_file("main-extra.txt", "extra");
+    repo.commit("Main advanced");
+
+    // The current main tip is now different from divergence_sha
+    let main_tip = repo.get_commit_sha("HEAD");
+    assert_ne!(divergence_sha, main_tip, "main must have advanced");
+
+    // Initialize stax and track the feature branch
+    repo.run_stax(&["set-trunk", "main"]);
+    repo.git(&["checkout", "my-feature"]);
+
+    let output = repo.run_stax(&["branch", "track", "--parent", "main"]);
+    output.assert_success();
+
+    // The stored revision must equal the merge-base, not main's current tip
+    let stored_rev = read_parent_revision(&repo, "my-feature");
+    let expected_merge_base = get_merge_base(&repo, "main", "my-feature");
+
+    assert_eq!(
+        stored_rev, expected_merge_base,
+        "parentBranchRevision should be the merge-base (divergence point), \
+         not the parent's current tip.\n  stored:   {}\n  expected: {}",
+        stored_rev, expected_merge_base
+    );
+    assert_ne!(
+        stored_rev, main_tip,
+        "parentBranchRevision must NOT be the parent's current tip"
+    );
+}
+
+/// When the branch was created at main's current HEAD (no advance), the stored
+/// revision is both the merge-base and the tip — function should still succeed.
+#[test]
+fn test_branch_track_at_current_tip_stores_tip_as_merge_base() {
+    let repo = TestRepo::new();
+
+    let main_tip = repo.get_commit_sha("HEAD");
+
+    // Create a feature branch right at main's current HEAD
+    repo.git(&["checkout", "-b", "fresh-feature"]);
+    repo.create_file("feature.txt", "content");
+    repo.commit("Feature commit");
+
+    repo.run_stax(&["set-trunk", "main"]);
+    repo.git(&["checkout", "fresh-feature"]);
+
+    let output = repo.run_stax(&["branch", "track", "--parent", "main"]);
+    output.assert_success();
+
+    let stored_rev = read_parent_revision(&repo, "fresh-feature");
+    let expected = get_merge_base(&repo, "main", "fresh-feature");
+
+    assert_eq!(stored_rev, expected);
+    // In this case merge-base == tip since feature was created right at tip
+    assert_eq!(stored_rev, main_tip);
+}
+
+// =============================================================================
+// End-to-end: track + restack with a diverged main
+// =============================================================================
+
+/// Full round-trip: branch off old main → advance main → `stax branch track` →
+/// `stax restack`. Must succeed without conflict because the stored revision is
+/// the correct merge-base, so `git rebase --onto` replays only the feature commits.
+#[test]
+fn test_track_then_restack_with_diverged_main_succeeds() {
+    let repo = TestRepo::new();
+
+    // Create feature at current main (divergence point)
+    repo.git(&["checkout", "-b", "long-feature"]);
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit 1");
+    repo.create_file("feature2.txt", "more feature content");
+    repo.commit("Feature commit 2");
+
+    // Advance main with unrelated changes (no file overlap → no conflict)
+    repo.git(&["checkout", "main"]);
+    repo.create_file("unrelated-a.txt", "unrelated");
+    repo.commit("Main unrelated A");
+    repo.create_file("unrelated-b.txt", "unrelated too");
+    repo.commit("Main unrelated B");
+
+    // Initialize stax and track
+    repo.run_stax(&["set-trunk", "main"]);
+    repo.git(&["checkout", "long-feature"]);
+
+    let track_out = repo.run_stax(&["branch", "track", "--parent", "main"]);
+    track_out.assert_success();
+
+    // Verify stored revision is merge-base
+    let stored_rev = read_parent_revision(&repo, "long-feature");
+    let merge_base = get_merge_base(&repo, "main", "long-feature");
+    assert_eq!(
+        stored_rev, merge_base,
+        "track must store merge-base before restack"
+    );
+
+    // Restack — must succeed because feature doesn't conflict with main's advances
+    let restack_out = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    restack_out.assert_success();
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "No rebase should be in progress after clean restack"
+    );
+
+    // The stored revision should now equal main's current HEAD
+    let stored_after = read_parent_revision(&repo, "long-feature");
+    let main_head = repo.get_commit_sha("main");
+    assert_eq!(
+        stored_after, main_head,
+        "After successful restack, parentBranchRevision should be updated to new parent HEAD"
+    );
+}


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Branch tracking now records the actual divergence point instead of the parent branch tip, and restacks use that stored provenance consistently. This avoids replaying unrelated commits and reduces spurious conflicts when the parent has moved on or history has drifted.

## Description of changes / notes for reviewers

- `stax branch track` now stores the merge-base between the branch and its parent as `parentBranchRevision`.
- Restack now always uses the stored upstream with `git rebase --onto` when provenance is available, and the new tests cover correct tracking, drifted metadata, and real conflict behavior.