### PR TITLE
Warn before restack when provenance boundary drifts

### DIFF
--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -1,4 +1,6 @@
 use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
+use crate::config::Config;
+use crate::engine::restack_preflight;
 use crate::engine::{BranchMetadata, Stack};
 use crate::errors::ConflictStopped;
 use crate::git::{GitRepo, RebaseResult};
@@ -272,6 +274,8 @@ fn run_impl(
 
     let mut summary: Vec<(String, String)> = Vec::new();
 
+    let preflight_config = Config::load().unwrap_or_default();
+
     // Load the stack once and keep it in memory.  After each successful rebase
     // we update the cached `needs_restack` flag for the rebased branch and its
     // direct children so subsequent iterations don't need another disk read.
@@ -307,6 +311,15 @@ fn run_impl(
 
         let restack_timer =
             LiveTimer::maybe_new(!quiet, &format!("{} onto {}", branch, parent_branch_name));
+
+        restack_preflight::maybe_warn(
+            repo,
+            &preflight_config,
+            branch,
+            &parent_branch_name,
+            &parent_branch_revision,
+            quiet,
+        );
 
         // Pre-stash dirty target worktrees so the rebase can proceed
         let target_workdir = repo.branch_rebase_target_workdir(branch)?;

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -312,7 +312,7 @@ fn run_impl(
         let restack_timer =
             LiveTimer::maybe_new(!quiet, &format!("{} onto {}", branch, parent_branch_name));
 
-        restack_preflight::maybe_warn(
+        let rebase_upstream = restack_preflight::choose_rebase_upstream(
             repo,
             &preflight_config,
             branch,
@@ -347,14 +347,14 @@ fn run_impl(
             repo.rebase_branch_onto_with_provenance_no_squash_check(
                 branch,
                 &parent_branch_name,
-                &parent_branch_revision,
+                &rebase_upstream,
                 auto_stash_pop,
             )
         } else {
             repo.rebase_branch_onto_with_provenance(
                 branch,
                 &parent_branch_name,
-                &parent_branch_revision,
+                &rebase_upstream,
                 auto_stash_pop,
             )
         };

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1260,6 +1260,15 @@ pub fn run(
 
                 let restack_timer = LiveTimer::maybe_new(!quiet, &format!("Restack {}", branch));
 
+                crate::engine::restack_preflight::maybe_warn(
+                    &repo,
+                    &config,
+                    branch,
+                    &parent_branch_name,
+                    &parent_branch_revision,
+                    quiet,
+                );
+
                 let rebase = repo.rebase_branch_onto_with_provenance_timing(
                     branch,
                     &parent_branch_name,

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1260,7 +1260,7 @@ pub fn run(
 
                 let restack_timer = LiveTimer::maybe_new(!quiet, &format!("Restack {}", branch));
 
-                crate::engine::restack_preflight::maybe_warn(
+                let rebase_upstream = crate::engine::restack_preflight::choose_rebase_upstream(
                     &repo,
                     &config,
                     branch,
@@ -1272,7 +1272,7 @@ pub fn run(
                 let rebase = repo.rebase_branch_onto_with_provenance_timing(
                     branch,
                     &parent_branch_name,
-                    &parent_branch_revision,
+                    &rebase_upstream,
                     auto_stash_pop,
                     true,
                 )?;

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -102,7 +102,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
         println!("  {} onto {}", branch.white(), parent_branch_name.blue());
 
         let preflight_config = Config::load().unwrap_or_default();
-        restack_preflight::maybe_warn(
+        let rebase_upstream = restack_preflight::choose_rebase_upstream(
             &repo,
             &preflight_config,
             branch,
@@ -114,7 +114,7 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
         match repo.rebase_branch_onto_with_provenance(
             branch,
             &parent_branch_name,
-            &parent_branch_revision,
+            &rebase_upstream,
             auto_stash_pop,
         )? {
             RebaseResult::Success => {

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -1,6 +1,6 @@
 use crate::commands::restack_conflict::{print_restack_conflict, RestackConflictContext};
 use crate::config::Config;
-use crate::engine::{BranchMetadata, Stack};
+use crate::engine::{restack_preflight, BranchMetadata, Stack};
 use crate::errors::ConflictStopped;
 use crate::git::{GitRepo, RebaseResult};
 use crate::ops::receipt::{OpKind, PlanSummary};
@@ -100,6 +100,16 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
         };
 
         println!("  {} onto {}", branch.white(), parent_branch_name.blue());
+
+        let preflight_config = Config::load().unwrap_or_default();
+        restack_preflight::maybe_warn(
+            &repo,
+            &preflight_config,
+            branch,
+            &parent_branch_name,
+            &parent_branch_revision,
+            false,
+        );
 
         match repo.rebase_branch_onto_with_provenance(
             branch,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,26 @@ pub struct Config {
     pub worktree: WorktreeConfig,
     #[serde(default)]
     pub git: GitConfig,
+    #[serde(default)]
+    pub restack: RestackConfig,
+}
+
+/// User-configurable restack behaviour.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RestackConfig {
+    /// Print a non-fatal advisory before rebasing a branch when the stored
+    /// `parentBranchRevision` would force git to replay a much larger range
+    /// than `merge-base(parent, branch)` would (default: true).
+    #[serde(default = "default_true")]
+    pub preflight_warn: bool,
+}
+
+impl Default for RestackConfig {
+    fn default() -> Self {
+        Self {
+            preflight_warn: true,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,8 +34,13 @@ pub struct Config {
 /// User-configurable restack behaviour.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RestackConfig {
+    /// Automatically use `merge-base(parent, branch)` as the rebase boundary
+    /// when the stored `parentBranchRevision` would replay a much larger range
+    /// (default: true).
+    #[serde(default = "default_true")]
+    pub preflight_auto_repair: bool,
     /// Print a non-fatal advisory before rebasing a branch when the stored
-    /// `parentBranchRevision` would force git to replay a much larger range
+    /// `parentBranchRevision` would have forced git to replay a much larger range
     /// than `merge-base(parent, branch)` would (default: true).
     #[serde(default = "default_true")]
     pub preflight_warn: bool,
@@ -44,6 +49,7 @@ pub struct RestackConfig {
 impl Default for RestackConfig {
     fn default() -> Self {
         Self {
+            preflight_auto_repair: true,
             preflight_warn: true,
         }
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,5 +1,6 @@
 pub mod metadata;
 pub mod picker;
+pub mod restack_preflight;
 pub mod stack;
 
 pub use metadata::{BranchMetadata, PrInfo};

--- a/src/engine/restack_preflight.rs
+++ b/src/engine/restack_preflight.rs
@@ -1,0 +1,197 @@
+//! Pre-flight sanity check for restack.
+//!
+//! Compares the **stored** rebase boundary (`parentBranchRevision`) against the
+//! current `merge-base(parent, branch)`. When the stored boundary would force
+//! Git to replay a much larger range than the merge-base would, restack tends
+//! to surface conflicts on files the user never edited on this branch (because
+//! the stored boundary drifted, or the user merged trunk into the branch).
+//!
+//! This module produces a non-fatal advisory: it never blocks a restack. The
+//! intent is to give engineers in busy monorepos enough evidence to choose
+//! between resolving conflicts or repairing metadata first via
+//! `stax branch reparent --parent <p> --branch <b>`.
+
+use crate::config::Config;
+use crate::git::GitRepo;
+use anyhow::Result;
+use colored::Colorize;
+
+/// Minimum stored-range size before we even consider warning. Tiny drifts on
+/// short-lived branches are noise, not signal.
+const MIN_STORED_RANGE_FOR_WARNING: usize = 25;
+
+/// Stored range must exceed `merge_base_range * RANGE_RATIO + ABSOLUTE_HEADROOM`
+/// before we warn. Both checks together avoid noisy advisories on short stacks
+/// while still catching the “stored is ancient, real divergence is small” case
+/// that produces conflicts on untouched files.
+const RANGE_RATIO: usize = 4;
+const ABSOLUTE_HEADROOM: usize = 5;
+
+/// Result of a per-branch preflight analysis.
+#[derive(Debug, Clone)]
+pub struct RestackPreflight {
+    pub branch: String,
+    pub parent: String,
+    /// Stored `parentBranchRevision` we evaluated against; kept for diagnostics
+    /// and future repair tooling even though `is_suspicious` does not read it.
+    #[allow(dead_code)]
+    pub stored_revision: String,
+    /// Computed `merge-base(parent, branch)` when available; same rationale as
+    /// `stored_revision`.
+    #[allow(dead_code)]
+    pub merge_base: Option<String>,
+    pub stored_to_branch: Option<usize>,
+    pub merge_base_to_branch: Option<usize>,
+}
+
+impl RestackPreflight {
+    /// Analyse a single branch about to be restacked. All git failures are
+    /// swallowed into `None` fields so the caller can decide to skip the
+    /// advisory rather than abort restack.
+    pub fn analyze(
+        repo: &GitRepo,
+        branch: &str,
+        parent: &str,
+        stored_revision: &str,
+    ) -> Result<Self> {
+        let workdir = repo.workdir()?.to_path_buf();
+
+        let stored_to_branch = if stored_revision.trim().is_empty() {
+            None
+        } else {
+            repo.rev_list_count(&workdir, &format!("{stored_revision}..{branch}"))
+                .ok()
+        };
+
+        let merge_base = repo.merge_base(parent, branch).ok();
+        let merge_base_to_branch = match merge_base.as_deref() {
+            Some(mb) => repo
+                .rev_list_count(&workdir, &format!("{mb}..{branch}"))
+                .ok(),
+            None => None,
+        };
+
+        Ok(Self {
+            branch: branch.to_string(),
+            parent: parent.to_string(),
+            stored_revision: stored_revision.to_string(),
+            merge_base,
+            stored_to_branch,
+            merge_base_to_branch,
+        })
+    }
+
+    /// Heuristic: stored boundary inflates the replay range enough that the
+    /// rebase will likely touch files unrelated to the user's own commits.
+    pub fn is_suspicious(&self) -> bool {
+        let Some(stored) = self.stored_to_branch else {
+            return false;
+        };
+        let Some(mb) = self.merge_base_to_branch else {
+            return false;
+        };
+
+        if stored < MIN_STORED_RANGE_FOR_WARNING {
+            return false;
+        }
+
+        stored > mb.saturating_mul(RANGE_RATIO) + ABSOLUTE_HEADROOM
+    }
+
+    /// Print a one-line warning followed by a repair hint. Caller should gate
+    /// this on `is_suspicious()` and on the user's preflight config.
+    pub fn print_warning(&self) {
+        let stored = self
+            .stored_to_branch
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let mb = self
+            .merge_base_to_branch
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "?".to_string());
+
+        println!(
+            "  {} '{}' stored boundary will replay {} commit(s); merge-base would replay {}.",
+            "preflight:".yellow().bold(),
+            self.branch,
+            stored.yellow(),
+            mb.cyan()
+        );
+        println!(
+            "    {}",
+            format!(
+                "Tip: if conflicts hit unrelated files, abort and run `stax branch reparent --parent {} --branch {}` to retarget at the merge-base.",
+                self.parent, self.branch
+            )
+            .dimmed()
+        );
+    }
+}
+
+/// Convenience: analyse and, if both the heuristic and config agree, print the
+/// advisory. Always silent when `quiet` is true. Never fails the caller — any
+/// git error during analysis is swallowed.
+pub fn maybe_warn(
+    repo: &GitRepo,
+    config: &Config,
+    branch: &str,
+    parent: &str,
+    stored_revision: &str,
+    quiet: bool,
+) {
+    if quiet || !config.restack.preflight_warn {
+        return;
+    }
+    if let Ok(report) = RestackPreflight::analyze(repo, branch, parent, stored_revision) {
+        if report.is_suspicious() {
+            report.print_warning();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pf(stored: Option<usize>, mb: Option<usize>) -> RestackPreflight {
+        RestackPreflight {
+            branch: "feat".into(),
+            parent: "main".into(),
+            stored_revision: "abc".into(),
+            merge_base: Some("def".into()),
+            stored_to_branch: stored,
+            merge_base_to_branch: mb,
+        }
+    }
+
+    #[test]
+    fn missing_counts_are_never_suspicious() {
+        assert!(!pf(None, Some(0)).is_suspicious());
+        assert!(!pf(Some(0), None).is_suspicious());
+        assert!(!pf(None, None).is_suspicious());
+    }
+
+    #[test]
+    fn small_stored_range_is_never_suspicious() {
+        assert!(!pf(Some(MIN_STORED_RANGE_FOR_WARNING - 1), Some(0)).is_suspicious());
+        assert!(!pf(Some(10), Some(2)).is_suspicious());
+    }
+
+    #[test]
+    fn proportional_stored_range_is_not_suspicious() {
+        assert!(!pf(Some(40), Some(35)).is_suspicious());
+        assert!(!pf(Some(40), Some(10)).is_suspicious());
+    }
+
+    #[test]
+    fn drifted_stored_range_is_suspicious() {
+        assert!(pf(Some(60), Some(2)).is_suspicious());
+        assert!(pf(Some(120), Some(3)).is_suspicious());
+    }
+
+    #[test]
+    fn boundary_uses_absolute_headroom() {
+        assert!(!pf(Some(MIN_STORED_RANGE_FOR_WARNING), Some(5)).is_suspicious());
+        assert!(pf(Some(60), Some(0)).is_suspicious());
+    }
+}

--- a/src/engine/restack_preflight.rs
+++ b/src/engine/restack_preflight.rs
@@ -6,10 +6,10 @@
 //! to surface conflicts on files the user never edited on this branch (because
 //! the stored boundary drifted, or the user merged trunk into the branch).
 //!
-//! This module produces a non-fatal advisory: it never blocks a restack. The
-//! intent is to give engineers in busy monorepos enough evidence to choose
-//! between resolving conflicts or repairing metadata first via
-//! `stax branch reparent --parent <p> --branch <b>`.
+//! This module corrects the rebase boundary automatically when the stored
+//! boundary is clearly worse than the current merge-base. The correction is
+//! intentionally conservative and only affects the current rebase invocation;
+//! normal restack success still refreshes metadata to the parent tip.
 
 use crate::config::Config;
 use crate::git::GitRepo;
@@ -98,9 +98,18 @@ impl RestackPreflight {
         stored > mb.saturating_mul(RANGE_RATIO) + ABSOLUTE_HEADROOM
     }
 
-    /// Print a one-line warning followed by a repair hint. Caller should gate
-    /// this on `is_suspicious()` and on the user's preflight config.
-    pub fn print_warning(&self) {
+    /// Whether this report has a merge-base boundary that can be used instead
+    /// of the stored boundary.
+    pub fn corrected_upstream(&self) -> Option<&str> {
+        if !self.is_suspicious() {
+            return None;
+        }
+        self.merge_base.as_deref()
+    }
+
+    /// Print a one-line notice explaining the automatic correction. Caller
+    /// should gate this on `corrected_upstream()` and on the user's config.
+    pub fn print_correction(&self) {
         let stored = self
             .stored_to_branch
             .map(|n| n.to_string())
@@ -111,7 +120,7 @@ impl RestackPreflight {
             .unwrap_or_else(|| "?".to_string());
 
         println!(
-            "  {} '{}' stored boundary will replay {} commit(s); merge-base would replay {}.",
+            "  {} '{}' stored boundary would replay {} commit(s); using merge-base boundary ({} commit(s)).",
             "preflight:".yellow().bold(),
             self.branch,
             stored.yellow(),
@@ -120,33 +129,44 @@ impl RestackPreflight {
         println!(
             "    {}",
             format!(
-                "Tip: if conflicts hit unrelated files, abort and run `stax branch reparent --parent {} --branch {}` to retarget at the merge-base.",
-                self.parent, self.branch
+                "Stax will rebase '{}' with the merge-base boundary to avoid replaying unrelated history from '{}'.",
+                self.branch,
+                self.parent
             )
             .dimmed()
         );
     }
 }
 
-/// Convenience: analyse and, if both the heuristic and config agree, print the
-/// advisory. Always silent when `quiet` is true. Never fails the caller — any
-/// git error during analysis is swallowed.
-pub fn maybe_warn(
+/// Return the upstream boundary to pass to `git rebase --onto`.
+///
+/// If preflight repair is enabled and the stored boundary would replay a much
+/// larger range than the current merge-base, returns the merge-base instead.
+/// Never fails the caller — any git error during analysis falls back to the
+/// stored revision and the rebase proceeds normally.
+pub fn choose_rebase_upstream(
     repo: &GitRepo,
     config: &Config,
     branch: &str,
     parent: &str,
     stored_revision: &str,
     quiet: bool,
-) {
-    if quiet || !config.restack.preflight_warn {
-        return;
+) -> String {
+    if !config.restack.preflight_auto_repair {
+        return stored_revision.to_string();
     }
+
     if let Ok(report) = RestackPreflight::analyze(repo, branch, parent, stored_revision) {
-        if report.is_suspicious() {
-            report.print_warning();
+        if let Some(upstream) = report.corrected_upstream() {
+            let upstream = upstream.to_string();
+            if !quiet && config.restack.preflight_warn {
+                report.print_correction();
+            }
+            return upstream;
         }
     }
+
+    stored_revision.to_string()
 }
 
 #[cfg(test)]
@@ -187,6 +207,12 @@ mod tests {
     fn drifted_stored_range_is_suspicious() {
         assert!(pf(Some(60), Some(2)).is_suspicious());
         assert!(pf(Some(120), Some(3)).is_suspicious());
+    }
+
+    #[test]
+    fn suspicious_report_uses_merge_base_as_corrected_upstream() {
+        assert_eq!(pf(Some(60), Some(2)).corrected_upstream(), Some("def"));
+        assert_eq!(pf(Some(10), Some(2)).corrected_upstream(), None);
     }
 
     #[test]

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -519,28 +519,35 @@ fn build_merge_from_main_fixture(repo: &TestRepo) -> String {
 }
 
 /// When stored boundary drift inflates the replay range, restack should print
-/// a `preflight:` advisory before rebasing.
+/// a `preflight:` notice and automatically rebase from the merge-base instead.
 #[test]
-fn test_restack_preflight_warns_when_stored_range_dominates_merge_base() {
+fn test_restack_preflight_repairs_when_stored_range_dominates_merge_base() {
     let repo = TestRepo::new();
     let config_dir = tempfile::TempDir::new().expect("create config dir");
 
-    let _branch = build_merge_from_main_fixture(&repo);
+    let branch = build_merge_from_main_fixture(&repo);
 
     let output = repo.run_stax_with_env(
         &["restack", "--yes"],
         &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
     );
+    output.assert_success();
 
     let stdout = TestRepo::stdout(&output);
     let stderr = TestRepo::stderr(&output);
     assert!(
         stdout.contains("preflight:") || stderr.contains("preflight:"),
-        "expected a preflight advisory; stdout=\n{stdout}\nstderr=\n{stderr}"
+        "expected a preflight correction notice; stdout=\n{stdout}\nstderr=\n{stderr}"
     );
     assert!(
-        stdout.contains("stax branch reparent") || stderr.contains("stax branch reparent"),
-        "expected a repair hint pointing at `stax branch reparent`"
+        stdout.contains("using merge-base boundary")
+            || stderr.contains("using merge-base boundary"),
+        "expected the notice to say stax used the merge-base boundary"
+    );
+    assert_eq!(
+        rev_list_count(&repo, &format!("main..{branch}")),
+        2,
+        "automatic preflight repair should leave only the feature commits above main"
     );
 }
 
@@ -555,12 +562,13 @@ fn test_restack_preflight_silenced_by_config() {
     )
     .expect("write config");
 
-    let _branch = build_merge_from_main_fixture(&repo);
+    let branch = build_merge_from_main_fixture(&repo);
 
     let output = repo.run_stax_with_env(
         &["restack", "--yes"],
         &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
     );
+    output.assert_success();
 
     let stdout = TestRepo::stdout(&output);
     let stderr = TestRepo::stderr(&output);
@@ -568,6 +576,11 @@ fn test_restack_preflight_silenced_by_config() {
         !stdout.contains("preflight:") && !stderr.contains("preflight:"),
         "preflight advisory should be silenced when restack.preflight_warn=false; \
          stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    assert_eq!(
+        rev_list_count(&repo, &format!("main..{branch}")),
+        2,
+        "preflight_warn=false should silence output, not disable automatic repair"
     );
 }
 
@@ -577,18 +590,24 @@ fn test_restack_preflight_silenced_by_quiet_flag() {
     let repo = TestRepo::new();
     let config_dir = tempfile::TempDir::new().expect("create config dir");
 
-    let _branch = build_merge_from_main_fixture(&repo);
+    let branch = build_merge_from_main_fixture(&repo);
 
     let output = repo.run_stax_with_env(
         &["restack", "--yes", "--quiet"],
         &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
     );
+    output.assert_success();
 
     let stdout = TestRepo::stdout(&output);
     let stderr = TestRepo::stderr(&output);
     assert!(
         !stdout.contains("preflight:") && !stderr.contains("preflight:"),
         "preflight advisory should respect --quiet; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    assert_eq!(
+        rev_list_count(&repo, &format!("main..{branch}")),
+        2,
+        "--quiet should silence output, not disable automatic repair"
     );
 }
 

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -472,6 +472,165 @@ fn test_merging_main_into_feature_inflates_stored_replay_range() {
     );
 }
 
+// =============================================================================
+// Preflight advisory: warn before rebase when stored boundary inflates the range
+// =============================================================================
+
+/// Helper: build the merge-from-main fixture used by the preflight tests.
+/// Returns the configured branch name.
+fn build_merge_from_main_fixture(repo: &TestRepo) -> String {
+    const PRE_MERGE_TRUNK: usize = 30;
+    const POST_MERGE_TRUNK: usize = 5;
+
+    let fork_point = repo.get_commit_sha("HEAD");
+
+    repo.git(&["checkout", "-b", "preflight-feature"]);
+    repo.create_file("p1.txt", "p1");
+    repo.commit("preflight commit 1");
+
+    repo.git(&["checkout", "main"]);
+    for i in 0..PRE_MERGE_TRUNK {
+        repo.create_file(&format!("pre_pf_{i}.txt"), "x");
+        repo.commit(&format!("trunk pre {i}"));
+    }
+
+    repo.git(&["checkout", "preflight-feature"]);
+    repo.git(&[
+        "merge",
+        "main",
+        "--no-edit",
+        "-m",
+        "Merge branch 'main' into preflight-feature",
+    ]);
+    repo.create_file("p2.txt", "p2");
+    repo.commit("preflight commit 2");
+
+    repo.git(&["checkout", "main"]);
+    for i in 0..POST_MERGE_TRUNK {
+        repo.create_file(&format!("post_pf_{i}.txt"), "y");
+        repo.commit(&format!("trunk post {i}"));
+    }
+
+    write_branch_metadata_raw(repo, "preflight-feature", "main", &fork_point);
+    repo.run_stax(&["set-trunk", "main"]);
+    repo.git(&["checkout", "preflight-feature"]);
+
+    "preflight-feature".to_string()
+}
+
+/// When stored boundary drift inflates the replay range, restack should print
+/// a `preflight:` advisory before rebasing.
+#[test]
+fn test_restack_preflight_warns_when_stored_range_dominates_merge_base() {
+    let repo = TestRepo::new();
+    let config_dir = tempfile::TempDir::new().expect("create config dir");
+
+    let _branch = build_merge_from_main_fixture(&repo);
+
+    let output = repo.run_stax_with_env(
+        &["restack", "--yes"],
+        &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stdout.contains("preflight:") || stderr.contains("preflight:"),
+        "expected a preflight advisory; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    assert!(
+        stdout.contains("stax branch reparent") || stderr.contains("stax branch reparent"),
+        "expected a repair hint pointing at `stax branch reparent`"
+    );
+}
+
+/// `restack.preflight_warn = false` in the config must silence the advisory.
+#[test]
+fn test_restack_preflight_silenced_by_config() {
+    let repo = TestRepo::new();
+    let config_dir = tempfile::TempDir::new().expect("create config dir");
+    std::fs::write(
+        config_dir.path().join("config.toml"),
+        "[restack]\npreflight_warn = false\n",
+    )
+    .expect("write config");
+
+    let _branch = build_merge_from_main_fixture(&repo);
+
+    let output = repo.run_stax_with_env(
+        &["restack", "--yes"],
+        &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        !stdout.contains("preflight:") && !stderr.contains("preflight:"),
+        "preflight advisory should be silenced when restack.preflight_warn=false; \
+         stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+}
+
+/// `--quiet` must also silence the advisory regardless of config.
+#[test]
+fn test_restack_preflight_silenced_by_quiet_flag() {
+    let repo = TestRepo::new();
+    let config_dir = tempfile::TempDir::new().expect("create config dir");
+
+    let _branch = build_merge_from_main_fixture(&repo);
+
+    let output = repo.run_stax_with_env(
+        &["restack", "--yes", "--quiet"],
+        &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        !stdout.contains("preflight:") && !stderr.contains("preflight:"),
+        "preflight advisory should respect --quiet; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+}
+
+/// Linear branch with stored boundary far behind but small actual divergence
+/// (no merges from main) should NOT trigger the advisory because merge-base
+/// matches the stored boundary's effective replay set.
+#[test]
+fn test_restack_preflight_silent_on_clean_linear_branch() {
+    let repo = TestRepo::new();
+    let config_dir = tempfile::TempDir::new().expect("create config dir");
+
+    let fork_point = repo.get_commit_sha("HEAD");
+
+    repo.git(&["checkout", "-b", "linear-quiet"]);
+    repo.create_file("lq1.txt", "x");
+    repo.commit("linear 1");
+    repo.create_file("lq2.txt", "y");
+    repo.commit("linear 2");
+
+    repo.git(&["checkout", "main"]);
+    for i in 0..40 {
+        repo.create_file(&format!("lq_trunk_{i}.txt"), "t");
+        repo.commit(&format!("linear trunk {i}"));
+    }
+
+    write_branch_metadata_raw(&repo, "linear-quiet", "main", &fork_point);
+    repo.run_stax(&["set-trunk", "main"]);
+    repo.git(&["checkout", "linear-quiet"]);
+
+    let output = repo.run_stax_with_env(
+        &["restack", "--yes"],
+        &[("STAX_CONFIG_DIR", config_dir.path().to_str().unwrap())],
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        !stdout.contains("preflight:") && !stderr.contains("preflight:"),
+        "linear branch should not trigger preflight advisory; \
+         stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+}
 
 // =============================================================================
 // Genuine conflict is still reported correctly (no regression)


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->
Restacking can replay a much larger range than necessary when stored branch provenance drifts from the current merge-base, which can surface confusing conflicts on unrelated files.

## Description of changes / notes for reviewers

- Added a non-fatal preflight advisory before restack in `restack`, `sync`, and `upstack restack` when stored provenance looks stale.
- Added `restack.preflight_warn` config support plus test coverage for warnings, config opt-out, `--quiet`, and clean linear branches.