### PR TITLE
Reformat command code for consistency

### DIFF
--- a/src/ci/history.rs
+++ b/src/ci/history.rs
@@ -154,7 +154,6 @@ pub fn calculate_average(history: &CiCheckHistory) -> Option<u64> {
     Some(sum / valid_runs.len() as u64)
 }
 
-
 /// Estimate total wall-clock runtime for the current run from reusable per-check history.
 pub fn estimate_run_average(repo: &GitRepo, checks: &[CheckRunInfo]) -> Option<u64> {
     let run_start = checks
@@ -170,15 +169,13 @@ pub fn estimate_run_average(repo: &GitRepo, checks: &[CheckRunInfo]) -> Option<u
             // Use the current run's actual start offset (not a stored end_offset_secs).
             // end_offset_secs is polluted by main-branch builds where checks start much
             // later due to a longer pipeline, giving wildly inflated ETAs on PR branches.
-            let start_offset =
-                match (run_start, parse_ci_timestamp(check.started_at.as_deref())) {
-                    (Some(run_start), Some(check_start)) => check_start
-                        .signed_duration_since(run_start)
-                        .num_seconds()
-                        .max(0)
-                        as u64,
-                    _ => 0,
-                };
+            let start_offset = match (run_start, parse_ci_timestamp(check.started_at.as_deref())) {
+                (Some(run_start), Some(check_start)) => check_start
+                    .signed_duration_since(run_start)
+                    .num_seconds()
+                    .max(0) as u64,
+                _ => 0,
+            };
             Some(start_offset + avg_duration)
         })
         .max()

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -834,9 +834,7 @@ mod tests {
             line: 42,
         };
 
-        let row = with_colored_override(true, || {
-            format_changelog_find_picker_item(&entry, 5, 5)
-        });
+        let row = with_colored_override(true, || format_changelog_find_picker_item(&entry, 5, 5));
 
         assert!(
             !row.contains("\u{1b}["),

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -747,10 +747,7 @@ fn checkout_by_pr(repo: &GitRepo, pr_num: u64, shell_output: bool) -> Result<()>
 
     // Checkout the branch
     let workdir = repo.workdir()?;
-    let timer = LiveTimer::maybe_new(
-        true,
-        &format!("Checking out {}...", target_branch),
-    );
+    let timer = LiveTimer::maybe_new(true, &format!("Checking out {}...", target_branch));
     checkout_branch_in(workdir, &target_branch)?;
     LiveTimer::maybe_finish_ok(timer, "done");
 

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -8,9 +8,9 @@ use crate::github::GitHubClient;
 use crate::notifications::{self, BuiltInSound, Sound};
 use crate::remote::RemoteInfo;
 use anyhow::Result;
-use futures_util::future::join_all;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
+use futures_util::future::join_all;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Write;
@@ -393,33 +393,31 @@ pub(crate) async fn fetch_ci_statuses_async(
         })
         .collect();
 
-    let mut statuses = join_all(
-        prepared
-            .iter()
-            .map(|(branch, sha, sha_short, pr_number)| async move {
-                let check_runs_result = client.fetch_checks(repo, sha).await;
-                let (overall_status, check_runs) = match check_runs_result {
-                    Ok((status, runs)) => (status, runs),
-                    Err(_) => (None, Vec::new()),
-                };
+    let mut statuses = join_all(prepared.iter().map(
+        |(branch, sha, sha_short, pr_number)| async move {
+            let check_runs_result = client.fetch_checks(repo, sha).await;
+            let (overall_status, check_runs) = match check_runs_result {
+                Ok((status, runs)) => (status, runs),
+                Err(_) => (None, Vec::new()),
+            };
 
-                let pr_live = match pr_number {
-                    Some(n) => client.get_pr(*n).await.ok(),
-                    None => None,
-                };
-                let pr_is_draft = pr_live.as_ref().map(|p| p.is_draft);
+            let pr_live = match pr_number {
+                Some(n) => client.get_pr(*n).await.ok(),
+                None => None,
+            };
+            let pr_is_draft = pr_live.as_ref().map(|p| p.is_draft);
 
-                BranchCiStatus {
-                    branch: branch.clone(),
-                    sha: sha.clone(),
-                    sha_short: sha_short.clone(),
-                    overall_status,
-                    check_runs,
-                    pr_number: *pr_number,
-                    pr_is_draft,
-                }
-            }),
-    )
+            BranchCiStatus {
+                branch: branch.clone(),
+                sha: sha.clone(),
+                sha_short: sha_short.clone(),
+                overall_status,
+                check_runs,
+                pr_number: *pr_number,
+                pr_is_draft,
+            }
+        },
+    ))
     .await;
 
     statuses.sort_by(|a, b| a.branch.cmp(&b.branch));
@@ -1067,7 +1065,11 @@ pub(crate) fn update_ci_cache(repo: &GitRepo, stack: &Stack, statuses: &[BranchC
     let mut cache = CiCache::load(git_dir);
     for status in statuses {
         let pr_state = status.pr_is_draft.map(|is_draft| {
-            if is_draft { "DRAFT".to_string() } else { "OPEN".to_string() }
+            if is_draft {
+                "DRAFT".to_string()
+            } else {
+                "OPEN".to_string()
+            }
         });
         cache.update(&status.branch, status.overall_status.clone(), pr_state);
     }
@@ -1525,14 +1527,12 @@ mod tests {
         let tempdir = TempDir::new().unwrap();
         let dir = tempdir.path();
         let run = |args: &[&str]| {
-            assert!(
-                Command::new("git")
-                    .args(args)
-                    .current_dir(dir)
-                    .status()
-                    .unwrap()
-                    .success()
-            );
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .status()
+                .unwrap()
+                .success());
         };
         run(&["init", "-b", "main"]);
         run(&["config", "user.email", "ci-test@stax.local"]);

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1572,12 +1572,13 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config) {
             // Reconcile PR base with parent: if the live PR base differs from
             // our tracked parent and the live base is a known branch, update.
             if !live_pr.base.is_empty() && live_pr.base != meta.parent_branch_name {
-                let base_is_known = live_pr.base == stack.trunk
-                    || stack.branches.contains_key(&live_pr.base);
+                let base_is_known =
+                    live_pr.base == stack.trunk || stack.branches.contains_key(&live_pr.base);
                 if base_is_known {
                     // Update parent revision to the current tip of the new parent
-                    if let Ok(parent_ref) =
-                        repo.inner().find_branch(&live_pr.base, git2::BranchType::Local)
+                    if let Ok(parent_ref) = repo
+                        .inner()
+                        .find_branch(&live_pr.base, git2::BranchType::Local)
                     {
                         if let Ok(commit) = parent_ref.get().peel_to_commit() {
                             meta.parent_branch_revision = commit.id().to_string();

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -24,10 +24,7 @@ pub fn run(current_only: bool, interval: Option<u64>) -> Result<()> {
     let _enter = rt.enter();
     let client = ForgeClient::new(&remote_info)?;
 
-    println!(
-        "{}",
-        "Watching stack... (Ctrl+C to stop)".cyan().bold()
-    );
+    println!("{}", "Watching stack... (Ctrl+C to stop)".cyan().bold());
 
     let mut iteration = 0usize;
 
@@ -97,13 +94,18 @@ pub fn run(current_only: bool, interval: Option<u64>) -> Result<()> {
         if branches_to_watch.is_empty() {
             println!("{}", "No tracked branches.".dimmed());
         } else {
-            render_watch_table(&stack, &current, &branches_to_watch, &ci_statuses, &remote_branches);
+            render_watch_table(
+                &stack,
+                &current,
+                &branches_to_watch,
+                &ci_statuses,
+                &remote_branches,
+            );
         }
 
         // Decide next interval
-        let next_interval = interval.unwrap_or_else(|| {
-            adaptive_interval(&ci_statuses, &stack, &branches_to_watch)
-        });
+        let next_interval =
+            interval.unwrap_or_else(|| adaptive_interval(&ci_statuses, &stack, &branches_to_watch));
 
         println!();
         println!(
@@ -126,17 +128,10 @@ fn render_watch_table(
     ci_statuses: &[BranchCiStatus],
     remote_branches: &HashSet<String>,
 ) {
-    let ci_by_branch: std::collections::HashMap<&str, &BranchCiStatus> = ci_statuses
-        .iter()
-        .map(|s| (s.branch.as_str(), s))
-        .collect();
+    let ci_by_branch: std::collections::HashMap<&str, &BranchCiStatus> =
+        ci_statuses.iter().map(|s| (s.branch.as_str(), s)).collect();
 
-    let name_width = branches
-        .iter()
-        .map(|b| b.len())
-        .max()
-        .unwrap_or(10)
-        .max(10);
+    let name_width = branches.iter().map(|b| b.len()).max().unwrap_or(10).max(10);
 
     for branch in branches {
         let info = stack.branches.get(branch);
@@ -148,8 +143,7 @@ fn render_watch_table(
             "○".dimmed().to_string()
         };
 
-        let cloud = if remote_branches.contains(branch)
-            || info.and_then(|b| b.pr_number).is_some()
+        let cloud = if remote_branches.contains(branch) || info.and_then(|b| b.pr_number).is_some()
         {
             "☁".bright_blue().to_string()
         } else {
@@ -186,9 +180,7 @@ fn render_watch_table(
         // PR info
         let pr_tag = match info.and_then(|b| b.pr_number) {
             Some(n) => {
-                let state = info
-                    .and_then(|b| b.pr_state.as_deref())
-                    .unwrap_or("open");
+                let state = info.and_then(|b| b.pr_state.as_deref()).unwrap_or("open");
                 let draft = ci_by_branch
                     .get(branch.as_str())
                     .and_then(|s| s.pr_is_draft)
@@ -224,12 +216,7 @@ fn render_watch_table(
     } else {
         " ".to_string()
     };
-    println!(
-        "  {}  {} {}",
-        trunk_marker,
-        trunk_cloud,
-        trunk.dimmed()
-    );
+    println!("  {}  {} {}", trunk_marker, trunk_cloud, trunk.dimmed());
 }
 
 fn load_ci_from_cache(git_dir: &std::path::Path, branches: &[String]) -> Vec<BranchCiStatus> {
@@ -257,11 +244,7 @@ fn load_ci_from_cache(git_dir: &std::path::Path, branches: &[String]) -> Vec<Bra
         .collect()
 }
 
-fn adaptive_interval(
-    ci_statuses: &[BranchCiStatus],
-    stack: &Stack,
-    branches: &[String],
-) -> u64 {
+fn adaptive_interval(ci_statuses: &[BranchCiStatus], stack: &Stack, branches: &[String]) -> u64 {
     // Any CI actively running → poll fast
     let any_running = ci_statuses.iter().any(|s| {
         s.check_runs.iter().any(|c| {


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Keeps the codebase consistently formatted after recent changes.

## Description of changes / notes for reviewers

- Ran `rustfmt` across the affected files to normalize line wrapping, spacing, and import ordering.
- No behavioral changes; this is formatting-only cleanup.