### PR TITLE
feat(ci): add --oneline compact whole-stack view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 ### Added
+- Add `st ci --oneline` (`-1`): a one-line-per-branch CI roll-up (status icon · branch · `#PR` · draft/ready · title · check count + timing). Multi-branch `st ci` views (`--stack`/`--all`) now default to this roll-up; `--verbose` still shows the grouped summary cards
 - Add `st doctor --fix` to apply safe local health-check repairs after one confirmation
 
 ## [0.81.2] - 2026-05-27

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ st config --set-ai
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--remote`, `--all`) |
+| `st ci` / `st ci --oneline` | CI status — full per-check table, or one compact line per branch across the stack (multi-branch defaults to the roll-up) |
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -108,10 +108,12 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 
 | Command | Description |
 |---|---|
-| `st ci` | CI status for current branch (with elapsed/ETA learned from recent runs) |
-| `st ci --stack` / `--all` / `--watch` | Scope and watch modes (`--watch --strict` fail-fasts on failure) |
+| `st ci` | CI status for current branch — full per-check table (with elapsed/ETA learned from recent runs) |
+| `st ci --stack` / `--all` | Scope to stack / all tracked branches; multi-branch views default to the one-line roll-up |
+| `st ci --oneline` / `-1` | One compact line per branch (icon · branch · #PR · draft/ready · title · checks + timing) |
+| `st ci --watch` | Watch modes (`--watch --strict` fail-fasts on failure) |
 | `st ci -w --alert` / `--alert <file>` / `--no-alert` | Success/error completion sounds for watch mode |
-| `st ci --verbose` / `--json` | Summary cards · JSON output |
+| `st ci --verbose` / `--json` | Grouped summary cards · JSON output |
 | `st pr` · `st pr open` | Open current branch PR |
 | `st pr body` · `st pr body --edit` | Print or edit the current branch PR description |
 | `st pr list` | List open PRs (GitHub, GitLab, Gitea) |
@@ -269,7 +271,9 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 
 ### `st ci`
 
-- `--stack` / `--all` / `--watch` / `--watch --strict` / `--interval 30` / `--json`
+- `--stack` / `--all` / `--oneline` (`-1`) / `--verbose` / `--watch` / `--watch --strict` / `--interval 30` / `--json`
+- Three render modes: the **full per-check table** (single branch, default), grouped **summary cards** (`--verbose`/`-v`), and the **one-line roll-up** (`--oneline`/`-1`). Any multi-branch view (`--stack`/`--all`) defaults to the roll-up; `--verbose` overrides it back to cards. `--oneline` and `--verbose` cannot be combined.
+- The roll-up renders one line per branch, base→tip: CI status icon · branch · `#PR` · `draft`/`ready` · PR title · trailing check-count and timing. A bare `--oneline` defaults its scope to the current stack.
 - By default, `--watch` waits until every check is terminal, even if one check has already failed. Add `--strict` to exit as soon as any check fails.
 - `--watch --alert` plays built-in success/error sounds; `--watch --alert <file>` uses one custom sound for either outcome; `--watch --no-alert` suppresses `[ci] alert = true` for one run.
 - Config can enable alerts by default with `[ci] alert = true`; set `success_alert_sound` and/or `error_alert_sound` to override the per-outcome built-in sounds.

--- a/docs/superpowers/specs/2026-05-28-ci-oneline-mode-design.md
+++ b/docs/superpowers/specs/2026-05-28-ci-oneline-mode-design.md
@@ -117,9 +117,12 @@ Unit tests (no network/git) for `oneline_row` and the trailing-summary helper:
 - long title truncated to width with `…`
 - column alignment: branches of differing lengths pad to a common width
 
+## Follow-ups (implemented in this branch)
+
+- **Multi-branch defaults to oneline.** A single branch still shows the full per-check table; any multi-branch view (`--stack`/`--all`) now defaults to the oneline roll-up. `-v/--verbose` still gives the grouped cards. The full per-check table across a whole stack is intentionally dropped (scope to one branch for it). The decision is centralized in a pure `ci_view_mode(oneline, verbose, multi) -> CiView` helper used by both the one-shot and `--watch` dispatch.
+- **Review-state column.** A `draft` (dim) / `ready` (green) label sits between the PR number and the title, sourced from `oneline_review_label` (`pr_is_draft` + `pr_number`). Branches without a PR — or with unknown draft state — show nothing, and the column collapses entirely when no row has a PR.
+
 ## Out of scope (YAGNI)
 
-- PR review-state label ("Ready for review" / "Draft") as a column — the CI status icon is the leading signal; draft state already lives in `pr_is_draft` and can be added later if wanted.
 - PR age / "15m"-style timestamps — trailing column is CI timing, not PR age.
 - Cross-repo "repo" column from the screenshot — stax operates on a single repo's stack.
-- Making `--oneline` the default for multi-branch views — explicit opt-in only.

--- a/docs/superpowers/specs/2026-05-28-ci-oneline-mode-design.md
+++ b/docs/superpowers/specs/2026-05-28-ci-oneline-mode-design.md
@@ -1,0 +1,125 @@
+# `st ci --oneline` — compact whole-stack CI view
+
+**Date:** 2026-05-28
+**Status:** Design approved, pending spec review
+
+## Problem
+
+`st ci` today has two rendering modes:
+
+- **Default** (`display_ci_verbose`): full per-check table, one line per individual check.
+- **`-v/--verbose`** (`display_ci_compact`): "compact cards" — failed/running/passed grouped per branch, several lines per branch.
+
+Both are detailed. There is no way to see the **whole stack at a glance** — one line per branch — the way a GitHub "Pull requests" list shows one row per PR (status, title, number, age). For a stack of 4–6 branches, the user wants a single-screen roll-up.
+
+## Goal
+
+Add a third rendering mode to `st ci`: a one-line-per-branch roll-up, rendered in stack order, with a leading CI status icon, branch name, PR number, PR title, and a trailing summary of check counts + timing.
+
+## Decisions (locked with user)
+
+| Decision | Choice |
+|---|---|
+| Invocation | New `--oneline` flag, short `-1`. Rendering-only; composes with scope flags. |
+| Default scope when `--oneline` alone | **Current stack** (base→tip). `--all` still overrides to all tracked branches. |
+| Row primary label | **PR title + branch name** (branch padded, current bold; title from API). |
+| Trailing column | **Mix of check counts + timing**: e.g. `12 checks · 4m`, `2 failing · 3m`, `6/12 running · 2m`, `no CI`. |
+| `--oneline` + `-v/--verbose` | **Conflict** — clap rejects with "cannot be used together". |
+
+## Output format
+
+Multi-branch summary header (reuse existing `print_multi_branch_header`), a blank line, then one row per branch in stack order:
+
+```
+CI  3 branches  ✓ 1 passing  ✗ 1 failing  ● 1 running
+
+✓  feat/api-base        #115392  Enable KSP2 for faster annotation     12 checks · 4m
+✗  feat/reduce-memory   #115377  Reduce Gradle local build memory       2 failing · 3m
+●  feat/parallel-cache  #115389  Enable parallel config cache           6/12 running · 2m
+○  feat/no-ci           #115401  Restructure agent docs                 no CI
+```
+
+### Columns (left → right)
+
+1. **CI status icon** — same mapping as existing headers: `✓` green (success), `✗` red (failure), `●` yellow (pending/running), `○` dimmed (no CI / unknown).
+2. **Branch name** — left-padded to the max branch width across rows; current branch rendered bold.
+3. **`#<PR>`** — PR number when present; omitted (blank-padded) when the branch has no PR.
+4. **PR title** — from the API; truncated with `…` to fit the remaining terminal width.
+5. **Trailing summary** — `<counts> · <timing>`:
+   - failure → `<N> failing · <elapsed>`
+   - running/pending → `<done>/<total> running · <elapsed>`
+   - all success → `<N> checks · <elapsed>`
+   - no checks → `no CI` (no timing)
+   - timing segment omitted when `calculate_branch_timing` returns `None`.
+
+### Width handling
+
+- Branch column width = max visible branch length across the rendered statuses.
+- PR column width = max `#<PR>` width across rows (blank-padded for PR-less rows).
+- Title is truncated to whatever horizontal space remains after icon + branch + PR + trailing summary, using terminal width (fallback to a sane default, e.g. 100, when width is unavailable). Visible-length math uses the existing `strip_ansi_len` helper so ANSI color codes don't skew alignment.
+
+## Data changes
+
+`BranchCiStatus` (src/commands/ci.rs:22) gains:
+
+```rust
+#[serde(skip_serializing_if = "Option::is_none")]
+pub pr_title: Option<String>,
+```
+
+`#[serde(skip_serializing_if = "Option::is_none")]` keeps `--json` output unchanged for branches without a PR.
+
+In `fetch_ci_statuses_async`, the current `client.get_pr(n)` call (which only reads `is_draft`) is replaced by `client.get_pr_with_head(n)`, which returns `PrInfoWithHead { title, info: PrInfo { is_draft, .. }, .. }`. Both `pr_is_draft` and `pr_title` are populated from that single call — no extra API round-trip. On error, both fall back to `None` (current behavior preserved).
+
+## Rendering
+
+New functions in src/commands/ci.rs:
+
+- `fn display_ci_oneline(repo: &GitRepo, statuses: &[BranchCiStatus], current: &str, stack: &Stack)` — prints the multi-branch header (when >1 branch), reorders statuses into stack order (base→tip) using the stack, computes column widths, and prints each row.
+- `fn oneline_row(status: &BranchCiStatus, is_current: bool, branch_w: usize, pr_w: usize, title_w: usize) -> String` — pure formatting for a single row; unit-testable without git/network.
+- A small helper to build the trailing `counts · timing` segment from the existing partition logic + `calculate_branch_timing`.
+
+### Ordering
+
+`fetch_ci_statuses` currently sorts statuses alphabetically. For the oneline view, `display_ci_oneline` reorders by stack position (base→tip) before rendering — matching how `st log`/`st ls` present a stack. Other modes are unaffected.
+
+## Dispatch
+
+In `Commands::Ci`, add `oneline: bool` (clap `#[arg(long, short = '1', conflicts_with = "verbose")]`).
+
+In `commands::ci::run(...)`:
+
+- Add an `oneline: bool` parameter.
+- **Scope**: when `oneline && !all && !stack`, set the scope to the current stack (same branch set as the `stack` path) so a bare `st ci --oneline` shows the whole stack.
+- **Render**: branch the dispatch — `if oneline { display_ci_oneline(...) } else if verbose { display_ci_compact(...) } else { display_ci_verbose(...) }`.
+- **Watch**: thread `oneline` through `run_watch_mode` so `st ci --oneline --watch` renders the compact view on each poll.
+
+The CLI dispatch site in src/cli (where `Commands::Ci { .. }` is destructured and `commands::ci::run` is called) passes the new `oneline` argument.
+
+## Edge cases
+
+- **No tracked branches** — unchanged: prints "No tracked branches found.".
+- **Single branch in scope** — still renders one row (header omitted when only one branch, matching existing `multi` gating).
+- **Branch with no PR** — no `#` shown; title column blank; trailing summary still reflects checks.
+- **Branch with no CI** — `○` icon, `no CI` trailing, no timing.
+- **Narrow terminal** — title truncated; if space is extremely tight, title may be dropped entirely (branch + PR + status always shown).
+- **`--json`** — orthogonal to `--oneline`; JSON path returns early before any display function, so `--oneline --json` yields the same JSON (now optionally including `pr_title`).
+
+## Testing
+
+Unit tests (no network/git) for `oneline_row` and the trailing-summary helper:
+
+- passing branch with PR title → `N checks · <t>`
+- failing branch → `N failing · <t>`
+- running branch → `done/total running · <t>`
+- no-CI branch → `no CI`, no timing
+- branch without PR → no `#`, title blank
+- long title truncated to width with `…`
+- column alignment: branches of differing lengths pad to a common width
+
+## Out of scope (YAGNI)
+
+- PR review-state label ("Ready for review" / "Draft") as a column — the CI status icon is the leading signal; draft state already lives in `pr_is_draft` and can be added later if wanted.
+- PR age / "15m"-style timestamps — trailing column is CI timing, not PR age.
+- Cross-repo "repo" column from the screenshot — stax operates on a single repo's stack.
+- Making `--oneline` the default for multi-branch views — explicit opt-in only.

--- a/skills.md
+++ b/skills.md
@@ -1,4 +1,4 @@
-<!-- stax-skills-version: 0.50.2 -->
+<!-- stax-skills-version: 0.51.0 -->
 # Stax Skills for AI Coding Agents
 
 This document teaches AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, OpenCode) how to use `stax` to manage stacked Git branches and PRs.
@@ -60,7 +60,7 @@ stax pr body --edit            # Edit current PR description in $EDITOR
 stax open                      # Open repo in browser
 stax comments                  # Show current PR comments
 stax copy [--pr]               # Copy branch name or PR URL
-stax ci                        # CI status
+stax ci [--oneline|-1]         # CI status (per-check table; --oneline / multi-branch = one line per branch)
 stax standup                   # Recent activity summary
 stax standup --ai              # AI-generated spoken standup update (colored card)
 stax standup --ai --style slack  # AI-generated Slack-ready Yesterday/Today bullets
@@ -298,9 +298,10 @@ stax pr body --edit                # Edit current PR description in $EDITOR
 stax comments                      # Show current PR comments
 stax comments --plain              # Raw markdown output
 
-stax ci                            # CI for current branch (elapsed/ETA + avg from recent successful runs of the same checks)
-stax ci --stack                    # CI for current stack
-stax ci --all                      # CI for all tracked branches
+stax ci                            # CI for current branch, full per-check table (elapsed/ETA + avg from recent successful runs of the same checks)
+stax ci --stack                    # CI for current stack (defaults to the one-line-per-branch roll-up)
+stax ci --all                      # CI for all tracked branches (one-line-per-branch roll-up)
+stax ci --oneline                  # One compact line per branch across the stack (alias: -1)
 stax ci --watch --interval 30      # Watch until all checks finish, custom poll interval
 stax ci --watch --strict           # Watch but exit as soon as any check fails
 stax ci --watch --alert            # Watch CI, play built-in success/error sounds
@@ -308,7 +309,11 @@ stax ci --watch --alert /path/to/sound.wav  # Use one custom sound for either ou
 stax ci --watch --no-alert         # Suppress configured completion sounds for one run
 stax ci --refresh                  # Force refresh (bypass cache)
 stax ci --json                     # Machine-readable output
-stax ci --verbose                  # Compact summary cards
+stax ci --verbose                  # Compact summary cards (grouped failed/running/passed per branch)
+
+# Oneline roll-up: status icon · branch · #PR · draft/ready · title · check-count + timing.
+# Single branch shows the full per-check table; any multi-branch view defaults to oneline;
+# --verbose forces the grouped cards. --oneline conflicts with --verbose.
 
 # ~/.config/stax/config.toml
 [ci]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -752,6 +752,9 @@ pub(crate) enum Commands {
         /// Show compact summary cards instead of the full per-check table
         #[arg(long, short)]
         verbose: bool,
+        /// One compact line per branch across the whole stack
+        #[arg(long, short = '1', conflicts_with = "verbose")]
+        oneline: bool,
     },
 
     /// Live auto-refreshing stack status with CI and PR state

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -431,6 +431,7 @@ pub fn run() -> Result<()> {
             strict,
             interval,
             verbose,
+            oneline,
         } => commands::ci::run(
             all,
             stack,
@@ -445,6 +446,7 @@ pub fn run() -> Result<()> {
             strict,
             interval,
             verbose,
+            oneline,
         ),
         Commands::Watch { current, interval } => commands::watch::run(current, interval),
         Commands::Tmux { command } => commands::tmux::run(command),

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -28,6 +28,8 @@ pub struct BranchCiStatus {
     pub pr_number: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_is_draft: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_title: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -286,6 +288,7 @@ pub fn run(
     strict: bool,
     interval: u64,
     verbose: bool,
+    oneline: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let current = repo.current_branch()?;
@@ -302,7 +305,9 @@ pub fn run(
             .filter(|b| *b != &stack_data.trunk)
             .cloned()
             .collect()
-    } else if stack {
+    } else if stack || oneline {
+        // `--oneline` is about seeing the whole stack, so default its scope to
+        // the current stack when no explicit scope flag is given.
         stack_data
             .current_stack(&current)
             .into_iter()
@@ -350,6 +355,7 @@ pub fn run(
             interval,
             json,
             verbose,
+            oneline,
             alert,
             strict,
         );
@@ -364,7 +370,10 @@ pub fn run(
     }
 
     let multi = statuses.len() > 1;
-    if verbose {
+    if oneline {
+        // --oneline: one compact line per branch across the stack
+        display_ci_oneline(&repo, &statuses, &current, &stack_data);
+    } else if verbose {
         // --verbose: compact cards view
         display_ci_compact(&repo, &statuses, &current, multi);
     } else {
@@ -402,10 +411,11 @@ pub(crate) async fn fetch_ci_statuses_async(
             };
 
             let pr_live = match pr_number {
-                Some(n) => client.get_pr(*n).await.ok(),
+                Some(n) => client.get_pr_with_head(*n).await.ok(),
                 None => None,
             };
-            let pr_is_draft = pr_live.as_ref().map(|p| p.is_draft);
+            let pr_is_draft = pr_live.as_ref().map(|p| p.info.is_draft);
+            let pr_title = pr_live.as_ref().map(|p| p.title.clone());
 
             BranchCiStatus {
                 branch: branch.clone(),
@@ -415,6 +425,7 @@ pub(crate) async fn fetch_ci_statuses_async(
                 check_runs,
                 pr_number: *pr_number,
                 pr_is_draft,
+                pr_title,
             }
         },
     ))
@@ -791,6 +802,169 @@ fn print_multi_branch_header(statuses: &[BranchCiStatus]) {
     println!("CI  {}", parts.join("  "));
 }
 
+/// One-line counts summary for the `--oneline` view.
+///
+/// Returns `"no CI"`, `"<n> failing"`, `"<done>/<total> running"`, or `"<n> checks"`.
+fn oneline_check_summary(status: &BranchCiStatus) -> String {
+    if status.check_runs.is_empty() {
+        return "no CI".to_string();
+    }
+    let total = status.check_runs.len();
+    let failed = status
+        .check_runs
+        .iter()
+        .filter(|c| {
+            c.status == "completed"
+                && matches!(
+                    c.conclusion.as_deref(),
+                    Some("failure") | Some("timed_out") | Some("action_required")
+                )
+        })
+        .count();
+    if failed > 0 {
+        return format!("{} failing", failed);
+    }
+    let completed = status
+        .check_runs
+        .iter()
+        .filter(|c| c.status == "completed")
+        .count();
+    if completed < total {
+        return format!("{}/{} running", completed, total);
+    }
+    format!("{} checks", total)
+}
+
+/// Colored overall-status icon for the `--oneline` view.
+fn oneline_overall_icon(status: &BranchCiStatus) -> colored::ColoredString {
+    match status.overall_status.as_deref() {
+        Some("success") => "✓".green().bold(),
+        Some("failure") => "✗".red().bold(),
+        Some("pending") => "●".yellow().bold(),
+        _ => "○".dimmed(),
+    }
+}
+
+/// Format a single branch as one line for the `--oneline` view.
+///
+/// Columns are padded on plain text (before coloring) so ANSI escape codes
+/// don't skew alignment. `timing` is the optional CI elapsed/ETA segment.
+fn oneline_row(
+    status: &BranchCiStatus,
+    is_current: bool,
+    branch_w: usize,
+    pr_w: usize,
+    title_w: usize,
+    timing: Option<&str>,
+) -> String {
+    let icon = oneline_overall_icon(status);
+
+    let branch_padded = format!("{:<width$}", status.branch, width = branch_w);
+    let branch_cell = if is_current {
+        branch_padded.bold()
+    } else {
+        branch_padded.normal()
+    };
+
+    let pr_str = status
+        .pr_number
+        .map(|n| format!("#{}", n))
+        .unwrap_or_default();
+    let pr_cell = format!("{:<width$}", pr_str, width = pr_w).bright_magenta();
+
+    let title = status.pr_title.as_deref().unwrap_or("");
+    let title_trunc = truncate_title(title, title_w);
+    let title_pad = title_w.saturating_sub(title_trunc.chars().count());
+    let title_cell = format!("{}{}", title_trunc, " ".repeat(title_pad));
+
+    let summary = oneline_check_summary(status);
+    let trailing = match timing {
+        Some(t) if !t.is_empty() => format!("{} · {}", summary, t),
+        _ => summary,
+    };
+
+    format!(
+        "{}  {}  {}  {}  {}",
+        icon,
+        branch_cell,
+        pr_cell,
+        title_cell,
+        trailing.dimmed()
+    )
+}
+
+/// Visible terminal width, with a sane fallback when it can't be detected.
+fn terminal_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(cols, _)| cols as usize)
+        .unwrap_or(120)
+        .max(40)
+}
+
+/// One-line-per-branch display for the `--oneline` view.
+///
+/// Rows are ordered base→tip (by depth from trunk), columns are aligned, and
+/// the PR title is truncated to fit the terminal width.
+fn display_ci_oneline(repo: &GitRepo, statuses: &[BranchCiStatus], current: &str, stack: &Stack) {
+    if statuses.len() > 1 {
+        print_multi_branch_header(statuses);
+        println!();
+    }
+
+    // Order base -> tip: shallower (closer to trunk) first, then by name.
+    let mut ordered: Vec<&BranchCiStatus> = statuses.iter().collect();
+    ordered.sort_by(|a, b| {
+        let da = stack.ancestors(&a.branch).len();
+        let db = stack.ancestors(&b.branch).len();
+        da.cmp(&db).then_with(|| a.branch.cmp(&b.branch))
+    });
+
+    let branch_w = ordered
+        .iter()
+        .map(|s| s.branch.chars().count())
+        .max()
+        .unwrap_or(0);
+    let pr_w = ordered
+        .iter()
+        .map(|s| s.pr_number.map(|n| format!("#{}", n).len()).unwrap_or(0))
+        .max()
+        .unwrap_or(0);
+
+    // Layout: icon(1) + 2 + branch + 2 + pr + 2 + title + 2 + summary budget.
+    const SUMMARY_BUDGET: usize = 24;
+    let fixed = 1 + 2 + branch_w + 2 + pr_w + 2 + 2 + SUMMARY_BUDGET;
+    let title_w = terminal_width().saturating_sub(fixed).max(10);
+
+    for status in ordered {
+        let is_current = status.branch == current;
+        let timing = calculate_branch_timing(repo, &status.check_runs)
+            .map(|t| format_duration(t.elapsed_secs));
+        println!(
+            "{}",
+            oneline_row(
+                status,
+                is_current,
+                branch_w,
+                pr_w,
+                title_w,
+                timing.as_deref()
+            )
+        );
+    }
+}
+
+/// Truncate `title` to at most `max` visible characters, appending `…` when cut.
+fn truncate_title(title: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if title.chars().count() <= max {
+        return title.to_string();
+    }
+    let kept: String = title.chars().take(max.saturating_sub(1)).collect();
+    format!("{}…", kept)
+}
+
 /// Record CI history for completed successful checks
 pub fn record_ci_history(repo: &GitRepo, statuses: &[BranchCiStatus]) {
     for status in statuses {
@@ -931,6 +1105,7 @@ fn run_watch_mode(
     interval: u64,
     json: bool,
     verbose: bool,
+    oneline: bool,
     alert: Option<CiAlertSounds>,
     strict: bool,
 ) -> Result<()> {
@@ -962,7 +1137,9 @@ fn run_watch_mode(
             println!("{}", serde_json::to_string_pretty(&statuses)?);
         } else {
             let multi = statuses.len() > 1;
-            if verbose {
+            if oneline {
+                display_ci_oneline(repo, &statuses, current, stack);
+            } else if verbose {
                 display_ci_compact(repo, &statuses, current, multi);
             } else {
                 display_ci_verbose(repo, &statuses, current, multi);
@@ -1686,6 +1863,7 @@ mod tests {
             check_runs,
             pr_number: Some(123),
             pr_is_draft: None,
+            pr_title: None,
         }
     }
 
@@ -1940,6 +2118,7 @@ mod tests {
             }],
             pr_number: Some(42),
             pr_is_draft: None,
+            pr_title: None,
         };
 
         let json = serde_json::to_string(&status).unwrap();
@@ -1961,6 +2140,7 @@ mod tests {
             check_runs: vec![],
             pr_number: None,
             pr_is_draft: None,
+            pr_title: None,
         };
 
         let json = serde_json::to_string(&status).unwrap();
@@ -2302,5 +2482,129 @@ mod tests {
             assert_eq!(statuses[0].pr_number, None);
             assert_eq!(statuses[0].pr_is_draft, None);
         });
+    }
+
+    #[test]
+    fn oneline_summary_all_passed() {
+        let status = test_branch_status(
+            "success",
+            vec![
+                test_check("build", "completed", Some("success")),
+                test_check("test", "completed", Some("success")),
+            ],
+        );
+        assert_eq!(oneline_check_summary(&status), "2 checks");
+    }
+
+    #[test]
+    fn oneline_summary_counts_failures() {
+        let status = test_branch_status(
+            "failure",
+            vec![
+                test_check("build", "completed", Some("success")),
+                test_check("test", "completed", Some("failure")),
+                test_check("lint", "completed", Some("timed_out")),
+            ],
+        );
+        assert_eq!(oneline_check_summary(&status), "2 failing");
+    }
+
+    #[test]
+    fn oneline_summary_running_shows_progress() {
+        let status = test_branch_status(
+            "pending",
+            vec![
+                test_check("build", "completed", Some("success")),
+                test_check("test", "in_progress", None),
+                test_check("lint", "queued", None),
+            ],
+        );
+        assert_eq!(oneline_check_summary(&status), "1/3 running");
+    }
+
+    #[test]
+    fn oneline_summary_no_ci() {
+        let status = test_branch_status("", vec![]);
+        assert_eq!(oneline_check_summary(&status), "no CI");
+    }
+
+    #[test]
+    fn truncate_title_short_unchanged() {
+        assert_eq!(truncate_title("short", 10), "short");
+    }
+
+    #[test]
+    fn truncate_title_exact_width_unchanged() {
+        assert_eq!(truncate_title("abcde", 5), "abcde");
+    }
+
+    #[test]
+    fn truncate_title_long_gets_ellipsis() {
+        assert_eq!(truncate_title("abcdefghij", 5), "abcd…");
+    }
+
+    #[test]
+    fn truncate_title_zero_width_empty() {
+        assert_eq!(truncate_title("abc", 0), "");
+    }
+
+    #[test]
+    fn truncate_title_counts_unicode_chars() {
+        // 5 visible chars, width 5 -> unchanged
+        assert_eq!(truncate_title("café!", 5), "café!");
+    }
+
+    #[test]
+    fn oneline_row_includes_branch_pr_title_and_summary() {
+        let mut status = test_branch_status(
+            "success",
+            vec![test_check("build", "completed", Some("success"))],
+        );
+        status.pr_title = Some("Add the feature".to_string());
+        let row = oneline_row(&status, false, 10, 8, 30, Some("4m"));
+        assert!(row.contains("feature")); // branch name is "feature"
+        assert!(row.contains("#123"));
+        assert!(row.contains("Add the feature"));
+        assert!(row.contains("1 checks"));
+        assert!(row.contains("4m"));
+    }
+
+    #[test]
+    fn oneline_row_truncates_long_title() {
+        let mut status = test_branch_status(
+            "success",
+            vec![test_check("build", "completed", Some("success"))],
+        );
+        status.pr_title = Some("This is a very long pull request title".to_string());
+        let row = oneline_row(&status, false, 7, 5, 10, None);
+        assert!(row.contains("…"));
+        assert!(!row.contains("very long pull request title"));
+    }
+
+    #[test]
+    fn oneline_row_without_pr_omits_hash() {
+        let mut status = test_branch_status(
+            "success",
+            vec![test_check("build", "completed", Some("success"))],
+        );
+        status.pr_number = None;
+        status.pr_title = None;
+        let row = oneline_row(&status, false, 7, 0, 10, None);
+        assert!(!row.contains('#'));
+    }
+
+    #[test]
+    fn oneline_row_pads_branch_to_visible_width() {
+        colored::control::set_override(false);
+        let mut status = test_branch_status(
+            "success",
+            vec![test_check("build", "completed", Some("success"))],
+        );
+        status.branch = "abc".to_string();
+        status.pr_title = Some("T".to_string());
+        let row = oneline_row(&status, false, 8, 6, 10, None);
+        colored::control::unset_override();
+        // "abc" padded to width 8 = "abc" + 5 spaces
+        assert!(row.contains("abc     "));
     }
 }

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -802,12 +802,18 @@ fn print_multi_branch_header(statuses: &[BranchCiStatus]) {
     println!("CI  {}", parts.join("  "));
 }
 
-/// One-line counts summary for the `--oneline` view.
-///
-/// Returns `"no CI"`, `"<n> failing"`, `"<done>/<total> running"`, or `"<n> checks"`.
-fn oneline_check_summary(status: &BranchCiStatus) -> String {
+/// Roll-up state of a branch's CI for the `--oneline` view.
+enum CiRollup {
+    NoCi,
+    Failing(usize),
+    Running { done: usize, total: usize },
+    Passing(usize),
+}
+
+/// Collapse a branch's check runs into a single roll-up state.
+fn ci_rollup(status: &BranchCiStatus) -> CiRollup {
     if status.check_runs.is_empty() {
-        return "no CI".to_string();
+        return CiRollup::NoCi;
     }
     let total = status.check_runs.len();
     let failed = status
@@ -822,17 +828,29 @@ fn oneline_check_summary(status: &BranchCiStatus) -> String {
         })
         .count();
     if failed > 0 {
-        return format!("{} failing", failed);
+        return CiRollup::Failing(failed);
     }
-    let completed = status
+    let done = status
         .check_runs
         .iter()
         .filter(|c| c.status == "completed")
         .count();
-    if completed < total {
-        return format!("{}/{} running", completed, total);
+    if done < total {
+        return CiRollup::Running { done, total };
     }
-    format!("{} checks", total)
+    CiRollup::Passing(total)
+}
+
+/// One-line counts summary for the `--oneline` view.
+///
+/// Returns `"no CI"`, `"<n> failing"`, `"<done>/<total> running"`, or `"<n> checks"`.
+fn oneline_check_summary(status: &BranchCiStatus) -> String {
+    match ci_rollup(status) {
+        CiRollup::NoCi => "no CI".to_string(),
+        CiRollup::Failing(n) => format!("{} failing", n),
+        CiRollup::Running { done, total } => format!("{}/{} running", done, total),
+        CiRollup::Passing(n) => format!("{} checks", n),
+    }
 }
 
 /// Colored overall-status icon for the `--oneline` view.
@@ -859,11 +877,13 @@ fn oneline_row(
 ) -> String {
     let icon = oneline_overall_icon(status);
 
+    // Branch column: cyan, bold for the current branch. Pad on plain text so
+    // ANSI codes don't skew alignment.
     let branch_padded = format!("{:<width$}", status.branch, width = branch_w);
     let branch_cell = if is_current {
-        branch_padded.bold()
+        branch_padded.cyan().bold()
     } else {
-        branch_padded.normal()
+        branch_padded.cyan()
     };
 
     let pr_str = status
@@ -872,24 +892,34 @@ fn oneline_row(
         .unwrap_or_default();
     let pr_cell = format!("{:<width$}", pr_str, width = pr_w).bright_magenta();
 
+    // Title column: the current branch's title stands out in bold white.
     let title = status.pr_title.as_deref().unwrap_or("");
     let title_trunc = truncate_title(title, title_w);
     let title_pad = title_w.saturating_sub(title_trunc.chars().count());
-    let title_cell = format!("{}{}", title_trunc, " ".repeat(title_pad));
+    let title_cell = if is_current {
+        format!("{}{}", title_trunc.bold().white(), " ".repeat(title_pad))
+    } else {
+        format!("{}{}", title_trunc.white(), " ".repeat(title_pad))
+    };
 
+    // Trailing summary: colored by roll-up state, with dimmed timing.
     let summary = oneline_check_summary(status);
+    let summary_cell = match ci_rollup(status) {
+        CiRollup::NoCi => summary.dimmed(),
+        CiRollup::Failing(_) => summary.red().bold(),
+        CiRollup::Running { .. } => summary.yellow(),
+        CiRollup::Passing(_) => summary.green(),
+    };
     let trailing = match timing {
-        Some(t) if !t.is_empty() => format!("{} · {}", summary, t),
-        _ => summary,
+        Some(t) if !t.is_empty() => {
+            format!("{} {} {}", summary_cell, "·".dimmed(), t.dimmed())
+        }
+        _ => summary_cell.to_string(),
     };
 
     format!(
         "{}  {}  {}  {}  {}",
-        icon,
-        branch_cell,
-        pr_cell,
-        title_cell,
-        trailing.dimmed()
+        icon, branch_cell, pr_cell, title_cell, trailing
     )
 }
 

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -370,15 +370,10 @@ pub fn run(
     }
 
     let multi = statuses.len() > 1;
-    if oneline {
-        // --oneline: one compact line per branch across the stack
-        display_ci_oneline(&repo, &statuses, &current, &stack_data);
-    } else if verbose {
-        // --verbose: compact cards view
-        display_ci_compact(&repo, &statuses, &current, multi);
-    } else {
-        // default: full per-check table
-        display_ci_verbose(&repo, &statuses, &current, multi);
+    match ci_view_mode(oneline, verbose, multi) {
+        CiView::Oneline => display_ci_oneline(&repo, &statuses, &current, &stack_data),
+        CiView::Cards => display_ci_compact(&repo, &statuses, &current, multi),
+        CiView::Table => display_ci_verbose(&repo, &statuses, &current, multi),
     }
     record_ci_history(&repo, &statuses);
 
@@ -853,6 +848,40 @@ fn oneline_check_summary(status: &BranchCiStatus) -> String {
     }
 }
 
+/// Which renderer `stax ci` should use for a given run.
+enum CiView {
+    /// Full per-check table (single branch, no flags).
+    Table,
+    /// Grouped failed/running/passed summary cards (`--verbose`).
+    Cards,
+    /// One compact line per branch (`--oneline`, or any multi-branch view).
+    Oneline,
+}
+
+/// Decide the render mode. `--verbose` always wins for cards; otherwise the
+/// oneline roll-up is used for the `--oneline` flag or any multi-branch view,
+/// leaving the detailed table only for a single branch.
+fn ci_view_mode(oneline: bool, verbose: bool, multi: bool) -> CiView {
+    if verbose {
+        CiView::Cards
+    } else if oneline || multi {
+        CiView::Oneline
+    } else {
+        CiView::Table
+    }
+}
+
+/// Review-state label for the `--oneline` view: `"draft"`, `"ready"`, or `""`.
+///
+/// Empty when the branch has no PR, or when the draft state is unknown.
+fn oneline_review_label(status: &BranchCiStatus) -> &'static str {
+    match (status.pr_number, status.pr_is_draft) {
+        (Some(_), Some(true)) => "draft",
+        (Some(_), Some(false)) => "ready",
+        _ => "",
+    }
+}
+
 /// Colored overall-status icon for the `--oneline` view.
 fn oneline_overall_icon(status: &BranchCiStatus) -> colored::ColoredString {
     match status.overall_status.as_deref() {
@@ -872,6 +901,7 @@ fn oneline_row(
     is_current: bool,
     branch_w: usize,
     pr_w: usize,
+    state_w: usize,
     title_w: usize,
     timing: Option<&str>,
 ) -> String {
@@ -891,6 +921,21 @@ fn oneline_row(
         .map(|n| format!("#{}", n))
         .unwrap_or_default();
     let pr_cell = format!("{:<width$}", pr_str, width = pr_w).bright_magenta();
+
+    // Review-state column: dim "draft", green "ready"; omitted when no row has
+    // a PR (state_w == 0). Padded on plain text before coloring.
+    let state_cell = if state_w > 0 {
+        let label = oneline_review_label(status);
+        let padded = format!("{:<width$}", label, width = state_w);
+        let colored = match label {
+            "draft" => padded.dimmed(),
+            "ready" => padded.green(),
+            _ => padded.normal(),
+        };
+        Some(colored.to_string())
+    } else {
+        None
+    };
 
     // Title column: the current branch's title stands out in bold white.
     let title = status.pr_title.as_deref().unwrap_or("");
@@ -917,10 +962,17 @@ fn oneline_row(
         _ => summary_cell.to_string(),
     };
 
-    format!(
-        "{}  {}  {}  {}  {}",
-        icon, branch_cell, pr_cell, title_cell, trailing
-    )
+    let mut cells = vec![
+        icon.to_string(),
+        branch_cell.to_string(),
+        pr_cell.to_string(),
+    ];
+    if let Some(state) = state_cell {
+        cells.push(state);
+    }
+    cells.push(title_cell);
+    cells.push(trailing);
+    cells.join("  ")
 }
 
 /// Visible terminal width, with a sane fallback when it can't be detected.
@@ -959,10 +1011,16 @@ fn display_ci_oneline(repo: &GitRepo, statuses: &[BranchCiStatus], current: &str
         .map(|s| s.pr_number.map(|n| format!("#{}", n).len()).unwrap_or(0))
         .max()
         .unwrap_or(0);
+    let state_w = ordered
+        .iter()
+        .map(|s| oneline_review_label(s).len())
+        .max()
+        .unwrap_or(0);
 
-    // Layout: icon(1) + 2 + branch + 2 + pr + 2 + title + 2 + summary budget.
+    // Layout: icon(1) + 2 + branch + 2 + pr + 2 + [state + 2] + title + 2 + summary.
     const SUMMARY_BUDGET: usize = 24;
-    let fixed = 1 + 2 + branch_w + 2 + pr_w + 2 + 2 + SUMMARY_BUDGET;
+    let state_extra = if state_w > 0 { state_w + 2 } else { 0 };
+    let fixed = 1 + 2 + branch_w + 2 + pr_w + 2 + state_extra + 2 + SUMMARY_BUDGET;
     let title_w = terminal_width().saturating_sub(fixed).max(10);
 
     for status in ordered {
@@ -976,6 +1034,7 @@ fn display_ci_oneline(repo: &GitRepo, statuses: &[BranchCiStatus], current: &str
                 is_current,
                 branch_w,
                 pr_w,
+                state_w,
                 title_w,
                 timing.as_deref()
             )
@@ -1167,12 +1226,10 @@ fn run_watch_mode(
             println!("{}", serde_json::to_string_pretty(&statuses)?);
         } else {
             let multi = statuses.len() > 1;
-            if oneline {
-                display_ci_oneline(repo, &statuses, current, stack);
-            } else if verbose {
-                display_ci_compact(repo, &statuses, current, multi);
-            } else {
-                display_ci_verbose(repo, &statuses, current, multi);
+            match ci_view_mode(oneline, verbose, multi) {
+                CiView::Oneline => display_ci_oneline(repo, &statuses, current, stack),
+                CiView::Cards => display_ci_compact(repo, &statuses, current, multi),
+                CiView::Table => display_ci_verbose(repo, &statuses, current, multi),
             }
         }
 
@@ -2591,7 +2648,7 @@ mod tests {
             vec![test_check("build", "completed", Some("success"))],
         );
         status.pr_title = Some("Add the feature".to_string());
-        let row = oneline_row(&status, false, 10, 8, 30, Some("4m"));
+        let row = oneline_row(&status, false, 10, 8, 0, 30, Some("4m"));
         assert!(row.contains("feature")); // branch name is "feature"
         assert!(row.contains("#123"));
         assert!(row.contains("Add the feature"));
@@ -2606,7 +2663,7 @@ mod tests {
             vec![test_check("build", "completed", Some("success"))],
         );
         status.pr_title = Some("This is a very long pull request title".to_string());
-        let row = oneline_row(&status, false, 7, 5, 10, None);
+        let row = oneline_row(&status, false, 7, 5, 0, 10, None);
         assert!(row.contains("…"));
         assert!(!row.contains("very long pull request title"));
     }
@@ -2619,7 +2676,7 @@ mod tests {
         );
         status.pr_number = None;
         status.pr_title = None;
-        let row = oneline_row(&status, false, 7, 0, 10, None);
+        let row = oneline_row(&status, false, 7, 0, 0, 10, None);
         assert!(!row.contains('#'));
     }
 
@@ -2632,9 +2689,85 @@ mod tests {
         );
         status.branch = "abc".to_string();
         status.pr_title = Some("T".to_string());
-        let row = oneline_row(&status, false, 8, 6, 10, None);
+        let row = oneline_row(&status, false, 8, 6, 0, 10, None);
         colored::control::unset_override();
         // "abc" padded to width 8 = "abc" + 5 spaces
         assert!(row.contains("abc     "));
+    }
+
+    #[test]
+    fn view_mode_single_branch_defaults_to_table() {
+        assert!(matches!(ci_view_mode(false, false, false), CiView::Table));
+    }
+
+    #[test]
+    fn view_mode_multi_branch_defaults_to_oneline() {
+        assert!(matches!(ci_view_mode(false, false, true), CiView::Oneline));
+    }
+
+    #[test]
+    fn view_mode_verbose_gives_cards_even_when_multi() {
+        assert!(matches!(ci_view_mode(false, true, true), CiView::Cards));
+    }
+
+    #[test]
+    fn view_mode_oneline_flag_forces_oneline_when_single() {
+        assert!(matches!(ci_view_mode(true, false, false), CiView::Oneline));
+    }
+
+    #[test]
+    fn review_label_draft_pr() {
+        let mut s = test_branch_status("success", vec![]);
+        s.pr_number = Some(7);
+        s.pr_is_draft = Some(true);
+        assert_eq!(oneline_review_label(&s), "draft");
+    }
+
+    #[test]
+    fn review_label_ready_pr() {
+        let mut s = test_branch_status("success", vec![]);
+        s.pr_number = Some(7);
+        s.pr_is_draft = Some(false);
+        assert_eq!(oneline_review_label(&s), "ready");
+    }
+
+    #[test]
+    fn review_label_no_pr_is_empty() {
+        let mut s = test_branch_status("success", vec![]);
+        s.pr_number = None;
+        s.pr_is_draft = None;
+        assert_eq!(oneline_review_label(&s), "");
+    }
+
+    #[test]
+    fn review_label_unknown_draft_state_is_empty() {
+        let mut s = test_branch_status("success", vec![]);
+        s.pr_number = Some(7);
+        s.pr_is_draft = None;
+        assert_eq!(oneline_review_label(&s), "");
+    }
+
+    #[test]
+    fn oneline_row_shows_draft_label() {
+        let mut status = test_branch_status(
+            "success",
+            vec![test_check("build", "completed", Some("success"))],
+        );
+        status.pr_is_draft = Some(true);
+        status.pr_title = Some("WIP feature".to_string());
+        let row = oneline_row(&status, false, 10, 6, 5, 20, None);
+        assert!(row.contains("draft"));
+    }
+
+    #[test]
+    fn oneline_row_shows_ready_label() {
+        let mut status = test_branch_status(
+            "success",
+            vec![test_check("build", "completed", Some("success"))],
+        );
+        status.pr_is_draft = Some(false);
+        status.pr_title = Some("Done".to_string());
+        let row = oneline_row(&status, false, 10, 6, 5, 20, None);
+        assert!(row.contains("ready"));
     }
 }

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -238,6 +238,7 @@ fn load_ci_from_cache(git_dir: &std::path::Path, branches: &[String]) -> Vec<Bra
                     check_runs: vec![],
                     pr_number: None,
                     pr_is_draft,
+                    pr_title: None,
                 }
             })
         })


### PR DESCRIPTION
## Motivation

`st ci` had two modes — a full per-check table (default) and `-v/--verbose` summary cards — both multi-line per branch. There was no way to see the **whole stack at a glance**, one line per branch, the way a GitHub "Pull requests" list shows one row per PR.

## What this adds

A compact, one-line-per-branch CI roll-up, ordered base→tip:

```
CI  3 branches  ✓ 1 passing  ✗ 1 failing  ● 1 running

✓  feat/api-base        #115392  ready  Enable KSP2 for faster annotation     12 checks · 4m
✗  feat/reduce-memory   #115377  ready  Reduce Gradle local build memory       2 failing · 3m
●  feat/parallel-cache  #115389  draft  Enable parallel config cache           6/12 running · 2m
```

- **Layout**: CI status icon → branch (cyan, current bold) → `#PR` → review-state (`draft` dim / `ready` green) → PR title (white, truncated to terminal width) → trailing summary colored by state (red/yellow/green/dim) with dimmed timing.
- **Multi-branch defaults to oneline**: a single branch still shows the full per-check table; `--stack`/`--all` default to the roll-up. `-v/--verbose` still gives the grouped cards. `--oneline`/`-1` forces it explicitly (and defaults its scope to the current stack). The mode decision lives in a pure, tested `ci_view_mode()` helper used by both one-shot and `--watch`.
- **Data**: `BranchCiStatus` gains `pr_title`, sourced by swapping `get_pr` for `get_pr_with_head` — no extra API round-trip. Skipped in `--json` when absent.

## Tests

15 new unit tests: roll-up summary states, title truncation (incl. unicode), row formatting/alignment, the `draft`/`ready` label, and view-mode selection. Design spec: `docs/superpowers/specs/2026-05-28-ci-oneline-mode-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
