### PR TITLE
Add PR body view and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ st config --set-ai
 | `st undo` / `st redo` | Recover / reapply risky operations |
 | `st run <cmd>` | Run a command on each branch in the stack |
 | `st draft [branch]` / `st undraft [branch]` | Toggle a PR between draft and ready-for-review |
-| `st pr` / `st pr list` / `st issue list` | Open current PR · list PRs · list issues |
+| `st pr` / `st pr body` / `st pr list` / `st issue list` | Open current PR · view/edit PR body · list PRs · list issues |
 
 Full reference: [docs/commands/core.md](docs/commands/core.md) · [docs/commands/reference.md](docs/commands/reference.md)
 

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -63,7 +63,7 @@ st create --below -am "fix: patch CVE-2026-0001"
 | Command | What it does |
 |---|---|
 | `st standup` | Summarize recent activity (`--ai` for AI version, `--ai --style slack` for Slack-ready bullets) |
-| `st pr` / `st pr list` | Open current PR in browser · list open PRs |
+| `st pr` / `st pr body` / `st pr list` | Open current PR in browser · view/edit PR body · list open PRs |
 | `st issue list` | List open issues |
 | `st changelog` | Generate changelog between refs (auto-resolves last tag) |
 | `st open` | Open the repository in the browser |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -113,6 +113,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st ci -w --alert` / `--alert <file>` / `--no-alert` | Success/error completion sounds for watch mode |
 | `st ci --verbose` / `--json` | Summary cards · JSON output |
 | `st pr` · `st pr open` | Open current branch PR |
+| `st pr body` · `st pr body --edit` | Print or edit the current branch PR description |
 | `st pr list` | List open PRs (GitHub, GitLab, Gitea) |
 | `st issue list` | List open issues |
 | `st comments` | Show PR comments |

--- a/skills.md
+++ b/skills.md
@@ -55,6 +55,8 @@ stax undo [op-id]              # Undo last/specific operation
 stax redo [op-id]              # Redo last/specific undone operation
 
 stax pr                        # Open current branch PR
+stax pr body                   # Print current PR description
+stax pr body --edit            # Edit current PR description in $EDITOR
 stax open                      # Open repo in browser
 stax comments                  # Show current PR comments
 stax copy [--pr]               # Copy branch name or PR URL
@@ -287,6 +289,8 @@ stax log                           # Stack + commit details
 stax diff                          # Diff each branch vs parent + aggregate stack diff
 stax range-diff                    # Range-diff branches needing restack
 
+stax pr body                       # Print current PR description
+stax pr body --edit                # Edit current PR description in $EDITOR
 stax comments                      # Show current PR comments
 stax comments --plain              # Raw markdown output
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1566,6 +1566,13 @@ enum PrCommands {
     /// Open the current branch PR in the browser
     Open,
 
+    /// Print or edit the current branch PR description
+    Body {
+        /// Open the PR description in $EDITOR and update it on save
+        #[arg(long)]
+        edit: bool,
+    },
+
     /// List open pull requests in the current repository
     List {
         /// Maximum number of pull requests to return (max: 100)
@@ -1992,6 +1999,7 @@ pub fn run() -> Result<()> {
         ),
         Commands::Pr { command } => match command.unwrap_or(PrCommands::Open) {
             PrCommands::Open => commands::pr::run_open(),
+            PrCommands::Body { edit } => commands::pr::run_body(edit),
             PrCommands::List { limit, json } => commands::pr::run_list(limit, json),
         },
         Commands::Issue { command } => match command {

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -8,8 +8,11 @@ use crate::engine::Stack;
 use crate::forge::{ForgeClient, RepoPrListItem};
 use crate::git::GitRepo;
 use crate::remote::RemoteInfo;
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use colored::Colorize;
+use std::io::Write;
+use std::process::Command;
+use termimad::MadSkin;
 
 const TITLE_MIN_WIDTH: usize = 24;
 const BRANCH_MIN_WIDTH: usize = 18;
@@ -74,6 +77,104 @@ pub fn run_list(limit: u8, json: bool) -> Result<()> {
 
     print_pr_table(&repo_label, &prs);
     Ok(())
+}
+
+/// Print or edit the PR body for the current branch.
+pub fn run_body(edit: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let current = repo.current_branch()?;
+    let stack = Stack::load(&repo)?;
+    let config = Config::load()?;
+
+    let branch_info = stack.branches.get(&current);
+    if branch_info.is_none() {
+        anyhow::bail!(
+            "Branch '{}' is not tracked. Use {} to track it first.",
+            current,
+            "stax branch track".cyan()
+        );
+    }
+
+    let pr_number = super::resolve_pr::resolve_pr_number(&repo, &stack, &current, &config)?;
+    if pr_number.is_none() {
+        anyhow::bail!(
+            "No PR found for branch '{}'. Use {} to create one.",
+            current,
+            "stax submit".cyan()
+        );
+    }
+    let pr_number = pr_number.unwrap();
+
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+    let client = ForgeClient::new(&remote_info)?;
+    let body = rt.block_on(async { client.get_pr_body(pr_number).await })?;
+
+    if edit {
+        let updated = edit_body(&body)?;
+        if updated == body {
+            println!("PR #{} body unchanged", pr_number.to_string().cyan());
+            return Ok(());
+        }
+
+        rt.block_on(async { client.update_pr_body(pr_number, &updated).await })?;
+        println!("Updated PR #{} body", pr_number.to_string().cyan());
+        return Ok(());
+    }
+
+    print_rendered_body(&body);
+    Ok(())
+}
+
+fn print_rendered_body(body: &str) {
+    let body = body.trim();
+    if body.is_empty() {
+        return;
+    }
+
+    let skin = MadSkin::default();
+    let rendered = skin.term_text(body);
+    println!("{}", rendered);
+}
+
+fn edit_body(body: &str) -> Result<String> {
+    let editor =
+        std::env::var("EDITOR").context("$EDITOR is not set; set EDITOR to edit PR body")?;
+    if editor.trim().is_empty() {
+        bail!("$EDITOR is empty; set EDITOR to edit PR body");
+    }
+
+    let mut file = tempfile::Builder::new()
+        .prefix("stax-pr-body-")
+        .suffix(".md")
+        .tempfile()
+        .context("Failed to create temporary PR body file")?;
+    file.write_all(body.as_bytes())
+        .context("Failed to write PR body to temporary file")?;
+    file.flush()
+        .context("Failed to flush temporary PR body file")?;
+
+    let path = file.path().to_path_buf();
+    let status = if cfg!(windows) {
+        Command::new("cmd")
+            .args(["/C", &format!("{} \"{}\"", editor, path.display())])
+            .status()
+    } else {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("{} \"$1\"", editor))
+            .arg("stax-editor")
+            .arg(&path)
+            .status()
+    }
+    .context("Failed to launch $EDITOR")?;
+
+    if !status.success() {
+        bail!("$EDITOR exited with status {}", status);
+    }
+
+    std::fs::read_to_string(&path).context("Failed to read edited PR body")
 }
 
 fn print_pr_table(repo_label: &str, prs: &[RepoPrListItem]) {

--- a/tests/pr_body_tests.rs
+++ b/tests/pr_body_tests.rs
@@ -1,0 +1,192 @@
+//! PR body command integration tests.
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::Path;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn write_test_config(home: &Path, api_base_url: &str) {
+    let config_dir = home.join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("Failed to create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("[remote]\napi_base_url = \"{}\"\n", api_base_url),
+    )
+    .expect("Failed to write config");
+}
+
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, pr_number: u64) {
+    let metadata = serde_json::json!({
+        "parentBranchName": "main",
+        "parentBranchRevision": repo.get_commit_sha("main"),
+        "prInfo": {
+            "number": pr_number,
+            "state": "OPEN"
+        }
+    });
+
+    let metadata_file = tempfile::NamedTempFile::new().expect("metadata temp file");
+    fs::write(metadata_file.path(), metadata.to_string()).expect("write metadata temp file");
+    let hash = repo.git(&[
+        "hash-object",
+        "-w",
+        metadata_file.path().to_str().expect("metadata path"),
+    ]);
+    assert!(
+        hash.status.success(),
+        "git hash-object failed: {}",
+        TestRepo::stderr(&hash)
+    );
+    let blob = TestRepo::stdout(&hash);
+    let update = repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{}", branch),
+        blob.trim(),
+    ]);
+    assert!(
+        update.status.success(),
+        "git update-ref failed: {}",
+        TestRepo::stderr(&update)
+    );
+}
+
+fn pr_fixture(number: u64, branch: &str, body: &str) -> serde_json::Value {
+    serde_json::json!({
+        "url": format!("https://api.github.com/repos/test/repo/pulls/{}", number),
+        "id": number,
+        "number": number,
+        "state": "open",
+        "draft": false,
+        "title": "Test PR",
+        "body": body,
+        "html_url": format!("https://github.com/test/repo/pull/{}", number),
+        "head": { "ref": branch, "sha": "aaaa", "label": format!("test:{}", branch) },
+        "base": { "ref": "main", "sha": "bbbb" }
+    })
+}
+
+fn setup_pr_body_repo(api_base_url: &str, pr_number: u64) -> (TestRepo, String, String) {
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), api_base_url);
+
+    let remote = repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/test/repo.git",
+    ]);
+    assert!(
+        remote.status.success(),
+        "failed to add remote: {}",
+        TestRepo::stderr(&remote)
+    );
+
+    repo.create_stack(&["feature-body"]);
+    let branch = repo.current_branch();
+    write_branch_pr_metadata(&repo, &branch, pr_number);
+
+    (repo, home, branch)
+}
+
+#[tokio::test]
+async fn pr_body_prints_current_pr_description() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let (repo, _home, branch) = setup_pr_body_repo(&mock_server.uri(), 42);
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test/repo/pulls/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(pr_fixture(
+            42,
+            &branch,
+            "Summary line\n\nDetails line",
+        )))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["pr", "body"], &[("STAX_GITHUB_TOKEN", "mock-token")]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(stdout.contains("Summary line"), "stdout was: {stdout}");
+    assert!(stdout.contains("Details line"), "stdout was: {stdout}");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn pr_body_edit_updates_current_pr_description() {
+    use std::os::unix::fs::PermissionsExt;
+
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let (repo, home, branch) = setup_pr_body_repo(&mock_server.uri(), 43);
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test/repo/pulls/43"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(pr_fixture(43, &branch, "Old body")))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/test/repo/pulls/43"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(pr_fixture(
+            43,
+            &branch,
+            "Updated body\n",
+        )))
+        .mount(&mock_server)
+        .await;
+
+    let editor = Path::new(&home).join("editor.sh");
+    fs::write(&editor, "#!/bin/sh\nprintf 'Updated body\\n' > \"$1\"\n")
+        .expect("write editor script");
+    let mut permissions = fs::metadata(&editor)
+        .expect("editor metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&editor, permissions).expect("chmod editor");
+
+    let output = repo.run_stax_with_env(
+        &["pr", "body", "--edit"],
+        &[
+            ("STAX_GITHUB_TOKEN", "mock-token"),
+            ("EDITOR", editor.to_str().expect("editor path")),
+        ],
+    );
+    output.assert_success();
+    assert!(
+        TestRepo::stdout(&output).contains("Updated PR #43 body"),
+        "stdout was: {}",
+        TestRepo::stdout(&output)
+    );
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(requests.iter().any(|request| {
+        request.method.as_str() == "PATCH"
+            && request.url.path() == "/repos/test/repo/pulls/43"
+            && String::from_utf8_lossy(&request.body).contains("Updated body\\n")
+    }));
+}
+
+#[test]
+fn pr_body_no_pr_fails() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature-body"]);
+
+    let output = repo.run_stax(&["pr", "body"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("No PR") || stderr.contains("submit"),
+        "expected missing PR message, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Motivation


Let users inspect and update the current branch PR description directly from the CLI without opening the browser.

## Description of changes / notes for reviewers

- Added `st pr body` to print the current PR description, and `st pr body --edit` to update it through `$EDITOR`.
- Updated command docs, README, and skills reference to include the new PR body workflow, plus integration tests covering print, edit, and missing-PR cases.
