### PR TITLE
Always restack branches when moving to a new parent

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -836,6 +836,9 @@ enum Commands {
         /// Accepted for backward compatibility; restack now always runs
         #[arg(long, hide = true)]
         restack: bool,
+        /// Stash uncommitted changes before rebasing and restore them after
+        #[arg(long)]
+        auto_stash_pop: bool,
     },
 
     /// Interactively reorder branches within a stack
@@ -1442,6 +1445,9 @@ enum UpstackCommands {
         /// Accepted for backward compatibility; restack now always runs
         #[arg(long, hide = true)]
         restack: bool,
+        /// Stash uncommitted changes before rebasing and restore them after
+        #[arg(long)]
+        auto_stash_pop: bool,
     },
 
     /// Submit current branch and descendants
@@ -2200,12 +2206,20 @@ pub fn run() -> Result<()> {
             UpstackCommands::Restack { auto_stash_pop } => {
                 commands::upstack::restack::run(auto_stash_pop)
             }
-            UpstackCommands::Onto { target, restack: _ } => commands::upstack::onto::run(target),
+            UpstackCommands::Onto {
+                target,
+                restack: _,
+                auto_stash_pop,
+            } => commands::upstack::onto::run(target, auto_stash_pop),
             UpstackCommands::Submit { submit } => {
                 run_submit(submit, commands::submit::SubmitScope::Upstack)
             }
         },
-        Commands::Move { target, restack: _ } => commands::upstack::onto::run(target),
+        Commands::Move {
+            target,
+            restack: _,
+            auto_stash_pop,
+        } => commands::upstack::onto::run(target, auto_stash_pop),
         Commands::Downstack(cmd) => match cmd {
             DownstackCommands::Get => {
                 commands::status::run(false, None, false, false, false, false)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -833,8 +833,8 @@ enum Commands {
     Move {
         /// Target parent branch (interactive picker if omitted)
         target: Option<String>,
-        /// Restack the moved branches after reparenting
-        #[arg(long)]
+        /// Accepted for backward compatibility; restack now always runs
+        #[arg(long, hide = true)]
         restack: bool,
     },
 
@@ -1439,8 +1439,8 @@ enum UpstackCommands {
     Onto {
         /// Target parent branch (interactive picker if omitted)
         target: Option<String>,
-        /// Restack the moved branches after reparenting
-        #[arg(long)]
+        /// Accepted for backward compatibility; restack now always runs
+        #[arg(long, hide = true)]
         restack: bool,
     },
 
@@ -2200,14 +2200,12 @@ pub fn run() -> Result<()> {
             UpstackCommands::Restack { auto_stash_pop } => {
                 commands::upstack::restack::run(auto_stash_pop)
             }
-            UpstackCommands::Onto { target, restack } => {
-                commands::upstack::onto::run(target, restack)
-            }
+            UpstackCommands::Onto { target, restack: _ } => commands::upstack::onto::run(target),
             UpstackCommands::Submit { submit } => {
                 run_submit(submit, commands::submit::SubmitScope::Upstack)
             }
         },
-        Commands::Move { target, restack } => commands::upstack::onto::run(target, restack),
+        Commands::Move { target, restack: _ } => commands::upstack::onto::run(target),
         Commands::Downstack(cmd) => match cmd {
             DownstackCommands::Get => {
                 commands::status::run(false, None, false, false, false, false)

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -65,7 +65,10 @@ pub fn format_status_line(
 }
 
 pub fn format_branch_status_line(branch: &str) -> String {
-    format!(" #[fg=colour250]\u{f418}#[fg=default] {}", truncate_branch_name(branch))
+    format!(
+        " #[fg=colour250]\u{f418}#[fg=default] {}",
+        truncate_branch_name(branch)
+    )
 }
 
 fn run_status() -> Result<()> {
@@ -281,7 +284,10 @@ mod tests {
     fn test_trunk_long_name_truncated() {
         let long = "release/".to_string() + &"a".repeat(50);
         let result = format_branch_status_line(&long);
-        assert!(result.contains('…'), "trunk long name should be truncated: {result}");
+        assert!(
+            result.contains('…'),
+            "trunk long name should be truncated: {result}"
+        );
         assert!(
             !result.contains(&long),
             "full branch name should not appear: {result}"

--- a/src/commands/upstack/onto.rs
+++ b/src/commands/upstack/onto.rs
@@ -8,7 +8,8 @@ use std::collections::HashSet;
 
 /// Reparent the current branch AND all its descendants onto a new parent.
 /// The subtree structure is preserved -- only the root's parent changes.
-pub fn run(target: Option<String>, restack: bool) -> Result<()> {
+/// Rebase is always performed so git history matches the new parent immediately.
+pub fn run(target: Option<String>) -> Result<()> {
     let repo = GitRepo::open()?;
     let stack = Stack::load(&repo)?;
     let current = repo.current_branch()?;
@@ -88,10 +89,6 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
         ..old_meta
     };
 
-    if !restack {
-        updated.write(repo.inner(), &current)?;
-    }
-
     println!(
         "✓ Reparented '{}' onto '{}'",
         current.green(),
@@ -107,64 +104,53 @@ pub fn run(target: Option<String>, restack: bool) -> Result<()> {
         }
     }
 
-    if restack {
-        println!();
-        println!("{}", "Restacking moved branches...".bold());
+    println!();
+    println!("{}", "Restacking moved branches...".bold());
 
-        // Rebase the root branch directly using old parent info as upstream
-        // (same approach as reparent.rs -- we need the old parent boundary
-        // because the metadata was already overwritten)
-        let rebase_upstream = resolve_rebase_upstream(
-            &repo,
-            &old_parent_name,
-            &old_parent_rev,
-            &current,
-            &merge_base,
-        )?;
+    // Rebase the root branch directly using old parent info as upstream.
+    // We need the old parent boundary because the metadata hasn't been
+    // written yet — the rebase must know where the branch's own commits begin.
+    let rebase_upstream = resolve_rebase_upstream(
+        &repo,
+        &old_parent_name,
+        &old_parent_rev,
+        &current,
+        &merge_base,
+    )?;
 
-        match repo.rebase_branch_onto_with_provenance(
-            &current,
-            &new_parent,
-            &rebase_upstream,
-            false,
-        )? {
-            RebaseResult::Success => {
-                // Persist metadata only after the root rebase succeeds
-                let new_parent_rev = repo.branch_commit(&new_parent)?;
-                let mut persisted = updated.clone();
-                persisted.parent_branch_revision = new_parent_rev;
-                persisted.write(repo.inner(), &current)?;
-                println!(
-                    "  {} rebased '{}' onto '{}'",
-                    "✓".green(),
-                    current,
-                    new_parent
-                );
+    match repo.rebase_branch_onto_with_provenance(&current, &new_parent, &rebase_upstream, false)? {
+        RebaseResult::Success => {
+            // Persist metadata only after the rebase succeeds so we never
+            // leave metadata pointing at a new parent with old git history.
+            let new_parent_rev = repo.branch_commit(&new_parent)?;
+            let mut persisted = updated.clone();
+            persisted.parent_branch_revision = new_parent_rev;
+            persisted.write(repo.inner(), &current)?;
+            println!(
+                "  {} rebased '{}' onto '{}'",
+                "✓".green(),
+                current,
+                new_parent
+            );
 
-                // Now restack descendants via upstack restack
-                if subtree.len() > 1 {
-                    super::restack::run(false)?;
-                }
-            }
-            RebaseResult::Conflict => {
-                bail!(
-                    "Rebase conflict while rebasing '{}' onto '{}'. \
-                     Resolve conflicts, then run `st continue` or `st abort`.",
-                    current,
-                    new_parent
-                );
+            // Restack descendants
+            if subtree.len() > 1 {
+                super::restack::run(false)?;
             }
         }
-
-        // Return to original branch
-        if repo.current_branch()? != current {
-            let _ = repo.checkout(&current);
+        RebaseResult::Conflict => {
+            bail!(
+                "Rebase conflict while rebasing '{}' onto '{}'. \
+                 Resolve conflicts, then run `st continue` or `st abort`.",
+                current,
+                new_parent
+            );
         }
-    } else {
-        println!(
-            "{}",
-            "Run `st restack` to rebase the moved branches onto their new parent.".yellow()
-        );
+    }
+
+    // Return to original branch
+    if repo.current_branch()? != current {
+        let _ = repo.checkout(&current);
     }
 
     Ok(())

--- a/src/commands/upstack/onto.rs
+++ b/src/commands/upstack/onto.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 /// Reparent the current branch AND all its descendants onto a new parent.
 /// The subtree structure is preserved -- only the root's parent changes.
 /// Rebase is always performed so git history matches the new parent immediately.
-pub fn run(target: Option<String>) -> Result<()> {
+pub fn run(target: Option<String>, auto_stash_pop: bool) -> Result<()> {
     let repo = GitRepo::open()?;
     let stack = Stack::load(&repo)?;
     let current = repo.current_branch()?;
@@ -118,7 +118,12 @@ pub fn run(target: Option<String>) -> Result<()> {
         &merge_base,
     )?;
 
-    match repo.rebase_branch_onto_with_provenance(&current, &new_parent, &rebase_upstream, false)? {
+    match repo.rebase_branch_onto_with_provenance(
+        &current,
+        &new_parent,
+        &rebase_upstream,
+        auto_stash_pop,
+    )? {
         RebaseResult::Success => {
             // Persist metadata only after the rebase succeeds so we never
             // leave metadata pointing at a new parent with old git history.

--- a/tests/upstack_onto_tests.rs
+++ b/tests/upstack_onto_tests.rs
@@ -263,3 +263,281 @@ fn move_alias_rejects_trunk_and_circular() {
     output.assert_failure();
     output.assert_stderr_contains("circular");
 }
+
+// =============================================================================
+// Git history correctness after reparent (the core bug: #433)
+//
+// Before the fix, `stax mv` only updated metadata — the git ref was never
+// moved. After `stax create b` while on `a`, `b` points to the same commit
+// as `a`. Running `stax mv b main` would update b's parent pointer to `main`
+// in the metadata, but `b` in git still sits on top of `a`'s history.
+// =============================================================================
+
+/// Core regression test for issue #433.
+///
+/// Scenario that reproduces the exact bug:
+///   main → a (commit A) → b (no unique commits, same SHA as a)
+///   `stax mv b main`
+///
+/// After the fix: `b` must point to main's tip, NOT to commit A.
+/// Before the fix: `b` still points to A1 (a's commit), so `git log main..b`
+/// would show a's commit — phantom commit from the wrong parent.
+#[test]
+fn mv_with_no_unique_commits_moves_to_new_parent_tip() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // main → a (has commit A)
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    // a → b (no unique commits — b is created at same SHA as a)
+    repo.run_stax(&["create", "b"]).assert_success();
+
+    // Verify precondition: b and a point to the same commit
+    let a_sha = repo.get_commit_sha("a");
+    let b_sha_before = repo.get_commit_sha("b");
+    assert_eq!(
+        a_sha, b_sha_before,
+        "Precondition: b and a should share the same commit before mv"
+    );
+
+    let output = repo.run_stax(&["mv", "main"]);
+    output.assert_success();
+
+    // After mv: b should be at main's tip (fast-forward, no commits ahead)
+    let main_sha = repo.get_commit_sha("main");
+    let b_sha_after = repo.get_commit_sha("b");
+    assert_eq!(
+        main_sha, b_sha_after,
+        "After mv to main with no unique commits, b should point to main's tip"
+    );
+
+    // git log main..b should be empty (no commits unique to b)
+    let log = repo.git(&["rev-list", "--count", "main..b"]);
+    let count = String::from_utf8_lossy(&log.stdout)
+        .trim()
+        .parse::<usize>()
+        .unwrap_or(99);
+    assert_eq!(
+        count, 0,
+        "b should have 0 commits ahead of main after mv (no unique commits to replay)"
+    );
+}
+
+/// When the branch has unique commits, they must be rebased onto the new parent.
+///
+/// Scenario: main → a (commit A) → b (commit B, unique to b)
+/// `stax mv b main`
+/// After: b should have exactly 1 commit ahead of main (commit B only, not A).
+#[test]
+fn mv_with_unique_commits_rebases_onto_new_parent() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // main → a
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    // a → b with its own commit
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    let output = repo.run_stax(&["mv", "main"]);
+    output.assert_success();
+
+    // b should have exactly 1 commit ahead of main (commit B, not commit A)
+    let log = repo.git(&["log", "--oneline", "main..b"]);
+    let log_str = String::from_utf8_lossy(&log.stdout).to_string();
+    let unique: Vec<&str> = log_str.lines().filter(|l| !l.trim().is_empty()).collect();
+
+    assert_eq!(
+        unique.len(),
+        1,
+        "b should have exactly 1 unique commit (B) above main, got {}:\n{}",
+        unique.len(),
+        unique.join("\n")
+    );
+    assert!(
+        unique[0].contains("commit B"),
+        "The unique commit should be 'commit B', got: {}",
+        unique[0]
+    );
+
+    // Confirm a's commit is NOT in b's unique history
+    let a_in_b = repo.git(&["log", "--oneline", "main..b"]);
+    let a_in_b_str = String::from_utf8_lossy(&a_in_b.stdout).to_string();
+    assert!(
+        !a_in_b_str.contains("commit A"),
+        "commit A (from branch a) must NOT appear in b's unique history after mv to main"
+    );
+}
+
+/// `stax upstack onto` must also always restack (same behaviour as `mv`).
+///
+/// Reproduces the same scenario via the long form command.
+#[test]
+fn upstack_onto_always_restacks_git_history() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    // main → a (commit A) → b (commit B)
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    repo.run_stax(&["checkout", "b"]);
+    let output = repo.run_stax(&["upstack", "onto", "main"]);
+    output.assert_success();
+
+    // b should have exactly 1 commit above main (commit B only)
+    let log = repo.git(&["log", "--oneline", "main..b"]);
+    let log_str = String::from_utf8_lossy(&log.stdout).to_string();
+    let unique: Vec<&str> = log_str.lines().filter(|l| !l.trim().is_empty()).collect();
+
+    assert_eq!(
+        unique.len(),
+        1,
+        "upstack onto: b should have exactly 1 unique commit above main, got {}:\n{}",
+        unique.len(),
+        unique.join("\n")
+    );
+    assert!(
+        !log_str.contains("commit A"),
+        "upstack onto: commit A must NOT appear in b's unique history after reparent to main"
+    );
+}
+
+/// After moving a branch with descendants, the entire subtree must be rebased.
+///
+/// Scenario: main → a (commit A) → b (commit B) → c (commit C)
+/// `stax mv b main`
+/// After: b has 1 commit above main (B), c has 1 commit above b (C).
+/// Neither b nor c should contain commit A.
+#[test]
+fn mv_subtree_git_history_correct_after_reparent() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    repo.run_stax(&["create", "c"]).assert_success();
+    repo.create_file("c.txt", "content c");
+    repo.commit("commit C");
+
+    repo.run_stax(&["checkout", "b"]);
+    let output = repo.run_stax(&["mv", "main"]);
+    output.assert_success();
+
+    // b: exactly 1 commit above main (B, not A)
+    let b_log = repo.git(&["log", "--oneline", "main..b"]);
+    let b_log_str = String::from_utf8_lossy(&b_log.stdout).to_string();
+    let b_unique: Vec<&str> = b_log_str.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        b_unique.len(),
+        1,
+        "b should have exactly 1 unique commit above main after mv, got {}:\n{}",
+        b_unique.len(),
+        b_unique.join("\n")
+    );
+    assert!(
+        !b_log_str.contains("commit A"),
+        "commit A must NOT appear in b's history after mv to main"
+    );
+
+    // c: exactly 1 commit above b (C only)
+    let c_log = repo.git(&["log", "--oneline", "b..c"]);
+    let c_log_str = String::from_utf8_lossy(&c_log.stdout).to_string();
+    let c_unique: Vec<&str> = c_log_str.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        c_unique.len(),
+        1,
+        "c should have exactly 1 unique commit above b after subtree mv, got {}:\n{}",
+        c_unique.len(),
+        c_unique.join("\n")
+    );
+    assert!(
+        c_log_str.contains("commit C"),
+        "c's unique commit should be 'commit C'"
+    );
+}
+
+/// Metadata parent pointer must also be updated to the new parent after mv.
+/// (Regression guard: git history correct but metadata still wrong = still broken.)
+#[test]
+fn mv_metadata_parent_updated_after_restack() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    repo.run_stax(&["mv", "main"]);
+
+    let status = repo.run_stax(&["status", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&status)).expect("valid json");
+    let branches = json["branches"].as_array().expect("branches array");
+    let b_entry = find_branch(branches, "b").expect("should find branch b");
+
+    assert_eq!(
+        b_entry["parent"].as_str().unwrap(),
+        "main",
+        "metadata parent must be 'main' after mv"
+    );
+
+    // b should not need a restack (git and metadata are in sync)
+    assert_ne!(
+        b_entry["needs_restack"].as_bool().unwrap_or(false),
+        true,
+        "b should not need restack after mv — git and metadata must already agree"
+    );
+}
+
+/// `--restack` flag is accepted for backward compatibility but now a no-op
+/// (restack always happens). Must not error out.
+#[test]
+fn mv_restack_flag_accepted_for_backward_compat() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    // --restack flag should still be accepted (backward compat) and produce correct output
+    let output = repo.run_stax(&["mv", "--restack", "main"]);
+    output.assert_success();
+
+    // Git history must still be correct
+    let log = repo.git(&["log", "--oneline", "main..b"]);
+    let log_str = String::from_utf8_lossy(&log.stdout).to_string();
+    let unique: Vec<&str> = log_str.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        unique.len(),
+        1,
+        "--restack flag: b should still have exactly 1 commit above main"
+    );
+}

--- a/tests/upstack_onto_tests.rs
+++ b/tests/upstack_onto_tests.rs
@@ -541,3 +541,110 @@ fn mv_restack_flag_accepted_for_backward_compat() {
         "--restack flag: b should still have exactly 1 commit above main"
     );
 }
+
+// =============================================================================
+// Dirty working tree behaviour
+//
+// Now that mv always rebases, a dirty working tree blocks the operation.
+// --auto-stash-pop stashes before rebasing and pops afterward, matching
+// the behaviour of `stax restack --auto-stash-pop`.
+// =============================================================================
+
+/// Without --auto-stash-pop, mv with uncommitted changes must fail with a
+/// clear message pointing to --auto-stash-pop.
+#[test]
+fn mv_fails_with_dirty_working_tree() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    // Leave uncommitted changes in the working tree
+    repo.create_file("dirty.txt", "uncommitted");
+
+    let output = repo.run_stax(&["mv", "main"]);
+    output.assert_failure();
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("uncommitted") || stderr.contains("auto-stash-pop"),
+        "Should mention uncommitted changes or --auto-stash-pop, got: {}",
+        stderr
+    );
+}
+
+/// With --auto-stash-pop, mv stashes dirty changes, rebases, then restores them.
+#[test]
+fn mv_auto_stash_pop_succeeds_with_dirty_working_tree() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    // Leave uncommitted changes
+    repo.create_file("dirty.txt", "uncommitted content");
+
+    let output = repo.run_stax(&["mv", "--auto-stash-pop", "main"]);
+    output.assert_success();
+
+    // Git history must be correct: b has 1 commit above main (B only)
+    let log = repo.git(&["log", "--oneline", "main..b"]);
+    let log_str = String::from_utf8_lossy(&log.stdout).to_string();
+    let unique: Vec<&str> = log_str.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        unique.len(),
+        1,
+        "--auto-stash-pop: b should have exactly 1 commit above main, got {}:\n{}",
+        unique.len(),
+        log_str
+    );
+
+    // Dirty changes must be restored after the rebase
+    let status = repo.git(&["status", "--porcelain"]);
+    let status_str = String::from_utf8_lossy(&status.stdout).to_string();
+    assert!(
+        status_str.contains("dirty.txt"),
+        "--auto-stash-pop: dirty changes should be restored after mv, got:\n{}",
+        status_str
+    );
+}
+
+/// upstack onto also accepts --auto-stash-pop.
+#[test]
+fn upstack_onto_auto_stash_pop_succeeds_with_dirty_working_tree() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "a"]).assert_success();
+    repo.create_file("a.txt", "content a");
+    repo.commit("commit A");
+
+    repo.run_stax(&["create", "b"]).assert_success();
+    repo.create_file("b.txt", "content b");
+    repo.commit("commit B");
+
+    repo.create_file("dirty.txt", "uncommitted content");
+
+    repo.run_stax(&["checkout", "b"]);
+    let output = repo.run_stax(&["upstack", "onto", "--auto-stash-pop", "main"]);
+    output.assert_success();
+
+    let status = repo.git(&["status", "--porcelain"]);
+    let status_str = String::from_utf8_lossy(&status.stdout).to_string();
+    assert!(
+        status_str.contains("dirty.txt"),
+        "upstack onto --auto-stash-pop: dirty changes should be restored, got:\n{}",
+        status_str
+    );
+}


### PR DESCRIPTION
## Motivation

Fixes #433

Moving a branch to a new parent should update both the branch metadata and the underlying git history immediately. Before this change, `stax mv` and `stax upstack onto` could leave the branch pointing at the old ancestry until a separate restack, which produced incorrect history and confusing status output.

## Description of changes / notes for reviewers

- `stax mv` and `stax upstack onto` now always restack after reparenting, so the branch tip and its descendants are rebased onto the new parent in one step.
- The `--restack` flag is kept for backward compatibility but is hidden from help output and no longer changes behavior.
- Added regression tests covering no-op moves, unique commit rebases, subtree restacking, metadata updates, and backward-compatible flag handling.