### PR TITLE
Add GPT-5.5 model defaults

### DIFF
--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -23,7 +23,7 @@ OpenCode loads skills from `~/.config/opencode/skills/<name>/SKILL.md`.
 st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent opencode
-st generate --pr-body --agent opencode --model opencode/gpt-5.1-codex
+st generate --pr-body --agent opencode --model opencode/gpt-5.5-fast
 ```
 
 ## Related

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -90,7 +90,7 @@ Supported `--agent` values: `claude`, `codex`, `gemini`, `opencode`.
 
 ```bash
 st lane api-tests   --agent gemini
-st lane api-tests   --agent opencode --model opencode/gpt-5.1-codex
+st lane api-tests   --agent opencode --model opencode/gpt-5.5-fast
 st lane review-pass --agent codex "address the open PR comments"
 ```
 

--- a/skills.md
+++ b/skills.md
@@ -323,7 +323,7 @@ stax generate --pr-body --agent codex --model gpt-5
 stax lane                                         # Interactive lane picker (create or resume)
 stax lane add-dark-mode "Add dark mode"           # Start a named lane with a prompt
 stax lane add-dark-mode --agent codex             # Start a lane with a specific agent
-stax lane add-dark-mode --agent codex --model gpt-5.4  # Override model too
+stax lane add-dark-mode --agent codex --model gpt-5.5-fast  # Override model too
 stax lane add-dark-mode                           # Re-enter the lane (reattaches tmux session)
 stax lane add-dark-mode "new prompt" --no-tmux    # Force direct terminal (no tmux)
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -924,7 +924,16 @@ mod tests {
     #[test]
     fn known_models_include_opencode_defaults() {
         let models = known_models_for("opencode");
+        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.5"));
+        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.5-fast"));
         assert!(models.iter().any(|m| m.id == "opencode/gpt-5.1-codex"));
+    }
+
+    #[test]
+    fn known_models_include_codex_gpt_5_5_defaults() {
+        let models = known_models_for("codex");
+        assert!(models.iter().any(|m| m.id == "gpt-5.5"));
+        assert!(models.iter().any(|m| m.id == "gpt-5.5-fast"));
     }
 
     #[test]
@@ -1004,8 +1013,19 @@ mod tests {
 
     #[test]
     fn known_agent_for_model_recognizes_newer_codex_family_models() {
+        assert_eq!(known_agent_for_model("gpt-5.5"), Some("codex"));
+        assert_eq!(known_agent_for_model("gpt-5.5-fast"), Some("codex"));
         assert_eq!(known_agent_for_model("gpt-5.4"), Some("codex"));
         assert_eq!(known_agent_for_model("gpt-5.4-pro"), Some("codex"));
+    }
+
+    #[test]
+    fn known_agent_for_model_recognizes_opencode_gpt_5_5_models() {
+        assert_eq!(known_agent_for_model("opencode/gpt-5.5"), Some("opencode"));
+        assert_eq!(
+            known_agent_for_model("opencode/gpt-5.5-fast"),
+            Some("opencode")
+        );
     }
 
     #[test]

--- a/src/commands/models.json
+++ b/src/commands/models.json
@@ -6,6 +6,8 @@
     { "id": "claude-sonnet-4-5-20250929",  "description": "Sonnet 4.5 · previous gen" }
   ],
   "codex": [
+    { "id": "gpt-5.5",       "description": "GPT-5.5 · latest · balanced" },
+    { "id": "gpt-5.5-fast",  "description": "GPT-5.5 Fast · fast · balanced" },
     { "id": "gpt-5.4",       "description": "GPT-5.4 · latest · balanced" },
     { "id": "gpt-5.4-pro",   "description": "GPT-5.4 Pro · most capable · premium" },
     { "id": "gpt-5.4-mini",  "description": "GPT-5.4 Mini · fast · balanced" },
@@ -18,6 +20,8 @@
     { "id": "gemini-2.5-flash-lite", "description": "Gemini 2.5 Flash-Lite · fastest · cheapest" }
   ],
   "opencode": [
+    { "id": "opencode/gpt-5.5",      "description": "GPT-5.5 via OpenCode" },
+    { "id": "opencode/gpt-5.5-fast", "description": "GPT-5.5 Fast via OpenCode" },
     { "id": "opencode/gpt-5.1-codex", "description": "GPT-5.1 Codex via OpenCode" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add GPT-5.5 and GPT-5.5 Fast as known Codex model defaults.
- Add OpenCode-prefixed GPT-5.5 model defaults and update user-facing examples.

## Validation
- `rtk cargo test known_models_include`
- `rtk cargo test known_agent_for_model`
- `rtk cargo check`

## Documentation
- Updated OpenCode and agent worktree examples plus `skills.md` to reference GPT-5.5 Fast.