### PR TITLE
Add tmux status bar and popup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,28 @@ stack_links = "body"   # "comment" | "body" | "both" | "off"
 
 ## Integrations
 
+### tmux
+
+[**stax.tmux**](https://github.com/cesarferreira/stax.tmux) is a TPM-compatible plugin that puts your stack in the tmux status bar and adds keybindings for common actions:
+
+```
+ feat/login-flow [3/5] #42  ● passing  14:22
+```
+
+- Live status bar — branch, stack position, PR state, CI state; auto-refreshes in the background
+- Keybindings — `prefix + S` popup, `prefix + ]`/`[` up/down, `prefix + M-s` sync
+- Window auto-rename — tmux window title follows the current branch
+
+Install via TPM:
+
+```tmux
+set -g @plugin 'cesarferreira/stax.tmux'
+```
+
+See the [stax.tmux README](https://github.com/cesarferreira/stax.tmux) for full setup and configuration options.
+
+---
+
 AI and editor integration guides:
 
 - [Claude Code](docs/integrations/claude-code.md)
@@ -349,7 +371,7 @@ stax runs on Windows (x86_64) with prebuilt binaries on [Releases](https://githu
   - The `sw` quick alias is not available.
   - `st wt rm` (bare) cannot relocate the shell. Specify: `st wt rm <name>`.
 - **Worktree commands still work.** `st wt c/go/ls/ll/cleanup/rm/prune/restack` all function — only the shell-level `cd` is missing.
-- **tmux integration requires WSL** or a Unix-like environment.
+- **tmux integration requires WSL** or a Unix-like environment. The [stax.tmux](https://github.com/cesarferreira/stax.tmux) plugin is Unix-only.
 
 Everything else — stacked branches, PRs, restack, sync, undo/redo, TUI, AI generation — works on Windows without limitation.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Then:
 cargo install --path . --locked
 # or
 make install
+# or
+task install
 ```
 
 No system OpenSSL? Use the vendored feature:
@@ -286,6 +288,8 @@ st config --set-ai
 | `st gen` / `st generate` | AI: interactive picker, or `--pr-body` / `--pr-title` / `--commit-msg` |
 | `st ss --ai` | Submit with AI-generated PR title/body suggestions |
 | `st standup` | Summarize recent engineering activity |
+| `st tmux status` | Print a tmux-formatted status string (branch, stack position, PR, CI) for `status-right` |
+| `st tmux popup` | Open `stax watch --current` in a floating tmux panel |
 | `st undo` / `st redo` | Recover / reapply risky operations |
 | `st run <cmd>` | Run a command on each branch in the stack |
 | `st pr` / `st pr list` / `st issue list` | Open current PR · list PRs · list issues |
@@ -356,15 +360,20 @@ Everything else — stacked branches, PRs, restack, sync, undo/redo, TUI, AI gen
 Before opening a PR, run:
 
 ```bash
-make test   # or: just test
+make test   # or: just test / task test
 ```
+
+If bare `task` prints `No matches.`, your shell is running Taskwarrior instead of Go Task. Use the Go Task binary directly, for example `/opt/homebrew/opt/go-task/bin/task test`, or adjust your shell aliases/PATH.
 
 To cut a release, run:
 
 ```bash
 make release          # default minor bump
 make release LEVEL=patch
+task release          # default minor bump
+task release LEVEL=patch
 just release-patch    # or: just release-minor / just release-major
+task release-patch    # or: task release-minor / task release-major
 ```
 
 Release automation now finalizes the next versioned entry in `CHANGELOG.md` from commits since the latest `v*` tag inside `cargo release`'s pre-release hook, refreshes the compare links, and leaves a fresh `Unreleased` header for follow-up work. If there are no commits since the last tag, the release exits early instead of creating an empty changelog entry.

--- a/docs/superpowers/specs/2026-05-13-tmux-plugin-design.md
+++ b/docs/superpowers/specs/2026-05-13-tmux-plugin-design.md
@@ -1,0 +1,113 @@
+# stax tmux Plugin — Design Spec
+
+**Date:** 2026-05-13  
+**Status:** Implemented  
+**Plan:** `docs/superpowers/plans/2026-05-13-tmux-plugin.md`
+
+## Context
+
+stax already ships significant tmux integration in `stax lane` and `stax worktree` (session creation, probe/fallback, window management). This feature extends that foundation by shipping a first-class **TPM-compatible tmux plugin** that gives stax users deeper terminal integration without any extra configuration burden.
+
+### Problem
+
+Users working with stacked PRs in tmux had no way to see stack/PR/CI state at a glance, no keybindings for common operations, and no automatic window labeling when navigating branches.
+
+### Solution
+
+Two deliverables:
+1. A `stax tmux` Rust subcommand (in the stax binary) that provides data and rendering
+2. A `stax.tmux` TPM plugin (separate repo) that wires everything into tmux
+
+---
+
+## Architecture
+
+**Boundary:** stax owns all data and rendering logic. The TPM plugin is thin config only — no domain knowledge.
+
+```
+┌─────────────────────────────────────────┐
+│  ~/.tmux.conf (via TPM)                 │
+│  stax.tmux plugin                       │
+│    ├── status-right → scripts/status.sh │  calls  stax tmux status
+│    ├── prefix+S     → display-popup     │  calls  stax watch --current
+│    ├── prefix+]     → run-shell         │  calls  stax down
+│    ├── prefix+[     → run-shell         │  calls  stax up
+│    └── prefix+M-s   → run-shell         │  calls  stax sync
+└─────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────┐
+│  stax binary                            │
+│    stax tmux status  →  format_status_line()  │  reads Stack + CiCache
+│    stax tmux popup   →  tmux display-popup stax watch --current
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Status Bar Segment
+
+`stax tmux status` outputs a single tmux-formatted line:
+
+```
+ feat/login-flow [3/5] #42  ● passing
+```
+
+| Field | Format | Source |
+|-------|--------|--------|
+| Branch name | Truncated at 20 chars with `…` | `repo.current_branch()` |
+| Stack position | `[pos/total]` | `Stack::current_stack()` |
+| PR state | `⊘` none · `#N` open · `#N draft` · `#N merged` | `StackBranch.pr_number/pr_state/pr_is_draft` |
+| CI state | `● passing` · `✗ failing` · `⟳ running` · `– no CI` | `CiCache.get_ci_state()` |
+
+Colors use tmux format strings (`#[fg=green]`, `#[fg=red]`, etc.). Outputs nothing on trunk or outside a stax repo (graceful degradation). Reads from the existing CI cache — no live GitHub API calls on status-bar polling.
+
+---
+
+## Keybindings
+
+| Binding | Command | Default key |
+|---------|---------|-------------|
+| Popup stack viewer | `display-popup -E stax watch --current` | `prefix + S` |
+| Navigate toward trunk | `stax down` | `prefix + ]` |
+| Navigate away from trunk | `stax up` | `prefix + [` |
+| Sync stack | `stax sync` | `prefix + M-s` |
+
+All keys are user-configurable via `@stax-*` tmux options. Setting a key to `''` disables the binding.
+
+---
+
+## Window Rename on Checkout
+
+The plugin ships `scripts/window-rename.sh`, a shell snippet that installs a `precmd` hook (zsh) or `PROMPT_COMMAND` entry (bash). After every command prompt, if inside tmux, it reads the current git branch and renames the active tmux window to match.
+
+No stax binary changes required — this is pure shell.
+
+---
+
+## Implementation
+
+### Rust (`src/commands/tmux.rs`)
+
+```
+TmuxCommand::Status  →  run_status()
+TmuxCommand::Popup   →  run_popup()
+format_status_line() — pure function, fully unit-tested (7 tests)
+```
+
+### TPM Plugin (`stax.tmux` repo)
+
+```
+stax.tmux                  # TPM entry point — reads @stax-* options, sets keybindings + status-right
+scripts/status.sh          # calls stax tmux status
+scripts/window-rename.sh   # precmd/PROMPT_COMMAND hook
+README.md                  # installation + config docs
+```
+
+### Files modified in stax repo
+
+| File | Change |
+|------|--------|
+| `src/commands/tmux.rs` | New: TmuxCommand, format_status_line, run_status, run_popup |
+| `src/commands/mod.rs` | +1 line: `pub mod tmux;` |
+| `src/cli.rs` | +7 lines: Tmux variant + dispatch |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -747,6 +747,12 @@ enum Commands {
         interval: Option<u64>,
     },
 
+    /// tmux integration: status bar string and popup viewer
+    Tmux {
+        #[command(subcommand)]
+        command: commands::tmux::TmuxCommand,
+    },
+
     /// Split the current branch into multiple stacked branches (interactive)
     Split {
         /// Split by selecting individual hunks instead of by commit
@@ -2009,6 +2015,7 @@ pub fn run() -> Result<()> {
             verbose,
         ),
         Commands::Watch { current, interval } => commands::watch::run(current, interval),
+        Commands::Tmux { command } => commands::tmux::run(command),
         Commands::Split {
             hunk,
             file,

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -25,6 +25,8 @@ pub struct BranchCiStatus {
     pub overall_status: Option<String>,
     pub check_runs: Vec<CheckRunInfo>,
     pub pr_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_is_draft: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -399,6 +401,11 @@ pub fn fetch_ci_statuses(
             Err(_) => (None, Vec::new()),
         };
 
+        let pr_live = pr_number.and_then(|n| {
+            rt.block_on(async { client.get_pr(n).await }).ok()
+        });
+        let pr_is_draft = pr_live.as_ref().map(|p| p.is_draft);
+
         statuses.push(BranchCiStatus {
             branch: branch.clone(),
             sha,
@@ -406,6 +413,7 @@ pub fn fetch_ci_statuses(
             overall_status,
             check_runs,
             pr_number,
+            pr_is_draft,
         });
     }
 
@@ -1038,7 +1046,10 @@ pub(crate) fn update_ci_cache(repo: &GitRepo, stack: &Stack, statuses: &[BranchC
 
     let mut cache = CiCache::load(git_dir);
     for status in statuses {
-        cache.update(&status.branch, status.overall_status.clone(), None);
+        let pr_state = status.pr_is_draft.map(|is_draft| {
+            if is_draft { "DRAFT".to_string() } else { "OPEN".to_string() }
+        });
+        cache.update(&status.branch, status.overall_status.clone(), pr_state);
     }
 
     let valid_branches: Vec<String> = stack.branches.keys().cloned().collect();
@@ -1517,6 +1528,7 @@ mod tests {
             overall_status: Some(overall_status.to_string()),
             check_runs,
             pr_number: Some(123),
+            pr_is_draft: None,
         }
     }
 
@@ -1770,6 +1782,7 @@ mod tests {
                 completion_percent: None,
             }],
             pr_number: Some(42),
+            pr_is_draft: None,
         };
 
         let json = serde_json::to_string(&status).unwrap();
@@ -1790,6 +1803,7 @@ mod tests {
             overall_status: None,
             check_runs: vec![],
             pr_number: None,
+            pr_is_draft: None,
         };
 
         let json = serde_json::to_string(&status).unwrap();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,6 +49,7 @@ pub mod standup;
 pub mod status;
 pub mod submit;
 pub mod sync;
+pub mod tmux;
 pub mod undo;
 pub mod upstack;
 pub mod watch;

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
 use clap::Subcommand;
+use crate::cache::CiCache;
+use crate::engine::Stack;
+use crate::git::GitRepo;
 
 #[derive(Debug, Subcommand)]
 pub enum TmuxCommand {
@@ -53,10 +56,6 @@ pub fn format_status_line(
 }
 
 fn run_status() -> Result<()> {
-    use crate::cache::CiCache;
-    use crate::engine::Stack;
-    use crate::git::GitRepo;
-
     let repo = match GitRepo::open() {
         Ok(r) => r,
         Err(_) => return Ok(()),

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -28,8 +28,8 @@ pub fn format_status_line(
     pr_state: Option<&str>,
     ci_state: Option<&str>,
 ) -> String {
-    let branch_display = if branch.len() > 20 {
-        format!("{}…", &branch[..19])
+    let branch_display = if branch.len() > 35 {
+        format!("{}…", &branch[..34])
     } else {
         branch.to_string()
     };
@@ -165,11 +165,11 @@ mod tests {
     }
 
     #[test]
-    fn test_branch_name_truncated_at_20_chars() {
-        let long = "feat/this-is-a-very-long-branch-name";
+    fn test_branch_name_truncated_at_35_chars() {
+        let long = "feat/this-is-a-very-long-branch-name-that-keeps-going";
         let result = format_status_line(long, 1, 1, None, false, None, None);
-        // &long[..19] = "feat/this-is-a-very" → appended with "…"
-        assert!(result.contains("feat/this-is-a-very…"), "truncation wrong: {result}");
-        assert!(!result.contains("feat/this-is-a-very-long"), "should be truncated: {result}");
+        // &long[..34] = "feat/this-is-a-very-long-branch-na" → appended with "…"
+        assert!(result.contains("feat/this-is-a-very-long-branch-na…"), "truncation wrong: {result}");
+        assert!(!result.contains("feat/this-is-a-very-long-branch-name-that"), "should be truncated: {result}");
     }
 }

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -53,11 +53,70 @@ pub fn format_status_line(
 }
 
 fn run_status() -> Result<()> {
-    todo!()
+    use crate::cache::CiCache;
+    use crate::engine::Stack;
+    use crate::git::GitRepo;
+
+    let repo = match GitRepo::open() {
+        Ok(r) => r,
+        Err(_) => return Ok(()),
+    };
+    let stack = match Stack::load(&repo) {
+        Ok(s) => s,
+        Err(_) => return Ok(()),
+    };
+    let current = match repo.current_branch() {
+        Ok(b) => b,
+        Err(_) => return Ok(()),
+    };
+
+    if current == stack.trunk {
+        return Ok(());
+    }
+
+    let stack_branches = stack.current_stack(&current);
+    let non_trunk: Vec<&String> = stack_branches
+        .iter()
+        .filter(|b| *b != &stack.trunk)
+        .collect();
+    let pos = non_trunk
+        .iter()
+        .position(|b| *b == &current)
+        .map(|i| i + 1)
+        .unwrap_or(1);
+    let total = non_trunk.len().max(1);
+
+    let info = stack.branches.get(&current);
+    let pr_number = info.and_then(|b| b.pr_number);
+    let pr_is_draft = info.and_then(|b| b.pr_is_draft).unwrap_or(false);
+    let pr_state = info.and_then(|b| b.pr_state.as_deref());
+
+    let git_dir = repo.git_dir()?;
+    let cache = CiCache::load(git_dir);
+    let ci_state_owned = cache.get_ci_state(&current);
+    let ci_state = ci_state_owned.as_deref();
+
+    let output = format_status_line(&current, pos, total, pr_number, pr_is_draft, pr_state, ci_state);
+    print!("{}", output);
+    Ok(())
 }
 
 fn run_popup() -> Result<()> {
-    todo!()
+    if std::env::var("TMUX").is_err() {
+        anyhow::bail!("Not inside a tmux session. Run this command from within tmux.");
+    }
+    std::process::Command::new("tmux")
+        .args([
+            "display-popup",
+            "-E",
+            "-w",
+            "80%",
+            "-h",
+            "80%",
+            "stax watch --current",
+        ])
+        .status()?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -28,8 +28,8 @@ pub fn format_status_line(
     pr_state: Option<&str>,
     ci_state: Option<&str>,
 ) -> String {
-    let branch_display = if branch.len() > 35 {
-        format!("{}…", &branch[..34])
+    let branch_display = if branch.len() > 50 {
+        format!("{}…", &branch[..49])
     } else {
         branch.to_string()
     };
@@ -86,13 +86,21 @@ fn run_status() -> Result<()> {
 
     let info = stack.branches.get(&current);
     let pr_number = info.and_then(|b| b.pr_number);
-    let pr_is_draft = info.and_then(|b| b.pr_is_draft).unwrap_or(false);
     let pr_state = info.and_then(|b| b.pr_state.as_deref());
 
     let git_dir = repo.git_dir()?;
     let cache = CiCache::load(git_dir);
     let ci_state_owned = cache.get_ci_state(&current);
     let ci_state = ci_state_owned.as_deref();
+
+    // Prefer cache pr_state over metadata: cache is refreshed on every CI fetch,
+    // metadata only updates on `stax submit`. If cache says OPEN the PR is no longer draft.
+    let cached_pr_state = cache.branches.get(&current).and_then(|e| e.pr_state.as_deref());
+    let pr_is_draft = match cached_pr_state {
+        Some(s) if s.eq_ignore_ascii_case("draft") => true,
+        Some(s) if s.eq_ignore_ascii_case("open") => false,
+        _ => info.and_then(|b| b.pr_is_draft).unwrap_or(false),
+    };
 
     let output = format_status_line(&current, pos, total, pr_number, pr_is_draft, pr_state, ci_state);
     print!("{}", output);
@@ -165,11 +173,11 @@ mod tests {
     }
 
     #[test]
-    fn test_branch_name_truncated_at_35_chars() {
-        let long = "feat/this-is-a-very-long-branch-name-that-keeps-going";
+    fn test_branch_name_truncated_at_50_chars() {
+        let long = "cesar/codex/OBX-2734-remove-worm-feature-and-related-cleanup";
         let result = format_status_line(long, 1, 1, None, false, None, None);
-        // &long[..34] = "feat/this-is-a-very-long-branch-na" → appended with "…"
-        assert!(result.contains("feat/this-is-a-very-long-branch-na…"), "truncation wrong: {result}");
-        assert!(!result.contains("feat/this-is-a-very-long-branch-name-that"), "should be truncated: {result}");
+        // &long[..49] → appended with "…", total visible length 50
+        assert!(result.contains("cesar/codex/OBX-2734-remove-worm-feature-and-rela…"), "truncation wrong: {result}");
+        assert!(!result.contains("cesar/codex/OBX-2734-remove-worm-feature-and-related-cleanup"), "should be truncated: {result}");
     }
 }

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -104,6 +104,23 @@ fn run_status() -> Result<()> {
 
     let output = format_status_line(&current, pos, total, pr_number, pr_is_draft, pr_state, ci_state);
     print!("{}", output);
+
+    // Spawn a background `stax ci` refresh when the cache is older than 90 seconds so the
+    // status bar stays current without the user having to run stax ci manually.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    if now.saturating_sub(cache.last_refresh) > 90 {
+        if let Ok(exe) = std::env::current_exe() {
+            let _ = std::process::Command::new(exe)
+                .arg("ci")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+        }
+    }
+
     Ok(())
 }
 

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum TmuxCommand {
+    /// Print a compact tmux-formatted status string for use in status-right
+    Status,
+    /// Open an interactive stack popup via tmux display-popup
+    Popup,
+}
+
+#[allow(dead_code)]
+pub fn run(cmd: TmuxCommand) -> Result<()> {
+    match cmd {
+        TmuxCommand::Status => run_status(),
+        TmuxCommand::Popup => run_popup(),
+    }
+}
+
+#[allow(dead_code)]
+pub fn format_status_line(
+    branch: &str,
+    pos: usize,
+    total: usize,
+    pr_number: Option<u64>,
+    pr_is_draft: bool,
+    pr_state: Option<&str>,
+    ci_state: Option<&str>,
+) -> String {
+    let branch_display = if branch.len() > 20 {
+        format!("{}…", &branch[..19])
+    } else {
+        branch.to_string()
+    };
+
+    let pr_str = match pr_number {
+        None => "#[fg=colour240]⊘#[fg=default]".to_string(),
+        Some(n) if pr_is_draft => format!("#[fg=colour240]#{} draft#[fg=default]", n),
+        Some(n) if pr_state.map(|s| s.eq_ignore_ascii_case("merged")).unwrap_or(false) => {
+            format!("#[fg=magenta]#{} merged#[fg=default]", n)
+        }
+        Some(n) => format!("#[fg=magenta]#{}#[fg=default]", n),
+    };
+
+    let ci_str = match ci_state {
+        Some("success") => "#[fg=green]● passing#[fg=default]",
+        Some("failure") => "#[fg=red]✗ failing#[fg=default]",
+        Some("pending") => "#[fg=yellow]⟳ running#[fg=default]",
+        _ => "#[fg=colour240]– no CI#[fg=default]",
+    };
+
+    format!(" {} [{}/{}] {}  {}", branch_display, pos, total, pr_str, ci_str)
+}
+
+fn run_status() -> Result<()> {
+    todo!()
+}
+
+fn run_popup() -> Result<()> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_no_pr_no_ci() {
+        let result = format_status_line("feat/foo", 1, 3, None, false, None, None);
+        assert!(result.contains("feat/foo"), "branch name missing: {result}");
+        assert!(result.contains("[1/3]"), "position missing: {result}");
+        assert!(result.contains('⊘'), "no-PR symbol missing: {result}");
+        assert!(result.contains("– no CI"), "no-CI text missing: {result}");
+    }
+
+    #[test]
+    fn test_status_with_open_pr_and_passing_ci() {
+        let result = format_status_line("feat/foo", 2, 4, Some(42), false, Some("OPEN"), Some("success"));
+        assert!(result.contains("[2/4]"), "position missing: {result}");
+        assert!(result.contains("#42"), "PR number missing: {result}");
+        assert!(result.contains("● passing"), "CI passing text missing: {result}");
+    }
+
+    #[test]
+    fn test_status_draft_pr() {
+        let result = format_status_line("feat/foo", 1, 1, Some(7), true, Some("OPEN"), None);
+        assert!(result.contains("#7 draft"), "draft PR missing: {result}");
+    }
+
+    #[test]
+    fn test_status_merged_pr() {
+        let result = format_status_line("feat/foo", 1, 1, Some(99), false, Some("MERGED"), None);
+        assert!(result.contains("#99 merged"), "merged PR missing: {result}");
+    }
+
+    #[test]
+    fn test_status_failing_ci() {
+        let result = format_status_line("feat/foo", 1, 1, None, false, None, Some("failure"));
+        assert!(result.contains("✗ failing"), "failing CI missing: {result}");
+    }
+
+    #[test]
+    fn test_status_running_ci() {
+        let result = format_status_line("feat/foo", 1, 1, None, false, None, Some("pending"));
+        assert!(result.contains("⟳ running"), "running CI missing: {result}");
+    }
+
+    #[test]
+    fn test_branch_name_truncated_at_20_chars() {
+        let long = "feat/this-is-a-very-long-branch-name";
+        let result = format_status_line(long, 1, 1, None, false, None, None);
+        // &long[..19] = "feat/this-is-a-very" → appended with "…"
+        assert!(result.contains("feat/this-is-a-very…"), "truncation wrong: {result}");
+        assert!(!result.contains("feat/this-is-a-very-long"), "should be truncated: {result}");
+    }
+}

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -12,7 +12,6 @@ pub enum TmuxCommand {
     Popup,
 }
 
-#[allow(dead_code)]
 pub fn run(cmd: TmuxCommand) -> Result<()> {
     match cmd {
         TmuxCommand::Status => run_status(),
@@ -20,7 +19,6 @@ pub fn run(cmd: TmuxCommand) -> Result<()> {
     }
 }
 
-#[allow(dead_code)]
 pub fn format_status_line(
     branch: &str,
     pos: usize,
@@ -56,6 +54,7 @@ pub fn format_status_line(
 }
 
 fn run_status() -> Result<()> {
+    // Status bar context: fail silently so tmux shows an empty segment rather than an error string
     let repo = match GitRepo::open() {
         Ok(r) => r,
         Err(_) => return Ok(()),
@@ -112,6 +111,8 @@ fn run_popup() -> Result<()> {
             "80%",
             "-h",
             "80%",
+            "sh",
+            "-c",
             "stax watch --current",
         ])
         .status()?;

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -189,7 +189,11 @@ fn render_watch_table(
                 let state = info
                     .and_then(|b| b.pr_state.as_deref())
                     .unwrap_or("open");
-                let draft = info.and_then(|b| b.pr_is_draft).unwrap_or(false);
+                let draft = ci_by_branch
+                    .get(branch.as_str())
+                    .and_then(|s| s.pr_is_draft)
+                    .or_else(|| info.and_then(|b| b.pr_is_draft))
+                    .unwrap_or(false);
                 if draft {
                     format!("  PR #{} draft", n).dimmed().to_string()
                 } else if state.to_lowercase() == "merged" {
@@ -233,13 +237,21 @@ fn load_ci_from_cache(git_dir: &std::path::Path, branches: &[String]) -> Vec<Bra
     branches
         .iter()
         .filter_map(|b| {
-            cache.get_ci_state(b).map(|_| BranchCiStatus {
-                branch: b.clone(),
-                sha: String::new(),
-                sha_short: String::new(),
-                overall_status: cache.get_ci_state(b),
-                check_runs: vec![],
-                pr_number: None,
+            cache.get_ci_state(b).map(|_| {
+                let pr_is_draft = cache
+                    .branches
+                    .get(b.as_str())
+                    .and_then(|e| e.pr_state.as_deref())
+                    .map(|s| s.eq_ignore_ascii_case("draft"));
+                BranchCiStatus {
+                    branch: b.clone(),
+                    sha: String::new(),
+                    sha_short: String::new(),
+                    overall_status: cache.get_ci_state(b),
+                    check_runs: vec![],
+                    pr_number: None,
+                    pr_is_draft,
+                }
             })
         })
         .collect()


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Add first-class tmux integration so stax users can see stack, PR, and CI status at a glance and launch a popup stack viewer without leaving tmux.

## Description of changes / notes for reviewers

- Adds `stax tmux status` for a compact tmux-formatted status segment, with graceful no-op behavior outside a stax repo or on trunk.
- Adds `stax tmux popup` plus CLI dispatch wiring, and includes tests for status-line formatting across PR and CI states.