### PR TITLE
Show pull request changes-requested status correctly

### DIFF
--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -943,11 +943,8 @@ impl GitHubClient {
                     .iter()
                     .filter(|r| r.state == "APPROVED")
                     .count();
-                let changes_requested = pr
-                    .reviews
-                    .nodes
-                    .iter()
-                    .any(|r| r.state == "CHANGES_REQUESTED");
+                let changes_requested =
+                    pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");
                 (pr.review_decision, approvals, changes_requested)
             })
             .unwrap_or((None, 0, false));


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Pull request review status could be reported incorrectly when a stale review still contained `CHANGES_REQUESTED`, even after the overall PR review state had changed.

## Description of changes / notes for reviewers

- Use GitHub's `reviewDecision` to determine whether changes are currently requested.
- Keep approval counting unchanged, while avoiding false positives from older review events.