### PR TITLE
perf: reuse loaded stack for cascade navigation

### DIFF
--- a/src/commands/cascade.rs
+++ b/src/commands/cascade.rs
@@ -9,15 +9,17 @@ use std::process::Command;
 pub fn run(no_pr: bool, no_submit: bool, auto_stash_pop: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let original = repo.current_branch()?;
+    let workdir = repo.workdir()?.to_path_buf();
+    let stack = Stack::load(&repo)?;
 
     println!("{}", "Cascading stack...".bold());
 
     // Warn if local trunk is behind its remote-tracking ref. This uses the
     // cached remote refs (no network call) so it's instant. The user can run
     // `stax rs` to fetch and sync trunk before cascading.
-    warn_if_trunk_stale(&repo);
+    warn_if_trunk_stale(&repo, &stack);
 
-    commands::navigate::bottom()?;
+    commands::navigate::bottom_with_loaded_stack(&stack, &workdir, &original)?;
     // A bottom-anchored restack already walks ancestors/current/descendants for
     // this stack, so we do not need a follow-up upstack restack.
     commands::restack::run(
@@ -59,9 +61,8 @@ pub fn run(no_pr: bool, no_submit: bool, auto_stash_pop: bool) -> Result<()> {
 /// Check whether local trunk is behind its remote-tracking ref and print a
 /// warning if so. Uses the cached remote refs — no network call. Non-fatal:
 /// the user may intentionally be working offline or not ready to sync yet.
-fn warn_if_trunk_stale(repo: &GitRepo) {
+fn warn_if_trunk_stale(repo: &GitRepo, stack: &Stack) {
     let Ok(config) = Config::load() else { return };
-    let Ok(stack) = Stack::load(repo) else { return };
     let Ok(workdir) = repo.workdir() else { return };
 
     let remote_ref = format!("{}/{}", config.remote_name(), stack.trunk);

--- a/src/commands/navigate.rs
+++ b/src/commands/navigate.rs
@@ -157,20 +157,28 @@ pub fn bottom() -> Result<()> {
     let current = repo.current_branch()?;
     let stack = Stack::load(&repo)?;
 
+    drop(repo);
+    bottom_with_loaded_stack(&stack, &workdir, &current)
+}
+
+pub(crate) fn bottom_with_loaded_stack(
+    stack: &Stack,
+    workdir: &std::path::Path,
+    current: &str,
+) -> Result<()> {
     // Get the current stack and find the bottom (first branch above trunk)
-    let current_stack = stack.current_stack(&current);
+    let current_stack = stack.current_stack(current);
 
     // Find the first branch that's not trunk
     let bottom_branch = current_stack.iter().find(|b| *b != &stack.trunk);
 
     match bottom_branch {
         Some(target) => {
-            if target == &current {
+            if target == current {
                 println!("{}", "Already at the bottom of the stack.".dimmed());
                 return Ok(());
             }
-            drop(repo);
-            switch_branch(&workdir, &current, target)?;
+            switch_branch(workdir, current, target)?;
             println!("Switched to branch '{}'", target.bright_cyan());
         }
         None => {


### PR DESCRIPTION
Fixes #382

## Summary
- Add a loaded-stack navigation path for bottom navigation.
- Reuse the stack already loaded by `cascade` instead of loading it once for the stale-trunk warning and again through `navigate::bottom()`.
- Keep the public navigation command behavior unchanged.

## Tests
- `cargo test --test navigation_tests`
- `cargo test --test integration_tests cascade`
- `cargo test --test navigation_tests test_bottom -- --nocapture`
- `rustfmt --check src/commands/navigate.rs src/commands/cascade.rs`
- `git diff --check`

## Docs
- Not updated: this is an internal performance refactor with no command, flag, output, or default behavior change.