### PR TITLE
fix: skip merged cleanup during update

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ st config --set-ai
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
-| `st update` | Sync trunk, restack current stack, then push/update PRs |
+| `st update` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs |
 | `st update --force --yes --no-prompt` | Run update without sync or submit prompts |
 | `st update --verbose` | Include detailed sync/restack/submit timing |
 | `st restack` | Rebase current stack onto parents locally |

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ st ss
 
 # 4. After the bottom PR merges on GitHub…
 st update          # sync trunk, restack this stack, update PRs
-st update --force --yes --no-prompt   # same flow without prompts
+st update --force --yes --no-prompt   # sync/restack/submit without prompts
 ```
 
 Picked the wrong trunk? Run `st trunk main` or `st init --trunk <branch>` to reconfigure.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ st ss
 
 # 4. After the bottom PR merges on GitHub…
 st update          # sync trunk, restack this stack, update PRs
-st update --force --yes --no-prompt   # sync/restack/submit without prompts
 ```
 
 Picked the wrong trunk? Run `st trunk main` or `st init --trunk <branch>` to reconfigure.

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -45,7 +45,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st rs --restack` | `rs` **plus** rebase the current stack onto updated trunk |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
-| `st update` | `sync --restack` **plus** push and update PRs |
+| `st update` | Sync trunk without merged-branch cleanup, restack, then push and update PRs |
 | `st update --force --yes --no-prompt` | Full update flow without sync or submit prompts |
 | `st update --verbose` | Same as `st update`, with detailed sync/restack/submit timing |
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -15,7 +15,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st sync` | `rs` | Pull trunk, delete merged branches (incl. squash merges), reparent children |
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
-| `st update` | | `sync --restack`, then push and create/update PRs for the current stack |
+| `st update` | | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack |
 | `st update --force --yes --no-prompt` | | Run the full update flow without sync or submit prompts |
 | `st update --verbose` | | Same as `st update`, with detailed sync/restack/submit timing |
 | `st restack` | | Rebase current stack locally — auto-normalizes missing/merged parents; `--stop-here` limits scope |

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -102,13 +102,13 @@ Restack + push + create/update PRs in a single flow.
 
 ## `st update`
 
-The "bottom PR merged, catch me up" command. Prints the plan up front, then runs sync → restack → submit.
+The "bottom PR merged, catch me up" command. Prints the plan up front, then syncs trunk without merged-branch cleanup, restacks, and submits.
 
 | Command | Behavior |
 |---|---|
-| `st update` | sync → restack → push → create/update PRs |
-| `st update --no-pr` | sync → restack → push |
-| `st update --no-submit` | sync → restack |
+| `st update` | sync trunk → restack → push → create/update PRs |
+| `st update --no-pr` | sync trunk → restack → push |
+| `st update --no-submit` | sync trunk → restack |
 | `st update --force` | force the sync step instead of prompting |
-| `st update --force --yes --no-prompt` | run the full sync/restack/submit flow without prompts |
+| `st update --force --yes --no-prompt` | run the full trunk-sync/restack/submit flow without prompts |
 | `st update --verbose` | show detailed sync/restack/submit timing |

--- a/skills.md
+++ b/skills.md
@@ -231,9 +231,9 @@ stax sync --force                  # Force sync without prompts
 stax sync --prune                  # Prune stale remotes
 stax sync --no-delete              # Keep merged branches
 stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
-stax update                        # Sync, restack, then submit
-stax update --no-pr                # Push only after sync/restack
-stax update --no-submit            # Sync/restack only
+stax update                        # Sync trunk, restack, then submit (no merged cleanup)
+stax update --no-pr                # Push only after trunk sync/restack
+stax update --no-submit            # Trunk sync/restack only
 stax update --force                # Force sync without prompts first
 stax update --force --yes --no-prompt # Full update without sync/submit prompts
 stax update --verbose              # Show detailed sync/restack/submit timings

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -19,7 +19,7 @@ pub fn run(
     let workdir = repo.workdir()?.to_path_buf();
 
     println!("{}", "Updating stack...".bold());
-    println!("  1. Sync trunk and clean merged branches");
+    println!("  1. Sync trunk");
     println!("  2. Restack current stack onto updated parents");
     if no_submit {
         println!("  3. Skip push and PR updates (--no-submit)");
@@ -33,7 +33,7 @@ pub fn run(
         true,  // restack
         false, // prune
         false, // full
-        true,  // delete_merged
+        false, // delete_merged
         false, // delete_upstream_gone
         force,
         safe,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2173,8 +2173,13 @@ fn test_refresh_no_submit_keeps_original_branch_and_restacks_stack() {
         stdout
     );
     assert!(
-        stdout.contains("1. Sync trunk and clean merged branches"),
+        stdout.contains("1. Sync trunk"),
         "Expected sync step, got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("clean merged branches"),
+        "Update should not advertise merged branch cleanup, got: {}",
         stdout
     );
     assert!(
@@ -2218,7 +2223,78 @@ fn test_refresh_no_submit_keeps_original_branch_and_restacks_stack() {
 }
 
 #[test]
-fn test_refresh_no_submit_handles_squash_merged_middle_branch() {
+fn test_update_no_submit_skips_merged_branch_cleanup() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "update-merged-parent"]);
+    let parent = repo.current_branch();
+    repo.create_file("parent.txt", "parent change\n");
+    repo.commit("Parent commit");
+    repo.git(&["push", "-u", "origin", &parent]);
+
+    repo.run_stax(&["bc", "update-merged-child"]);
+    let child = repo.current_branch();
+    repo.create_file("child.txt", "child change\n");
+    repo.commit("Child commit");
+
+    repo.run_stax(&["checkout", "main"]);
+    let merge = repo.git(&["merge", "--no-ff", &parent, "-m", "Merge parent"]);
+    assert!(
+        merge.status.success(),
+        "failed to merge parent into main\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&merge),
+        TestRepo::stderr(&merge)
+    );
+
+    repo.run_stax(&["checkout", &child]);
+    let output = repo.run_stax(&["update", "--no-submit", "--force"]);
+    assert!(
+        output.status.success(),
+        "update --no-submit failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        !stdout.contains("Detect merged branches"),
+        "update should skip merged-branch detection, got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("Found 1 merged branch"),
+        "update should not report merged branches, got: {}",
+        stdout
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|b| b == &parent),
+        "merged parent branch should remain after update"
+    );
+
+    let status = repo.run_stax(&["status", "--json"]);
+    assert!(
+        status.status.success(),
+        "status failed after update\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&status),
+        TestRepo::stderr(&status)
+    );
+    let status_json: Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("Invalid JSON");
+    let branches_json = status_json["branches"]
+        .as_array()
+        .expect("Expected branches array");
+    assert!(
+        branches_json
+            .iter()
+            .any(|b| b["name"].as_str() == Some(parent.as_str())),
+        "merged parent branch should remain tracked after update"
+    );
+}
+
+#[test]
+fn test_refresh_no_submit_preserves_squash_merged_middle_branch() {
     let repo = TestRepo::new_with_remote();
 
     repo.run_stax(&["bc", "refresh-squash-parent"]);
@@ -2278,8 +2354,8 @@ fn test_refresh_no_submit_handles_squash_merged_middle_branch() {
 
     let branches = repo.list_branches();
     assert!(
-        !branches.iter().any(|b| b == &parent),
-        "Expected merged parent branch to be deleted"
+        branches.iter().any(|b| b == &parent),
+        "Expected refresh alias to preserve merged parent branch"
     );
 
     let count_output = repo.git(&["rev-list", "--count", &format!("main..{}", child)]);


### PR DESCRIPTION
## Summary

- stop `st update` / `st refresh` from running merged-branch detection and cleanup
- keep `st sync` / `st rs` cleanup behavior unchanged
- update docs and agent skill guidance for the new command boundary

## Verification

- PASS: `cargo test --test integration_tests test_refresh_no_submit_keeps_original_branch_and_restacks_stack -- --nocapture`
- PASS: `cargo test --test integration_tests test_refresh_no_submit_preserves_squash_merged_middle_branch -- --nocapture`
- PASS: `cargo test --test integration_tests test_update_no_submit_skips_merged_branch_cleanup -- --nocapture`
- PASS: `git diff --check`
- BLOCKED: `make test` could not run because Docker daemon/socket was unavailable
- FAIL unrelated: `make test-native` fails at `worktree_cli_tests::lane_existing_tmux_session_with_prompt_opens_new_window`; this branch has no diff in `tests/worktree_cli_tests.rs`