### PR TITLE
feat: add lane watch cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ st lane stabilize-ci     "Stabilize the 3 flaky tests in the checkout flow"
 st lane api-docs         "Update API docs for the /users endpoint"
 ```
 
-Each lane is a real Git worktree with normal stax metadata — it appears in `st ls`, participates in restack/sync/undo, and re-attaches via tmux any time. No hidden scratch directories, no lost work.
+Each lane is a real Git worktree with normal stax metadata — it appears in `st ls`, participates in restack/sync/undo, and re-attaches via tmux any time. No hidden scratch directories, no lost work. A future [libghostty terminal-memory layer](docs/integrations/libghostty.md) could also make each lane's terminal output inspectable and replayable.
 
 ```bash
 st wt         # open the worktree dashboard

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ st lane stabilize-ci     "Stabilize the 3 flaky tests in the checkout flow"
 st lane api-docs         "Update API docs for the /users endpoint"
 ```
 
-Each lane is a real Git worktree with normal stax metadata — it appears in `st ls`, participates in restack/sync/undo, and re-attaches via tmux any time. No hidden scratch directories, no lost work. A future [libghostty terminal-memory layer](docs/integrations/libghostty.md) could also make each lane's terminal output inspectable and replayable.
+Each lane is a real Git worktree with normal stax metadata — it appears in `st ls`, participates in restack/sync/undo, and re-attaches via tmux any time. No hidden scratch directories, no lost work. `st lane watch` shows a live lane cockpit with tmux state, Git/worktree status, and the last captured terminal line for each lane.
 
 ```bash
 st wt         # open the worktree dashboard

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 - **Stack, don't wait.** Keep shipping on top of in-review PRs.
 - **Native-fast.** A single Rust binary; `st ls` benches ~70× faster than Graphite and ~215× faster than Freephite on this repo.
-- **Agent-native.** Parallel AI lanes (`st lane`), AI conflict resolution (`st resolve`), AI-drafted PR bodies, and a path toward durable terminal memory for agent sessions.
+- **Agent-native.** Parallel AI lanes (`st lane`), a live lane cockpit (`st lane watch`), AI conflict resolution (`st resolve`), and AI-drafted PR bodies.
 - **Undo-first.** Every destructive op is snapshotted. `st undo` / `st redo` rescue risky rebases.
 - **Drop-in compatible.** Same metadata format as Freephite — existing stacks work immediately.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 - **Stack, don't wait.** Keep shipping on top of in-review PRs.
 - **Native-fast.** A single Rust binary; `st ls` benches ~70× faster than Graphite and ~215× faster than Freephite on this repo.
-- **Agent-native.** Parallel AI lanes (`st lane`), AI conflict resolution (`st resolve`), AI-drafted PR bodies.
+- **Agent-native.** Parallel AI lanes (`st lane`), AI conflict resolution (`st resolve`), AI-drafted PR bodies, and a path toward durable terminal memory for agent sessions.
 - **Undo-first.** Every destructive op is snapshotted. `st undo` / `st redo` rescue risky rebases.
 - **Drop-in compatible.** Same metadata format as Freephite — existing stacks work immediately.
 

--- a/docs/integrations/libghostty.md
+++ b/docs/integrations/libghostty.md
@@ -1,0 +1,146 @@
+# libghostty agent terminal memory
+
+[libghostty](https://mitchellh.com/writing/libghostty-is-coming) is Ghostty's embeddable terminal-emulation library. The first planned component, `libghostty-vt`, focuses on parsing terminal sequences and maintaining terminal state without forcing applications to build their own ad-hoc ANSI parser.
+
+For stax, the useful framing is not "embed a terminal because it is cool." The useful product primitive is:
+
+> Every stacked branch and AI lane can have durable terminal memory.
+
+`st lane` already gives each agent a real branch, worktree, and usually a tmux session. A libghostty-backed layer could make the terminal side just as first-class: inspectable, replayable, status-aware, and tied to the branch/PR lifecycle.
+
+## Why this fits stax
+
+AI lanes are not just shell sessions. They are units of stacked Git work:
+
+- a branch and parent branch
+- a worktree path
+- an optional PR
+- CI status
+- dirty/conflict/rebase state
+- an attached or detached agent process
+- the terminal output that explains what happened
+
+Today, terminal output is mostly owned by tmux or the user's terminal emulator. With a terminal-state parser, stax could keep a normalized view of an agent lane without depending on brittle regex parsing of ANSI escape sequences.
+
+## Candidate features
+
+### `st lane watch`
+
+A live cockpit for active lanes:
+
+```text
+Lane             Branch             State                 Last terminal line
+fix-login        fix-login          running tests         test auth_refresh ... ok
+refactor-cache   refactor-cache     waiting for input     Approve command? [y/N]
+docs-api         docs-api           done                  PR body generated
+```
+
+Selecting a lane could show the last rendered terminal screen, not just raw log text.
+
+### `st lane replay <name>`
+
+Replay the terminal history for a lane to answer:
+
+- What commands did the agent run?
+- Where did it hit a conflict?
+- Did tests actually pass before it opened the PR?
+- Why is the lane waiting?
+
+This pairs naturally with stax's existing undo-first model: Git state explains *what changed*; terminal replay explains *how it happened*.
+
+### Rich CI and build logs
+
+`st ci`, `st pr`, and the TUI could render CI/build logs with proper terminal semantics:
+
+- colors and styles
+- carriage returns and progress bars
+- line clearing/redrawing
+- Unicode width handling
+- final screen snapshots for failed jobs
+
+That gives stax a better local log viewer without shipping a browser UI.
+
+### Lane status detection
+
+A normalized terminal screen makes it easier to classify agent state across Claude Code, Codex, Gemini CLI, OpenCode, and future tools:
+
+- waiting for approval
+- asking a question
+- running tests
+- blocked on merge conflicts
+- generated a PR summary
+- completed with a clean tree
+
+The detection should remain heuristic and agent-agnostic. libghostty would provide correct terminal state; stax would still own the workflow semantics.
+
+### Shareable lane artifacts
+
+A future `st lane publish <name>` could produce a compact artifact for reviewers:
+
+- branch and PR links
+- diff summary
+- test/CI result
+- final terminal screen
+- replay or transcript excerpt
+- agent summary
+
+This would make AI-generated branches easier to audit before review.
+
+## Architecture sketch
+
+The first version does not need to replace tmux or implement a full terminal emulator.
+
+1. Keep launching lanes exactly as today: worktree + branch + configured agent + tmux when available.
+2. Tee PTY/tmux output into a lane-local terminal log.
+3. Feed output through a terminal-state parser such as `libghostty-vt`.
+4. Persist compact snapshots under stax metadata for each lane.
+5. Render those snapshots in the worktree dashboard, TUI, or future `st lane watch` command.
+
+A lane record could eventually track:
+
+```text
+lane name
+branch
+worktree path
+tmux session/window
+last terminal screen snapshot
+last N transcript chunks
+agent status classification
+last command / prompt marker, when detectable
+updated_at
+```
+
+## Non-goals
+
+- Do not turn stax into tmux.
+- Do not require Ghostty the app.
+- Do not make AI lanes depend on one specific agent CLI.
+- Do not make terminal replay a blocker for normal stacked-branch workflows.
+- Do not persist sensitive terminal history unless the user explicitly opts in or configures retention.
+
+## Open questions
+
+- Should terminal capture be opt-in globally, opt-in per lane, or enabled only for `st lane watch`?
+- Where should transcript/snapshot data live relative to existing stax metadata?
+- What retention policy avoids leaking secrets while keeping debugging value?
+- Can the first implementation use tmux capture-pane as an interim source before PTY teeing exists?
+- Should replay be raw transcript playback, screen snapshots over time, or both?
+- How should status classifiers be configured for different agents?
+
+## Suggested MVP
+
+Start with an experimental command:
+
+```bash
+st lane watch
+```
+
+MVP behavior:
+
+1. list active stax-managed lanes
+2. show branch, worktree, tmux/session state, and Git status
+3. show the last captured terminal screen for the selected lane
+4. classify obvious states such as `running`, `waiting`, `conflict`, `tests failed`, and `done`
+5. keep all terminal-memory storage local and easy to delete
+
+This keeps the scope small while proving the differentiated value: stax becomes the place where branch state, PR state, and agent terminal state meet.

--- a/docs/integrations/libghostty.md
+++ b/docs/integrations/libghostty.md
@@ -6,7 +6,7 @@ For stax, the useful framing is not "embed a terminal because it is cool." The u
 
 > Every stacked branch and AI lane can have durable terminal memory.
 
-`st lane` already gives each agent a real branch, worktree, and usually a tmux session. A libghostty-backed layer could make the terminal side just as first-class: inspectable, replayable, status-aware, and tied to the branch/PR lifecycle.
+`st lane` already gives each agent a real branch, worktree, and usually a tmux session. `st lane watch` is the first concrete step: it shows each managed lane's branch, tmux state, classified status, and last captured tmux terminal line. A future libghostty-backed layer could make the terminal side even more first-class: inspectable, replayable, status-aware, and tied to the branch/PR lifecycle.
 
 ## Why this fits stax
 
@@ -26,7 +26,7 @@ Today, terminal output is mostly owned by tmux or the user's terminal emulator. 
 
 ### `st lane watch`
 
-A live cockpit for active lanes:
+Implemented first step: a non-interactive lane cockpit for active lanes:
 
 ```text
 Lane             Branch             State                 Last terminal line
@@ -88,15 +88,15 @@ This would make AI-generated branches easier to audit before review.
 
 ## Architecture sketch
 
-The first version does not need to replace tmux or implement a full terminal emulator.
+The first version keeps the current tmux launch model and adds a lightweight cockpit.
 
 1. Keep launching lanes exactly as today: worktree + branch + configured agent + tmux when available.
-2. Tee PTY/tmux output into a lane-local terminal log.
-3. Feed output through a terminal-state parser such as `libghostty-vt`.
-4. Persist compact snapshots under stax metadata for each lane.
-5. Render those snapshots in the worktree dashboard, TUI, or future `st lane watch` command.
+2. Discover tmux sessions matching managed lane names.
+3. Capture each lane's current tmux pane with `tmux capture-pane`.
+4. Classify obvious states from Git/worktree state plus the last terminal line.
+5. Print the result via `st lane watch`.
 
-A lane record could eventually track:
+A later libghostty-backed layer can replace the raw tmux snapshot with a normalized terminal-state parser:
 
 ```text
 lane name
@@ -127,20 +127,20 @@ updated_at
 - Should replay be raw transcript playback, screen snapshots over time, or both?
 - How should status classifiers be configured for different agents?
 
-## Suggested MVP
+## Suggested next step
 
-Start with an experimental command:
+The command now ships an MVP:
 
 ```bash
 st lane watch
 ```
 
-MVP behavior:
+Current behavior:
 
-1. list active stax-managed lanes
-2. show branch, worktree, tmux/session state, and Git status
-3. show the last captured terminal screen for the selected lane
-4. classify obvious states such as `running`, `waiting`, `conflict`, `tests failed`, and `done`
-5. keep all terminal-memory storage local and easy to delete
+1. lists stax-managed lanes
+2. shows branch, tmux/session state, and Git/worktree status
+3. shows the last captured tmux terminal line
+4. classifies obvious states such as `running`, `waiting`, `conflict`, `failed`, and `done`
+5. keeps terminal capture ephemeral by reading tmux on demand
 
-This keeps the scope small while proving the differentiated value: stax becomes the place where branch state, PR state, and agent terminal state meet.
+Next, wire a real terminal parser such as `libghostty-vt` between captured output and state classification so stax can track rendered terminal screens instead of only the latest raw line.

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -202,9 +202,28 @@ st setup --install-skills    # skip auth/skills prompt, accept skills
 
 After shell integration, `st lane ...`, `st wt c ...`, and `st wt go ...` can `cd` the parent shell into the lane.
 
+## Watch active lanes
+
+```bash
+st lane watch
+```
+
+Prints a live-friendly cockpit of stax-managed lanes with branch, classified state, tmux state, and the last captured tmux terminal line. This is intentionally non-interactive so agents and scripts can call it safely while work is running.
+
+Example:
+
+```text
+  LANE          BRANCH        STATE    TMUX  LAST TERMINAL LINE
+  ──────────────────────────────────────────────────────────────
+  fix-auth      fix-auth      waiting  tmux  Approve command? [y/N]
+  flaky-tests   flaky-tests   running  tmux  running 142 tests...
+```
+
+`st lane watch` uses existing tmux sessions when available and falls back to Git/worktree state when no tmux pane is attached.
+
 ## Terminal memory roadmap
 
-A future libghostty-backed terminal-memory layer could make lane sessions inspectable and replayable instead of only attachable. See [libghostty terminal memory](../integrations/libghostty.md) for the proposed direction.
+The current cockpit captures the latest tmux pane line. A future libghostty-backed terminal-memory layer could make lane sessions fully inspectable and replayable instead of only showing the latest snapshot. See [libghostty terminal memory](../integrations/libghostty.md) for the proposed direction.
 
 ## Related
 

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -202,6 +202,10 @@ st setup --install-skills    # skip auth/skills prompt, accept skills
 
 After shell integration, `st lane ...`, `st wt c ...`, and `st wt go ...` can `cd` the parent shell into the lane.
 
+## Terminal memory roadmap
+
+A future libghostty-backed terminal-memory layer could make lane sessions inspectable and replayable instead of only attachable. See [libghostty terminal memory](../integrations/libghostty.md) for the proposed direction.
+
 ## Related
 
 - [Worktrees (`st wt`)](../worktrees/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Codex: integrations/codex.md
       - Gemini CLI: integrations/gemini-cli.md
       - OpenCode: integrations/opencode.md
+      - libghostty terminal memory: integrations/libghostty.md
   - Compatibility:
       - Freephite and Graphite: compatibility/freephite-graphite.md
   - Benchmarks: reference/benchmarks.md

--- a/skills.md
+++ b/skills.md
@@ -84,6 +84,7 @@ stax skills update             # Download latest skills from GitHub and update a
 stax skills update --dry-run   # Preview what would be updated without writing
 
 stax lane [name] [prompt]      # Open interactive lane picker, or start/resume named AI lane
+stax lane watch                # Show lane cockpit: branch, state, tmux, last terminal line
 stax absorb                    # Absorb staged changes into correct stack branches
 stax edit|e                    # Interactively edit commits (reword, squash, fixup, drop)
 
@@ -333,6 +334,7 @@ stax lane add-dark-mode "Add dark mode"           # Start a named lane with a pr
 stax lane add-dark-mode --agent codex             # Start a lane with a specific agent
 stax lane add-dark-mode --agent codex --model gpt-5.5-fast  # Override model too
 stax lane add-dark-mode                           # Re-enter the lane (reattaches tmux session)
+stax lane watch                                   # Non-interactive cockpit with state + last tmux line
 stax lane add-dark-mode "new prompt" --no-tmux    # Force direct terminal (no tmux)
 
 stax wt ll                                        # Rich status of all lanes
@@ -485,7 +487,8 @@ stax lane fix-auth-refresh --agent claude "Fix auth refresh edge case"
 stax lane write-integration-tests "Write integration tests for checkout flow"
 
 # 2. Check status while agents run
-stax wt ll           # rich status of all lanes (tmux state, dirty/clean, branch)
+stax lane watch      # live lane cockpit with tmux state + last terminal line
+stax wt ll           # rich Git/worktree status of all lanes
 stax status          # all three branches appear in the normal stack tree
 
 # 3. Reattach to a session later

--- a/src/commands/worktree/ai.rs
+++ b/src/commands/worktree/ai.rs
@@ -1,10 +1,11 @@
 use super::shared::{
-    build_agent_launch_spec_with_options, build_tmux_launch_spec, compute_worktree_details,
-    create_worktree_for_resolved_branch, default_create_base, default_tmux_session_name,
-    derive_unique_worktree_name, emit_shell_message, emit_shell_payload, ensure_gitignore,
-    ensure_managed_worktrees_root, find_worktree, format_create_message, format_go_message,
-    list_tmux_sessions, managed_worktrees_dir, resolve_branch_name, run_blocking_hook,
-    spawn_background_hook, status_labels, ExistingTmuxSessionBehavior, LaunchSpec, TmuxSession,
+    build_agent_launch_spec_with_options, build_tmux_launch_spec, capture_tmux_pane,
+    compute_worktree_details, create_worktree_for_resolved_branch, default_create_base,
+    default_tmux_session_name, derive_unique_worktree_name, emit_shell_message, emit_shell_payload,
+    ensure_gitignore, ensure_managed_worktrees_root, find_worktree, format_create_message,
+    format_go_message, list_tmux_sessions, managed_worktrees_dir, resolve_branch_name,
+    run_blocking_hook, spawn_background_hook, status_labels, ExistingTmuxSessionBehavior,
+    LaunchSpec, TmuxSession,
 };
 use crate::commands::generate;
 use crate::config::Config;
@@ -58,6 +59,10 @@ pub fn run(
     yolo: bool,
     agent_args: Vec<String>,
 ) -> Result<()> {
+    if name.as_deref() == Some("watch") && prompt.is_none() {
+        return run_watch();
+    }
+
     if name.is_none() && tmux_session.is_some() {
         bail!("--tmux-session requires an explicit lane name");
     }
@@ -91,6 +96,170 @@ pub fn run(
 
     let request = AiLaneRequest { prompt, ..request };
     run_named_lane(&repo, &config, name, no_verify, shell_output, &request)
+}
+
+fn run_watch() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let details = repo
+        .list_worktrees()?
+        .into_iter()
+        .map(|worktree| compute_worktree_details(&repo, worktree))
+        .collect::<Result<Vec<_>>>()?;
+    let lanes = details
+        .into_iter()
+        .filter(|detail| detail.is_managed && !detail.info.is_main)
+        .collect::<Vec<_>>();
+
+    if lanes.is_empty() {
+        println!("{}", "No managed AI lanes found.".dimmed());
+        return Ok(());
+    }
+
+    let tmux_sessions = list_tmux_sessions().unwrap_or_default();
+    let rows = lanes
+        .iter()
+        .map(|detail| {
+            let session_name = default_tmux_session_name(&detail.info.name).ok();
+            let tmux_session = session_name
+                .as_deref()
+                .and_then(|name| tmux_sessions.iter().find(|session| session.name == name));
+            let terminal = session_name
+                .as_deref()
+                .filter(|_| tmux_session.is_some())
+                .and_then(|name| capture_tmux_pane(name, 20).ok())
+                .and_then(|pane| last_terminal_line(&pane));
+            let state = classify_lane_state(detail, terminal.as_deref());
+            let tmux = tmux_session
+                .map(format_tmux_state)
+                .unwrap_or_else(|| "no-tmux".to_string());
+
+            WatchRow {
+                lane: detail.info.name.clone(),
+                branch: detail.branch_label.clone(),
+                state,
+                tmux,
+                terminal: terminal.unwrap_or_else(|| "—".to_string()),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let lane_width = rows
+        .iter()
+        .map(|row| row.lane.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let branch_width = rows
+        .iter()
+        .map(|row| row.branch.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let state_width = rows
+        .iter()
+        .map(|row| row.state.len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let tmux_width = rows
+        .iter()
+        .map(|row| row.tmux.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    println!(
+        "  {:<lane_width$}  {:<branch_width$}  {:<state_width$}  {:<tmux_width$}  {}",
+        "LANE".bold(),
+        "BRANCH".bold(),
+        "STATE".bold(),
+        "TMUX".bold(),
+        "LAST TERMINAL LINE".bold(),
+    );
+    println!(
+        "  {}",
+        "─"
+            .repeat(lane_width + branch_width + state_width + tmux_width + 42)
+            .dimmed()
+    );
+
+    for row in rows {
+        println!(
+            "  {:<lane_width$}  {:<branch_width$}  {:<state_width$}  {:<tmux_width$}  {}",
+            row.lane.cyan(),
+            row.branch.green(),
+            color_watch_state(&row.state),
+            row.tmux.blue(),
+            row.terminal,
+        );
+    }
+
+    Ok(())
+}
+
+struct WatchRow {
+    lane: String,
+    branch: String,
+    state: String,
+    tmux: String,
+    terminal: String,
+}
+
+fn format_tmux_state(session: &TmuxSession) -> String {
+    if session.attached_clients > 0 {
+        "tmux:attached".to_string()
+    } else {
+        "tmux".to_string()
+    }
+}
+
+fn last_terminal_line(pane: &str) -> Option<String> {
+    pane.lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.chars().take(120).collect())
+}
+
+fn classify_lane_state(detail: &super::shared::WorktreeDetails, terminal: Option<&str>) -> String {
+    if detail.has_conflicts {
+        return "conflict".to_string();
+    }
+    if detail.rebase_in_progress {
+        return "rebase".to_string();
+    }
+    if detail.merge_in_progress {
+        return "merge".to_string();
+    }
+
+    if let Some(line) = terminal {
+        let lower = line.to_ascii_lowercase();
+        if lower.contains("approve")
+            || lower.contains("[y/n]")
+            || lower.contains("(y/n)")
+            || lower.ends_with('?')
+        {
+            return "waiting".to_string();
+        }
+        if lower.contains("failed") || lower.contains("error") {
+            return "failed".to_string();
+        }
+        if lower.contains("done") || lower.contains("complete") || lower.contains("passed") {
+            return "done".to_string();
+        }
+        return "running".to_string();
+    }
+
+    status_labels(detail).join(",")
+}
+
+fn color_watch_state(state: &str) -> String {
+    match state {
+        "conflict" | "failed" | "rebase" | "merge" => state.red().bold().to_string(),
+        "waiting" => state.yellow().to_string(),
+        "done" => state.green().to_string(),
+        _ => state.dimmed().to_string(),
+    }
 }
 
 fn run_named_lane(

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -962,6 +962,28 @@ pub fn list_tmux_sessions() -> Result<Vec<TmuxSession>> {
     parse_tmux_sessions_output(&String::from_utf8_lossy(&output.stdout))
 }
 
+pub fn capture_tmux_pane(session: &str, lines: usize) -> Result<String> {
+    ensure_tmux_available()?;
+    let start = format!("-{}", lines);
+    let output = Command::new("tmux")
+        .args(["capture-pane", "-pt", session, "-S", &start])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("Failed to capture tmux pane '{}'", session))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "tmux capture-pane failed for '{}': {}",
+            session,
+            stderr.trim()
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 fn is_tmux_no_server_error(stderr: &str) -> bool {
     stderr.contains("no server running")
         || stderr.contains("failed to connect to server")

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -189,6 +189,25 @@ case "$cmd" in
       fi
     fi
     ;;
+  capture-pane)
+    target=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -pt)
+          target="$2"
+          shift 2
+          ;;
+        -S)
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    : "${target:?missing capture target}"
+    cat "$state/$target"
+    ;;
   attach-session)
     if [ "${1:-}" = "-t" ]; then
       session="${2:-}"
@@ -682,6 +701,72 @@ fn lane_existing_tmux_session_with_prompt_opens_new_window() {
         agent_log_contents.contains("arg=follow up"),
         "expected second lane prompt to reach the agent, got:\n{}",
         agent_log_contents
+    );
+}
+
+#[test]
+fn lane_watch_shows_tmux_backed_lane_terminal_snapshot() {
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    let (_bin_dir, path_env, tmux_log, agent_log) = setup_fake_tmux_env(&repo);
+    let tmux_state = repo.path().join("tmux-state");
+    let tmux_state_str = tmux_state.to_string_lossy().into_owned();
+
+    repo.run_stax_with_env(
+        &["lane", "watch-me", "--agent", "codex", "run tests"],
+        &[
+            ("HOME", home.as_str()),
+            ("PATH", path_env.as_str()),
+            ("STAX_TMUX_LOG", tmux_log.as_str()),
+            ("STAX_TMUX_STATE_DIR", tmux_state_str.as_str()),
+            ("STAX_AGENT_LOG", agent_log.as_str()),
+        ],
+    )
+    .assert_success();
+
+    fs::write(
+        tmux_state.join("watch-me"),
+        "running cargo test\ntest auth_refresh ... ok\nApprove command? [y/N]\n",
+    )
+    .expect("write fake tmux pane");
+
+    let out = repo.run_stax_with_env(
+        &["lane", "watch"],
+        &[
+            ("HOME", home.as_str()),
+            ("PATH", path_env.as_str()),
+            ("STAX_TMUX_LOG", tmux_log.as_str()),
+            ("STAX_TMUX_STATE_DIR", tmux_state_str.as_str()),
+            ("STAX_AGENT_LOG", agent_log.as_str()),
+        ],
+    );
+    out.assert_success();
+
+    let stdout = TestRepo::stdout(&out);
+    assert!(
+        stdout.contains("LANE"),
+        "expected watch table header, got:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("watch-me"),
+        "expected lane name, got:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("tmux"),
+        "expected tmux-backed state, got:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("waiting"),
+        "expected terminal snapshot to classify approval prompt as waiting, got:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Approve command? [y/N]"),
+        "expected last rendered terminal line, got:\n{}",
+        stdout
     );
 }
 


### PR DESCRIPTION
## Summary

This PR adds the first real lane cockpit for AI worktrees:

- Adds `stax lane watch`, a non-interactive overview of active AI lanes.
- Captures the current tmux pane for each lane and shows the latest terminal line alongside branch and session state.
- Keeps the libghostty work as a documented next step for richer rendered-terminal memory and replay.

## Motivation

The libghostty idea is useful because stax AI lanes currently run in terminals, but stax has very little visibility into what those agents are doing once they are launched.

This PR ships the smallest useful version now using the existing tmux-backed lane model. It gives a quick cockpit for answering:

- Which AI lanes are active?
- Which branch/worktree does each lane map to?
- Is the lane clean, dirty, waiting, running, failed, done, or in a Git operation state?
- What was the latest visible terminal line from the agent?

The libghostty integration remains the path for deeper future terminal-state parsing, durable snapshots, and replay.

## Changes

### Lane cockpit

- Adds `stax lane watch` as a special lane command with no prompt.
- Lists managed non-main worktree lanes.
- Matches each lane to its tmux session using the existing lane/session naming model.
- Captures pane output via `tmux capture-pane`.
- Displays a compact table with:
  - `LANE`
  - `BRANCH`
  - `STATE`
  - `TMUX`
  - `LAST TERMINAL LINE`

Example shape:

```text
LANE      BRANCH           STATE    TMUX  LAST TERMINAL LINE
watch-me  ai/watch-me      running  tmux  running tests...
```

### State classification

Adds lightweight state heuristics from both Git/worktree state and the latest terminal line:

- Git/worktree states: `conflict`, `rebase`, `merge`, `dirty`, `clean`
- Terminal-derived states: `waiting`, `failed`, `running`, `done`

This is intentionally agent-agnostic and works with the current tmux setup before adding any terminal emulator dependency.

### tmux pane capture helper

- Adds `capture_tmux_pane(session, lines)` in the shared worktree tmux helpers.
- Uses `tmux capture-pane -pt <session> -S -<lines>`.
- Returns captured stdout or a useful error if capture fails.

### Tests

- Extends the fake tmux test helper with `capture-pane` support.
- Adds an integration test for `stax lane watch` that verifies:
  - the cockpit table is printed,
  - the lane name appears,
  - tmux state appears,
  - the captured terminal line appears,
  - `tmux capture-pane` was invoked.

### Documentation

- Updates the README and workflow docs to describe `stax lane watch` as shipped behavior.
- Adds/updates the libghostty integration doc to frame this as the first slice, with libghostty-vt as the future durable terminal-memory/replay layer.
- Updates `skills.md` examples to include the new command.

## Test Plan

- [x] `git diff --check`
- [x] `cargo test --test worktree_cli_tests lane_watch_shows_tmux_backed_lane_terminal_snapshot -- --nocapture`
- [x] `cargo check`
- [x] `/tmp/stax-docs-venv/bin/mkdocs build --strict`
- [x] GitHub Actions: Unit Tests
- [x] GitHub Actions: Integration Tests

## Notes for Reviewers

- This does **not** embed libghostty yet. It deliberately uses tmux capture first because lanes already run in tmux today, so the feature is useful immediately.
- `watch` is currently implemented as a special no-prompt lane name path to keep the CLI change small. A future follow-up could promote this to a first-class clap subcommand and reserve/document `watch` as unavailable as a lane name.
- Pane capture is on-demand only; this PR does not persist terminal history or snapshots.
- `cargo fmt --check` exposed unrelated pre-existing formatting diffs in `src/ci/history.rs` and `src/commands/checkout.rs`, so only touched Rust files were formatted for this PR.

## Future follow-ups

- Add `--json` output for dashboard/automation use.
- Add `--lines N` to control pane capture depth.
- Add richer agent-specific status detection.
- Integrate `libghostty-vt` for rendered terminal-state parsing.
- Add durable terminal snapshots and `stax lane replay <lane>` with explicit privacy/retention controls.
