### PR TITLE
feat: support repo-local config

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ st config --set-ai         # pick AI agent + model
 st config --reset-ai       # clear saved AI pairing and re-prompt
 ```
 
-Config lives at `~/.config/stax/config.toml`:
+Config lives at `~/.config/stax/config.toml`. A repo-local `.config/stax/config.toml`
+is used when present, and `STAX_CONFIG_DIR` overrides both:
 
 ```toml
 [submit]

--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ st config --set-ai         # pick AI agent + model
 st config --reset-ai       # clear saved AI pairing and re-prompt
 ```
 
-Config lives at `~/.config/stax/config.toml`. A repo-root `stax.toml`
-overrides only the values it sets, and `STAX_CONFIG_DIR` overrides both:
+Config lives at `~/.config/stax/config.toml`. When `STAX_CONFIG_DIR` is unset,
+a repo-root `stax.toml` overlays only the values it sets:
 
 ```toml
 [submit]

--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ st config --set-ai         # pick AI agent + model
 st config --reset-ai       # clear saved AI pairing and re-prompt
 ```
 
-Config lives at `~/.config/stax/config.toml`. A repo-local `.config/stax/config.toml`
-is used when present, and `STAX_CONFIG_DIR` overrides both:
+Config lives at `~/.config/stax/config.toml`. A repo-root `stax.toml`
+overrides only the values it sets, and `STAX_CONFIG_DIR` overrides both:
 
 ```toml
 [submit]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -7,7 +7,11 @@ st config --reset-ai          # clear saved AI defaults and re-prompt
 st config --reset-ai --no-prompt
 ```
 
-Main config path: `~/.config/stax/config.toml`.
+Config is resolved in this order:
+
+1. `STAX_CONFIG_DIR/config.toml` when `STAX_CONFIG_DIR` is set.
+2. `.config/stax/config.toml` at the current git repository root when it exists.
+3. `~/.config/stax/config.toml`.
 
 ## Example config
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -10,8 +10,8 @@ st config --reset-ai --no-prompt
 Config is resolved in this order:
 
 1. `STAX_CONFIG_DIR/config.toml` when `STAX_CONFIG_DIR` is set.
-2. `.config/stax/config.toml` at the current git repository root when it exists.
-3. `~/.config/stax/config.toml`.
+2. `~/.config/stax/config.toml`.
+3. `stax.toml` at the current git repository root overlays only the values it sets.
 
 ## Example config
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -7,11 +7,11 @@ st config --reset-ai          # clear saved AI defaults and re-prompt
 st config --reset-ai --no-prompt
 ```
 
-Config is resolved in this order:
+Config is loaded as follows:
 
 1. `STAX_CONFIG_DIR/config.toml` when `STAX_CONFIG_DIR` is set.
-2. `~/.config/stax/config.toml`.
-3. `stax.toml` at the current git repository root overlays only the values it sets.
+2. Otherwise, `~/.config/stax/config.toml` is loaded.
+3. If present, `stax.toml` at the current git repository root overlays only the values it sets.
 
 ## Example config
 

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -177,7 +177,7 @@ By default, managed worktrees live outside the repository at:
 ~/.stax/worktrees/<repo>
 ```
 
-Override in `~/.config/stax/config.toml`:
+Override in `~/.config/stax/config.toml`, or in a repo-local `.config/stax/config.toml`:
 
 ```toml
 [worktree]

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -184,7 +184,7 @@ By default, managed worktrees live outside the repository at:
 ~/.stax/worktrees/<repo>
 ```
 
-Override in `~/.config/stax/config.toml`, or in a repo-local `.config/stax/config.toml`:
+Override in `~/.config/stax/config.toml`, or set shared project overrides in repo-root `stax.toml`:
 
 ```toml
 [worktree]

--- a/skills.md
+++ b/skills.md
@@ -191,7 +191,7 @@ stax submit --ai --body            # Generate/update PR body only
 stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
 
-# ~/.config/stax/config.toml
+# ~/.config/stax/config.toml or repo-local .config/stax/config.toml
 [submit]
 stack_links = "body"               # "comment" | "body" | "both" | "off"
 

--- a/skills.md
+++ b/skills.md
@@ -191,7 +191,7 @@ stax submit --ai --body            # Generate/update PR body only
 stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
 
-# ~/.config/stax/config.toml, with repo-root stax.toml for shared overrides
+# ~/.config/stax/config.toml; repo-root stax.toml overlays shared values
 [submit]
 stack_links = "body"               # "comment" | "body" | "both" | "off"
 

--- a/skills.md
+++ b/skills.md
@@ -191,7 +191,7 @@ stax submit --ai --body            # Generate/update PR body only
 stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
 
-# ~/.config/stax/config.toml or repo-local .config/stax/config.toml
+# ~/.config/stax/config.toml, with repo-root stax.toml for shared overrides
 [submit]
 stack_links = "body"               # "comment" | "body" | "both" | "off"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::remote::ForgeType;
@@ -382,7 +382,24 @@ impl Config {
 
     /// Get the config file path
     pub fn path() -> Result<PathBuf> {
+        if std::env::var("STAX_CONFIG_DIR").is_err() {
+            if let Some(path) = Self::repo_local_path()? {
+                return Ok(path);
+            }
+        }
+
         Ok(Self::dir()?.join("config.toml"))
+    }
+
+    /// Get the repo-local config file path when the current directory is inside
+    /// a git repository and `.config/stax/config.toml` exists at its root.
+    fn repo_local_path() -> Result<Option<PathBuf>> {
+        let Some(root) = git_root()? else {
+            return Ok(None);
+        };
+
+        let path = root.join(".config").join("stax").join("config.toml");
+        Ok(path.exists().then_some(path))
     }
 
     /// Get the credentials file path (separate from config, not for dotfiles)
@@ -782,6 +799,26 @@ impl Config {
     pub fn remote_forge_override(&self) -> Option<ForgeType> {
         self.remote.forge
     }
+}
+
+fn git_root() -> Result<Option<PathBuf>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output();
+
+    let Ok(output) = output else {
+        return Ok(None);
+    };
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let root = String::from_utf8(output.stdout)?.trim().to_string();
+    if root.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(Path::new(&root).to_path_buf()))
 }
 
 #[cfg(test)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -845,23 +845,9 @@ impl Config {
 }
 
 fn git_root() -> Result<Option<PathBuf>> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output();
-
-    let Ok(output) = output else {
-        return Ok(None);
-    };
-    if !output.status.success() {
-        return Ok(None);
-    }
-
-    let root = String::from_utf8(output.stdout)?.trim().to_string();
-    if root.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(Path::new(&root).to_path_buf()))
+    Ok(git2::Repository::discover(".")
+        .ok()
+        .and_then(|repo| repo.workdir().map(PathBuf::from)))
 }
 
 fn merge_toml_values(base: &mut toml::Value, overlay: toml::Value) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -408,23 +408,17 @@ impl Config {
 
     /// Get the config file path
     pub fn path() -> Result<PathBuf> {
-        if std::env::var("STAX_CONFIG_DIR").is_err() {
-            if let Some(path) = Self::repo_local_path()? {
-                return Ok(path);
-            }
-        }
-
         Ok(Self::dir()?.join("config.toml"))
     }
 
     /// Get the repo-local config file path when the current directory is inside
-    /// a git repository and `.config/stax/config.toml` exists at its root.
+    /// a git repository and `stax.toml` exists at its root.
     fn repo_local_path() -> Result<Option<PathBuf>> {
         let Some(root) = git_root()? else {
             return Ok(None);
         };
 
-        let path = root.join(".config").join("stax").join("config.toml");
+        let path = root.join("stax.toml");
         Ok(path.exists().then_some(path))
     }
 
@@ -447,13 +441,36 @@ impl Config {
     /// Load config from file
     pub fn load() -> Result<Self> {
         let path = Self::path()?;
+        if std::env::var("STAX_CONFIG_DIR").is_ok() {
+            return Self::load_path_or_default(&path);
+        }
+
+        let config = Self::load_path_or_default(&path)?;
+        if let Some(repo_path) = Self::repo_local_path()? {
+            Self::load_with_overlay(config, &repo_path)
+        } else {
+            Ok(config)
+        }
+    }
+
+    fn load_path_or_default(path: &Path) -> Result<Self> {
         if path.exists() {
-            let content = fs::read_to_string(&path)?;
+            let content = fs::read_to_string(path)?;
             let config: Config = toml::from_str(&content)?;
             Ok(config)
         } else {
             Ok(Config::default())
         }
+    }
+
+    fn load_with_overlay(config: Config, repo_path: &Path) -> Result<Self> {
+        let mut base = toml::Value::try_from(config)?;
+        let repo_content = fs::read_to_string(repo_path)
+            .with_context(|| format!("Failed to read repo config {}", repo_path.display()))?;
+        let repo_overlay: toml::Value = toml::from_str(&repo_content)
+            .with_context(|| format!("Failed to parse repo config {}", repo_path.display()))?;
+        merge_toml_values(&mut base, repo_overlay);
+        Ok(base.try_into()?)
     }
 
     /// Save config to file
@@ -845,6 +862,24 @@ fn git_root() -> Result<Option<PathBuf>> {
     }
 
     Ok(Some(Path::new(&root).to_path_buf()))
+}
+
+fn merge_toml_values(base: &mut toml::Value, overlay: toml::Value) {
+    match (base, overlay) {
+        (toml::Value::Table(base_table), toml::Value::Table(overlay_table)) => {
+            for (key, value) in overlay_table {
+                match base_table.get_mut(&key) {
+                    Some(base_value) => merge_toml_values(base_value, value),
+                    None => {
+                        base_table.insert(key, value);
+                    }
+                }
+            }
+        }
+        (base_value, overlay_value) => {
+            *base_value = overlay_value;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -29,6 +29,13 @@ fn write_auth_config(
     fs::write(config_dir.join("config.toml"), contents).unwrap();
 }
 
+fn restore_env_var(name: &str, value: Option<String>) {
+    match value {
+        Some(value) => env::set_var(name, value),
+        None => env::remove_var(name),
+    }
+}
+
 #[cfg(unix)]
 fn write_mock_gh(home: &Path, script_body: &str) -> String {
     use std::os::unix::fs::PermissionsExt;
@@ -45,6 +52,115 @@ fn write_mock_gh(home: &Path, script_body: &str) -> String {
 
     let original_path = env::var("PATH").unwrap_or_default();
     format!("{}:{}", bin_dir.display(), original_path)
+}
+
+#[test]
+fn config_path_prefers_repo_local_config_when_present() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir =
+        std::env::temp_dir().join(format!("stax-test-local-config-{}", std::process::id()));
+    let repo_dir = temp_dir.join("repo");
+    let config_dir = repo_dir.join(".config").join("stax");
+
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
+    fs::create_dir_all(temp_dir.join("home")).unwrap();
+
+    env::set_var("HOME", temp_dir.join("home"));
+    env::remove_var("STAX_CONFIG_DIR");
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&repo_dir).unwrap();
+
+    assert_eq!(
+        Config::path().unwrap().canonicalize().unwrap(),
+        config_dir.join("config.toml").canonicalize().unwrap()
+    );
+    assert!(!Config::load().unwrap().ui.tips);
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn config_path_uses_global_config_when_repo_local_config_is_absent() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir =
+        std::env::temp_dir().join(format!("stax-test-global-config-{}", std::process::id()));
+    let repo_dir = temp_dir.join("repo");
+    let home_dir = temp_dir.join("home");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&home_dir).unwrap();
+
+    env::set_var("HOME", &home_dir);
+    env::remove_var("STAX_CONFIG_DIR");
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&repo_dir).unwrap();
+
+    assert_eq!(
+        Config::path().unwrap(),
+        home_dir.join(".config").join("stax").join("config.toml")
+    );
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn config_path_env_override_wins_over_repo_local_config() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir =
+        std::env::temp_dir().join(format!("stax-test-env-config-{}", std::process::id()));
+    let repo_dir = temp_dir.join("repo");
+    let local_config_dir = repo_dir.join(".config").join("stax");
+    let override_config_dir = temp_dir.join("override-stax");
+
+    fs::create_dir_all(&local_config_dir).unwrap();
+    fs::create_dir_all(&override_config_dir).unwrap();
+    fs::write(local_config_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
+
+    env::set_var("HOME", temp_dir.join("home"));
+    env::set_var("STAX_CONFIG_DIR", &override_config_dir);
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&repo_dir).unwrap();
+
+    assert_eq!(
+        Config::path().unwrap(),
+        override_config_dir.join("config.toml")
+    );
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+    let _ = fs::remove_dir_all(&temp_dir);
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -111,6 +111,44 @@ fn config_load_overlays_repo_stax_toml_when_present() {
 }
 
 #[test]
+fn config_load_discovers_repo_stax_toml_from_nested_directory() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir = std::env::temp_dir().join(format!(
+        "stax-test-nested-local-config-{}",
+        std::process::id()
+    ));
+    let repo_dir = temp_dir.join("repo");
+    let nested_dir = repo_dir.join("src").join("nested");
+    let home_dir = temp_dir.join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
+
+    fs::create_dir_all(&nested_dir).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(global_config_dir.join("config.toml"), "[ui]\ntips = true\n").unwrap();
+    fs::write(repo_dir.join("stax.toml"), "[ui]\ntips = false\n").unwrap();
+
+    env::set_var("HOME", &home_dir);
+    env::remove_var("STAX_CONFIG_DIR");
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&nested_dir).unwrap();
+
+    assert!(!Config::load().unwrap().ui.tips);
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
 fn config_path_uses_global_config_when_repo_local_config_is_absent() {
     let _guard = env_lock();
 
@@ -255,7 +293,10 @@ fn config_save_writes_global_config_when_repo_stax_toml_exists() {
     config.ui.tips = false;
     config.save().unwrap();
 
-    assert!(global_config_path.exists());
+    let saved_global_config = fs::read_to_string(&global_config_path).unwrap();
+    let saved_config: Config = toml::from_str(&saved_global_config).unwrap();
+    assert!(!saved_config.ui.tips);
+    assert!(saved_global_config.contains("tips = false"));
     assert_eq!(
         fs::read_to_string(repo_dir.join("stax.toml")).unwrap(),
         "[ui]\ntips = false\n"

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -55,7 +55,7 @@ fn write_mock_gh(home: &Path, script_body: &str) -> String {
 }
 
 #[test]
-fn config_path_prefers_repo_local_config_when_present() {
+fn config_load_overlays_repo_stax_toml_when_present() {
     let _guard = env_lock();
 
     let original_home = env::var("HOME").ok();
@@ -64,13 +64,23 @@ fn config_path_prefers_repo_local_config_when_present() {
     let temp_dir =
         std::env::temp_dir().join(format!("stax-test-local-config-{}", std::process::id()));
     let repo_dir = temp_dir.join("repo");
-    let config_dir = repo_dir.join(".config").join("stax");
+    let home_dir = temp_dir.join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
 
-    fs::create_dir_all(&config_dir).unwrap();
-    fs::write(config_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
-    fs::create_dir_all(temp_dir.join("home")).unwrap();
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        "[ui]\ntips = true\n[branch]\nformat = \"{user}/{message}\"\nreplacement = \"_\"\n[worktree.hooks]\npost_start = \"global-start\"\npost_go = \"global-go\"\n",
+    )
+    .unwrap();
+    fs::write(
+        repo_dir.join("stax.toml"),
+        "[ui]\ntips = false\n[worktree.hooks]\npost_go = \"repo-go\"\n",
+    )
+    .unwrap();
 
-    env::set_var("HOME", temp_dir.join("home"));
+    env::set_var("HOME", &home_dir);
     env::remove_var("STAX_CONFIG_DIR");
     Command::new("git")
         .arg("init")
@@ -80,10 +90,19 @@ fn config_path_prefers_repo_local_config_when_present() {
     env::set_current_dir(&repo_dir).unwrap();
 
     assert_eq!(
-        Config::path().unwrap().canonicalize().unwrap(),
-        config_dir.join("config.toml").canonicalize().unwrap()
+        Config::path().unwrap(),
+        global_config_dir.join("config.toml")
     );
-    assert!(!Config::load().unwrap().ui.tips);
+
+    let config = Config::load().unwrap();
+    assert!(!config.ui.tips);
+    assert_eq!(config.branch.format.as_deref(), Some("{user}/{message}"));
+    assert_eq!(config.branch.replacement, "_");
+    assert_eq!(
+        config.worktree.hooks.post_start.as_deref(),
+        Some("global-start")
+    );
+    assert_eq!(config.worktree.hooks.post_go.as_deref(), Some("repo-go"));
 
     env::set_current_dir(original_dir).unwrap();
     restore_env_var("HOME", original_home);
@@ -142,6 +161,12 @@ fn config_path_env_override_wins_over_repo_local_config() {
     fs::create_dir_all(&local_config_dir).unwrap();
     fs::create_dir_all(&override_config_dir).unwrap();
     fs::write(local_config_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
+    fs::write(repo_dir.join("stax.toml"), "[ui]\ntips = false\n").unwrap();
+    fs::write(
+        override_config_dir.join("config.toml"),
+        "[ui]\ntips = true\n",
+    )
+    .unwrap();
 
     env::set_var("HOME", temp_dir.join("home"));
     env::set_var("STAX_CONFIG_DIR", &override_config_dir);
@@ -155,6 +180,85 @@ fn config_path_env_override_wins_over_repo_local_config() {
     assert_eq!(
         Config::path().unwrap(),
         override_config_dir.join("config.toml")
+    );
+    assert!(Config::load().unwrap().ui.tips);
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn config_load_ignores_old_repo_dot_config_path() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir =
+        std::env::temp_dir().join(format!("stax-test-old-local-config-{}", std::process::id()));
+    let repo_dir = temp_dir.join("repo");
+    let old_config_dir = repo_dir.join(".config").join("stax");
+    let home_dir = temp_dir.join("home");
+
+    fs::create_dir_all(&old_config_dir).unwrap();
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::write(old_config_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
+
+    env::set_var("HOME", &home_dir);
+    env::remove_var("STAX_CONFIG_DIR");
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&repo_dir).unwrap();
+
+    assert!(Config::load().unwrap().ui.tips);
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn config_save_writes_global_config_when_repo_stax_toml_exists() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir = std::env::temp_dir().join(format!(
+        "stax-test-save-global-config-{}",
+        std::process::id()
+    ));
+    let repo_dir = temp_dir.join("repo");
+    let home_dir = temp_dir.join("home");
+    let global_config_path = home_dir.join(".config").join("stax").join("config.toml");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&home_dir).unwrap();
+    fs::write(repo_dir.join("stax.toml"), "[ui]\ntips = false\n").unwrap();
+
+    env::set_var("HOME", &home_dir);
+    env::remove_var("STAX_CONFIG_DIR");
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&repo_dir).unwrap();
+
+    let mut config = Config::default();
+    config.ui.tips = false;
+    config.save().unwrap();
+
+    assert!(global_config_path.exists());
+    assert_eq!(
+        fs::read_to_string(repo_dir.join("stax.toml")).unwrap(),
+        "[ui]\ntips = false\n"
     );
 
     env::set_current_dir(original_dir).unwrap();


### PR DESCRIPTION
## Summary
- resolve .config/stax/config.toml from the current git repository root when present
- keep STAX_CONFIG_DIR as the highest-priority override and global config as fallback
- document config precedence and repo-local worktree hook usage

## Tests
- env PKG_CONFIG_PATH=/opt/homebrew/opt/libgit2/lib/pkgconfig rtk cargo test config::tests::config_path -- --nocapture
- env PKG_CONFIG_PATH=/opt/homebrew/opt/libgit2/lib/pkgconfig rtk make test
