### PR TITLE
feat: add create alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ st config --set-ai
 | `st ls` / `st ll` | Show stack health and PR status (`st ll` adds PR URLs/details) |
 | `st watch` | Live auto-refreshing stack status with CI and PR state (adaptive polling: 15s active CI → 60s open PRs → 120s idle) |
 | `st watch --current` | Watch only the current stack |
-| `st create <name>` | Create a branch stacked on current |
+| `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
 | `st ss` | Submit the full stack, open/update linked PRs |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -9,7 +9,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st` | Launch the interactive TUI |
 | `st ls` | Show stack with PR, rebase, and metadata-repair status |
 | `st ll` | Like `st ls` plus PR URLs and detail |
-| `st create <name>` | Create a branch stacked on current |
+| `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -49,7 +49,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 
 | Command | Alias | Description |
 |---|---|---|
-| `st create <name>` | `c`, `bc` | Create stacked branch (TTY menu when nothing staged and `-m`) |
+| `st create <name>` | `c`, `add`, `bc` | Create stacked branch (TTY menu when nothing staged and `-m`) |
 | `st create --ai` | | Generate a branch name from local changes (`-a` also generates a first commit message) |
 | `st create <name> --below` | | Insert a new branch below current |
 | `st modify` | `m` | Amend staged changes into current commit (`-a` stages all, `-r` restacks after) |
@@ -190,6 +190,7 @@ st wt go ui-polish --run "cursor ." --tmux
 
 ### `st create`
 
+- `st add <name>` is an alias for `st create <name>`
 - `-m "msg"` set commit message (with nothing staged in a TTY: menu for stage all, `--patch`, empty branch, or abort)
 - `-am "msg"` stage all and commit
 - `--ai` generate missing branch name and/or first commit message from local changes

--- a/skills.md
+++ b/skills.md
@@ -42,7 +42,7 @@ stax branch ...|b              # Branch subcommands
 stax upstack ...|us            # Descendant-scope commands
 stax downstack ...|ds          # Ancestor-scope commands
 
-stax create|c                  # Create stacked branch (--ai can name it from changes)
+stax create|c|add              # Create stacked branch (--ai can name it from changes)
 stax modify|m                  # Amend current commit (menu when nothing staged)
 stax rename                    # Rename current branch
 stax detach                    # Remove branch from stack, reparent children
@@ -138,6 +138,7 @@ Release prep rewrites the next released changelog entry from non-merge commits s
 
 ```bash
 stax create <name>                 # Create branch stacked on current
+stax add <name>                    # Alias for create
 stax create -m "message"           # Use commit message (TTY menu if nothing staged)
 stax create -a                     # Stage all before creating
 stax create -am "message"          # Stage all + commit (bypasses menu)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -641,7 +641,7 @@ enum Commands {
     Stack(StackCommands),
 
     /// Create a new branch stacked on current
-    #[command(visible_alias = "c")]
+    #[command(visible_aliases = ["c", "add"])]
     Create {
         /// Name for the new branch
         name: Option<String>,
@@ -2818,6 +2818,19 @@ mod tests {
                 yes: true,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn create_add_alias_parses_as_create_command() {
+        let cli = parse_cli(&["stax", "add", "feature-alias", "--below"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Create {
+                name: Some(ref name),
+                below: true,
+                ..
+            }) if name == "feature-alias"
         ));
     }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1558,6 +1558,16 @@ fn gt_parity_c_alias() {
 }
 
 #[test]
+fn create_add_alias_help_matches_create_command() {
+    let output = stax(&["add", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Create a new branch"));
+    assert!(stdout.contains("--below"));
+    assert!(stdout.contains("--ai"));
+}
+
+#[test]
 fn gt_parity_create_am_flags() {
     // gt create -am "message" -> stax create -am "message"
     let output = stax(&["create", "--help"]);


### PR DESCRIPTION
## Summary

- Add `st add` as a visible top-level alias for `st create`.
- Document the alias in README, command docs, and `skills.md`.
- Cover the alias with clap parser and CLI help tests.

## Verification

- `cargo test --test cli_tests create_add_alias_help_matches_create_command -- --nocapture`
- `cargo test cli::tests::create_add_alias_parses_as_create_command -- --nocapture`
- `rustfmt --edition 2021 --check src/cli.rs tests/cli_tests.rs`
- `make test` (Docker nextest): 1654 tests run, 1654 passed

Note: full `cargo fmt --check` reports pre-existing formatting drift in unrelated files, so touched Rust files were checked directly with rustfmt.