### PR TITLE
Guard create --below collisions and scoped stack links

### DIFF
--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -21,6 +21,7 @@ st create --below -am "fix: patch CVE-2026-0001"
 ```
 
 `--below` auto-stashes prepared tracked and untracked changes before moving to the lower base, then reapplies them on the inserted branch. With `-am`, those changes are staged and committed on the new lower branch.
+When `-m` or `--ai` derives a branch name that already exists, Stax stops instead of creating a suffixed duplicate; pass an explicit different name or checkout/reparent the existing branch.
 
 ## Submit and merge
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -196,6 +196,7 @@ st wt go ui-polish --run "cursor ." --tmux
 - `st create --ai -m "msg"` keeps the commit message and generates the branch name
 - `-n`, `--no-verify` skip pre-commit and commit-msg hooks when creating a commit
 - `-m` / `-am` create the commit before creating the destination branch, including with `--from` and `--below`, so hook failures or interrupts do not leave orphan branches
+- `-m` / `--ai` derived branch names refuse collisions instead of creating `-2` duplicates; pass an explicit different name or checkout/reparent the existing branch
 - `--insert` reparent children of the current branch onto the new branch
 - `--below` create from the current branch's parent and reparent the current branch onto the new branch; prepared tracked and untracked changes are auto-stashed and reapplied onto the new lower branch, and `-m`/`-am` commits staged changes there
 - `st branch create --message "msg" --prefix feature/`

--- a/skills.md
+++ b/skills.md
@@ -151,6 +151,7 @@ stax create --below -am "message"  # Auto-stash/apply, stage all, commit on new 
 stax bc <name>                     # Hidden shortcut alias
 # create -m/-am commits before branch creation, including --from/--below,
 # so hook failures or interrupts do not leave orphan branches or -2 retries.
+# -m/--ai derived branch names refuse collisions instead of creating -2 duplicates.
 # --below keeps prepared work in place by stashing before moving downstack,
 # then applying it on the inserted lower branch.
 

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -432,7 +432,7 @@ pub fn run(
     // it offers an interactive menu (or bails in non-TTY). Use -a/--all to
     // skip the menu and force-stage.
     // When neither name nor message is provided, launch interactive wizard.
-    let (input, commit_message, stage_mode, generated_from_message) = if let Some(n) = &name {
+    let (input, commit_message, stage_mode, generated_branch_name) = if let Some(n) = &name {
         let commit_message = ai_message;
         let stage_mode = if commit_message.is_some() {
             if all {
@@ -487,7 +487,7 @@ pub fn run(
     };
     let existing_branches = repo.list_branches()?;
     let branch_name =
-        resolve_branch_name_conflicts(&branch_name, &existing_branches, generated_from_message)?;
+        resolve_branch_name_conflicts(&branch_name, &existing_branches, generated_branch_name)?;
 
     // Before creating the branch, resolve the staging question. Doing this
     // early means declining ("Abort" / empty `--patch` exit) is a clean no-op
@@ -1539,25 +1539,16 @@ enum BranchNameConflict<'a> {
 fn resolve_branch_name_conflicts(
     branch_name: &str,
     existing_branches: &[String],
-    generated_from_message: bool,
+    generated_branch_name: bool,
 ) -> Result<String> {
     match detect_branch_name_conflict(branch_name, existing_branches) {
         None => Ok(branch_name.to_string()),
-        Some(BranchNameConflict::Exact(_) | BranchNameConflict::ExistingIsDescendant(_))
-            if generated_from_message =>
-        {
-            for suffix in 2..1000 {
-                let candidate = append_branch_suffix(branch_name, suffix);
-                if detect_branch_name_conflict(&candidate, existing_branches).is_none() {
-                    return Ok(candidate);
-                }
-            }
-
-            bail!(
-                "Cannot create a unique branch name from '{}'. Too many similarly named branches already exist.",
-                branch_name
-            );
-        }
+        Some(conflict) if generated_branch_name => bail!(
+            "{}\n\
+             Generated branch names are not auto-suffixed.\n\
+             Checkout/reparent the existing branch or pass an explicit different branch name.",
+            branch_name_conflict_message(branch_name, conflict)
+        ),
         Some(conflict) => bail!("{}", branch_name_conflict_message(branch_name, conflict)),
     }
 }
@@ -1602,13 +1593,6 @@ fn branch_name_conflict_message(branch_name: &str, conflict: BranchNameConflict<
              Either delete '{}' first, or use a different name.",
             branch_name, existing, existing
         ),
-    }
-}
-
-fn append_branch_suffix(branch_name: &str, suffix: usize) -> String {
-    match branch_name.rsplit_once('/') {
-        Some((prefix, leaf)) => format!("{}/{}-{}", prefix, leaf, suffix),
-        None => format!("{}-{}", branch_name, suffix),
     }
 }
 

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1550,8 +1550,10 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         }
         async_timings.pr_create_update = create_update_started_at.elapsed();
 
-        // Sync stack links on ALL PRs in the stack, even on otherwise no-op submit runs.
-        let prs_with_numbers: Vec<_> = pr_infos
+        // Sync stack links with full current-stack context, even for scoped
+        // submit commands where only one branch needed push/PR work.
+        let stack_link_pr_infos = stack_pr_infos_for_links(&stack, &current, &pr_infos);
+        let prs_with_numbers: Vec<_> = stack_link_pr_infos
             .iter()
             .filter_map(|p| p.pr_number.map(|num| (num, p.branch.clone())))
             .collect();
@@ -1560,8 +1562,12 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         for (pr_number, _branch) in &prs_with_numbers {
             let sync_timer =
                 LiveTimer::maybe_new(!quiet, &format!("Syncing stack links on #{}...", pr_number));
-            let stack_links =
-                generate_stack_links_markdown(&pr_infos, *pr_number, &remote_info, &stack.trunk);
+            let stack_links = generate_stack_links_markdown(
+                &stack_link_pr_infos,
+                *pr_number,
+                &remote_info,
+                &stack.trunk,
+            );
 
             match stack_links_mode {
                 StackLinksMode::Comment | StackLinksMode::Both => {
@@ -1798,6 +1804,32 @@ fn push_branches(
         );
     }
     Ok(())
+}
+
+fn stack_pr_infos_for_links(
+    stack: &Stack,
+    current: &str,
+    processed_pr_infos: &[StackPrInfo],
+) -> Vec<StackPrInfo> {
+    let processed_pr_numbers: HashMap<&str, Option<u64>> = processed_pr_infos
+        .iter()
+        .map(|info| (info.branch.as_str(), info.pr_number))
+        .collect();
+
+    stack
+        .current_stack(current)
+        .into_iter()
+        .filter(|branch| branch != &stack.trunk)
+        .map(|branch| {
+            let pr_number = processed_pr_numbers
+                .get(branch.as_str())
+                .copied()
+                .flatten()
+                .or_else(|| stack.branches.get(&branch).and_then(|info| info.pr_number));
+
+            StackPrInfo { branch, pr_number }
+        })
+        .collect()
 }
 
 fn rejected_push_branches(porcelain: &str, branches: &[&str]) -> Vec<String> {
@@ -2529,9 +2561,12 @@ mod tests {
     use super::{
         build_ai_pr_details_prompt, existing_ai_prompt_items, existing_ai_targets_for_auto_accept,
         parse_ai_pr_details, rejected_push_branches, resolve_ai_targets,
-        resolve_is_draft_without_prompt, truncate_ai_diff, AiPrTargets, MAX_AI_DIFF_BYTES,
-        PR_TYPE_DEFAULT_INDEX, PR_TYPE_OPTIONS,
+        resolve_is_draft_without_prompt, stack_pr_infos_for_links, truncate_ai_diff, AiPrTargets,
+        StackPrInfo, MAX_AI_DIFF_BYTES, PR_TYPE_DEFAULT_INDEX, PR_TYPE_OPTIONS,
     };
+    use crate::engine::stack::StackBranch;
+    use crate::engine::Stack;
+    use std::collections::HashMap;
 
     #[test]
     fn no_prompt_defaults_to_draft() {
@@ -2561,6 +2596,84 @@ mod tests {
         assert_eq!(
             rejected_push_branches(porcelain, &["feature", "feature-a"]),
             vec!["feature-a".to_string()]
+        );
+    }
+
+    #[test]
+    fn stack_links_for_scoped_submit_use_full_current_stack_context() {
+        let stack = Stack {
+            trunk: "main".to_string(),
+            branches: HashMap::from([
+                (
+                    "main".to_string(),
+                    StackBranch {
+                        name: "main".to_string(),
+                        parent: None,
+                        parent_revision: None,
+                        children: vec!["base".to_string()],
+                        needs_restack: false,
+                        pr_number: None,
+                        pr_state: None,
+                        pr_is_draft: None,
+                    },
+                ),
+                (
+                    "base".to_string(),
+                    StackBranch {
+                        name: "base".to_string(),
+                        parent: Some("main".to_string()),
+                        parent_revision: Some("main-sha".to_string()),
+                        children: vec!["middle".to_string()],
+                        needs_restack: false,
+                        pr_number: Some(10),
+                        pr_state: Some("OPEN".to_string()),
+                        pr_is_draft: Some(false),
+                    },
+                ),
+                (
+                    "middle".to_string(),
+                    StackBranch {
+                        name: "middle".to_string(),
+                        parent: Some("base".to_string()),
+                        parent_revision: Some("base-sha".to_string()),
+                        children: vec!["leaf".to_string()],
+                        needs_restack: false,
+                        pr_number: Some(20),
+                        pr_state: Some("OPEN".to_string()),
+                        pr_is_draft: Some(false),
+                    },
+                ),
+                (
+                    "leaf".to_string(),
+                    StackBranch {
+                        name: "leaf".to_string(),
+                        parent: Some("middle".to_string()),
+                        parent_revision: Some("middle-sha".to_string()),
+                        children: vec![],
+                        needs_restack: false,
+                        pr_number: Some(30),
+                        pr_state: Some("OPEN".to_string()),
+                        pr_is_draft: Some(false),
+                    },
+                ),
+            ]),
+        };
+
+        let infos = stack_pr_infos_for_links(
+            &stack,
+            "middle",
+            &[StackPrInfo {
+                branch: "middle".to_string(),
+                pr_number: Some(22),
+            }],
+        );
+
+        assert_eq!(
+            infos
+                .iter()
+                .map(|info| (info.branch.as_str(), info.pr_number))
+                .collect::<Vec<_>>(),
+            vec![("base", Some(10)), ("middle", Some(22)), ("leaf", Some(30))]
         );
     }
 

--- a/tests/create_ai_tests.rs
+++ b/tests/create_ai_tests.rs
@@ -200,3 +200,43 @@ fn create_ai_yes_without_staging_generates_branch_only() {
     assert!(prompt.contains("\"branch\""));
     assert!(!prompt.contains("\"message\""));
 }
+
+#[test]
+fn create_ai_generated_branch_rejects_collision() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["create", "ai-collision"]);
+    assert!(
+        output.status.success(),
+        "create failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    repo.create_file("src/lib.rs", "pub fn collision() {}\n");
+
+    let home = TempDir::new().expect("create home");
+    write_test_config_with_ai(home.path());
+    let prompt_log = home.path().join("prompt.txt");
+    let bin_dir = write_fake_claude(home.path(), r#"{"branch":"ai-collision"}"#, &prompt_log);
+    let env = ai_env(home.path(), &bin_dir);
+    let env = env_refs(&env);
+
+    let output = repo.run_stax_with_env(&["create", "--ai", "--yes"], &env);
+    assert!(!output.status.success());
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("already exists")
+            && stderr.contains("Generated branch names are not auto-suffixed")
+            && stderr.contains("explicit different branch name"),
+        "Expected generated-name collision error, got: {}",
+        stderr
+    );
+    assert_eq!(repo.current_branch(), "ai-collision");
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|branch| branch == "ai-collision-2"),
+        "AI-generated collision must not create a suffixed duplicate branch"
+    );
+}

--- a/tests/create_below_tests.rs
+++ b/tests/create_below_tests.rs
@@ -215,6 +215,70 @@ fn test_create_below_with_message_commits_on_new_branch() {
 }
 
 #[test]
+fn test_create_below_with_message_rejects_generated_name_collision_in_stack() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&[
+        "below-collision-parent",
+        "below-collision-current",
+        "below-collision-hotfix",
+    ]);
+    let current = &branches[1];
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    let output = repo.run_stax(&["create", "--below", "-m", "below collision hotfix"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("already exists")
+            && stderr.contains("Generated branch names are not auto-suffixed")
+            && stderr.contains("explicit different branch name"),
+        "Expected actionable generated-name collision error, got: {}",
+        stderr
+    );
+    assert_eq!(
+        repo.current_branch(),
+        *current,
+        "failed below create should leave the current branch checked out"
+    );
+    assert!(
+        !repo
+            .list_branches()
+            .iter()
+            .any(|branch| branch.contains("below-collision-hotfix-2")),
+        "below create must not silently create a suffixed duplicate branch"
+    );
+    assert_current_parent_contains(&repo, "below-collision-parent");
+}
+
+#[test]
+fn test_create_below_with_explicit_name_collision_uses_normal_conflict_error() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["below-explicit-current", "below-explicit-existing"]);
+    let current = &branches[0];
+
+    repo.run_stax(&["checkout", current]).assert_success();
+    let output = repo.run_stax(&["create", "below-explicit-existing", "--below"]);
+    output.assert_failure();
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("already exists"),
+        "Expected normal branch conflict error, got: {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("Generated branch names"),
+        "Explicit branch-name collisions should not mention generated names: {}",
+        stderr
+    );
+}
+
+#[test]
 fn test_create_below_auto_stashes_dirty_worktree_onto_new_branch() {
     let repo = TestRepo::new();
     repo.run_stax(&["status"]).assert_success();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -530,7 +530,7 @@ fn test_branch_create_with_message() {
 }
 
 #[test]
-fn test_branch_create_with_message_uses_unique_suffix_on_collision() {
+fn test_branch_create_with_message_rejects_generated_name_collision() {
     let repo = TestRepo::new();
 
     let output = repo.run_stax(&["bc", "-m", "Add new feature"]);
@@ -542,23 +542,30 @@ fn test_branch_create_with_message_uses_unique_suffix_on_collision() {
     let first_branch = repo.current_branch();
 
     let output = repo.run_stax(&["bc", "-m", "Add new feature"]);
-    assert!(
-        output.status.success(),
-        "Failed second create: {}",
-        TestRepo::stderr(&output)
-    );
-    let second_branch = repo.current_branch();
+    assert!(!output.status.success());
 
-    assert_ne!(first_branch, second_branch);
+    let stderr = TestRepo::stderr(&output);
     assert!(
-        second_branch.ends_with("-2") && second_branch.to_lowercase().contains("new-feature"),
-        "Expected suffixed branch name, got: {}",
-        second_branch
+        stderr.contains("already exists")
+            && stderr.contains("Generated branch names are not auto-suffixed")
+            && stderr.contains("explicit different branch name"),
+        "Expected generated-name collision error, got: {}",
+        stderr
+    );
+    assert_eq!(
+        repo.current_branch(),
+        first_branch,
+        "failed create should leave the existing branch checked out"
     );
 
     let branches = repo.list_branches();
     assert!(branches.iter().any(|b| b == &first_branch));
-    assert!(branches.iter().any(|b| b == &second_branch));
+    assert!(
+        !branches
+            .iter()
+            .any(|branch| branch.to_lowercase().contains("new-feature-2")),
+        "generated-name collision must not create a suffixed duplicate branch"
+    );
 }
 
 #[test]
@@ -7883,6 +7890,135 @@ mod forge_mock_tests {
         let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
         assert_eq!(payload["body"], "## Summary\n\nhello");
+    }
+
+    #[tokio::test]
+    async fn test_branch_submit_stack_links_include_full_stack_context() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        let _remote_root = remote_root.keep();
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-link-parent"]);
+        assert!(
+            output.status.success(),
+            "Failed to create parent: {}",
+            TestRepo::stderr(&output)
+        );
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Add parent");
+        let parent = repo.current_branch();
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &parent]);
+        assert!(
+            push.status.success(),
+            "Failed to push parent: {}",
+            TestRepo::stderr(&push)
+        );
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-link-child"]);
+        assert!(
+            output.status.success(),
+            "Failed to create child: {}",
+            TestRepo::stderr(&output)
+        );
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Add child");
+        let child = repo.current_branch();
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &child]);
+        assert!(
+            push.status.success(),
+            "Failed to push child: {}",
+            TestRepo::stderr(&push)
+        );
+
+        write_branch_pr_metadata(&repo, &parent, "main", 101, Some(false));
+        write_branch_pr_metadata(&repo, &child, &parent, 102, Some(false));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(102, &child, &parent, "Child PR", "child body"),
+            ))
+            .mount(&mock_server)
+            .await;
+
+        for (number, branch, base, comment_id, body) in [
+            (101_u64, parent.as_str(), "main", 901_u64, "parent body"),
+            (
+                102_u64,
+                child.as_str(),
+                parent.as_str(),
+                902_u64,
+                "child body",
+            ),
+        ] {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/test/repo/issues/{}/comments", number)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    issue_comment_fixture(comment_id, "<!-- stax-stack-comment -->\nold")
+                ])))
+                .mount(&mock_server)
+                .await;
+
+            Mock::given(method("PATCH"))
+                .and(path(format!(
+                    "/repos/test/repo/issues/comments/{}",
+                    comment_id
+                )))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(issue_comment_fixture(
+                        comment_id,
+                        "<!-- stax-stack-comment -->\nupdated",
+                    )),
+                )
+                .mount(&mock_server)
+                .await;
+
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/test/repo/pulls/{}", number)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(
+                    github_pull_fixture_with_details(number, branch, base, "PR", body),
+                ))
+                .mount(&mock_server)
+                .await;
+        }
+
+        let output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["branch", "submit", "--yes", "--no-prompt"],
+        );
+        assert!(
+            output.status.success(),
+            "branch submit failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let child_comment_patch = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "PATCH"
+                    && request.url.path() == "/repos/test/repo/issues/comments/902"
+            })
+            .expect("expected child stack-comment update");
+        let payload: serde_json::Value = serde_json::from_slice(&child_comment_patch.body).unwrap();
+        let body = payload["body"].as_str().expect("comment body");
+        assert!(
+            body.contains("PR #101") && body.contains("PR #102"),
+            "scoped submit stack links should include parent and child PRs, got: {}",
+            body
+        );
+        assert!(
+            body.contains("PR #102** 👈"),
+            "current PR should keep the pointer, got: {}",
+            body
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- refuse generated `st create -m` / `--ai` branch names when they collide with an existing branch instead of silently creating a suffixed duplicate
- build stack-link comments and bodies from the full current stack context during scoped submit
- document the generated-name collision behavior

## Repro
1. Create a branch from a generated name, for example `st create -m "Add topic"`.
2. Retry the same generated name; previously this could create `add-topic-2`, now it errors with guidance to checkout/reparent or pass a different explicit name.
3. Create a generic stack with parent/child PR metadata.
4. Run `st branch submit` on a branch with a parent PR; previously the stack-link comment could be generated from only the scoped branch, now it includes the full stack context.

## Tests
- `cargo test --test integration_tests test_branch_create_with_message_rejects_generated_name_collision`
- `cargo test --test create_ai_tests create_ai_generated_branch_rejects_collision`
- `cargo test --test create_below_tests test_create_below_with_message_rejects_generated_name_collision_in_stack`
- `cargo test --test create_below_tests`
- `cargo test --test integration_tests test_branch_submit_stack_links_include_full_stack_context`
- `cargo test --lib commands::submit::tests::stack_links_for_scoped_submit_use_full_current_stack_context`
- `make test`