### PR TITLE
Add downstack-only merge scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,11 @@ st ss         # submit PRs for the ones that are ready
 Merge from the bottom of the stack up to your current branch, with CI and readiness checks:
 
 ```bash
-st merge              # local cascade merge
-st merge --when-ready # wait/poll until PRs are mergeable
-st merge --remote     # merge remotely on GitHub while you keep working
-st merge --all        # merge the whole stack regardless of position
+st merge                  # local cascade merge
+st merge --when-ready     # wait/poll until PRs are mergeable
+st merge --ds             # merge ancestors, rebase current branch
+st merge --remote         # merge remotely on GitHub while you keep working
+st merge --all            # merge the whole stack regardless of position
 ```
 
 → [Merge and cascade](docs/workflows/merge-and-cascade.md)
@@ -266,7 +267,7 @@ st config --set-ai
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current |
 | `st ss` | Submit the full stack, open/update linked PRs |
-| `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--remote`, `--all`) |
+| `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--remote`, `--all`) |
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -20,6 +20,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st ss` | Submit the whole stack — open or update linked PRs |
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
+| `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
 | `st cascade` | Restack, push, and create/update PRs in one shot |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -27,6 +27,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`
+- `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; incompatible with `--all`, `--remote`, and `--queue`
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains
 
@@ -218,7 +219,7 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 ### `st merge`
 
 - `--dry-run` / `--yes`
-- `--all` / `--method squash|merge|rebase`
+- `--all` / `--downstack-only` (`--ds`) / `--method squash|merge|rebase`
 - `--when-ready` · `--when-ready --interval 10`
 - `--remote` · `--remote --all` · `--remote --timeout 60 --interval 10`
 - `--queue` · `--queue --all --yes`

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -21,12 +21,15 @@ During descendant rebases, boundaries are provenance-aware so already-integrated
 ```bash
 st merge --dry-run
 st merge --all
+st merge --downstack-only                 # alias: --ds
 st merge --method squash|merge|rebase
 st merge --when-ready                       # wait for readiness explicitly
 st merge --when-ready --interval 10
 st merge --no-wait --no-delete --no-sync
 st merge --timeout 60 --yes
 ```
+
+`--downstack-only` (`--ds`) merges only ancestors below the current branch, then rebases the current branch onto trunk and keeps descendants stacked above it. It is incompatible with `--all`, `--remote`, and `--queue`.
 
 `--when-ready` is incompatible with `--dry-run`, `--no-wait`, and `--remote`.
 
@@ -41,6 +44,18 @@ st merge
 ```
 
 Merges up to `auth-api`; `auth-ui` and `auth-tests` remain for later.
+
+### Downstack-only merge
+
+Use `--downstack-only` when you want to land prerequisites but keep the checked-out branch open:
+
+```bash
+# stack: main ← auth ← auth-api ← auth-ui ← auth-tests
+st checkout auth-ui
+st merge --ds
+```
+
+Merges `auth` and `auth-api`; `auth-ui` is rebased onto `main`, and `auth-tests` remains stacked on `auth-ui`.
 
 ## `st merge --remote` (GitHub only)
 

--- a/skills.md
+++ b/skills.md
@@ -201,6 +201,8 @@ stax upstack submit                # Submit current + descendants
 stax downstack submit              # Submit ancestors + current
 
 stax merge --all                   # Merge whole stack
+stax merge --downstack-only        # Merge ancestors below current, then rebase current
+stax merge --ds                    # Alias for --downstack-only
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
 stax merge --when-ready            # Wait for CI + approval before each merge

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -277,6 +277,9 @@ enum Commands {
         /// Merge entire stack (ignore current position)
         #[arg(long)]
         all: bool,
+        /// Merge ancestors below current, then rebase current branch
+        #[arg(long, visible_alias = "ds", conflicts_with_all = ["all", "remote", "queue"])]
+        downstack_only: bool,
         /// Show merge plan without merging
         #[arg(long)]
         dry_run: bool,
@@ -322,6 +325,9 @@ enum Commands {
         /// Merge entire stack (include descendants above current)
         #[arg(long)]
         all: bool,
+        /// Merge ancestors below current, then rebase current branch
+        #[arg(long, visible_alias = "ds", conflicts_with = "all")]
+        downstack_only: bool,
         /// Merge method: squash, merge, rebase
         #[arg(long, default_value = "squash")]
         method: String,
@@ -1753,6 +1759,7 @@ pub fn run() -> Result<()> {
         Commands::Submit { submit } => run_submit(submit, commands::submit::SubmitScope::Stack),
         Commands::Merge {
             all,
+            downstack_only,
             dry_run,
             method,
             no_delete,
@@ -1783,6 +1790,7 @@ pub fn run() -> Result<()> {
             } else if when_ready {
                 commands::merge_when_ready::run(
                     all,
+                    downstack_only,
                     merge_method,
                     timeout,
                     interval,
@@ -1794,6 +1802,7 @@ pub fn run() -> Result<()> {
             } else {
                 commands::merge::run(
                     all,
+                    downstack_only,
                     dry_run,
                     merge_method,
                     no_delete,
@@ -1807,6 +1816,7 @@ pub fn run() -> Result<()> {
         }
         Commands::MergeWhenReady {
             all,
+            downstack_only,
             method,
             timeout,
             interval,
@@ -1818,6 +1828,7 @@ pub fn run() -> Result<()> {
             let merge_method = method.parse().unwrap_or_default();
             commands::merge_when_ready::run(
                 all,
+                downstack_only,
                 merge_method,
                 timeout,
                 interval,

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -38,6 +38,10 @@ struct MergeScope {
     remaining: Vec<MergeBranchInfo>,
     /// The trunk branch name
     trunk: String,
+    /// The branch that was checked out when merge started
+    current: String,
+    /// Whether current branch is excluded from the merge scope
+    downstack_only: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,6 +53,7 @@ pub(crate) enum PrBaseUpdate {
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     all: bool,
+    downstack_only: bool,
     dry_run: bool,
     method: MergeMethod,
     no_delete: bool,
@@ -89,7 +94,7 @@ pub fn run(
     }
 
     // Calculate merge scope based on current position
-    let mut scope = calculate_merge_scope(&repo, &stack, &current, all)?;
+    let mut scope = calculate_merge_scope(&stack, &current, all, downstack_only);
 
     if scope.to_merge.is_empty() {
         if !quiet {
@@ -469,8 +474,12 @@ pub fn run(
             }
         }
 
-        // Checkout trunk after cleanup
-        let _ = repo.checkout(&scope.trunk);
+        let checkout_after_cleanup = if scope.downstack_only {
+            &scope.current
+        } else {
+            &scope.trunk
+        };
+        let _ = repo.checkout(checkout_after_cleanup);
     }
 
     // Print summary
@@ -532,7 +541,12 @@ pub fn run(
                     "branches"
                 }
             );
-            println!("  • Switched to: {}", scope.trunk.cyan());
+            let checkout_after_cleanup = if scope.downstack_only {
+                &scope.current
+            } else {
+                &scope.trunk
+            };
+            println!("  • Switched to: {}", checkout_after_cleanup.cyan());
         }
 
         if !scope.remaining.is_empty() {
@@ -587,11 +601,11 @@ pub fn run(
 
 /// Calculate which branches to merge based on current position
 fn calculate_merge_scope(
-    _repo: &GitRepo,
     stack: &Stack,
     current: &str,
     all: bool,
-) -> Result<MergeScope> {
+    downstack_only: bool,
+) -> MergeScope {
     // Get ancestors of current branch (from current up to trunk)
     let mut ancestors = stack.ancestors(current);
     ancestors.reverse(); // Now bottom-to-top (trunk-adjacent first)
@@ -615,23 +629,29 @@ fn calculate_merge_scope(
         });
     }
 
-    // Add current branch
     let current_info = stack.branches.get(current);
     let current_pr = current_info.and_then(|b| b.pr_number);
     let current_position = to_merge.len() + 1;
 
-    to_merge.push(MergeBranchInfo {
+    let current_branch_info = MergeBranchInfo {
         branch: current.to_string(),
         pr_number: current_pr,
         pr_status: None,
         is_current: true,
         position: current_position,
-    });
+    };
+
+    let mut remaining: Vec<MergeBranchInfo> = Vec::new();
+
+    if downstack_only {
+        remaining.push(current_branch_info);
+    } else {
+        to_merge.push(current_branch_info);
+    }
 
     // Get descendants (branches above current)
     let descendants = stack.descendants(current);
 
-    let mut remaining: Vec<MergeBranchInfo> = Vec::new();
     for (idx, branch) in descendants.iter().enumerate() {
         let branch_info = stack.branches.get(branch);
         let pr_number = branch_info.and_then(|b| b.pr_number);
@@ -651,11 +671,13 @@ fn calculate_merge_scope(
         remaining = Vec::new();
     }
 
-    Ok(MergeScope {
+    MergeScope {
         to_merge,
         remaining,
         trunk: stack.trunk.clone(),
-    })
+        current: current.to_string(),
+        downstack_only,
+    }
 }
 
 /// Print the merge preview box
@@ -667,6 +689,7 @@ fn print_merge_preview(scope: &MergeScope, method: &MergeMethod) {
     let current = scope
         .to_merge
         .iter()
+        .chain(scope.remaining.iter())
         .find(|b| b.is_current)
         .map(|b| b.branch.as_str())
         .unwrap_or("unknown");
@@ -674,6 +697,7 @@ fn print_merge_preview(scope: &MergeScope, method: &MergeMethod) {
     let current_pr = scope
         .to_merge
         .iter()
+        .chain(scope.remaining.iter())
         .find(|b| b.is_current)
         .and_then(|b| b.pr_number)
         .map(|n| format!(" (PR #{})", n))
@@ -691,10 +715,16 @@ fn print_merge_preview(scope: &MergeScope, method: &MergeMethod) {
     } else {
         "PRs"
     };
+    let scope_label = if scope.downstack_only {
+        "below current"
+    } else {
+        "from bottom → current"
+    };
     println!(
-        "This will merge {} {} from bottom → current:",
+        "This will merge {} {} {}:",
         scope.to_merge.len().to_string().bold(),
-        pr_word
+        pr_word,
+        scope_label
     );
     println!();
 
@@ -726,10 +756,17 @@ fn print_branch_box(branches: &[MergeBranchInfo], included: bool, trunk: &str) {
             .unwrap_or_else(|| "no PR".to_string());
 
         // Branch header
+        let current_marker = if branch.is_current {
+            " (current)".cyan().to_string()
+        } else {
+            String::new()
+        };
+
         println!(
-            "  {}. {} {}",
+            "  {}. {}{} {}",
             branch.position.to_string().bold(),
             branch.branch.bold(),
+            current_marker,
             format!("({})", pr_text).dimmed()
         );
 
@@ -1262,6 +1299,73 @@ fn record_ci_history_for_branch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::stack::StackBranch;
+    use std::collections::HashMap;
+
+    fn create_test_stack() -> Stack {
+        let mut branches = HashMap::new();
+
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                parent_revision: None,
+                children: vec!["feature-a".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+
+        branches.insert(
+            "feature-a".to_string(),
+            StackBranch {
+                name: "feature-a".to_string(),
+                parent: Some("main".to_string()),
+                parent_revision: None,
+                children: vec!["feature-b".to_string()],
+                needs_restack: false,
+                pr_number: Some(1),
+                pr_state: Some("OPEN".to_string()),
+                pr_is_draft: Some(false),
+            },
+        );
+
+        branches.insert(
+            "feature-b".to_string(),
+            StackBranch {
+                name: "feature-b".to_string(),
+                parent: Some("feature-a".to_string()),
+                parent_revision: None,
+                children: vec!["feature-c".to_string()],
+                needs_restack: false,
+                pr_number: Some(2),
+                pr_state: Some("OPEN".to_string()),
+                pr_is_draft: Some(false),
+            },
+        );
+
+        branches.insert(
+            "feature-c".to_string(),
+            StackBranch {
+                name: "feature-c".to_string(),
+                parent: Some("feature-b".to_string()),
+                parent_revision: None,
+                children: vec![],
+                needs_restack: false,
+                pr_number: Some(3),
+                pr_state: Some("OPEN".to_string()),
+                pr_is_draft: Some(false),
+            },
+        );
+
+        Stack {
+            branches,
+            trunk: "main".to_string(),
+        }
+    }
 
     #[test]
     fn test_strip_ansi_empty_string() {
@@ -1369,11 +1473,43 @@ mod tests {
                 position: 3,
             }],
             trunk: "main".to_string(),
+            current: "feature-b".to_string(),
+            downstack_only: false,
         };
 
         assert_eq!(scope.to_merge.len(), 2);
         assert_eq!(scope.remaining.len(), 1);
         assert_eq!(scope.trunk, "main");
+    }
+
+    #[test]
+    fn test_calculate_merge_scope_downstack_only_excludes_current() {
+        let stack = create_test_stack();
+
+        let scope = calculate_merge_scope(&stack, "feature-b", false, true);
+
+        let to_merge: Vec<_> = scope.to_merge.iter().map(|b| b.branch.as_str()).collect();
+        let remaining: Vec<_> = scope.remaining.iter().map(|b| b.branch.as_str()).collect();
+
+        assert_eq!(to_merge, vec!["feature-a"]);
+        assert_eq!(remaining, vec!["feature-b", "feature-c"]);
+        assert!(scope.remaining[0].is_current);
+        assert_eq!(scope.remaining[0].position, 2);
+        assert_eq!(scope.current, "feature-b");
+        assert!(scope.downstack_only);
+    }
+
+    #[test]
+    fn test_calculate_merge_scope_downstack_only_direct_child_has_no_merge_targets() {
+        let stack = create_test_stack();
+
+        let scope = calculate_merge_scope(&stack, "feature-a", false, true);
+
+        let remaining: Vec<_> = scope.remaining.iter().map(|b| b.branch.as_str()).collect();
+
+        assert!(scope.to_merge.is_empty());
+        assert_eq!(remaining, vec!["feature-a", "feature-b", "feature-c"]);
+        assert!(scope.remaining[0].is_current);
     }
 
     #[test]

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -45,6 +45,10 @@ struct MergeWhenReadyScope {
     remaining: Vec<String>,
     /// Trunk branch name
     trunk: String,
+    /// The branch that was checked out when merge started
+    current: String,
+    /// Whether current branch is excluded from the merge scope
+    downstack_only: bool,
 }
 
 /// Status of a branch during the land process
@@ -89,6 +93,7 @@ enum WaitResult {
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     all: bool,
+    downstack_only: bool,
     method: MergeMethod,
     timeout_mins: u64,
     interval_secs: u64,
@@ -130,7 +135,7 @@ pub fn run(
 
     // Calculate scope: bottom->current are merged; descendants are either merged (--all)
     // or rebased after merges so their PR bases stay valid.
-    let scope = calculate_merge_scope(&stack, &current, all);
+    let scope = calculate_merge_scope(&stack, &current, all, downstack_only);
 
     // Build branch info list
     let mut branches: Vec<LandBranchInfo> = Vec::new();
@@ -202,7 +207,7 @@ pub fn run(
     // Show preview
     if !quiet {
         println!();
-        print_land_preview(&branches, &scope.trunk, &method);
+        print_land_preview(&branches, &scope.trunk, &method, scope.downstack_only);
     }
 
     // Confirm
@@ -458,6 +463,10 @@ pub fn run(
         }
     }
 
+    if scope.downstack_only && failed_pr.is_none() {
+        let _ = repo.checkout(&scope.current);
+    }
+
     // Cleanup merged branches
     if !no_delete && !merged_prs.is_empty() {
         if !quiet {
@@ -491,8 +500,12 @@ pub fn run(
             }
         }
 
-        // Checkout trunk after cleanup
-        let _ = repo.checkout(&scope.trunk);
+        let checkout_after_cleanup = if scope.downstack_only {
+            &scope.current
+        } else {
+            &scope.trunk
+        };
+        let _ = repo.checkout(checkout_after_cleanup);
     }
 
     // Finish transaction
@@ -561,7 +574,12 @@ pub fn run(
                     "branches"
                 }
             );
-            println!("  • Switched to: {}", scope.trunk.cyan());
+            let checkout_after_cleanup = if scope.downstack_only {
+                &scope.current
+            } else {
+                &scope.trunk
+            };
+            println!("  • Switched to: {}", checkout_after_cleanup.cyan());
         }
 
         // Send macOS notification
@@ -618,13 +636,22 @@ pub fn run(
 }
 
 /// Calculate which branches to merge and which descendants remain to be rebased.
-fn calculate_merge_scope(stack: &Stack, current: &str, all: bool) -> MergeWhenReadyScope {
+fn calculate_merge_scope(
+    stack: &Stack,
+    current: &str,
+    all: bool,
+    downstack_only: bool,
+) -> MergeWhenReadyScope {
     let mut to_merge = stack.ancestors(current);
     to_merge.reverse();
     to_merge.retain(|b| b != &stack.trunk);
-    to_merge.push(current.to_string());
 
     let mut remaining = stack.descendants(current);
+    if downstack_only {
+        remaining.insert(0, current.to_string());
+    } else {
+        to_merge.push(current.to_string());
+    }
 
     if all && !remaining.is_empty() {
         to_merge.extend(remaining);
@@ -635,19 +662,32 @@ fn calculate_merge_scope(stack: &Stack, current: &str, all: bool) -> MergeWhenRe
         to_merge,
         remaining,
         trunk: stack.trunk.clone(),
+        current: current.to_string(),
+        downstack_only,
     }
 }
 
 /// Print the merge-when-ready preview
-fn print_land_preview(branches: &[LandBranchInfo], trunk: &str, method: &MergeMethod) {
+fn print_land_preview(
+    branches: &[LandBranchInfo],
+    trunk: &str,
+    method: &MergeMethod,
+    downstack_only: bool,
+) {
     print_header("Merge When Ready");
     println!();
 
     let pr_word = if branches.len() == 1 { "PR" } else { "PRs" };
+    let scope_label = if downstack_only {
+        "below current"
+    } else {
+        "bottom-up"
+    };
     println!(
-        "Will merge {} {} bottom-up into {}:",
+        "Will merge {} {} {} into {}:",
         branches.len().to_string().bold(),
         pr_word,
+        scope_label,
         trunk.cyan()
     );
     println!();
@@ -1001,20 +1041,44 @@ mod tests {
     fn test_calculate_merge_scope_from_middle_without_all_keeps_descendants_remaining() {
         let stack = create_test_stack();
 
-        let scope = calculate_merge_scope(&stack, "feature-b", false);
+        let scope = calculate_merge_scope(&stack, "feature-b", false, false);
 
         assert_eq!(scope.to_merge, vec!["feature-a", "feature-b"]);
         assert_eq!(scope.remaining, vec!["feature-c"]);
         assert_eq!(scope.trunk, "main");
+        assert_eq!(scope.current, "feature-b");
+        assert!(!scope.downstack_only);
     }
 
     #[test]
     fn test_calculate_merge_scope_with_all_includes_descendants() {
         let stack = create_test_stack();
 
-        let scope = calculate_merge_scope(&stack, "feature-b", true);
+        let scope = calculate_merge_scope(&stack, "feature-b", true, false);
 
         assert_eq!(scope.to_merge, vec!["feature-a", "feature-b", "feature-c"]);
         assert!(scope.remaining.is_empty());
+    }
+
+    #[test]
+    fn test_calculate_merge_scope_downstack_only_excludes_current() {
+        let stack = create_test_stack();
+
+        let scope = calculate_merge_scope(&stack, "feature-b", false, true);
+
+        assert_eq!(scope.to_merge, vec!["feature-a"]);
+        assert_eq!(scope.remaining, vec!["feature-b", "feature-c"]);
+        assert_eq!(scope.current, "feature-b");
+        assert!(scope.downstack_only);
+    }
+
+    #[test]
+    fn test_calculate_merge_scope_downstack_only_direct_child_has_no_merge_targets() {
+        let stack = create_test_stack();
+
+        let scope = calculate_merge_scope(&stack, "feature-a", false, true);
+
+        assert!(scope.to_merge.is_empty());
+        assert_eq!(scope.remaining, vec!["feature-a", "feature-b", "feature-c"]);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5520,6 +5520,11 @@ fn test_merge_help() {
     let stdout = TestRepo::stdout(&output);
     assert!(stdout.contains("--all"), "Expected --all flag in help");
     assert!(
+        stdout.contains("--downstack-only"),
+        "Expected --downstack-only flag in help"
+    );
+    assert!(stdout.contains("--ds"), "Expected --ds alias in help");
+    assert!(
         stdout.contains("--dry-run"),
         "Expected --dry-run flag in help"
     );
@@ -5548,6 +5553,78 @@ fn test_merge_help() {
     assert!(
         stdout.contains("--remote"),
         "Expected --remote flag in help"
+    );
+}
+
+#[test]
+fn test_merge_downstack_only_conflicts_with_all() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--downstack-only", "--all"]);
+    let stderr = TestRepo::stderr(&output);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-success for conflicting flags"
+    );
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
+        "Expected clap conflict error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_merge_downstack_only_conflicts_with_remote() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--downstack-only", "--remote"]);
+    let stderr = TestRepo::stderr(&output);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-success for conflicting flags"
+    );
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
+        "Expected clap conflict error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_merge_downstack_only_conflicts_with_queue() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--downstack-only", "--queue"]);
+    let stderr = TestRepo::stderr(&output);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-success for conflicting flags"
+    );
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
+        "Expected clap conflict error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_merge_ds_alias_conflicts_with_all() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--ds", "--all"]);
+    let stderr = TestRepo::stderr(&output);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-success for conflicting flags"
+    );
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
+        "Expected clap conflict error, got: {}",
+        stderr
     );
 }
 


### PR DESCRIPTION
## Summary

- add `st merge --downstack-only` (`--ds`) to merge ancestors below the current branch while keeping the current branch open
- rebase the current branch first in the remaining stack chain, preserving descendants above it
- support the same scope for `st merge --when-ready` and reject incompatible `--all`, `--remote`, and `--queue` combinations
- update README, docs, and `skills.md`

Fixes #371.

## Tests

- `cargo test merge_scope --lib`
- `cargo test --test integration_tests test_merge_help`
- `cargo test --test integration_tests merge_downstack_only`
- `cargo test --test integration_tests test_merge_ds_alias_conflicts_with_all`

Full suite not run locally; targeted merge scope and CLI coverage only.