### PR TITLE
perf: attribute absorb files with one log walk

### DIFF
--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -331,36 +331,15 @@ fn attribute_files(
 ) -> Result<AbsorbPlan> {
     let mut branch_files: HashMap<String, Vec<String>> = HashMap::new();
     let mut unattributed: Vec<String> = Vec::new();
+    let branch_by_file = collect_file_attribution(workdir, branch_boundaries)?;
 
     for file in files {
-        let mut attributed = false;
-
-        // Walk branches from top to bottom (most recent first)
-        for (branch, parent) in branch_boundaries.iter().rev() {
-            let output = Command::new("git")
-                .args([
-                    "log",
-                    "--oneline",
-                    "-1",
-                    &format!("{}..{}", parent, branch),
-                    "--",
-                    file,
-                ])
-                .current_dir(workdir)
-                .output()?;
-
-            if output.status.success() && !output.stdout.is_empty() {
-                branch_files
-                    .entry(branch.clone())
-                    .or_default()
-                    .push(file.clone());
-                attributed = true;
-                break;
-            }
-        }
-
-        if !attributed {
-            unattributed.push(file.clone());
+        match branch_by_file.get(file) {
+            Some(branch) => branch_files
+                .entry(branch.clone())
+                .or_default()
+                .push(file.clone()),
+            None => unattributed.push(file.clone()),
         }
     }
 
@@ -377,6 +356,92 @@ fn attribute_files(
         groups,
         unattributed,
     })
+}
+
+fn collect_branch_tips(
+    workdir: &Path,
+    branch_boundaries: &[(String, String)],
+) -> Result<HashMap<String, String>> {
+    let mut branch_tips = HashMap::new();
+
+    for (branch, _) in branch_boundaries {
+        let output = Command::new("git")
+            .args(["rev-parse", branch])
+            .current_dir(workdir)
+            .output()?;
+
+        if !output.status.success() {
+            bail!("Failed to resolve branch tip for '{}'", branch);
+        }
+
+        let tip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        branch_tips.insert(tip, branch.clone());
+    }
+
+    Ok(branch_tips)
+}
+
+fn next_branch_after(branch: &str, branch_boundaries: &[(String, String)]) -> Option<String> {
+    let idx = branch_boundaries
+        .iter()
+        .position(|(candidate, _)| candidate == branch)?;
+    branch_boundaries
+        .get(idx + 1)
+        .map(|(next_branch, _)| next_branch.clone())
+}
+
+fn collect_file_attribution(
+    workdir: &Path,
+    branch_boundaries: &[(String, String)],
+) -> Result<HashMap<String, String>> {
+    let mut branch_by_file = HashMap::new();
+    let Some((first_branch, base)) = branch_boundaries.first() else {
+        return Ok(branch_by_file);
+    };
+    let top_branch = branch_boundaries
+        .last()
+        .map(|(branch, _)| branch.as_str())
+        .unwrap_or(base);
+    let branch_tips = collect_branch_tips(workdir, branch_boundaries)?;
+    let mut current_branch = first_branch.clone();
+    let mut branch_after_current_commit: Option<String> = None;
+
+    let output = Command::new("git")
+        .args([
+            "log",
+            "--format=commit:%H",
+            "--name-only",
+            "--diff-filter=AM",
+            "--reverse",
+            "--ancestry-path",
+            &format!("{}..{}", base, top_branch),
+        ])
+        .current_dir(workdir)
+        .output()?;
+
+    if !output.status.success() {
+        bail!("Failed to collect file attribution for absorb");
+    }
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(commit) = line.strip_prefix("commit:") {
+            if let Some(next_branch) = branch_after_current_commit.take() {
+                current_branch = next_branch;
+            }
+            if let Some(tip_branch) = branch_tips.get(commit) {
+                branch_after_current_commit = next_branch_after(tip_branch, branch_boundaries);
+            }
+            continue;
+        }
+
+        branch_by_file.insert(line.to_string(), current_branch.clone());
+    }
+
+    Ok(branch_by_file)
 }
 
 /// Get the first-line commit message of a branch's tip.

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -411,7 +411,6 @@ fn collect_file_attribution(
             "log",
             "--format=commit:%H",
             "--name-only",
-            "--diff-filter=AM",
             "--reverse",
             "--ancestry-path",
             &format!("{}..{}", base, top_branch),

--- a/tests/absorb_tests.rs
+++ b/tests/absorb_tests.rs
@@ -216,3 +216,32 @@ fn absorb_moves_changes_to_their_owning_branch() {
         "hello from feature-a"
     );
 }
+
+#[test]
+fn absorb_keeps_branch_boundary_when_parent_tip_deletes_file() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "feature-a"]).assert_success();
+    repo.create_file("scratch.txt", "temporary");
+    repo.commit("add scratch file");
+    fs::remove_file(repo.path().join("scratch.txt")).unwrap();
+    repo.git(&["add", "scratch.txt"]);
+    repo.commit("remove scratch file");
+
+    repo.run_stax(&["create", "feature-b"]).assert_success();
+    repo.create_file("b.txt", "owned by feature-b");
+    repo.commit("add b.txt in feature-b");
+
+    repo.create_file("b.txt", "updated on top");
+    repo.git(&["add", "b.txt"]);
+
+    let output = repo.run_stax(&["absorb", "--dry-run"]);
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+
+    assert!(
+        stdout.contains("feature-b"),
+        "b.txt should stay attributed to feature-b after a parent deletion-only tip: {stdout}"
+    );
+}


### PR DESCRIPTION
Fixes #384

## Summary
- Replace the nested staged-file by branch `git log` loop with a single ordered stack log walk.
- Track branch-tip boundaries while walking commits so later file modifications still win.
- Preserve unattributed staged-file behavior for files not found in the stack history.
- Cover branch-boundary tips that only delete files so child branch attribution stays correct.

## Tests
- `cargo test --test absorb_tests absorb_keeps_branch_boundary_when_parent_tip_deletes_file`
- `cargo test --test absorb_tests`
- `rustfmt --edition 2021 --check src/commands/absorb.rs tests/absorb_tests.rs`
- `git diff --check`

## Docs
- Not updated: this is an internal performance refactor with no command, flag, output, or default behavior change.