### PR TITLE
Sync refreshes tracked PR metadata before completing

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -16,6 +16,8 @@
 - When adding or changing CLI commands/flags, update both `README.md` and `docs/` command references in the same change and verify parity against `stax --help` before marking docs complete.
 - AI standup prompts that ask for `Today` must include concrete in-flight signals (recent branch work, opened PRs, or Jira tickets with PRs) and tell the model to carry unfinished work forward; otherwise the model fills missing context with generic review/cleanup/backlog bullets.
 - Long-running reporting or AI commands must show progress for human-facing output while keeping `--json` and plain-text modes free of progress noise; use stderr for progress when stdout may be copied, piped, or parsed.
+- Command completion footers must be printed after all foreground work has finished; if a best-effort metadata refresh or cache update can block, show it as a timed progress step and include it in the total.
+- Sync metadata refreshes must scale with local tracked branches, not repo-wide forge state; avoid listing every open PR when the command only needs metadata for known PR numbers.
 - When a feature has both command docs and workflow guides, keep one canonical docs page for the command surface and have workflow pages link back to it instead of duplicating subcommand semantics.
 - Shell integration snippets that define common command names (`stax`, `st`, `sw`) must clear conflicting aliases first; zsh expands aliases while parsing function definitions and can abort shell startup otherwise.
 - Shared bash/zsh shell snippets must use shell-specific command lookup (`whence -p` in zsh, `type -P` in bash) when they need the real binary path; bash-only flags in shared wrappers can break every `st`/`stax` invocation on zsh.

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -11,6 +11,7 @@ use crate::errors::ConflictStopped;
 use crate::forge::ForgeClient;
 use crate::git::repo::BranchDeleteResolution;
 use crate::git::{GitRepo, RebaseResult, RebaseTimings};
+use crate::github::pr::PrInfo as ForgePrInfo;
 use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
@@ -18,10 +19,13 @@ use crate::remote::{self, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use futures_util::stream::{self, StreamExt};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};
+
+const PR_METADATA_REFRESH_CONCURRENCY: usize = 8;
 
 #[derive(Debug, Default)]
 struct SyncStats {
@@ -1486,6 +1490,10 @@ pub fn run(
         .ok()
         .flatten();
 
+    if let Some(pr_refresh_elapsed) = refresh_pr_draft_states(&repo, &config, quiet) {
+        step_timings.push(("refresh PR metadata".to_string(), pr_refresh_elapsed));
+    }
+
     if verbose && !quiet {
         println!();
         println!("{}", "Sync timing summary:".bold());
@@ -1516,94 +1524,142 @@ pub fn run(
         }
     }
 
-    refresh_pr_draft_states(&repo, &config);
-
     Ok(())
 }
 
 /// Fetch live PR state from the forge for all tracked branches and update
 /// both branch metadata and CiCache. Called at end of sync so that operations
 /// like `gh pr ready`, `gh pr merge`, or `gh pr edit --base` are reflected.
-fn refresh_pr_draft_states(repo: &GitRepo, config: &Config) {
+fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Option<Duration> {
+    let started_at = Instant::now();
+    let stack = match Stack::load(repo) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+    let tracked_pr_branches: Vec<(String, u64)> = stack
+        .branches
+        .iter()
+        .filter_map(|(branch_name, branch_info)| {
+            if branch_name == &stack.trunk {
+                return None;
+            }
+            branch_info
+                .pr_number
+                .map(|pr_number| (branch_name.clone(), pr_number))
+        })
+        .collect();
+    if tracked_pr_branches.is_empty() {
+        return None;
+    }
+
+    let timer = LiveTimer::maybe_new(!quiet, "Refresh PR metadata");
+
     let remote_info = match RemoteInfo::from_repo(repo, config) {
         Ok(info) => info,
-        Err(_) => return,
+        Err(_) => {
+            LiveTimer::maybe_finish_skipped(timer, "skipped");
+            return Some(started_at.elapsed());
+        }
     };
     let rt = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
-        Err(_) => return,
+        Err(_) => {
+            LiveTimer::maybe_finish_skipped(timer, "skipped");
+            return Some(started_at.elapsed());
+        }
     };
     let _enter = rt.enter();
     let client = match ForgeClient::new(&remote_info) {
         Ok(c) => c,
-        Err(_) => return,
-    };
-    let stack = match Stack::load(repo) {
-        Ok(s) => s,
-        Err(_) => return,
+        Err(_) => {
+            LiveTimer::maybe_finish_skipped(timer, "skipped");
+            return Some(started_at.elapsed());
+        }
     };
     let git_dir = match repo.git_dir() {
         Ok(p) => p,
-        Err(_) => return,
+        Err(_) => {
+            LiveTimer::maybe_finish_skipped(timer, "skipped");
+            return Some(started_at.elapsed());
+        }
     };
     let mut cache = CiCache::load(&git_dir);
     let mut cache_dirty = false;
 
-    for (branch_name, branch_info) in &stack.branches {
-        if branch_name == &stack.trunk {
+    let live_prs = rt.block_on(async {
+        stream::iter(
+            tracked_pr_branches
+                .into_iter()
+                .map(|(branch_name, pr_number)| {
+                    let client = client.clone();
+                    async move { (branch_name, client.get_pr(pr_number).await.ok()) }
+                }),
+        )
+        .buffer_unordered(PR_METADATA_REFRESH_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await
+    });
+
+    for (branch_name, live_pr) in live_prs {
+        let Some(live_pr) = live_pr else {
             continue;
-        }
-        let pr_number = match branch_info.pr_number {
-            Some(n) => n,
-            None => continue,
-        };
-        let live_pr = match rt.block_on(client.get_pr(pr_number)) {
-            Ok(p) => p,
-            Err(_) => continue,
         };
 
-        // Update branch metadata with fresh state, is_draft, and base
-        if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch_name) {
-            if let Some(ref mut pr_info) = meta.pr_info {
-                pr_info.is_draft = Some(live_pr.is_draft);
-                pr_info.state = live_pr.state.clone();
-            }
-
-            // Reconcile PR base with parent: if the live PR base differs from
-            // our tracked parent and the live base is a known branch, update.
-            if !live_pr.base.is_empty() && live_pr.base != meta.parent_branch_name {
-                let base_is_known =
-                    live_pr.base == stack.trunk || stack.branches.contains_key(&live_pr.base);
-                if base_is_known {
-                    // Update parent revision to the current tip of the new parent
-                    if let Ok(parent_ref) = repo
-                        .inner()
-                        .find_branch(&live_pr.base, git2::BranchType::Local)
-                    {
-                        if let Ok(commit) = parent_ref.get().peel_to_commit() {
-                            meta.parent_branch_revision = commit.id().to_string();
-                        }
-                    }
-                    meta.parent_branch_name = live_pr.base.clone();
-                }
-            }
-
-            let _ = meta.write(repo.inner(), branch_name);
-        }
-
-        // Update CiCache with the live PR state
-        let pr_state = live_pr.state.clone();
-        let existing_ci = cache
-            .branches
-            .get(branch_name.as_str())
-            .and_then(|e| e.ci_state.clone());
-        cache.update(branch_name, existing_ci, Some(pr_state));
+        apply_live_pr_state(repo, &stack, &mut cache, &branch_name, &live_pr);
         cache_dirty = true;
     }
 
     if cache_dirty {
         let _ = cache.save(&git_dir);
     }
+
+    LiveTimer::maybe_finish_timed(timer);
+    Some(started_at.elapsed())
+}
+
+fn apply_live_pr_state(
+    repo: &GitRepo,
+    stack: &Stack,
+    cache: &mut CiCache,
+    branch_name: &str,
+    live_pr: &ForgePrInfo,
+) {
+    let pr_state = live_pr.state.to_uppercase();
+
+    // Update branch metadata with fresh state, is_draft, and base
+    if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch_name) {
+        if let Some(ref mut pr_info) = meta.pr_info {
+            pr_info.is_draft = Some(live_pr.is_draft);
+            pr_info.state = pr_state.clone();
+        }
+
+        // Reconcile PR base with parent: if the live PR base differs from
+        // our tracked parent and the live base is a known branch, update.
+        if !live_pr.base.is_empty() && live_pr.base != meta.parent_branch_name {
+            let base_is_known =
+                live_pr.base == stack.trunk || stack.branches.contains_key(&live_pr.base);
+            if base_is_known {
+                // Update parent revision to the current tip of the new parent
+                if let Ok(parent_ref) = repo
+                    .inner()
+                    .find_branch(&live_pr.base, git2::BranchType::Local)
+                {
+                    if let Ok(commit) = parent_ref.get().peel_to_commit() {
+                        meta.parent_branch_revision = commit.id().to_string();
+                    }
+                }
+                meta.parent_branch_name = live_pr.base.clone();
+            }
+        }
+
+        let _ = meta.write(repo.inner(), branch_name);
+    }
+
+    let existing_ci = cache
+        .branches
+        .get(branch_name)
+        .and_then(|e| e.ci_state.clone());
+    cache.update(branch_name, existing_ci, Some(pr_state));
 }
 
 fn sync_fetch_refs(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12716,6 +12716,61 @@ mod forge_mock_tests {
         // If metadata ref was deleted (sync cleaned up the merged branch), that's also correct
     }
 
+    #[tokio::test]
+    async fn test_sync_shows_and_targets_pr_metadata_refresh() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let repo = setup_branch_with_remote(home.path(), "feature-pr-refresh");
+        let branch = repo.current_branch();
+        write_branch_pr_metadata(&repo, &branch, "main", 530, Some(false));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/530"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(530, &branch, "main", "aaaa")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["sync"]);
+        assert!(
+            output.status.success(),
+            "Sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        let stdout = TestRepo::stdout(&output);
+        let refresh_index = stdout
+            .find("Refresh PR metadata")
+            .unwrap_or_else(|| panic!("Expected visible PR refresh timing, got:\n{}", stdout));
+        let complete_index = stdout
+            .find("Sync complete!")
+            .unwrap_or_else(|| panic!("Expected sync completion footer, got:\n{}", stdout));
+        assert!(
+            refresh_index < complete_index,
+            "PR refresh must finish before Sync complete is printed, got:\n{}",
+            stdout
+        );
+
+        let requests = mock_server.received_requests().await.unwrap_or_default();
+        assert!(
+            requests
+                .iter()
+                .any(|r| r.method.as_str() == "GET" && r.url.path() == "/repos/test/repo/pulls/530"),
+            "Expected sync to refresh the tracked PR directly"
+        );
+        assert!(
+            requests.iter().all(|r| {
+                !(r.method.as_str() == "GET" && r.url.path() == "/repos/test/repo/pulls")
+            }),
+            "Sync PR metadata refresh must not scan the repo-wide open PR list"
+        );
+    }
+
     /// When a PR is closed (not merged) via `gh pr close`, sync should update
     /// the metadata state to CLOSED so stax knows the PR is no longer active.
     #[tokio::test]


### PR DESCRIPTION
## Summary
This change fixes `sync` so PR metadata refresh is bounded, visible in progress output, and completed before the final `Sync complete!` footer is printed.

## What Changed
- Moved PR metadata refresh into the main timed sync flow so it contributes to overall command timing.
- Added a dedicated `Refresh PR metadata` progress step for human-facing output.
- Parallelized live PR lookups with a bounded concurrency limit of 8 to avoid sequential refresh latency.
- Switched refresh logic to target only locally tracked PR branches instead of scanning repo-wide open PR state.
- Extracted branch/CiCache reconciliation into `apply_live_pr_state` to keep the refresh path clearer and easier to maintain.
- Added regression coverage verifying:
  - the refresh step is visible before `Sync complete!`
  - tracked PRs are fetched directly by PR number
  - the sync refresh does not scan the full open-PR list
- Documented the durable lessons in `learnings.md`.

## Why
Previously, sync could hide a best-effort metadata refresh after the completion footer and incur unnecessary latency by working from repo-wide PR state. The new flow makes the work visible, finishes it before the command reports completion, and scales with the set of locally tracked branches.

## Verification
- Added an integration test covering the refresh timing and request shape.
- Existing sync behavior remains covered by the integration suite around branch state, PR state, and metadata reconciliation.

## Notes
- PR metadata refresh remains best-effort: failures are skipped rather than failing the whole sync.
- The refresh still updates branch metadata and CiCache when live PR data is available.