### PR TITLE
Warn before restack replays the wrong boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ st resolve
 st resolve --agent codex --model gpt-5.3-codex
 ```
 
+Before each rebase, stax also runs a **preflight advisory** that compares the
+stored parent boundary against `merge-base(parent, branch)`. When they diverge
+sharply — the “my restack hit conflicts on files I never touched” case — stax
+prints a one-line warning and points at `stax branch reparent` to repair the
+boundary. Disable globally with `[restack] preflight_warn = false`, or per-run
+with `--quiet`.
+
 ### Undo / redo
 
 `restack`, `submit`, and `reorder` each snapshot branch state before they touch anything. Recovery is one command away.

--- a/README.md
+++ b/README.md
@@ -204,12 +204,13 @@ st resolve
 st resolve --agent codex --model gpt-5.3-codex
 ```
 
-Before each rebase, stax also runs a **preflight advisory** that compares the
+Before each rebase, stax also runs a **preflight repair** that compares the
 stored parent boundary against `merge-base(parent, branch)`. When they diverge
 sharply — the “my restack hit conflicts on files I never touched” case — stax
-prints a one-line warning and points at `stax branch reparent` to repair the
-boundary. Disable globally with `[restack] preflight_warn = false`, or per-run
-with `--quiet`.
+automatically uses the merge-base boundary for that rebase and prints a
+one-line notice. Silence the notice with `[restack] preflight_warn = false` or
+`--quiet`; disable the automatic correction with
+`[restack] preflight_auto_repair = false`.
 
 ### Undo / redo
 

--- a/docs/commands/stack-health.md
+++ b/docs/commands/stack-health.md
@@ -37,6 +37,26 @@ Repairs:
 - Deletes invalid metadata
 - Reports branches that need restack
 
+## Restack preflight advisory
+
+Before rebasing each branch, `st restack`, `st upstack restack`, and `st rs --restack`
+compare the stored `parentBranchRevision` against `merge-base(parent, branch)`.
+When the stored boundary would force git to replay a much larger range than the
+merge-base, stax prints a non-fatal advisory:
+
+```text
+  preflight: 'feature-x' stored boundary will replay 312 commit(s); merge-base would replay 2.
+    Tip: if conflicts hit unrelated files, abort and run `stax branch reparent --parent main --branch feature-x` to retarget at the merge-base.
+```
+
+This usually means metadata drifted (e.g. branch tracked late) or `git merge main`
+was run on the branch instead of restack — both produce conflicts on files you
+never edited. Resolve by aborting the rebase and running the suggested
+`stax branch reparent` to repair the boundary, then restack again.
+
+Disable globally with `[restack] preflight_warn = false` in
+`~/.config/stax/config.toml`. The advisory is also suppressed by `--quiet`.
+
 ## `st run <cmd>` (alias: `st test <cmd>`)
 
 Run a shell command on each branch in the stack, bottom to top (excluding trunk), returning to the starting branch afterward.

--- a/docs/commands/stack-health.md
+++ b/docs/commands/stack-health.md
@@ -37,25 +37,27 @@ Repairs:
 - Deletes invalid metadata
 - Reports branches that need restack
 
-## Restack preflight advisory
+## Restack preflight repair
 
 Before rebasing each branch, `st restack`, `st upstack restack`, and `st rs --restack`
 compare the stored `parentBranchRevision` against `merge-base(parent, branch)`.
 When the stored boundary would force git to replay a much larger range than the
-merge-base, stax prints a non-fatal advisory:
+merge-base, stax automatically uses the merge-base as the rebase boundary for
+that operation and prints a non-fatal notice:
 
 ```text
-  preflight: 'feature-x' stored boundary will replay 312 commit(s); merge-base would replay 2.
-    Tip: if conflicts hit unrelated files, abort and run `stax branch reparent --parent main --branch feature-x` to retarget at the merge-base.
+  preflight: 'feature-x' stored boundary would replay 312 commit(s); using merge-base boundary (2 commit(s)).
+    Stax will rebase 'feature-x' with the merge-base boundary to avoid replaying unrelated history from 'main'.
 ```
 
 This usually means metadata drifted (e.g. branch tracked late) or `git merge main`
-was run on the branch instead of restack — both produce conflicts on files you
-never edited. Resolve by aborting the rebase and running the suggested
-`stax branch reparent` to repair the boundary, then restack again.
+was run on the branch instead of restack — both can produce conflicts on files
+you never edited. The repair happens automatically; after a successful restack,
+metadata is refreshed to the current parent tip as usual.
 
-Disable globally with `[restack] preflight_warn = false` in
-`~/.config/stax/config.toml`. The advisory is also suppressed by `--quiet`.
+Silence the notice with `[restack] preflight_warn = false` in
+`~/.config/stax/config.toml` or with `--quiet`. Disable the automatic correction
+with `[restack] preflight_auto_repair = false`.
 
 ## `st run <cmd>` (alias: `st test <cmd>`)
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -40,6 +40,12 @@ Main config path: `~/.config/stax/config.toml`.
 [ui]
 # tips = true
 
+[restack]
+# preflight_warn = true   # warn before rebase if stored parent boundary
+                          # would replay a much larger range than merge-base
+                          # (catches "conflicts on files I didn't touch" caused
+                          # by stale metadata or `git merge main` into a branch)
+
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" — global default
 # model = "claude-sonnet-4-5-20250929"

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -41,10 +41,9 @@ Main config path: `~/.config/stax/config.toml`.
 # tips = true
 
 [restack]
-# preflight_warn = true   # warn before rebase if stored parent boundary
-                          # would replay a much larger range than merge-base
-                          # (catches "conflicts on files I didn't touch" caused
-                          # by stale metadata or `git merge main` into a branch)
+# preflight_auto_repair = true # automatically use merge-base when stored parent
+                               # boundary would replay a much larger range
+# preflight_warn = true        # print a notice when that automatic repair happens
 
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" — global default

--- a/skills.md
+++ b/skills.md
@@ -234,7 +234,7 @@ stax restack --continue            # Continue after conflicts
 stax restack --dry-run             # Predict conflicts only
 stax restack --submit-after yes    # ask|yes|no
 stax restack --auto-stash-pop      # Stash/pop dirty target worktrees
-stax restack --quiet               # Also silences the preflight advisory below
+stax restack --quiet               # Also silences the preflight notice below
 
 stax cascade                       # Restack bottom-up then submit
 stax cascade --no-pr               # Push only, skip PR updates
@@ -425,20 +425,15 @@ git add -A
 stax continue
 ```
 
-If conflicts touch files you never edited on this branch, look for the
-`preflight:` advisory printed at the start of restack — it indicates the
-stored `parentBranchRevision` is far out of step with `merge-base(parent, branch)`
-(common after `git merge main` into the branch, or when the branch was tracked
-late). Fix the boundary instead of resolving conflicts blindly:
+If stax detects that the stored `parentBranchRevision` would replay much more
+history than `merge-base(parent, branch)`, it prints a `preflight:` notice and
+automatically uses the merge-base boundary for that rebase. This is the common
+cause of “conflicts on files I never edited” after `git merge main` into a
+branch or late tracking.
 
-```bash
-stax abort
-stax branch reparent --parent main --branch <current>   # retargets at merge-base
-stax restack
-```
-
-Disable the advisory globally with `[restack] preflight_warn = false` in
-`~/.config/stax/config.toml`, or per-run with `--quiet`.
+Silence the notice with `[restack] preflight_warn = false` or `--quiet`.
+Disable the automatic correction with `[restack] preflight_auto_repair = false`
+only when debugging old boundary behaviour.
 
 ### Repair Broken Metadata
 

--- a/skills.md
+++ b/skills.md
@@ -234,6 +234,7 @@ stax restack --continue            # Continue after conflicts
 stax restack --dry-run             # Predict conflicts only
 stax restack --submit-after yes    # ask|yes|no
 stax restack --auto-stash-pop      # Stash/pop dirty target worktrees
+stax restack --quiet               # Also silences the preflight advisory below
 
 stax cascade                       # Restack bottom-up then submit
 stax cascade --no-pr               # Push only, skip PR updates
@@ -423,6 +424,21 @@ stax restack
 git add -A
 stax continue
 ```
+
+If conflicts touch files you never edited on this branch, look for the
+`preflight:` advisory printed at the start of restack — it indicates the
+stored `parentBranchRevision` is far out of step with `merge-base(parent, branch)`
+(common after `git merge main` into the branch, or when the branch was tracked
+late). Fix the boundary instead of resolving conflicts blindly:
+
+```bash
+stax abort
+stax branch reparent --parent main --branch <current>   # retargets at merge-base
+stax restack
+```
+
+Disable the advisory globally with `[restack] preflight_warn = false` in
+`~/.config/stax/config.toml`, or per-run with `--quiet`.
 
 ### Repair Broken Metadata
 


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Reduce confusing restack failures where git replays a much larger range than expected, often leading to conflicts on files the user never touched.

## Description of changes / notes for reviewers

- Document the new preflight advisory that compares the stored parent boundary against `merge-base(parent, branch)` before restack runs.
- Add guidance for the repair flow using `stax branch reparent`, plus config and CLI controls to suppress the warning globally or per run.