### PR TITLE
Fix CI watch terminal-state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ st config --set-ai
 | `st create <name> --below` | Insert a new branch below current |
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
-| `st ci -w --alert` | Watch CI until completion, then play success/error sounds |
+| `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
+| `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st refresh` | Sync trunk, restack current stack, then push/update PRs |
 | `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -108,7 +108,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | Command | Description |
 |---|---|
 | `st ci` | CI status for current branch (with elapsed/ETA learned from recent runs) |
-| `st ci --stack` / `--all` / `--watch` | Scope and watch modes |
+| `st ci --stack` / `--all` / `--watch` | Scope and watch modes (`--watch --strict` fail-fasts on failure) |
 | `st ci -w --alert` / `--alert <file>` / `--no-alert` | Success/error completion sounds for watch mode |
 | `st ci --verbose` / `--json` | Summary cards · JSON output |
 | `st pr` · `st pr open` | Open current branch PR |
@@ -250,7 +250,8 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 
 ### `st ci`
 
-- `--stack` / `--all` / `--watch` / `--interval 30` / `--json`
+- `--stack` / `--all` / `--watch` / `--watch --strict` / `--interval 30` / `--json`
+- By default, `--watch` waits until every check is terminal, even if one check has already failed. Add `--strict` to exit as soon as any check fails.
 - `--watch --alert` plays built-in success/error sounds; `--watch --alert <file>` uses one custom sound for either outcome; `--watch --no-alert` suppresses `[ci] alert = true` for one run.
 - Config can enable alerts by default with `[ci] alert = true`; set `success_alert_sound` and/or `error_alert_sound` to override the per-outcome built-in sounds.
 

--- a/skills.md
+++ b/skills.md
@@ -289,7 +289,8 @@ stax comments --plain              # Raw markdown output
 stax ci                            # CI for current branch (elapsed/ETA + avg from recent successful runs of the same checks)
 stax ci --stack                    # CI for current stack
 stax ci --all                      # CI for all tracked branches
-stax ci --watch --interval 30      # Watch CI, custom poll interval
+stax ci --watch --interval 30      # Watch until all checks finish, custom poll interval
+stax ci --watch --strict           # Watch but exit as soon as any check fails
 stax ci --watch --alert            # Watch CI, play built-in success/error sounds
 stax ci --watch --alert /path/to/sound.wav  # Use one custom sound for either outcome
 stax ci --watch --no-alert         # Suppress configured completion sounds for one run

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -720,6 +720,9 @@ enum Commands {
         /// Disable configured CI completion alerts for this run
         #[arg(long, requires = "watch", conflicts_with = "alert")]
         no_alert: bool,
+        /// Exit watch mode as soon as any check fails
+        #[arg(long, requires = "watch")]
+        strict: bool,
         /// Polling interval in seconds (default: 15)
         #[arg(long, default_value = "15")]
         interval: u64,
@@ -1966,6 +1969,7 @@ pub fn run() -> Result<()> {
             watch,
             alert,
             no_alert,
+            strict,
             interval,
             verbose,
         } => commands::ci::run(
@@ -1979,6 +1983,7 @@ pub fn run() -> Result<()> {
                 None => commands::ci::CiAlertSoundArg::DefaultSound,
             }),
             no_alert,
+            strict,
             interval,
             verbose,
         ),

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -280,6 +280,7 @@ pub fn run(
     watch: bool,
     alert_arg: Option<CiAlertSoundArg>,
     no_alert: bool,
+    strict: bool,
     interval: u64,
     verbose: bool,
 ) -> Result<()> {
@@ -347,6 +348,7 @@ pub fn run(
             json,
             verbose,
             alert,
+            strict,
         );
     }
 
@@ -803,8 +805,28 @@ pub fn record_ci_history(repo: &GitRepo, statuses: &[BranchCiStatus]) {
 fn all_checks_complete(statuses: &[BranchCiStatus]) -> bool {
     statuses.iter().all(|s| {
         // Branches with no CI configured are considered "done" (nothing to wait for)
-        s.check_runs.is_empty() || s.overall_status.as_deref() != Some("pending")
+        s.check_runs.is_empty()
+            || s.check_runs
+                .iter()
+                .all(|check| check_run_is_terminal(check.status.as_str()))
     })
+}
+
+fn check_run_is_terminal(status: &str) -> bool {
+    !matches!(
+        status,
+        "queued" | "in_progress" | "waiting" | "requested" | "pending"
+    )
+}
+
+fn ci_watch_should_exit(statuses: &[BranchCiStatus], strict: bool) -> bool {
+    (strict && has_ci_failure(statuses)) || all_checks_complete(statuses)
+}
+
+fn has_ci_failure(statuses: &[BranchCiStatus]) -> bool {
+    statuses
+        .iter()
+        .any(|s| s.overall_status.as_deref() == Some("failure"))
 }
 
 fn resolve_ci_alert_sounds(
@@ -884,6 +906,7 @@ fn run_watch_mode(
     json: bool,
     verbose: bool,
     alert: Option<CiAlertSounds>,
+    strict: bool,
 ) -> Result<()> {
     let poll_duration = Duration::from_secs(interval);
     let mut iteration = 0;
@@ -920,16 +943,14 @@ fn run_watch_mode(
             }
         }
 
-        let complete = all_checks_complete(&statuses);
+        let failed = has_ci_failure(&statuses);
+        let complete = ci_watch_should_exit(&statuses, strict);
 
         if complete {
-            let has_failure = statuses
-                .iter()
-                .any(|s| s.overall_status.as_deref() == Some("failure"));
             println!();
             let width = 50;
             let line = "═".repeat(width);
-            if has_failure {
+            if failed {
                 let failed_branch = statuses
                     .iter()
                     .find(|s| s.overall_status.as_deref() == Some("failure"))
@@ -964,7 +985,7 @@ fn run_watch_mode(
             }
 
             record_ci_history(repo, &statuses);
-            let alert_outcome = if has_failure {
+            let alert_outcome = if failed {
                 CiAlertOutcome::Error
             } else {
                 CiAlertOutcome::Success
@@ -1472,6 +1493,70 @@ mod tests {
         assert_eq!(render_progress_bar(99, 10), "▰▰▰▰▰▰▰▰▰▱");
         // 100% fills all blocks
         assert_eq!(render_progress_bar(100, 10), "▰▰▰▰▰▰▰▰▰▰");
+    }
+
+    fn test_check(name: &str, status: &str, conclusion: Option<&str>) -> CheckRunInfo {
+        CheckRunInfo {
+            name: name.to_string(),
+            status: status.to_string(),
+            conclusion: conclusion.map(str::to_string),
+            url: None,
+            started_at: None,
+            completed_at: None,
+            elapsed_secs: None,
+            average_secs: None,
+            completion_percent: None,
+        }
+    }
+
+    fn test_branch_status(overall_status: &str, check_runs: Vec<CheckRunInfo>) -> BranchCiStatus {
+        BranchCiStatus {
+            branch: "feature".to_string(),
+            sha: "0123456789abcdef".to_string(),
+            sha_short: "0123456".to_string(),
+            overall_status: Some(overall_status.to_string()),
+            check_runs,
+            pr_number: Some(123),
+        }
+    }
+
+    #[test]
+    fn ci_watch_waits_for_running_checks_after_failure() {
+        let statuses = vec![test_branch_status(
+            "failure",
+            vec![
+                test_check("codeowners", "completed", Some("action_required")),
+                test_check("integration", "in_progress", None),
+            ],
+        )];
+
+        assert!(!all_checks_complete(&statuses));
+    }
+
+    #[test]
+    fn ci_watch_strict_exits_on_failure_before_running_checks_complete() {
+        let statuses = vec![test_branch_status(
+            "failure",
+            vec![
+                test_check("codeowners", "completed", Some("action_required")),
+                test_check("integration", "in_progress", None),
+            ],
+        )];
+
+        assert!(ci_watch_should_exit(&statuses, true));
+    }
+
+    #[test]
+    fn ci_watch_exits_after_all_checks_are_terminal_with_failure() {
+        let statuses = vec![test_branch_status(
+            "failure",
+            vec![
+                test_check("codeowners", "completed", Some("action_required")),
+                test_check("integration", "completed", Some("success")),
+            ],
+        )];
+
+        assert!(ci_watch_should_exit(&statuses, false));
     }
 
     #[test]

--- a/tests/ci_tests.rs
+++ b/tests/ci_tests.rs
@@ -155,6 +155,7 @@ fn test_ci_alert_flags_are_recognized() {
         vec!["ci", "--watch", "--alert"],
         vec!["ci", "--watch", "--alert", "/tmp/ci-done.wav"],
         vec!["ci", "--watch", "--no-alert"],
+        vec!["ci", "--watch", "--strict"],
     ] {
         let output = repo.run_stax(&args);
         let stderr = TestRepo::stderr(&output);


### PR DESCRIPTION
## Summary

- Make `st ci --watch` wait until every check is terminal before exiting, even when one check has already failed.
- Add `st ci --watch --strict` for the previous fail-fast behavior.
- Update README, command docs, and `skills.md` for the changed watch behavior.

## Verification

- `cargo test ci_watch_ --lib`
- `cargo test --test ci_tests`
- `make test` (1605 passed, 0 skipped)

Closes #366