### PR TITLE
fix: avoid duplicate fetch during update

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,7 @@ impl From<SubmitOptions> for commands::submit::SubmitOptions {
             publish: submit.publish,
             no_pr: submit.no_pr,
             no_fetch: submit.no_fetch,
+            prefetched: false,
             no_verify: submit.no_verify,
             force: submit.force,
             yes: submit.yes,
@@ -1901,6 +1902,7 @@ pub fn run() -> Result<()> {
             quiet,
             verbose,
             auto_stash_pop,
+            &[],
         ),
         Commands::Restack {
             all,

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -577,8 +577,10 @@ pub fn run(
                 true,       // force
                 false,      // safe
                 false,      // continue
-                quiet, false, // verbose
+                quiet,
+                false, // verbose
                 false, // auto_stash_pop
+                &[],
             ) {
                 if !quiet {
                     println!();

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -473,8 +473,10 @@ pub fn run(
             true,  // force
             false, // safe
             false, // continue
-            quiet, false, // verbose
+            quiet,
+            false, // verbose
             false, // auto_stash_pop
+            &[],
         ) {
             if !quiet {
                 println!();

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -613,8 +613,10 @@ pub fn run(
                 true,       // force
                 false,      // safe
                 false,      // continue
-                quiet, false, // verbose
+                quiet,
+                false, // verbose
                 false, // auto_stash_pop
+                &[],
             ) {
                 if !quiet {
                     println!();

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -1,4 +1,5 @@
 use crate::commands;
+use crate::engine::Stack;
 use crate::git::{local_branch_exists_in, GitRepo};
 use anyhow::Result;
 use colored::Colorize;
@@ -17,6 +18,16 @@ pub fn run(
     let repo = GitRepo::open()?;
     let original = repo.current_branch()?;
     let workdir = repo.workdir()?.to_path_buf();
+    let stack = Stack::load(&repo)?;
+    let submit_fetch_refs = if no_submit {
+        Vec::new()
+    } else {
+        stack
+            .current_stack(&original)
+            .into_iter()
+            .filter(|branch| branch != &stack.trunk)
+            .collect::<Vec<_>>()
+    };
 
     println!("{}", "Updating stack...".bold());
     println!("  1. Sync trunk");
@@ -41,6 +52,7 @@ pub fn run(
         false, // quiet
         verbose,
         auto_stash_pop,
+        &submit_fetch_refs,
     )?;
 
     if repo.rebase_in_progress()? {
@@ -55,6 +67,7 @@ pub fn run(
         commands::submit::SubmitScope::Stack,
         commands::submit::SubmitOptions {
             no_pr,
+            prefetched: true,
             yes,
             no_prompt,
             verbose,

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -48,6 +48,7 @@ pub struct SubmitOptions {
     pub publish: bool,
     pub no_pr: bool,
     pub no_fetch: bool,
+    pub prefetched: bool,
     pub no_verify: bool,
     /// Deprecated; kept for CLI compatibility (currently a no-op).
     pub force: bool,
@@ -247,6 +248,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         publish,
         no_pr,
         no_fetch,
+        prefetched,
         no_verify,
         force,
         yes,
@@ -356,8 +358,8 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
 
     // Fetch trunk + branches being submitted + (for narrow scope) parents used in validation.
     // Run `git ls-remote --heads` in parallel for an up-to-date remote branch name set.
-    let (fetch_summary, remote_branches) = if no_fetch {
-        if !quiet {
+    let (fetch_summary, remote_branches) = if no_fetch || prefetched {
+        if no_fetch && !quiet {
             println!(
                 "  {} {}",
                 "Skipping fetch".yellow(),
@@ -367,7 +369,12 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         let rb = remote::get_remote_branches(repo.workdir()?, &remote_info.name)?
             .into_iter()
             .collect::<HashSet<_>>();
-        ("skipped (--no-fetch)".to_string(), rb)
+        let summary = if no_fetch {
+            "skipped (--no-fetch)"
+        } else {
+            "already fetched by update"
+        };
+        (summary.to_string(), rb)
     } else {
         let refs = branches_to_fetch_for_submit(&repo, &stack, scope, &branches_to_submit)?;
         let fetch_timer =

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -123,6 +123,7 @@ pub fn run(
     quiet: bool,
     verbose: bool,
     mut auto_stash_pop: bool,
+    extra_fetch_refs: &[String],
 ) -> Result<()> {
     let sync_started_at = Instant::now();
     let mut step_timings: Vec<(String, Duration)> = Vec::new();
@@ -188,6 +189,19 @@ pub fn run(
     let output;
     // Remote branch names for merged detection (`None` when `--no-delete`: trunk-only fetch).
     let remote_branches_for_merged: Option<HashSet<String>>;
+    let remote_heads_for_extra_fetch = if !full && !extra_fetch_refs.is_empty() {
+        Some(
+            remote::ls_remote_heads(&workdir, &remote_name)
+                .context("Failed to list remote heads before fetch")?,
+        )
+    } else {
+        None
+    };
+    let fetch_refs = sync_fetch_refs(
+        &stack.trunk,
+        extra_fetch_refs,
+        remote_heads_for_extra_fetch.as_ref(),
+    );
 
     if full {
         let fetch_args: Vec<&str> = vec!["fetch", "--prune", "--no-tags", remote_name.as_str()];
@@ -204,16 +218,19 @@ pub fn run(
         } else {
             None
         };
-    } else if delete_merged {
+    } else if delete_merged && remote_heads_for_extra_fetch.is_none() {
         let workdir_fetch = workdir.clone();
         let remote_fetch = remote_name.clone();
-        let trunk = stack.trunk.clone();
+        let fetch_refs = fetch_refs.clone();
         let workdir_ls = workdir.clone();
         let remote_ls = remote_name.clone();
 
         let fetch_handle = std::thread::spawn(move || {
             Command::new("git")
-                .args(["fetch", "--no-tags", remote_fetch.as_str(), trunk.as_str()])
+                .arg("fetch")
+                .arg("--no-tags")
+                .arg(remote_fetch)
+                .args(fetch_refs)
                 .current_dir(&workdir_fetch)
                 .output()
         });
@@ -233,14 +250,26 @@ pub fn run(
             prune_stale_remote_tracking_refs(&workdir, remote_name.as_str(), &stack, &heads);
         }
         remote_branches_for_merged = Some(heads);
+    } else if delete_merged {
+        output = Command::new("git")
+            .arg("fetch")
+            .arg("--no-tags")
+            .arg(remote_name.as_str())
+            .args(&fetch_refs)
+            .current_dir(&workdir)
+            .output()
+            .context("Failed to fetch")?;
+        let heads = remote_heads_for_extra_fetch.expect("remote heads checked for extra refs");
+        if output.status.success() {
+            prune_stale_remote_tracking_refs(&workdir, remote_name.as_str(), &stack, &heads);
+        }
+        remote_branches_for_merged = Some(heads);
     } else {
         output = Command::new("git")
-            .args([
-                "fetch",
-                "--no-tags",
-                remote_name.as_str(),
-                stack.trunk.as_str(),
-            ])
+            .arg("fetch")
+            .arg("--no-tags")
+            .arg(remote_name.as_str())
+            .args(&fetch_refs)
             .current_dir(&workdir)
             .output()
             .context("Failed to fetch")?;
@@ -1513,6 +1542,25 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config) {
     if cache_dirty {
         let _ = cache.save(&git_dir);
     }
+}
+
+fn sync_fetch_refs(
+    trunk: &str,
+    extra_fetch_refs: &[String],
+    remote_heads: Option<&HashSet<String>>,
+) -> Vec<String> {
+    let mut refs = vec![trunk.to_string()];
+    for ref_name in extra_fetch_refs {
+        if ref_name != trunk
+            && remote_heads
+                .map(|heads| heads.contains(ref_name))
+                .unwrap_or(true)
+            && !refs.iter().any(|existing| existing == ref_name)
+        {
+            refs.push(ref_name.clone());
+        }
+    }
+    refs
 }
 
 /// Drop stale `refs/remotes/<remote>/<branch>` for stax-tracked branches that no longer exist on the remote.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -296,6 +296,15 @@ impl TestRepo {
             .expect("Failed to execute stax")
     }
 
+    fn run_stax_with_env(&self, args: &[&str], envs: &[(&str, &Path)]) -> Output {
+        let mut command = sanitized_stax_command();
+        command.args(args).current_dir(self.path());
+        for (key, value) in envs {
+            command.env(key, value);
+        }
+        command.output().expect("Failed to execute stax")
+    }
+
     /// Get stdout as string from output
     fn stdout(output: &Output) -> String {
         String::from_utf8_lossy(&output.stdout).to_string()
@@ -2290,6 +2299,94 @@ fn test_update_no_submit_skips_merged_branch_cleanup() {
             .iter()
             .any(|b| b["name"].as_str() == Some(parent.as_str())),
         "merged parent branch should remain tracked after update"
+    );
+}
+
+#[test]
+fn test_update_submit_does_not_refetch_trunk_after_sync() {
+    let repo = TestRepo::new_with_remote();
+    configure_submit_remote(&repo);
+
+    repo.run_stax(&["bc", "update-fetch-dedupe"]);
+    let branch = repo.current_branch();
+    repo.create_file("feature.txt", "feature\n");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", &branch]);
+
+    let trace_dir = test_tempdir();
+    let trace_file = trace_dir.path().join("git-trace.log");
+    let output = repo.run_stax_with_env(
+        &["update", "--no-pr", "--force", "--yes", "--no-prompt"],
+        &[("GIT_TRACE", trace_file.as_path())],
+    );
+
+    assert!(
+        output.status.success(),
+        "update --no-pr failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let trace = fs::read_to_string(&trace_file).expect("failed to read git trace");
+    let fetch_lines = trace
+        .lines()
+        .filter(|line| line.contains("git fetch") && line.contains(" --no-tags "))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        fetch_lines.len(),
+        1,
+        "update should fetch once. Trace:\n{}",
+        trace
+    );
+    assert!(fetch_lines[0].contains(" origin "));
+    assert!(fetch_lines[0].contains(" main"));
+    assert!(fetch_lines[0].contains(&branch));
+}
+
+#[test]
+fn test_update_submit_fetches_once_with_unpublished_branch() {
+    let repo = TestRepo::new_with_remote();
+    configure_submit_remote(&repo);
+
+    repo.run_stax(&["bc", "update-fetch-new-branch"]);
+    let branch = repo.current_branch();
+    repo.create_file("feature.txt", "feature\n");
+    repo.commit("Feature commit");
+
+    let trace_dir = test_tempdir();
+    let trace_file = trace_dir.path().join("git-trace.log");
+    let output = repo.run_stax_with_env(
+        &["update", "--no-pr", "--force", "--yes", "--no-prompt"],
+        &[("GIT_TRACE", trace_file.as_path())],
+    );
+
+    assert!(
+        output.status.success(),
+        "update --no-pr failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let trace = fs::read_to_string(&trace_file).expect("failed to read git trace");
+    let fetch_lines = trace
+        .lines()
+        .filter(|line| line.contains("git fetch") && line.contains(" --no-tags "))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        fetch_lines.len(),
+        1,
+        "update should fetch once. Trace:\n{}",
+        trace
+    );
+    assert!(fetch_lines[0].contains(" origin "));
+    assert!(fetch_lines[0].contains(" main"));
+    assert!(!fetch_lines[0].contains(&branch));
+
+    assert!(
+        repo.list_remote_branches().contains(&branch),
+        "update should still push unpublished branch"
     );
 }
 


### PR DESCRIPTION
## Motivation

`st update` fetched from `origin` during sync, then immediately fetched again during submit. That made update slower and noisy even though the submit phase can reuse refs fetched by update.

## Description of changes / notes for reviewers

- Fetch current-stack remote refs during the update sync fetch, alongside trunk.
- Call submit from update with an internal prefetched mode so normal `st submit` still fetches as before.
- Skip unpublished branch names in the combined fetch so new branches still push cleanly.
- Add integration coverage for existing remote branches and unpublished branches, both asserting update fetches once.

## Validation

- `cargo test --lib`
- `cargo test --test integration_tests test_update -- --nocapture`
- `cargo test --test integration_tests test_submit -- --nocapture`
- `make test`