### PR TITLE
fix: fail closed on review lookup errors

### DIFF
--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -932,21 +932,24 @@ impl GitHubClient {
             }
         }
 
-        let (review_decision, approvals, changes_requested) = response
+        let data = response
             .data
-            .and_then(|d| d.repository)
-            .and_then(|r| r.pull_request)
-            .map(|pr| {
-                let approvals = pr
-                    .reviews
-                    .nodes
-                    .iter()
-                    .filter(|r| r.state == "APPROVED")
-                    .count();
-                let changes_requested = pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");
-                (pr.review_decision, approvals, changes_requested)
-            })
-            .unwrap_or((None, 0, false));
+            .context("GraphQL response did not include review data")?;
+        let repository = data
+            .repository
+            .context("GraphQL response did not include repository data")?;
+        let pr = repository
+            .pull_request
+            .context("GraphQL response did not include pull request review data")?;
+
+        let approvals = pr
+            .reviews
+            .nodes
+            .iter()
+            .filter(|r| r.state == "APPROVED")
+            .count();
+        let changes_requested = pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");
+        let review_decision = pr.review_decision;
 
         Ok((review_decision, approvals, changes_requested))
     }
@@ -1984,6 +1987,43 @@ mod tests {
 
         assert!(error.contains("Failed to get review status for PR #11"));
         assert!(error.contains("GraphQL error: rate limit exceeded"));
+    }
+
+    #[tokio::test]
+    async fn test_get_pr_merge_status_fails_closed_on_missing_review_data() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/11"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/11",
+                "id": 11,
+                "number": 11,
+                "state": "open",
+                "draft": false,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "title": "Ready-looking PR",
+                "head": { "ref": "feature-a", "sha": "aaaa", "label": "test-owner:feature-a" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "repository": { "pullRequest": null } }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let error = client.get_pr_merge_status(11).await.unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("Failed to get review status for PR #11"));
+        assert!(error.contains("pull request review data"));
     }
 
     #[tokio::test]

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -862,6 +862,11 @@ impl GitHubClient {
             .context("Failed to get PR")?;
 
         let head_sha = pr.head.sha.clone();
+        let state = pr
+            .state
+            .as_ref()
+            .map(|s| format!("{:?}", s))
+            .unwrap_or_default();
 
         // Get CI status (default to NoCi if we can't fetch - don't block on missing info)
         let ci_status = self
@@ -872,20 +877,19 @@ impl GitHubClient {
             .map(|s| CiStatus::from_str(&s))
             .unwrap_or(CiStatus::NoCi);
 
-        // Get review info via GraphQL
-        let (review_decision, approvals, changes_requested) = self
-            .get_pr_reviews(pr_number)
-            .await
-            .with_context(|| format!("Failed to get review status for PR #{}", pr_number))?;
+        let (review_decision, approvals, changes_requested) = if state.eq_ignore_ascii_case("open")
+        {
+            self.get_pr_reviews(pr_number)
+                .await
+                .with_context(|| format!("Failed to get review status for PR #{}", pr_number))?
+        } else {
+            (None, 0, false)
+        };
 
         Ok(PrMergeStatus {
             number: pr.number,
             title: pr.title.clone().unwrap_or_default(),
-            state: pr
-                .state
-                .as_ref()
-                .map(|s| format!("{:?}", s))
-                .unwrap_or_default(),
+            state,
             is_draft: pr.draft.unwrap_or(false),
             mergeable: pr.mergeable,
             mergeable_state: pr
@@ -1987,6 +1991,36 @@ mod tests {
 
         assert!(error.contains("Failed to get review status for PR #11"));
         assert!(error.contains("GraphQL error: rate limit exceeded"));
+    }
+
+    #[tokio::test]
+    async fn test_get_pr_merge_status_skips_reviews_for_closed_pr() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/11"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/11",
+                "id": 11,
+                "number": 11,
+                "state": "closed",
+                "draft": false,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "title": "Already merged PR",
+                "head": { "ref": "feature-a", "sha": "aaaa", "label": "test-owner:feature-a" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let status = client.get_pr_merge_status(11).await.unwrap();
+
+        assert_eq!(status.status_text(), "Closed");
+        assert!(!status.is_ready());
+        assert_eq!(status.review_decision, None);
+        assert_eq!(status.approvals, 0);
     }
 
     #[tokio::test]

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -876,7 +876,7 @@ impl GitHubClient {
         let (review_decision, approvals, changes_requested) = self
             .get_pr_reviews(pr_number)
             .await
-            .unwrap_or((None, 0, false));
+            .with_context(|| format!("Failed to get review status for PR #{}", pr_number))?;
 
         Ok(PrMergeStatus {
             number: pr.number,
@@ -943,8 +943,7 @@ impl GitHubClient {
                     .iter()
                     .filter(|r| r.state == "APPROVED")
                     .count();
-                let changes_requested =
-                    pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");
+                let changes_requested = pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");
                 (pr.review_decision, approvals, changes_requested)
             })
             .unwrap_or((None, 0, false));
@@ -1948,6 +1947,43 @@ mod tests {
         let client = create_test_client(&mock_server).await;
         let body = client.get_pr_body(11).await.unwrap();
         assert_eq!(body, "## Summary\n\nhello");
+    }
+
+    #[tokio::test]
+    async fn test_get_pr_merge_status_fails_closed_on_review_graphql_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/11"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/11",
+                "id": 11,
+                "number": 11,
+                "state": "open",
+                "draft": false,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "title": "Ready-looking PR",
+                "head": { "ref": "feature-a", "sha": "aaaa", "label": "test-owner:feature-a" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [{ "message": "rate limit exceeded" }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let error = client.get_pr_merge_status(11).await.unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("Failed to get review status for PR #11"));
+        assert!(error.contains("GraphQL error: rate limit exceeded"));
     }
 
     #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6160,7 +6160,7 @@ mod forge_mock_tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
-    use wiremock::matchers::{method, path, path_regex, query_param};
+    use wiremock::matchers::{body_string_contains, method, path, path_regex, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn ensure_crypto_provider() {
@@ -6502,6 +6502,7 @@ mod forge_mock_tests {
 
         Mock::given(method("POST"))
             .and(path("/graphql"))
+            .and(body_string_contains("reviewDecision"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": {
                     "repository": {
@@ -8228,6 +8229,8 @@ mod forge_mock_tests {
         let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
         assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
 
+        mount_github_review_status(&mock_server, "APPROVED").await;
+
         let merge_output = run_stax_with_env(
             &repo,
             home.path(),
@@ -8328,6 +8331,8 @@ mod forge_mock_tests {
             })))
             .mount(&mock_server)
             .await;
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         let merge_output = run_stax_with_env(
             &repo,
@@ -8461,6 +8466,8 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
+        mount_github_review_status(&mock_server, "APPROVED").await;
+
         let merge_output = run_stax_with_env(
             &repo,
             home.path(),
@@ -8576,6 +8583,8 @@ mod forge_mock_tests {
             })))
             .mount(&mock_server)
             .await;
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         let merge_output = run_stax_with_env(
             &repo,
@@ -8728,6 +8737,8 @@ mod forge_mock_tests {
             })))
             .mount(&mock_server)
             .await;
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         let merge_output = run_stax_with_env(
             &repo,
@@ -8916,6 +8927,8 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
+        mount_github_review_status(&mock_server, "APPROVED").await;
+
         let merge_output = run_stax_with_env(
             &repo,
             home.path(),
@@ -9084,6 +9097,8 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
+        mount_github_review_status(&mock_server, "APPROVED").await;
+
         let merge_output = run_stax_with_env(
             &repo,
             home.path(),
@@ -9242,6 +9257,8 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
+        mount_github_review_status(&mock_server, "APPROVED").await;
+
         let merge_output = run_stax_with_env(
             &repo,
             home.path(),
@@ -9383,6 +9400,8 @@ mod forge_mock_tests {
             .with_priority(2)
             .mount(&mock_server)
             .await;
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         let queue_output = run_stax_with_env(
             &repo,
@@ -11207,6 +11226,8 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
+        mount_github_review_status(&mock_server, "APPROVED").await;
+
         install_reject_all_pre_receive(&remote_root);
 
         let merge_output = run_stax_with_env(
@@ -11365,6 +11386,8 @@ mod forge_mock_tests {
             })))
             .mount(&mock_server)
             .await;
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         install_reject_all_pre_receive(&remote_root);
 
@@ -11552,6 +11575,8 @@ mod forge_mock_tests {
                 .mount(&mock_server)
                 .await;
         }
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         let merge_output = run_stax_with_env(
             &repo,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6493,6 +6493,29 @@ mod forge_mock_tests {
             .await;
     }
 
+    async fn mount_github_review_status(mock_server: &MockServer, decision: &str) {
+        let nodes = if decision == "APPROVED" {
+            serde_json::json!([{ "state": "APPROVED" }])
+        } else {
+            serde_json::json!([])
+        };
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewDecision": decision,
+                            "reviews": { "nodes": nodes }
+                        }
+                    }
+                }
+            })))
+            .mount(mock_server)
+            .await;
+    }
+
     async fn mount_github_stack_links_off_sync(
         mock_server: &MockServer,
         number: u64,
@@ -7954,6 +7977,8 @@ mod forge_mock_tests {
             })))
             .mount(&mock_server)
             .await;
+
+        mount_github_review_status(&mock_server, "APPROVED").await;
 
         // During the "already merged" path, merge must still retarget the next PR to trunk.
         Mock::given(method("PATCH"))


### PR DESCRIPTION
Fixes #377

## Summary
- Stop defaulting failed review GraphQL lookups to “no changes requested”.
- Surface review lookup failures from `get_pr_merge_status()` so merge-when-ready does not treat incomplete review data as ready.
- Fail closed on both explicit GraphQL errors and missing review payload data.
- Skip review lookup for closed PR status because closed/already-merged PRs are already non-ready and do not need review gates.
- Add mocked GraphQL tests plus the merge already-merged regression coverage.

## Tests
- `cargo test --test integration_tests forge_mock_tests::test_merge_already_merged_pr_still_rebases_next_branch_and_reparents_metadata -- --nocapture`
- `cargo test github::pr::tests::test_get_pr_merge_status_fails_closed_on_review_graphql_error --lib`
- `cargo test github::pr::tests::test_get_pr_merge_status_fails_closed_on_missing_review_data --lib`
- `cargo test github::pr::tests::test_get_pr_merge_status_skips_reviews_for_closed_pr --lib`
- `cargo test github::pr::tests::test_pr_merge_status_is_blocked_changes_requested --lib`
- `rustfmt --edition 2021 --check src/github/pr.rs tests/integration_tests.rs`
- `git diff --check`

## Docs
- Not updated: this changes an error path in merge readiness, not command syntax, flags, or documented workflows.