### PR TITLE
feat(config): add submit.single_stack option

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Config lives at `~/.config/stax/config.toml`:
 ```toml
 [submit]
 stack_links = "body"   # "comment" | "body" | "both" | "off"
+single_stack = "on"    # "on" | "off" — when "off", skip stack-link sync while only one PR exists
 ```
 
 → [Full config reference](docs/configuration/index.md)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -26,6 +26,7 @@ Main config path: `~/.config/stax/config.toml`.
 
 [submit]
 # stack_links = "comment" # "comment" | "body" | "both" | "off"
+# single_stack = "on"     # "on" | "off" — when "off", skip stack-link sync while the stack has only one PR
 
 [ci]
 # alert = false
@@ -155,9 +156,12 @@ Where `st submit` writes the stack graph for a PR:
 ```toml
 [submit]
 stack_links = "body"   # "comment" | "body" | "both" | "off"
+single_stack = "on"    # "on" | "off"
 ```
 
 When body output is enabled, stax appends a managed block to the bottom of the PR body and only rewrites that managed block on future submits.
+
+`single_stack` controls whether stack links are written when the stack contains only one PR. With the default `"on"`, links are always synced per `stack_links`. With `"off"`, stax skips link sync — and removes any stale links left over from a previous `"on"` setting — while the stack has a single PR. As soon as a second PR is submitted on the same stack, links populate on every PR (including the original) automatically.
 
 ## Forge type override
 

--- a/skills.md
+++ b/skills.md
@@ -200,6 +200,7 @@ stax submit --rerequest-review     # Re-request existing reviewers on update
 # ~/.config/stax/config.toml
 [submit]
 stack_links = "body"               # "comment" | "body" | "both" | "off"
+single_stack = "on"                # "on" | "off" — when "off", skip stack-link sync while only one PR exists; populates on all PRs as soon as the stack reaches 2
 
 stax branch submit                 # Submit current branch only
 stax bs                            # Hidden shortcut alias for branch submit

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -33,7 +33,9 @@ pub fn run(reset_ai: bool, no_prompt: bool, yes: bool, set_ai: bool) -> Result<(
     println!("  [submit]");
     println!(r#"  stack_links = "comment"  # "comment" | "body" | "both" | "off""#);
     println!(r#"  # Example: stack_links = "body""#);
-    println!(r#"  single_stack = "on"      # "on" | "off" — when "off", suppress stack-link sync while only one PR exists"#);
+    println!(
+        r#"  single_stack = "on"      # "on" | "off" — when "off", suppress stack-link sync while only one PR exists"#
+    );
 
     println!();
     println!("{}", "CI watch alerts:".blue().bold());

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -33,6 +33,7 @@ pub fn run(reset_ai: bool, no_prompt: bool, yes: bool, set_ai: bool) -> Result<(
     println!("  [submit]");
     println!(r#"  stack_links = "comment"  # "comment" | "body" | "both" | "off""#);
     println!(r#"  # Example: stack_links = "body""#);
+    println!(r#"  single_stack = "on"      # "on" | "off" — when "off", suppress stack-link sync while only one PR exists"#);
 
     println!();
     println!("{}", "CI watch alerts:".blue().bold());

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,5 +1,5 @@
 use crate::commands::open::open_url_in_browser;
-use crate::config::{Config, StackLinksMode};
+use crate::config::{Config, SingleStackMode, StackLinksMode};
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
@@ -284,6 +284,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let stack = Stack::load(&repo)?;
     let config = Config::load()?;
     let stack_links_mode = config.submit.stack_links;
+    let single_stack_mode = config.submit.single_stack;
 
     // Track if --draft was explicitly passed (we'll ask interactively if not)
     let draft_flag_set = draft;
@@ -1564,6 +1565,12 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         let stack_link_contexts = stack_link_contexts_for_sync(&stack, &current, &pr_infos);
 
         let stack_links_started_at = Instant::now();
+        let effective_stack_links_mode =
+            if single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1 {
+                StackLinksMode::Off
+            } else {
+                stack_links_mode
+            };
         for (pr_number, _branch, stack_link_pr_infos) in &stack_link_contexts {
             let sync_timer =
                 LiveTimer::maybe_new(!quiet, &format!("Syncing stack links on #{}...", pr_number));
@@ -1574,7 +1581,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 &stack.trunk,
             );
 
-            match stack_links_mode {
+            match effective_stack_links_mode {
                 StackLinksMode::Comment | StackLinksMode::Both => {
                     if created_pr_numbers.contains(pr_number) {
                         client
@@ -1592,7 +1599,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             }
 
             let current_body = client.get_pr_body(*pr_number).await?;
-            let desired_body = match stack_links_mode {
+            let desired_body = match effective_stack_links_mode {
                 StackLinksMode::Body | StackLinksMode::Both => {
                     upsert_stack_links_in_body(&current_body, &stack_links)
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -107,6 +107,12 @@ pub struct SubmitConfig {
     /// Where stax-managed stack links should be synced on submit.
     #[serde(default)]
     pub stack_links: StackLinksMode,
+    /// Whether to sync stack links when the stack has only one PR.
+    /// `On` (default) always syncs per `stack_links`. `Off` skips link sync
+    /// (and cleans up stale links) while the stack has <= 1 PRs; once a 2nd
+    /// PR exists, all PRs in the stack get links synced normally.
+    #[serde(default)]
+    pub single_stack: SingleStackMode,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -129,6 +135,14 @@ pub enum StackLinksMode {
     Comment,
     Body,
     Both,
+    Off,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SingleStackMode {
+    #[default]
+    On,
     Off,
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -56,6 +56,7 @@ fn test_default_config() {
     assert_eq!(config.remote.name, "origin");
     assert_eq!(config.remote.base_url, "https://github.com");
     assert_eq!(config.submit.stack_links, StackLinksMode::Comment);
+    assert_eq!(config.submit.single_stack, SingleStackMode::On);
     assert!(!config.ci.alert);
     assert!(config.ci.success_alert_sound.is_none());
     assert!(config.ci.error_alert_sound.is_none());
@@ -129,6 +130,61 @@ fn test_submit_stack_links_rejects_unknown_value() {
         r#"
 [submit]
 stack_links = "weird"
+"#,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("unknown variant"));
+}
+
+#[test]
+fn test_submit_single_stack_defaults_to_on() {
+    let config: Config = toml::from_str(
+        r#"
+[remote]
+name = "origin"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.submit.single_stack, SingleStackMode::On);
+}
+
+#[test]
+fn test_submit_single_stack_round_trip_off() {
+    let config: Config = toml::from_str(
+        r#"
+[submit]
+single_stack = "off"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.submit.single_stack, SingleStackMode::Off);
+
+    let encoded = toml::to_string(&config).unwrap();
+    assert!(encoded.contains("single_stack = \"off\""));
+}
+
+#[test]
+fn test_submit_single_stack_round_trip_on() {
+    let config: Config = toml::from_str(
+        r#"
+[submit]
+single_stack = "on"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.submit.single_stack, SingleStackMode::On);
+}
+
+#[test]
+fn test_submit_single_stack_rejects_unknown_value() {
+    let err = toml::from_str::<Config>(
+        r#"
+[submit]
+single_stack = "maybe"
 "#,
     )
     .unwrap_err();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6352,12 +6352,27 @@ mod forge_mock_tests {
     }
 
     fn write_test_config_with_submit(home: &Path, api_base_url: &str, stack_links: Option<&str>) {
+        write_test_config_with_submit_full(home, api_base_url, stack_links, None);
+    }
+
+    fn write_test_config_with_submit_full(
+        home: &Path,
+        api_base_url: &str,
+        stack_links: Option<&str>,
+        single_stack: Option<&str>,
+    ) {
         let config_dir = home.join(".config").join("stax");
         std::fs::create_dir_all(&config_dir).expect("Failed to create config dir");
         let config_path = config_dir.join("config.toml");
         let mut config = format!("[remote]\napi_base_url = \"{}\"\n", api_base_url);
-        if let Some(mode) = stack_links {
-            config.push_str(&format!("\n[submit]\nstack_links = \"{}\"\n", mode));
+        if stack_links.is_some() || single_stack.is_some() {
+            config.push_str("\n[submit]\n");
+            if let Some(mode) = stack_links {
+                config.push_str(&format!("stack_links = \"{}\"\n", mode));
+            }
+            if let Some(mode) = single_stack {
+                config.push_str(&format!("single_stack = \"{}\"\n", mode));
+            }
         }
         fs::write(&config_path, config).expect("Failed to write config");
     }
@@ -8443,6 +8458,328 @@ mod forge_mock_tests {
         let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
         let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
         assert_eq!(payload["body"], "## Summary\n\nhello");
+    }
+
+    #[tokio::test]
+    async fn test_submit_single_stack_off_solo_pr_cleans_up_stale_links() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_submit_full(
+            home.path(),
+            &mock_server.uri(),
+            Some("comment"),
+            Some("off"),
+        );
+        let repo = setup_branch_with_remote(home.path(), "feature-single-off");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/42",
+                    "id": 42,
+                    "number": 42,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": "feature-single-off", "sha": "aaaa", "label": "test:feature-single-off" },
+                    "base": { "ref": "main", "sha": "bbbb" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        // Pre-existing stale stack comment from a prior single_stack="on" submit.
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                issue_comment_fixture(901, "<!-- stax-stack-comment -->\nold")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/repos/test/repo/issues/comments/901"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "draft": false,
+                "body": "## Summary\n\nhello\n\n<!-- stax-stack-links:start -->\nold\n<!-- stax-stack-links:end -->",
+                "head": { "ref": "feature-single-off", "sha": "aaaa", "label": "test:feature-single-off" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": "feature-single-off", "sha": "aaaa", "label": "test:feature-single-off" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["submit", "--yes", "--no-prompt"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+        let requests = mock_server.received_requests().await.unwrap();
+
+        // single_stack=off + solo PR should suppress the configured `comment` mode
+        // and behave like `off`: delete the stale comment and strip body links.
+        assert!(
+            requests.iter().any(|r| r.method.as_str() == "DELETE"
+                && r.url.path() == "/repos/test/repo/issues/comments/901"),
+            "expected stale stack comment to be deleted"
+        );
+        assert!(
+            !requests.iter().any(|r| r.method.as_str() == "POST"
+                && r.url.path() == "/repos/test/repo/issues/42/comments"),
+            "should not create a stack comment for a solo PR when single_stack=off"
+        );
+        let body_patch = find_body_patch(&requests, "/repos/test/repo/pulls/42");
+        let payload: serde_json::Value = serde_json::from_slice(&body_patch.body).unwrap();
+        assert_eq!(
+            payload["body"], "## Summary\n\nhello",
+            "body stack-links block should be stripped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_submit_single_stack_off_two_pr_stack_still_syncs_links() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_submit_full(
+            home.path(),
+            &mock_server.uri(),
+            Some("comment"),
+            Some("off"),
+        );
+
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        let _remote_root = remote_root.keep();
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "single-off-parent"]);
+        assert!(
+            output.status.success(),
+            "Failed to create parent: {}",
+            TestRepo::stderr(&output)
+        );
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Add parent");
+        let parent = repo.current_branch();
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &parent]);
+        assert!(
+            push.status.success(),
+            "Failed to push parent: {}",
+            TestRepo::stderr(&push)
+        );
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "single-off-child"]);
+        assert!(
+            output.status.success(),
+            "Failed to create child: {}",
+            TestRepo::stderr(&output)
+        );
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Add child");
+        let child = repo.current_branch();
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &child]);
+        assert!(
+            push.status.success(),
+            "Failed to push child: {}",
+            TestRepo::stderr(&push)
+        );
+
+        write_branch_pr_metadata(&repo, &parent, "main", 101, Some(false));
+        write_branch_pr_metadata(&repo, &child, &parent, 102, Some(false));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(102, &child, &parent, "Child PR", "child body"),
+            ))
+            .mount(&mock_server)
+            .await;
+
+        for (number, branch, base, comment_id, body) in [
+            (101_u64, parent.as_str(), "main", 901_u64, "parent body"),
+            (
+                102_u64,
+                child.as_str(),
+                parent.as_str(),
+                902_u64,
+                "child body",
+            ),
+        ] {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/test/repo/issues/{}/comments", number)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    issue_comment_fixture(comment_id, "<!-- stax-stack-comment -->\nold")
+                ])))
+                .mount(&mock_server)
+                .await;
+
+            Mock::given(method("PATCH"))
+                .and(path(format!(
+                    "/repos/test/repo/issues/comments/{}",
+                    comment_id
+                )))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(issue_comment_fixture(
+                        comment_id,
+                        "<!-- stax-stack-comment -->\nupdated",
+                    )),
+                )
+                .mount(&mock_server)
+                .await;
+
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/test/repo/pulls/{}", number)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(
+                    github_pull_fixture_with_details(number, branch, base, "PR", body),
+                ))
+                .mount(&mock_server)
+                .await;
+        }
+
+        let output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["branch", "submit", "--yes", "--no-prompt"],
+        );
+        assert!(
+            output.status.success(),
+            "branch submit failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        // With 2 PRs in the stack the override does NOT apply — both PRs get
+        // their stack-link comments patched.
+        let requests = mock_server.received_requests().await.unwrap();
+        for comment_id in [901_u64, 902_u64] {
+            let patch = requests
+                .iter()
+                .find(|r| {
+                    r.method.as_str() == "PATCH"
+                        && r.url.path()
+                            == format!("/repos/test/repo/issues/comments/{}", comment_id)
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "expected PATCH on stack comment {} when stack has 2 PRs",
+                        comment_id
+                    )
+                });
+            let payload: serde_json::Value = serde_json::from_slice(&patch.body).unwrap();
+            let body = payload["body"].as_str().expect("comment body");
+            assert!(
+                body.contains("PR #101") && body.contains("PR #102"),
+                "stack links should reference both PRs, got: {}",
+                body
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_single_stack_on_default_syncs_solo_pr_comment() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        // Explicitly set stack_links=comment but leave single_stack unset
+        // (default = "on") — regression guard that default behavior is intact.
+        write_test_config_with_submit(home.path(), &mock_server.uri(), Some("comment"));
+        let repo = setup_branch_with_remote(home.path(), "feature-single-on");
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "url": "https://api.github.com/repos/test/repo/pulls/42",
+                    "id": 42,
+                    "number": 42,
+                    "state": "open",
+                    "draft": false,
+                    "head": { "ref": "feature-single-on", "sha": "aaaa", "label": "test:feature-single-on" },
+                    "base": { "ref": "main", "sha": "bbbb" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                issue_comment_fixture(901, "<!-- stax-stack-comment -->\nold")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/issues/comments/901"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(issue_comment_fixture(
+                    901,
+                    "<!-- stax-stack-comment -->\nupdated",
+                )),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "draft": false,
+                "body": "## Summary\n\nhello",
+                "head": { "ref": "feature-single-on", "sha": "aaaa", "label": "test:feature-single-on" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test/repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "draft": false,
+                "head": { "ref": "feature-single-on", "sha": "aaaa", "label": "test:feature-single-on" },
+                "base": { "ref": "main", "sha": "bbbb" }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["submit", "--yes", "--no-prompt"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert!(
+            requests.iter().any(|r| r.method.as_str() == "PATCH"
+                && r.url.path() == "/repos/test/repo/issues/comments/901"),
+            "default (single_stack=on) should still sync the stack comment on a solo PR"
+        );
     }
 
     #[tokio::test]

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -85,6 +85,22 @@ fn rev_list_count(repo: &TestRepo, range: &str) -> usize {
         .unwrap_or(0)
 }
 
+fn assert_git_success(repo: &TestRepo, args: &[&str], context: &str) {
+    let out = repo.git(args);
+    assert!(
+        out.status.success(),
+        "{} failed: git {}\nstdout:\n{}\nstderr:\n{}",
+        context,
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn create_empty_commit(repo: &TestRepo, message: &str) {
+    assert_git_success(repo, &["commit", "--allow-empty", "-m", message], message);
+}
+
 // =============================================================================
 // Happy path: stored revision is the correct merge-base
 // =============================================================================
@@ -320,16 +336,19 @@ fn test_many_trunk_commits_linear_restack_only_replays_feature_commits() {
     // last-known parent tip while engineers landed TRUNK_COMMITS on main.
     let old_main_tip = repo.get_commit_sha("HEAD");
 
-    repo.git(&["checkout", "-b", "busy-feature"]);
+    assert_git_success(
+        &repo,
+        &["checkout", "-b", "busy-feature"],
+        "create busy-feature",
+    );
     repo.create_file("feat1.txt", "feature one");
     repo.commit("Feature work 1");
     repo.create_file("feat2.txt", "feature two");
     repo.commit("Feature work 2");
 
-    repo.git(&["checkout", "main"]);
+    assert_git_success(&repo, &["checkout", "main"], "checkout main");
     for i in 0..TRUNK_COMMITS {
-        repo.create_file(&format!("trunk_{i}.txt"), &i.to_string());
-        repo.commit(&format!("Trunk churn commit {i}"));
+        create_empty_commit(&repo, &format!("Trunk churn commit {i}"));
     }
 
     let trunk_delta = rev_list_count(&repo, &format!("{old_main_tip}..main"));
@@ -341,7 +360,11 @@ fn test_many_trunk_commits_linear_restack_only_replays_feature_commits() {
     write_branch_metadata_raw(&repo, "busy-feature", "main", &old_main_tip);
     repo.run_stax(&["set-trunk", "main"]);
 
-    repo.git(&["checkout", "busy-feature"]);
+    assert_git_success(
+        &repo,
+        &["checkout", "busy-feature"],
+        "checkout busy-feature",
+    );
     let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
     output.assert_success();
     assert!(
@@ -367,24 +390,27 @@ fn test_sync_restack_many_trunk_commits_preserves_linear_feature_depth() {
 
     let old_main_tip = repo.get_commit_sha("HEAD");
 
-    repo.git(&["checkout", "-b", "sync-busy"]);
+    assert_git_success(&repo, &["checkout", "-b", "sync-busy"], "create sync-busy");
     repo.create_file("sf1.txt", "x");
     repo.commit("sync feature 1");
     repo.create_file("sf2.txt", "y");
     repo.commit("sync feature 2");
-    repo.git(&["push", "-u", "origin", "sync-busy"]);
+    assert_git_success(
+        &repo,
+        &["push", "-u", "origin", "sync-busy"],
+        "push sync-busy",
+    );
 
-    repo.git(&["checkout", "main"]);
+    assert_git_success(&repo, &["checkout", "main"], "checkout main");
     for i in 0..TRUNK_COMMITS {
-        repo.create_file(&format!("remote_trunk_{i}.txt"), "bulk");
-        repo.commit(&format!("main advance {i}"));
+        create_empty_commit(&repo, &format!("main advance {i}"));
     }
-    repo.git(&["push", "origin", "main"]);
+    assert_git_success(&repo, &["push", "origin", "main"], "push main");
 
     write_branch_metadata_raw(&repo, "sync-busy", "main", &old_main_tip);
     repo.run_stax(&["set-trunk", "main"]);
 
-    repo.git(&["checkout", "sync-busy"]);
+    assert_git_success(&repo, &["checkout", "sync-busy"], "checkout sync-busy");
     let output = repo.run_stax(&["sync", "--restack", "--force", "--quiet", "--no-delete"]);
     output.assert_success();
     assert!(!repo.has_rebase_in_progress());


### PR DESCRIPTION
## Summary

Adds a new `submit.single_stack` config option that controls whether stax syncs stack-link comments/body blocks while a stack contains only one PR.

Closes #240 

```toml
[submit]
stack_links = "comment"   # existing — where stack links go
single_stack = "on"       # new — "on" (default) | "off"
```

- **`on` (default):** existing behavior — stack links are synced per `stack_links` on every submit, regardless of stack size.
- **`off`:** stax skips link sync (and cleans up any stale links left over from a previous `on` setting) while the stack has ≤ 1 PRs. As soon as a second PR is submitted on the same stack, links populate on **every** PR — including the one that was previously solo — automatically.

## How it works

In `src/commands/submit.rs` the sync loop now computes an `effective_stack_links_mode`. When `single_stack == Off` and the current stack contains at most one PR, the effective mode is forced to `Off` for that pass — which routes through the existing cleanup branch (delete stack comment, strip body links). When the stack reaches 2+ PRs the override doesn't apply, and because the sync loop already iterates the full current stack, `update_stack_comment` falls back to `create_stack_comment` for any prior PR that has no comment yet. No new code paths — just a gate.

## Changes

- **Config**: new `SingleStackMode` enum (`On` default, `Off`) and `submit.single_stack` field, mirroring the existing `StackLinksMode` shape.
- **Submit**: effective-mode override in the stack-link sync loop in `commands/submit.rs`.
- **Tests**: unit tests for config parsing (defaults, round-trip, rejects unknown), plus three integration tests:
  - `single_stack=off` + solo PR → existing stale comment deleted, body links stripped.
  - `single_stack=off` + 2-PR stack → both PRs get stack-link comments populated (override does not apply).
  - `single_stack=on` (default) + solo PR → comment synced as before (regression guard).
- **Docs**: `docs/configuration/index.md`, `README.md`, and `skills.md` updated to document the new option.

## Test plan

- [x] `cargo test --lib config::` — all 59 config unit tests pass
- [x] `cargo test --test integration_tests forge_mock_tests::test_submit_single_stack` — 3 new integration tests pass
- [x] `make test` — full Docker suite, **1669 tests pass, 0 failed, 0 skipped**
- [x] Dogfooded: submitted this PR via local `stax submit` with `single_stack = "off"` set; verified the resulting PR has no stack-link comment and no body stack-links block (correct behavior for a solo PR).
