### PR TITLE
Add draft and undraft commands for tracked PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ st config --set-ai
 | `st standup` | Summarize recent engineering activity |
 | `st undo` / `st redo` | Recover / reapply risky operations |
 | `st run <cmd>` | Run a command on each branch in the stack |
+| `st draft [branch]` / `st undraft [branch]` | Toggle a PR between draft and ready-for-review |
 | `st pr` / `st pr list` / `st issue list` | Open current PR · list PRs · list issues |
 
 Full reference: [docs/commands/core.md](docs/commands/core.md) · [docs/commands/reference.md](docs/commands/reference.md)

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -27,6 +27,8 @@ st create --below -am "fix: patch CVE-2026-0001"
 | Command | What it does |
 |---|---|
 | `st ss` | Submit the whole stack — open or update linked PRs |
+| `st draft [branch]` | Convert the current (or named) branch's PR to draft |
+| `st undraft [branch]` | Mark the current (or named) branch's PR as ready for review |
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -688,6 +688,18 @@ enum Commands {
     /// Open the repository in browser
     Open,
 
+    /// Mark the current (or named) branch's PR as a draft
+    Draft {
+        /// Branch to operate on (defaults to current)
+        branch: Option<String>,
+    },
+
+    /// Mark the current (or named) branch's PR as ready for review
+    Undraft {
+        /// Branch to operate on (defaults to current)
+        branch: Option<String>,
+    },
+
     /// Show comments on the current branch's PR
     Comments {
         /// Output raw markdown without rendering
@@ -1971,6 +1983,8 @@ pub fn run() -> Result<()> {
             None => print_subcommand_help("issue"),
         },
         Commands::Open => commands::open::run(),
+        Commands::Draft { branch } => commands::draft::run(branch, true),
+        Commands::Undraft { branch } => commands::draft::run(branch, false),
         Commands::Comments { plain } => commands::comments::run(plain),
         Commands::Ci {
             all,

--- a/src/commands/draft.rs
+++ b/src/commands/draft.rs
@@ -1,0 +1,83 @@
+use crate::config::Config;
+use crate::engine::metadata::PrInfo;
+use crate::engine::{BranchMetadata, Stack};
+use crate::forge::ForgeClient;
+use crate::git::GitRepo;
+use crate::remote::RemoteInfo;
+use anyhow::Result;
+use colored::Colorize;
+
+pub fn run(branch: Option<String>, is_draft: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let stack = Stack::load(&repo)?;
+    let config = Config::load()?;
+
+    let target = branch.unwrap_or_else(|| repo.current_branch().unwrap_or_default());
+
+    let branch_info = stack.branches.get(&target);
+    if branch_info.is_none() {
+        anyhow::bail!(
+            "Branch '{}' is not tracked. Use {} to track it first.",
+            target,
+            "stax branch track".cyan()
+        );
+    }
+
+    let pr_number = super::resolve_pr::resolve_pr_number(&repo, &stack, &target, &config)?;
+    let Some(pr_number) = pr_number else {
+        anyhow::bail!(
+            "No PR found for branch '{}'. Use {} to create one.",
+            target,
+            "stax submit".cyan()
+        );
+    };
+
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+    let client = ForgeClient::new(&remote_info)?;
+
+    let current_is_draft = branch_info
+        .and_then(|b| b.pr_is_draft)
+        .unwrap_or(false);
+
+    if current_is_draft == is_draft {
+        let state = if is_draft { "already a draft" } else { "already published" };
+        println!("PR #{} is {}.", pr_number, state);
+        return Ok(());
+    }
+
+    rt.block_on(async { client.set_pr_draft(pr_number, is_draft).await })?;
+
+    // Update local metadata
+    if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), &target) {
+        if let Some(ref mut pr_info) = meta.pr_info {
+            pr_info.is_draft = Some(is_draft);
+        } else {
+            meta.pr_info = Some(PrInfo {
+                number: pr_number,
+                state: "open".to_string(),
+                is_draft: Some(is_draft),
+            });
+        }
+        let _ = meta.write(repo.inner(), &target);
+    }
+
+    if is_draft {
+        println!(
+            "PR #{} on {} marked as {}.",
+            pr_number.to_string().cyan(),
+            target.cyan(),
+            "draft".yellow()
+        );
+    } else {
+        println!(
+            "PR #{} on {} marked as {}.",
+            pr_number.to_string().cyan(),
+            target.cyan(),
+            "ready for review".green()
+        );
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod demo;
 pub mod detach;
 pub mod diff;
 pub mod doctor;
+pub mod draft;
 pub mod edit;
 pub mod generate;
 pub(crate) mod github_list;


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Let users quickly toggle the review state of a tracked branch's PR from stax, without leaving the CLI.

## Description of changes / notes for reviewers

- Adds `stax draft` and `stax undraft` commands for the current branch or a named branch.
- Reuses existing PR resolution and Forge client support to update the PR state, then refreshes local branch metadata to keep draft status in sync.