### PR TITLE
fix: sync PR state and base from GitHub during sync

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1476,9 +1476,9 @@ pub fn run(
     Ok(())
 }
 
-/// Fetch live PR draft state from the forge for all tracked branches and update
+/// Fetch live PR state from the forge for all tracked branches and update
 /// both branch metadata and CiCache. Called at end of sync so that operations
-/// like `gh pr ready` are reflected without needing a separate `stax ci` run.
+/// like `gh pr ready`, `gh pr merge`, or `gh pr edit --base` are reflected.
 fn refresh_pr_draft_states(repo: &GitRepo, config: &Config) {
     let remote_info = match RemoteInfo::from_repo(repo, config) {
         Ok(info) => info,
@@ -1517,20 +1517,36 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config) {
             Err(_) => continue,
         };
 
-        // Update branch metadata with fresh is_draft
+        // Update branch metadata with fresh state, is_draft, and base
         if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch_name) {
             if let Some(ref mut pr_info) = meta.pr_info {
                 pr_info.is_draft = Some(live_pr.is_draft);
-                let _ = meta.write(repo.inner(), branch_name);
+                pr_info.state = live_pr.state.clone();
             }
+
+            // Reconcile PR base with parent: if the live PR base differs from
+            // our tracked parent and the live base is a known branch, update.
+            if !live_pr.base.is_empty() && live_pr.base != meta.parent_branch_name {
+                let base_is_known = live_pr.base == stack.trunk
+                    || stack.branches.contains_key(&live_pr.base);
+                if base_is_known {
+                    // Update parent revision to the current tip of the new parent
+                    if let Ok(parent_ref) =
+                        repo.inner().find_branch(&live_pr.base, git2::BranchType::Local)
+                    {
+                        if let Ok(commit) = parent_ref.get().peel_to_commit() {
+                            meta.parent_branch_revision = commit.id().to_string();
+                        }
+                    }
+                    meta.parent_branch_name = live_pr.base.clone();
+                }
+            }
+
+            let _ = meta.write(repo.inner(), branch_name);
         }
 
-        // Update CiCache — preserve existing CI state, refresh pr_state
-        let pr_state = if live_pr.is_draft {
-            "DRAFT".to_string()
-        } else {
-            "OPEN".to_string()
-        };
+        // Update CiCache with the live PR state
+        let pr_state = live_pr.state.clone();
         let existing_ci = cache
             .branches
             .get(branch_name.as_str())

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -501,13 +501,19 @@ impl GitHubClient {
             .await
             .context("Failed to get PR")?;
 
-        Ok(PrInfo {
-            number: pr.number,
-            state: pr
-                .state
+        let state = if pr.merged_at.is_some() {
+            "MERGED".to_string()
+        } else {
+            pr.state
                 .as_ref()
                 .map(|s| format!("{:?}", s))
-                .unwrap_or_default(),
+                .unwrap_or_default()
+                .to_uppercase()
+        };
+
+        Ok(PrInfo {
+            number: pr.number,
+            state,
             is_draft: pr.draft.unwrap_or(false),
             base: pr.base.ref_field.clone(),
         })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12163,4 +12163,213 @@ mod forge_mock_tests {
             );
         }
     }
+
+    // ─── Tests for gh CLI metadata corruption fix ───────────────────────────
+
+    /// When a PR is merged via `gh pr merge`, the live PR state is "closed" with
+    /// merged_at set. After sync, the branch metadata's prInfo.state should be
+    /// updated to "MERGED" so that subsequent syncs can use Method 2 detection.
+    #[tokio::test]
+    async fn test_sync_refreshes_pr_state_from_github_merged() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let repo = setup_branch_with_remote(home.path(), "feature-gh-merged");
+        let branch = repo.current_branch();
+        write_branch_pr_metadata(&repo, &branch, "main", 500, Some(false));
+
+        // Simulate: PR was merged via `gh pr merge` — GitHub returns state=closed + merged_at set
+        let mut merged_pr = github_pull_fixture(500, &branch, "main", "aaaa");
+        merged_pr["state"] = serde_json::json!("closed");
+        merged_pr["merged_at"] = serde_json::json!("2026-05-20T10:00:00Z");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/500"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(merged_pr))
+            .mount(&mock_server)
+            .await;
+
+        // Run sync — it should refresh PR state in metadata
+        let output = run_stax_with_env(&repo, home.path(), &["sync"]);
+        assert!(
+            output.status.success(),
+            "Sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        // Verify: metadata should now show state=MERGED
+        let metadata_ref = format!("refs/branch-metadata/{}", branch);
+        let metadata_output = repo.git(&["show", &metadata_ref]);
+        if metadata_output.status.success() {
+            let metadata: serde_json::Value =
+                serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+            assert_eq!(
+                metadata["prInfo"]["state"], "MERGED",
+                "Expected prInfo.state to be MERGED after gh pr merge, got: {}",
+                metadata["prInfo"]["state"]
+            );
+        }
+        // If metadata ref was deleted (sync cleaned up the merged branch), that's also correct
+    }
+
+    /// When a PR is closed (not merged) via `gh pr close`, sync should update
+    /// the metadata state to CLOSED so stax knows the PR is no longer active.
+    #[tokio::test]
+    async fn test_sync_refreshes_pr_state_from_github_closed() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let repo = setup_branch_with_remote(home.path(), "feature-gh-closed");
+        let branch = repo.current_branch();
+        write_branch_pr_metadata(&repo, &branch, "main", 501, Some(false));
+
+        // Simulate: PR was closed via `gh pr close` — state=closed, no merged_at
+        let mut closed_pr = github_pull_fixture(501, &branch, "main", "aaaa");
+        closed_pr["state"] = serde_json::json!("closed");
+        closed_pr["merged_at"] = serde_json::json!(null);
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/501"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(closed_pr))
+            .mount(&mock_server)
+            .await;
+
+        // Run sync
+        let output = run_stax_with_env(&repo, home.path(), &["sync"]);
+        assert!(
+            output.status.success(),
+            "Sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        // Verify: metadata should now show state=CLOSED
+        let metadata_ref = format!("refs/branch-metadata/{}", branch);
+        let metadata_output = repo.git(&["show", &metadata_ref]);
+        assert!(
+            metadata_output.status.success(),
+            "Metadata ref should still exist for closed-but-unmerged PR"
+        );
+        let metadata: serde_json::Value =
+            serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+        assert_eq!(
+            metadata["prInfo"]["state"], "CLOSED",
+            "Expected prInfo.state to be CLOSED after gh pr close, got: {}",
+            metadata["prInfo"]["state"]
+        );
+    }
+
+    /// When a PR's base is changed via `gh pr edit --base`, sync should detect
+    /// the mismatch and update parentBranchName in metadata to match the live
+    /// PR base, preventing stale restack targets.
+    #[tokio::test]
+    async fn test_sync_reconciles_pr_base_with_parent_metadata() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+
+        // Create a stack: main <- feature-base <- feature-child
+        let repo = setup_branch_with_remote(home.path(), "feature-base");
+        let base_branch = repo.current_branch();
+        write_branch_pr_metadata(&repo, &base_branch, "main", 510, Some(false));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "feature-child"]);
+        assert!(output.status.success());
+        let child_branch = "feature-child".to_string();
+        repo.create_file("child.txt", "child content");
+        repo.commit("Child commit");
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &child_branch]);
+        assert!(push.status.success());
+        write_branch_pr_metadata(&repo, &child_branch, &base_branch, 511, Some(false));
+
+        // Simulate: user ran `gh pr edit --base main` on feature-child
+        // The live PR now has base=main, but metadata still says parent=feature-base
+        let mut rebased_pr = github_pull_fixture(511, &child_branch, "main", "aaaa");
+        rebased_pr["state"] = serde_json::json!("open");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/511"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(rebased_pr))
+            .mount(&mock_server)
+            .await;
+
+        // Also mock the parent branch's PR (still open)
+        let parent_pr = github_pull_fixture(510, &base_branch, "main", "aaaa");
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/510"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(parent_pr))
+            .mount(&mock_server)
+            .await;
+
+        // Run sync
+        let output = run_stax_with_env(&repo, home.path(), &["sync"]);
+        assert!(
+            output.status.success(),
+            "Sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        // Verify: feature-child's metadata should now have parentBranchName=main
+        let metadata_ref = format!("refs/branch-metadata/{}", child_branch);
+        let metadata_output = repo.git(&["show", &metadata_ref]);
+        assert!(metadata_output.status.success());
+        let metadata: serde_json::Value =
+            serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+        assert_eq!(
+            metadata["parentBranchName"], "main",
+            "Expected parentBranchName to be reconciled to 'main' (live PR base), got: {}",
+            metadata["parentBranchName"]
+        );
+    }
+
+    /// Verify that get_pr returns "MERGED" state (not "Closed") when GitHub
+    /// reports a PR with merged_at set.
+    #[tokio::test]
+    async fn test_get_pr_returns_merged_state_for_merged_pr() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let repo = setup_branch_with_remote(home.path(), "feature-merged-state");
+        let branch = repo.current_branch();
+        write_branch_pr_metadata(&repo, &branch, "main", 520, Some(false));
+
+        // Mock a merged PR response
+        let mut merged_pr = github_pull_fixture(520, &branch, "main", "aaaa");
+        merged_pr["state"] = serde_json::json!("closed");
+        merged_pr["merged_at"] = serde_json::json!("2026-05-20T12:00:00Z");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/520"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(merged_pr))
+            .mount(&mock_server)
+            .await;
+
+        // Use `stax ci` which fetches PR state — verify it shows merged, not closed
+        let output = run_stax_with_env(&repo, home.path(), &["sync"]);
+        assert!(
+            output.status.success(),
+            "sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        // Verify metadata state is MERGED (not "Closed" from raw GitHub state)
+        let metadata_ref = format!("refs/branch-metadata/{}", branch);
+        let metadata_output = repo.git(&["show", &metadata_ref]);
+        if metadata_output.status.success() {
+            let metadata: serde_json::Value =
+                serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+            assert_eq!(
+                metadata["prInfo"]["state"], "MERGED",
+                "get_pr should return MERGED for PRs with merged_at set, got: {}",
+                metadata["prInfo"]["state"]
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

When PRs are mutated via `gh` CLI (`gh pr merge`, `gh pr close`, `gh pr edit --base`), stax metadata becomes stale/corrupted because `refresh_pr_draft_states()` only synced the `is_draft` field — the `state` and `base` were never written back to branch metadata.

This causes:
- Merged PRs showing as OPEN in stax until the remote branch is deleted (Method 4 compensates)
- Closed PRs never being cleaned up (metadata persists indefinitely)
- Wrong restack targets after `gh pr edit --base`

## Fix

**`src/github/pr.rs`** — `get_pr()` now checks `merged_at` to return `MERGED` instead of GitHub's raw `Closed` state (matching GitLab's behavior and enabling Method 2 merge detection in sync).

**`src/commands/sync.rs`** — `refresh_pr_draft_states()` now:
- Writes the full live `state` (OPEN/CLOSED/MERGED) back to `prInfo.state` in branch metadata
- Uses the actual live PR state for CiCache (was hardcoding DRAFT/OPEN)
- Reconciles the PR's live `base` with `parentBranchName` when they diverge, preventing stale restack targets

## Tests

4 new integration tests (TDD — written before the fix):
- `test_sync_refreshes_pr_state_from_github_merged`
- `test_sync_refreshes_pr_state_from_github_closed`
- `test_sync_reconciles_pr_base_with_parent_metadata`
- `test_get_pr_returns_merged_state_for_merged_pr`

Full suite passes (218 integration + 651 unit + all other test binaries = 0 failures).