### PR TITLE
Fix worktree create for remote branches

### DIFF
--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -9,7 +9,7 @@ For the full `st worktree` / `st wt` command surface and cleanup semantics, see 
 `st lane <name> [prompt]`:
 
 1. Finds or creates a named worktree lane
-2. Resolves the branch for that lane (creates one if needed, writes stax metadata for new managed branches)
+2. Resolves the branch for that lane (opens an existing local/fetched remote branch, or creates one if needed and writes stax metadata for new managed branches)
 3. Launches your configured AI agent inside it
 4. Prefers tmux when available so you can resume later
 

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -19,6 +19,9 @@ st wt c
 # Create or reuse a named lane
 st wt c payments-api
 
+# Check out a fetched remote branch into a worktree
+st wt c origin/payments-api
+
 # Start a new lane from an explicit base
 st wt c payments-api --from main
 
@@ -46,6 +49,7 @@ st wt rs
 - no `name` → random two-word lane slug
 - `name` matches an existing worktree → reuse it
 - `name` matches an existing branch → create a worktree for that branch
+- `name` matches a fetched branch on the configured remote → create a local tracking branch and worktree
 - otherwise → create a new branch and a new worktree
 
 `st wt go [name]` only opens existing worktrees. With no `name`, it opens a picker.
@@ -55,10 +59,12 @@ Selectors accepted by `go`, `path`, `rm`, and reuse paths in `create`:
 - worktree name
 - full branch name
 - unique branch suffix (e.g. `payments-api` matching `cesar/payments-api`)
+- fetched remote branch name or configured-remote-qualified name (e.g. `payments-api` or `origin/payments-api`)
 - absolute worktree path
 
 ### Base branch rules for new lanes
 
+- fetched remote branches keep their remote tip and upstream tracking branch
 - `--from <branch>` explicitly sets the base
 - otherwise if the current branch is tracked by stax → new lane stacks on current
 - otherwise → new lane starts from trunk
@@ -103,6 +109,7 @@ If you run `create` / `go` without shell integration and without a launcher, sta
 
 - new branches created by `st wt c foo` → **managed**
 - existing tracked branches opened as lanes → stay **managed**
+- fetched remote branches opened as local tracking branches → **unmanaged** until `st branch track`
 - existing plain Git branches opened as worktrees → **unmanaged** until `st branch track`
 
 Managed lanes behave like first-class stax branches: they show in `st ls`, participate in restack/sync/undo, and are targeted by `st wt restack`. Unmanaged lanes still show up in `ls`, `ll`, `go`, `rm`, and `prune`, but stax keeps history-rewriting operations conservative.

--- a/skills.md
+++ b/skills.md
@@ -87,7 +87,7 @@ stax lane [name] [prompt]      # Open interactive lane picker, or start/resume n
 stax absorb                    # Absorb staged changes into correct stack branches
 stax edit|e                    # Interactively edit commits (reword, squash, fixup, drop)
 
-stax worktree create [branch]  # Create a worktree for an existing or new branch
+stax worktree create [branch]  # Create a worktree for an existing local/fetched remote/new branch
 stax worktree list             # List all worktrees (* = current)
 stax worktree ll               # Richer worktree status (managed/prunable/conflict state)
 stax worktree go <name>        # Navigate to a worktree (requires shell integration)
@@ -106,7 +106,7 @@ stax setup --print             # Print shell integration snippet for manual inst
 # Worktree shortcuts
 stax wt                        # Open worktree dashboard (TTY) or print worktree help
 stax w                         # List worktrees
-stax wtc [branch]              # Create worktree
+stax wtc [branch]              # Create worktree (local branch, fetched remote branch, or new branch)
 stax wtls                      # List worktrees
 stax wtll                      # Long worktree list
 stax wtgo <name>               # Navigate to worktree path
@@ -440,8 +440,11 @@ stax setup
 stax setup --yes               # Shell integration + skills + auth import from gh when available
 stax setup --install-skills    # Non-interactive onboarding: shell integration + AI agent skills
 
-# Create a worktree for an existing branch
+# Create a worktree for an existing local branch
 stax worktree create feature/payments-api
+
+# Create a local tracking branch and worktree from a fetched remote branch
+stax worktree create origin/feature/payments-api
 
 # List all worktrees
 stax w
@@ -520,7 +523,7 @@ Symbols:
 6. Check stack shape (`stax ls` / `stax ll`) before submit or merge.
 7. Use `stax lane <name> [prompt]` to give each AI agent its own isolated worktree — prevents agents from conflicting on the same files.
 8. After trunk moves, run `stax wt rs` once instead of rebasing each agent worktree manually.
-9. Use `stax worktree create` when you want a worktree for an existing branch or for human parallel development — `st lane` is the higher-level AI shortcut.
+9. Use `stax worktree create` when you want a worktree for an existing local branch, fetched remote branch, or human parallel development — `st lane` is the higher-level AI shortcut.
 10. Run `stax setup` once per machine to enable `stax worktree go` and the `sw` alias without executing `stax` on every shell startup.
 
 ## Tips

--- a/src/commands/worktree/ai.rs
+++ b/src/commands/worktree/ai.rs
@@ -1,14 +1,13 @@
 use super::shared::{
     build_agent_launch_spec_with_options, build_tmux_launch_spec, compute_worktree_details,
-    default_create_base, default_tmux_session_name, derive_unique_worktree_name,
-    emit_shell_message, emit_shell_payload, ensure_gitignore, ensure_managed_worktrees_root,
-    find_worktree, format_create_message, format_go_message, list_tmux_sessions,
-    managed_worktrees_dir, resolve_branch_name, run_blocking_hook, spawn_background_hook,
-    status_labels, ExistingTmuxSessionBehavior, LaunchSpec, TmuxSession,
+    create_worktree_for_resolved_branch, default_create_base, default_tmux_session_name,
+    derive_unique_worktree_name, emit_shell_message, emit_shell_payload, ensure_gitignore,
+    ensure_managed_worktrees_root, find_worktree, format_create_message, format_go_message,
+    list_tmux_sessions, managed_worktrees_dir, resolve_branch_name, run_blocking_hook,
+    spawn_background_hook, status_labels, ExistingTmuxSessionBehavior, LaunchSpec, TmuxSession,
 };
 use crate::commands::generate;
 use crate::config::Config;
-use crate::engine::BranchMetadata;
 use crate::git::repo::WorktreeInfo;
 use crate::git::GitRepo;
 use anyhow::{bail, Context, Result};
@@ -106,18 +105,19 @@ fn run_named_lane(
         return run_existing_lane(config, &worktree, no_verify, shell_output, request);
     }
 
-    let (branch_name, branch_exists) = resolve_branch_name(repo, config, &input_name)?;
+    let resolved_branch = resolve_branch_name(repo, config, &input_name)?;
+    let branch_name = resolved_branch.name.clone();
     if let Some(worktree) = find_worktree(repo, &branch_name)? {
         return run_existing_lane(config, &worktree, no_verify, shell_output, request);
     }
 
-    let base_branch = if branch_exists {
-        None
-    } else {
+    let base_branch = if resolved_branch.needs_base_branch() {
         let base_branch = default_create_base(repo)?;
         repo.branch_commit(&base_branch)
             .with_context(|| format!("Base branch '{}' does not exist", base_branch))?;
         Some(base_branch)
+    } else {
+        None
     };
 
     let worktree_name = derive_unique_worktree_name(repo, &branch_name)?;
@@ -135,40 +135,26 @@ fn run_named_lane(
     ensure_managed_worktrees_root(repo, config, &worktrees_dir)?;
     let main_repo_workdir = repo.main_repo_workdir()?;
     ensure_gitignore(&main_repo_workdir, &config.worktree.root_dir)?;
-
-    if branch_exists {
-        repo.worktree_create(&branch_name, &worktree_path)?;
-    } else {
-        let from_branch = base_branch
-            .as_deref()
-            .expect("base branch is always set for a new lane");
-        repo.worktree_create_new_branch(&branch_name, &worktree_path, from_branch)?;
-        let parent_rev = repo.branch_commit(from_branch)?;
-        let meta = BranchMetadata::new(from_branch, &parent_rev);
-        meta.write(repo.inner(), &branch_name)?;
-    }
+    create_worktree_for_resolved_branch(
+        repo,
+        &resolved_branch,
+        &worktree_path,
+        base_branch.as_deref(),
+    )?;
 
     let copied_files = repo.tracked_file_count_at(&worktree_path).unwrap_or(0);
     let repo_name = main_repo_workdir
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "repo".to_string());
-    let from_label = if let Some(base_branch) = base_branch.as_deref() {
-        if repo.has_remote(base_branch) {
-            format!("origin/{}", base_branch)
-        } else {
-            base_branch.to_string()
-        }
-    } else {
-        branch_name.clone()
-    };
+    let from_label = resolved_branch.source_label(repo, base_branch.as_deref());
     format_create_message(
         &repo_name,
         &worktree_name,
         &branch_name,
         &from_label,
         copied_files,
-        branch_exists,
+        resolved_branch.is_existing(),
     );
 
     if !no_verify {

--- a/src/commands/worktree/create.rs
+++ b/src/commands/worktree/create.rs
@@ -1,12 +1,12 @@
 use super::shared::{
-    build_launch_spec, default_create_base, derive_unique_worktree_name, emit_shell_payload,
-    ensure_gitignore, ensure_managed_worktrees_root, find_worktree, format_create_message,
-    format_go_message, generate_random_lane_slug, managed_worktrees_dir, pick_branch_interactively,
+    build_launch_spec, create_worktree_for_resolved_branch, default_create_base,
+    derive_unique_worktree_name, emit_shell_payload, ensure_gitignore,
+    ensure_managed_worktrees_root, find_worktree, format_create_message, format_go_message,
+    generate_random_lane_slug, managed_worktrees_dir, pick_branch_interactively,
     resolve_branch_name, run_blocking_hook, spawn_background_hook, LaunchOptions,
 };
 use crate::commands::shell_setup;
 use crate::config::Config;
-use crate::engine::BranchMetadata;
 use crate::git::GitRepo;
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
@@ -86,7 +86,8 @@ pub fn run(
         (false, None) => generate_random_lane_slug(&repo, &config)?,
     };
 
-    let (branch_name, branch_exists) = resolve_branch_name(&repo, &config, &input_name)?;
+    let resolved_branch = resolve_branch_name(&repo, &config, &input_name)?;
+    let branch_name = resolved_branch.name.clone();
     if let Some(worktree) = find_worktree(&repo, &branch_name)? {
         let launch = build_launch_spec(&config, &launch_options, &worktree.name)?;
         format_go_message(&worktree);
@@ -118,13 +119,13 @@ pub fn run(
         return Ok(());
     }
 
-    let base_branch = if branch_exists {
-        None
-    } else {
+    let base_branch = if resolved_branch.needs_base_branch() {
         let base_branch = from.unwrap_or(default_create_base(&repo)?);
         repo.branch_commit(&base_branch)
             .with_context(|| format!("Base branch '{}' does not exist", base_branch))?;
         Some(base_branch)
+    } else {
+        None
     };
 
     let worktree_name = worktree_name.unwrap_or(derive_unique_worktree_name(&repo, &branch_name)?);
@@ -142,40 +143,26 @@ pub fn run(
     ensure_managed_worktrees_root(&repo, &config, &worktrees_dir)?;
     let main_repo_workdir = repo.main_repo_workdir()?;
     ensure_gitignore(&main_repo_workdir, &config.worktree.root_dir)?;
-
-    if branch_exists {
-        repo.worktree_create(&branch_name, &worktree_path)?;
-    } else {
-        let from_branch = base_branch
-            .as_deref()
-            .expect("base branch is always set for a new branch");
-        repo.worktree_create_new_branch(&branch_name, &worktree_path, from_branch)?;
-        let parent_rev = repo.branch_commit(from_branch)?;
-        let meta = BranchMetadata::new(from_branch, &parent_rev);
-        meta.write(repo.inner(), &branch_name)?;
-    }
+    create_worktree_for_resolved_branch(
+        &repo,
+        &resolved_branch,
+        &worktree_path,
+        base_branch.as_deref(),
+    )?;
 
     let copied_files = repo.tracked_file_count_at(&worktree_path).unwrap_or(0);
     let repo_name = main_repo_workdir
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "repo".to_string());
-    let from_label = if let Some(base_branch) = base_branch.as_deref() {
-        if repo.has_remote(base_branch) {
-            format!("origin/{}", base_branch)
-        } else {
-            base_branch.to_string()
-        }
-    } else {
-        branch_name.clone()
-    };
+    let from_label = resolved_branch.source_label(&repo, base_branch.as_deref());
     format_create_message(
         &repo_name,
         &worktree_name,
         &branch_name,
         &from_label,
         copied_files,
-        branch_exists,
+        resolved_branch.is_existing(),
     );
 
     if !no_verify {

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -464,11 +464,59 @@ pub fn worktree_matches(worktree: &WorktreeInfo, name: &str) -> bool {
             .unwrap_or(false)
 }
 
-pub fn resolve_branch_name(repo: &GitRepo, config: &Config, input: &str) -> Result<(String, bool)> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedBranchSource {
+    Local,
+    Remote { remote_ref: String },
+    New,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBranchName {
+    pub name: String,
+    pub source: ResolvedBranchSource,
+}
+
+impl ResolvedBranchName {
+    pub fn is_existing(&self) -> bool {
+        matches!(
+            self.source,
+            ResolvedBranchSource::Local | ResolvedBranchSource::Remote { .. }
+        )
+    }
+
+    pub fn needs_base_branch(&self) -> bool {
+        matches!(self.source, ResolvedBranchSource::New)
+    }
+
+    pub fn source_label(&self, repo: &GitRepo, base_branch: Option<&str>) -> String {
+        if let Some(base_branch) = base_branch {
+            return if repo.has_remote(base_branch) {
+                format!("origin/{}", base_branch)
+            } else {
+                base_branch.to_string()
+            };
+        }
+
+        match &self.source {
+            ResolvedBranchSource::Remote { remote_ref } => remote_ref.clone(),
+            ResolvedBranchSource::Local | ResolvedBranchSource::New => self.name.clone(),
+        }
+    }
+}
+
+pub fn resolve_branch_name(
+    repo: &GitRepo,
+    config: &Config,
+    input: &str,
+) -> Result<ResolvedBranchName> {
     let branches = repo.list_branches()?;
 
     if let Some(branch) = branches.iter().find(|branch| branch.as_str() == input) {
-        return Ok((branch.clone(), true));
+        return Ok(ResolvedBranchName {
+            name: branch.clone(),
+            source: ResolvedBranchSource::Local,
+        });
     }
 
     let suffix_matches: Vec<String> = branches
@@ -476,9 +524,6 @@ pub fn resolve_branch_name(repo: &GitRepo, config: &Config, input: &str) -> Resu
         .filter(|branch| branch.ends_with(&format!("/{}", input)))
         .cloned()
         .collect();
-    if suffix_matches.len() == 1 {
-        return Ok((suffix_matches[0].clone(), true));
-    }
     if suffix_matches.len() > 1 {
         bail!(
             "Multiple branches match '{}': {}",
@@ -486,10 +531,134 @@ pub fn resolve_branch_name(repo: &GitRepo, config: &Config, input: &str) -> Resu
             suffix_matches.join(", ")
         );
     }
+    if suffix_matches.len() == 1 {
+        return Ok(ResolvedBranchName {
+            name: suffix_matches[0].clone(),
+            source: ResolvedBranchSource::Local,
+        });
+    }
+
+    let remote_name = config.remote_name();
+    let remote_prefix = format!("{}/", remote_name);
+    let mut remote_branches: Vec<String> = repo
+        .remote_branch_names(remote_name)?
+        .into_iter()
+        .filter(|branch| branch != "HEAD")
+        .collect();
+    remote_branches.sort();
+
+    if let Some(remote_branch) = input.strip_prefix(&remote_prefix) {
+        if remote_branch.is_empty() {
+            bail!("Remote branch name cannot be empty.");
+        }
+
+        if branches.iter().any(|branch| branch == remote_branch) {
+            return Ok(ResolvedBranchName {
+                name: remote_branch.to_string(),
+                source: ResolvedBranchSource::Local,
+            });
+        }
+
+        if remote_branches
+            .iter()
+            .any(|branch| branch.as_str() == remote_branch)
+        {
+            return Ok(ResolvedBranchName {
+                name: remote_branch.to_string(),
+                source: ResolvedBranchSource::Remote {
+                    remote_ref: input.to_string(),
+                },
+            });
+        }
+
+        bail!("Remote branch '{}' not found.", input);
+    }
+
+    if remote_branches
+        .iter()
+        .any(|branch| branch.as_str() == input)
+    {
+        return Ok(ResolvedBranchName {
+            name: input.to_string(),
+            source: ResolvedBranchSource::Remote {
+                remote_ref: format!("{}{}", remote_prefix, input),
+            },
+        });
+    }
+
+    let remote_suffix_matches: Vec<String> = remote_branches
+        .iter()
+        .filter(|branch| branch.ends_with(&format!("/{}", input)))
+        .cloned()
+        .collect();
+    if remote_suffix_matches.len() == 1 {
+        let branch = remote_suffix_matches[0].clone();
+        return Ok(ResolvedBranchName {
+            name: branch.clone(),
+            source: ResolvedBranchSource::Remote {
+                remote_ref: format!("{}{}", remote_prefix, branch),
+            },
+        });
+    }
+    if remote_suffix_matches.len() > 1 {
+        let matches = remote_suffix_matches
+            .iter()
+            .map(|branch| format!("{}{}", remote_prefix, branch))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!("Multiple remote branches match '{}': {}", input, matches);
+    }
 
     let formatted = config.format_branch_name(input);
     let exists = branches.iter().any(|branch| branch == &formatted);
-    Ok((formatted, exists))
+    if exists {
+        return Ok(ResolvedBranchName {
+            name: formatted,
+            source: ResolvedBranchSource::Local,
+        });
+    }
+
+    if remote_branches
+        .iter()
+        .any(|branch| branch.as_str() == formatted)
+    {
+        return Ok(ResolvedBranchName {
+            name: formatted.clone(),
+            source: ResolvedBranchSource::Remote {
+                remote_ref: format!("{}{}", remote_prefix, formatted),
+            },
+        });
+    }
+
+    Ok(ResolvedBranchName {
+        name: formatted,
+        source: ResolvedBranchSource::New,
+    })
+}
+
+pub fn create_worktree_for_resolved_branch(
+    repo: &GitRepo,
+    resolved_branch: &ResolvedBranchName,
+    worktree_path: &Path,
+    base_branch: Option<&str>,
+) -> Result<()> {
+    match &resolved_branch.source {
+        ResolvedBranchSource::Local => {
+            repo.worktree_create(&resolved_branch.name, worktree_path)?;
+        }
+        ResolvedBranchSource::Remote { remote_ref } => {
+            repo.worktree_create_tracking_branch(&resolved_branch.name, worktree_path, remote_ref)?;
+        }
+        ResolvedBranchSource::New => {
+            let from_branch = base_branch.context("Base branch is required for a new branch")?;
+            repo.worktree_create_new_branch(&resolved_branch.name, worktree_path, from_branch)?;
+            let parent_rev = repo.branch_commit(from_branch)?;
+            let meta = BranchMetadata::new(from_branch, &parent_rev);
+            meta.write(repo.inner(), &resolved_branch.name)?;
+        }
+    }
+
+    Ok(())
 }
 
 pub fn derive_unique_worktree_name(repo: &GitRepo, branch: &str) -> Result<String> {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -640,6 +640,33 @@ impl GitRepo {
         Ok(())
     }
 
+    /// Create a new linked worktree at `path` by creating a local branch that tracks `remote_ref`.
+    pub fn worktree_create_tracking_branch(
+        &self,
+        branch: &str,
+        path: &Path,
+        remote_ref: &str,
+    ) -> Result<()> {
+        let main_dir = self.main_repo_workdir()?;
+        let output = self.run_git(
+            &main_dir,
+            &[
+                "worktree",
+                "add",
+                "--track",
+                "-b",
+                branch,
+                path.to_str().context("Non-UTF-8 worktree path")?,
+                remote_ref,
+            ],
+        )?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!("git worktree add --track -b failed: {}", stderr);
+        }
+        Ok(())
+    }
+
     /// Create a new linked worktree at `path` with a brand-new `branch` stacked on `base`.
     pub fn worktree_create_new_branch(&self, branch: &str, path: &Path, base: &str) -> Result<()> {
         let main_dir = self.main_repo_workdir()?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -61,6 +61,7 @@ fn apply_sanitized_test_env(cmd: &mut Command) {
     cmd.env_remove("GITHUB_TOKEN")
         .env_remove("STAX_GITHUB_TOKEN")
         .env_remove("STAX_SHELL_INTEGRATION")
+        .env_remove("STAX_CONFIG_DIR")
         .env_remove("GH_TOKEN")
         .env("GIT_CONFIG_GLOBAL", null_path)
         .env("GIT_CONFIG_SYSTEM", null_path)
@@ -121,6 +122,7 @@ fn hermetic_git_command() -> Command {
 /// A test repository that creates a temporary git repo with proper initialization
 pub struct TestRepo {
     dir: TempDir,
+    home_dir: TempDir,
     /// Optional bare repository acting as "origin" remote
     #[allow(dead_code)]
     remote_dir: Option<TempDir>,
@@ -171,6 +173,7 @@ impl TestRepo {
 
         Self {
             dir,
+            home_dir: test_tempdir(),
             remote_dir: None,
         }
     }
@@ -357,10 +360,21 @@ impl TestRepo {
         self.dir.path().to_path_buf()
     }
 
+    pub fn clean_home(&self) -> String {
+        let home = self.home_dir.path();
+        fs::create_dir_all(home.join(".config").join("stax")).expect("Failed to create clean home");
+        home.to_string_lossy().into_owned()
+    }
+
+    fn apply_default_stax_env(&self, cmd: &mut Command) {
+        cmd.env("HOME", self.home_dir.path());
+    }
+
     /// Run a stax command in this repository
     pub fn run_stax(&self, args: &[&str]) -> Output {
-        sanitized_stax_command()
-            .args(args)
+        let mut cmd = sanitized_stax_command();
+        self.apply_default_stax_env(&mut cmd);
+        cmd.args(args)
             .current_dir(self.path())
             .output()
             .expect("Failed to execute stax")
@@ -369,6 +383,7 @@ impl TestRepo {
     /// Run a stax command with additional environment variables.
     pub fn run_stax_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
         let mut cmd = sanitized_stax_command();
+        self.apply_default_stax_env(&mut cmd);
         cmd.args(args).current_dir(self.path());
         for (key, value) in env {
             cmd.env(key, value);
@@ -378,8 +393,9 @@ impl TestRepo {
 
     /// Run a stax command in a specific directory
     pub fn run_stax_in(&self, cwd: &Path, args: &[&str]) -> Output {
-        sanitized_stax_command()
-            .args(args)
+        let mut cmd = sanitized_stax_command();
+        self.apply_default_stax_env(&mut cmd);
+        cmd.args(args)
             .current_dir(cwd)
             .output()
             .expect("Failed to execute stax")
@@ -388,6 +404,7 @@ impl TestRepo {
     /// Run a stax command in a specific directory with additional environment variables.
     pub fn run_stax_in_with_env(&self, cwd: &Path, args: &[&str], env: &[(&str, &str)]) -> Output {
         let mut cmd = sanitized_stax_command();
+        self.apply_default_stax_env(&mut cmd);
         cmd.args(args).current_dir(cwd);
         for (key, value) in env {
             cmd.env(key, value);

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -5,12 +5,6 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
-fn clean_home(repo: &TestRepo) -> String {
-    let home = repo.path().join(".test-home");
-    fs::create_dir_all(home.join(".config").join("stax")).expect("create clean home");
-    home.to_string_lossy().into_owned()
-}
-
 fn default_worktree_root(repo: &TestRepo, home: &str) -> PathBuf {
     let repo_name = repo
         .path()
@@ -245,6 +239,18 @@ done
     )
 }
 
+fn push_remote_only_branch(repo: &TestRepo, branch: &str, file: &str, content: &str) -> String {
+    repo.git(&["checkout", "-B", branch, "main"])
+        .assert_success();
+    repo.create_file(file, content);
+    repo.commit(&format!("Commit {}", branch));
+    let sha = repo.head_sha();
+    repo.git(&["push", "-u", "origin", branch]).assert_success();
+    repo.git(&["checkout", "main"]).assert_success();
+    repo.git(&["branch", "-D", branch]).assert_success();
+    sha
+}
+
 #[test]
 fn wt_without_subcommand_prints_help_noninteractive() {
     let repo = TestRepo::new();
@@ -268,7 +274,7 @@ fn wt_without_subcommand_prints_help_noninteractive() {
 #[test]
 fn wt_create_without_name_creates_random_lane() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     let out = repo.run_stax_with_env(&["wt", "c"], &[("HOME", home.as_str())]);
     out.assert_success();
@@ -319,9 +325,107 @@ fn wt_create_without_name_creates_random_lane() {
 }
 
 #[test]
+fn wt_create_checks_out_remote_only_branch() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    let remote_sha = push_remote_only_branch(
+        &repo,
+        "remote-only",
+        "remote.txt",
+        "remote branch content\n",
+    );
+
+    let out = repo.run_stax_with_env(
+        &["wt", "c", "remote-only", "--no-verify"],
+        &[("HOME", home.as_str())],
+    );
+    out.assert_success()
+        .assert_stderr_contains("Checked out existing branch")
+        .assert_stderr_contains("remote-only");
+
+    let worktree_path = default_worktree_root(&repo, &home).join("remote-only");
+    assert!(
+        worktree_path.join("remote.txt").exists(),
+        "expected remote branch file to exist in worktree"
+    );
+    assert_eq!(repo.get_commit_sha("remote-only"), remote_sha);
+    assert_eq!(repo.get_commit_sha("origin/remote-only"), remote_sha);
+
+    let upstream_remote = repo.git(&["config", "branch.remote-only.remote"]);
+    upstream_remote
+        .assert_success()
+        .assert_stdout_contains("origin");
+    let upstream_merge = repo.git(&["config", "branch.remote-only.merge"]);
+    upstream_merge
+        .assert_success()
+        .assert_stdout_contains("refs/heads/remote-only");
+}
+
+#[test]
+fn wt_create_accepts_remote_qualified_branch_name() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    let remote_sha = push_remote_only_branch(
+        &repo,
+        "remote-qualified",
+        "qualified.txt",
+        "remote branch content\n",
+    );
+
+    let out = repo.run_stax_with_env(
+        &["wt", "c", "origin/remote-qualified", "--no-verify"],
+        &[("HOME", home.as_str())],
+    );
+    out.assert_success()
+        .assert_stderr_contains("Checked out existing branch")
+        .assert_stderr_contains("remote-qualified");
+
+    let worktree_path = default_worktree_root(&repo, &home).join("remote-qualified");
+    assert!(
+        worktree_path.join("qualified.txt").exists(),
+        "expected remote branch file to exist in worktree"
+    );
+    assert_eq!(repo.get_commit_sha("remote-qualified"), remote_sha);
+
+    let accidental_ref = repo.git(&[
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/origin/remote-qualified",
+    ]);
+    assert!(
+        !accidental_ref.status.success(),
+        "remote-qualified input should not create refs/heads/origin/remote-qualified"
+    );
+}
+
+#[test]
+fn wt_create_rejects_ambiguous_remote_branch_suffix() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    push_remote_only_branch(&repo, "team-a/shared", "team-a.txt", "a\n");
+    push_remote_only_branch(&repo, "team-b/shared", "team-b.txt", "b\n");
+
+    let out = repo.run_stax_with_env(
+        &["wt", "c", "shared", "--no-verify"],
+        &[("HOME", home.as_str())],
+    );
+    out.assert_failure()
+        .assert_stderr_contains("Multiple remote branches match 'shared'")
+        .assert_stderr_contains("origin/team-a/shared")
+        .assert_stderr_contains("origin/team-b/shared");
+
+    let worktrees = linked_worktree_dirs_default(&repo, &home);
+    assert!(
+        worktrees.is_empty(),
+        "ambiguous remote suffix should not create a worktree"
+    );
+}
+
+#[test]
 fn wt_create_reuses_existing_worktree_target() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["create", "feature-lane"], &[("HOME", home.as_str())])
         .assert_success();
@@ -349,7 +453,7 @@ fn wt_create_reuses_existing_worktree_target() {
 #[test]
 fn wt_create_with_agent_launches_in_new_worktree() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
     let bin_dir = repo.path().join("fake-bin");
     fs::create_dir_all(&bin_dir).expect("create fake bin");
     let log_path = repo.path().join("codex.log");
@@ -420,7 +524,7 @@ done
 #[test]
 fn wt_tmux_creates_then_attaches_existing_session() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
     let (_bin_dir, path_env, tmux_log, agent_log) = setup_fake_tmux_env(&repo);
     let tmux_state = repo.path().join("tmux-state");
     let tmux_state_str = tmux_state.to_string_lossy().into_owned();
@@ -487,7 +591,7 @@ fn wt_tmux_creates_then_attaches_existing_session() {
 #[test]
 fn wt_tmux_switches_client_when_already_inside_tmux() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
     let (_bin_dir, path_env, tmux_log, agent_log) = setup_fake_tmux_env(&repo);
     let tmux_state = repo.path().join("tmux-state");
     let tmux_state_str = tmux_state.to_string_lossy().into_owned();
@@ -521,7 +625,7 @@ fn wt_tmux_switches_client_when_already_inside_tmux() {
 #[test]
 fn lane_existing_tmux_session_with_prompt_opens_new_window() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
     let (_bin_dir, path_env, tmux_log, agent_log) = setup_fake_tmux_env(&repo);
     let tmux_state = repo.path().join("tmux-state");
     let tmux_state_str = tmux_state.to_string_lossy().into_owned();
@@ -584,7 +688,7 @@ fn lane_existing_tmux_session_with_prompt_opens_new_window() {
 #[test]
 fn wt_create_prints_cd_hint_when_shell_env_is_set_without_shell_wrapper() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     let out = repo.run_stax_with_env(
         &["wt", "c", "shell-env-lane"],
@@ -614,7 +718,7 @@ fn wt_create_prints_cd_hint_when_shell_env_is_set_without_shell_wrapper() {
 #[test]
 fn wt_go_prints_cd_hint_when_shell_env_is_set_without_shell_wrapper() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "go-shell-env"], &[("HOME", home.as_str())])
         .assert_success();
@@ -647,7 +751,7 @@ fn wt_go_prints_cd_hint_when_shell_env_is_set_without_shell_wrapper() {
 #[test]
 fn wt_create_without_shell_integration_suggests_install() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     let out = repo.run_stax_with_env(&["wt", "c", "install-shell"], &[("HOME", home.as_str())]);
     out.assert_success();
@@ -668,7 +772,7 @@ fn wt_create_without_shell_integration_suggests_install() {
 #[test]
 fn wt_go_without_shell_integration_suggests_install() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "go-install-shell"], &[("HOME", home.as_str())])
         .assert_success();
@@ -695,7 +799,7 @@ fn wt_go_without_shell_integration_suggests_install() {
 #[test]
 fn wt_ls_stays_compact_and_wt_ll_shows_status() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "status-lane"], &[("HOME", home.as_str())])
         .assert_success();
@@ -820,7 +924,7 @@ fn wt_remove_accepts_disambiguated_path_suffix_for_detached_duplicates() {
 #[test]
 fn wt_create_respects_explicit_repo_local_root_dir() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
     write_worktree_config(&home, ".worktrees");
 
     let out = repo.run_stax_with_env(&["wt", "c", "local-root"], &[("HOME", home.as_str())]);
@@ -841,7 +945,7 @@ fn wt_create_respects_explicit_repo_local_root_dir() {
 #[test]
 fn wt_prune_cleans_stale_git_worktree_entries() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "prune-me"], &[("HOME", home.as_str())])
         .assert_success();
@@ -875,7 +979,7 @@ fn wt_prune_cleans_stale_git_worktree_entries() {
 #[test]
 fn wt_cleanup_prunes_and_removes_safe_candidates() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "merged-lane"], &[("HOME", home.as_str())])
         .assert_success();
@@ -943,7 +1047,7 @@ fn wt_cleanup_prunes_and_removes_safe_candidates() {
 #[test]
 fn wt_cleanup_dry_run_previews_without_applying() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "merged-lane"], &[("HOME", home.as_str())])
         .assert_success();
@@ -1096,7 +1200,7 @@ fn wt_remove_confirmed_dirty_worktree_uses_forced_git_remove() {
 #[test]
 fn wt_remove_without_name_removes_current_worktree() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "remove-me"], &[("HOME", home.as_str())])
         .assert_success();
@@ -1113,7 +1217,7 @@ fn wt_remove_without_name_removes_current_worktree() {
 #[test]
 fn wt_remove_delete_branch_from_current_worktree_removes_branch_too() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "remove-branch"], &[("HOME", home.as_str())])
         .assert_success();
@@ -1145,7 +1249,7 @@ fn wt_remove_delete_branch_from_current_worktree_removes_branch_too() {
 #[test]
 fn wt_restack_only_touches_stax_managed_worktrees() {
     let repo = TestRepo::new();
-    let home = clean_home(&repo);
+    let home = repo.clean_home();
 
     repo.run_stax_with_env(&["wt", "c", "managed-lane"], &[("HOME", home.as_str())])
         .assert_success();


### PR DESCRIPTION
## Summary

Fixes #361.

- Resolve `st wt c <name>` / `st lane <name>` targets as local branch, fetched remote branch, or new branch.
- For remote-only matches, create a local tracking branch in the worktree with `git worktree add --track -b <branch> <path> <remote>/<branch>`.
- Treat `origin/<branch>` as a remote-qualified branch selector instead of silently creating `refs/heads/origin/<branch>` from trunk.
- Share the resolved-branch worktree creation path between `wt c` and `lane`.
- Make integration-test stax subprocesses use a per-repo test home outside the git worktree and ignore ambient `STAX_CONFIG_DIR`, so local user config cannot change branch naming or worktree config and generated stax config cannot be committed by fixture helpers.
- Document the fetched-remote behavior in worktree docs and `skills.md`.

## Tests

- `cargo test --test worktree_cli_tests remote -- --nocapture`
- `cargo test --test worktree_cli_tests -- --nocapture`
- `cargo test --test abort_tests test_abort_during_rebase_conflict -- --nocapture`
- `cargo test --test abort_tests -- --nocapture`
- `cargo build --bin st`
- Manual temp-repo repro with rebuilt `target/debug/st`: `st wt c remote-only --no-verify` checks out the remote branch tip, sets upstream tracking, and includes the remote-only file.
