### PR TITLE
Add get command for remote branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ st config --set-ai
 | `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
+| `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax, and check it out |
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--remote`, `--all`) |
 | `st ci` / `st ci --oneline` | CI status — full per-check table, or one compact line per branch across the stack (multi-branch defaults to the roll-up) |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -12,6 +12,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
+| `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax, and check it out |
 
 If you discover a hotfix while working upstack, keep the edits in place:
 

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -12,6 +12,7 @@
 | `st trunk <branch>` | Set trunk to `<branch>` |
 | `st prev` | Toggle to previous branch |
 | `st co` | Interactive branch picker |
+| `st get <branch>` | Fetch, checkout, and track a remote branch |
 
 ## Checkout shortcuts
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -52,6 +52,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st create <name>` | `c`, `add`, `bc` | Create stacked branch (TTY menu when nothing staged and `-m`) |
 | `st create --ai` | | Generate a branch name from local changes (`-a` also generates a first commit message) |
 | `st create <name> --below` | | Insert a new branch below current |
+| `st get <branch>` | | Fetch, checkout, and track a remote branch |
 | `st modify` | `m` | Amend staged changes into current commit (`-a` stages all, `-r` restacks after) |
 | `st rename` | | Rename current branch |
 | `st branch track` | | Track an existing branch |
@@ -268,6 +269,12 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 ### `st checkout`
 
 - `--trunk` / `--parent` / `--child 1`
+
+### `st get`
+
+- `--parent <branch>` records a non-trunk parent in stax metadata
+- `--no-checkout` fetches and tracks without switching branches
+- `--force` resets an existing divergent local branch to the remote tip
 
 ### `st ci`
 

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -24,6 +24,7 @@ st status   # your existing stack appears immediately
 | `fp bc` | `gt create` | `st create` · `st bc` |
 | — | `gt create --insert` | `st create --insert` |
 | — | — | `st create --below` |
+| — | `gt get` | `st get` |
 | `fp bco` | `gt checkout` | `st checkout` · `st co` |
 | `fp bu` | `gt up` | `st up` · `st bu` |
 | `fp bd` | `gt down` | `st down` · `st bd` |

--- a/skills.md
+++ b/skills.md
@@ -29,6 +29,7 @@ stax sync|rs                   # Sync trunk + clean merged branches
 stax restack                   # Rebase branch/stack onto parents
 stax cascade                   # Restack bottom-up and submit updates
 
+stax get <branch>              # Fetch, checkout, and track remote branch
 stax checkout|co|bco           # Checkout branch (interactive by default)
 stax trunk|t                   # Checkout trunk
 stax trunk <branch>            # Set trunk branch
@@ -268,6 +269,9 @@ stax top                           # Tip of current stack
 stax bottom                        # Base branch above trunk
 stax p                             # Previous branch
 
+stax get teammate-branch           # Fetch remote branch, track under trunk, checkout
+stax get teammate-branch --parent base-branch  # Track fetched branch under explicit parent
+stax get teammate-branch --no-checkout  # Fetch and track without switching branches
 stax branch track --parent main    # Track existing branch under parent
 stax branch track --all-prs        # Import your open PRs
 stax branch untrack <branch>       # Remove stax metadata only

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -482,6 +482,21 @@ pub(crate) enum Commands {
         shell_output: bool,
     },
 
+    /// Fetch, checkout, and track a remote branch
+    Get {
+        /// Remote branch name to fetch
+        branch: String,
+        /// Parent branch to record in stax metadata (defaults to trunk)
+        #[arg(short, long)]
+        parent: Option<String>,
+        /// Fetch and track without checking out the branch
+        #[arg(long)]
+        no_checkout: bool,
+        /// Reset an existing local branch to the remote tip
+        #[arg(short, long)]
+        force: bool,
+    },
+
     /// Continue after resolving conflicts
     #[command(visible_alias = "cont")]
     Continue,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -359,6 +359,12 @@ pub fn run() -> Result<()> {
             child,
             shell_output,
         } => commands::checkout::run(branch, pr, trunk, parent, child, shell_output),
+        Commands::Get {
+            branch,
+            parent,
+            no_checkout,
+            force,
+        } => commands::get::run(branch, parent, no_checkout, force),
         Commands::Continue => commands::continue_cmd::run_and_resume_restack(),
         Commands::Resolve {
             agent,

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,0 +1,234 @@
+use crate::commands::checkout;
+use crate::config::Config;
+use crate::engine::BranchMetadata;
+use crate::git::GitRepo;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::Path;
+use std::process::Command;
+
+pub fn run(branch: String, parent: Option<String>, no_checkout: bool, force: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let workdir = repo.workdir()?.to_path_buf();
+    let config = Config::load()?;
+    let remote = config.remote_name().to_string();
+    let branch = normalize_remote_branch(&branch, &remote)?;
+    let trunk = repo.trunk_branch()?;
+    let parent_branch = parent.unwrap_or_else(|| trunk.clone());
+
+    if branch == trunk {
+        anyhow::bail!(
+            "'{}' is the trunk branch and cannot be tracked. Use {} to checkout trunk.",
+            branch,
+            "stax trunk".cyan()
+        );
+    }
+
+    if repo.branch_commit(&parent_branch).is_err() {
+        anyhow::bail!("Parent branch '{}' does not exist locally.", parent_branch);
+    }
+
+    println!(
+        "{} {} from {}...",
+        "Fetching".blue().bold(),
+        branch.cyan(),
+        remote.cyan()
+    );
+    fetch_remote_branch(&workdir, &remote, &branch)?;
+
+    let remote_ref = format!("{}/{}", remote, branch);
+    let remote_sha = rev_parse(&workdir, &remote_ref)?;
+    let local_exists = local_branch_exists(&workdir, &branch)?;
+
+    if local_exists {
+        let local_sha = rev_parse(&workdir, &branch)?;
+        if local_sha != remote_sha {
+            if !force {
+                anyhow::bail!(
+                    "Local branch '{}' already exists and differs from '{}'.\n\
+                     Re-run with {} to reset the local branch to the remote tip.",
+                    branch,
+                    remote_ref,
+                    "--force".cyan()
+                );
+            }
+            force_update_local_branch(&workdir, &branch, &remote_ref)?;
+            println!(
+                "{} {} to {}.",
+                "Reset".yellow().bold(),
+                branch.cyan(),
+                remote_ref.cyan()
+            );
+        }
+        set_upstream(&workdir, &branch, &remote_ref)?;
+    } else {
+        create_tracking_branch(&workdir, &branch, &remote_ref)?;
+        println!(
+            "{} {} tracking {}.",
+            "Created".green().bold(),
+            branch.cyan(),
+            remote_ref.cyan()
+        );
+    }
+
+    let repo = GitRepo::open()?;
+    write_tracking_metadata(&repo, &branch, &parent_branch)?;
+
+    if no_checkout {
+        println!(
+            "{} {} with parent {}.",
+            "Tracked".green().bold(),
+            branch.cyan(),
+            parent_branch.cyan()
+        );
+    } else {
+        checkout::run(Some(branch), None, false, false, None, false)?;
+    }
+
+    Ok(())
+}
+
+fn normalize_remote_branch(branch: &str, remote: &str) -> Result<String> {
+    let trimmed = branch.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Branch name cannot be empty.");
+    }
+
+    if let Some(local) = trimmed.strip_prefix(&format!("{remote}/")) {
+        if local.is_empty() {
+            anyhow::bail!("Branch name cannot be empty.");
+        }
+        return Ok(local.to_string());
+    }
+
+    if trimmed.starts_with("refs/") {
+        anyhow::bail!("Pass a branch name, not a full ref: '{}'.", branch);
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn write_tracking_metadata(repo: &GitRepo, branch: &str, parent_branch: &str) -> Result<()> {
+    if let Some(existing) = BranchMetadata::read(repo.inner(), branch)? {
+        if existing.parent_branch_name != parent_branch {
+            anyhow::bail!(
+                "Branch '{}' is already tracked with parent '{}'.\n\
+                 Use {} to change its parent.",
+                branch,
+                existing.parent_branch_name,
+                "stax branch reparent".cyan()
+            );
+        }
+        return Ok(());
+    }
+
+    let parent_rev = repo
+        .merge_base(parent_branch, branch)
+        .or_else(|_| repo.branch_commit(parent_branch))?;
+    let meta = BranchMetadata::new(parent_branch, &parent_rev);
+    meta.write(repo.inner(), branch)?;
+    Ok(())
+}
+
+fn fetch_remote_branch(workdir: &Path, remote: &str, branch: &str) -> Result<()> {
+    let refspec = format!("refs/heads/{branch}:refs/remotes/{remote}/{branch}");
+    let output = Command::new("git")
+        .args(["fetch", "--no-tags", remote, &refspec])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to run git fetch {}", remote))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    anyhow::bail!(
+        "Remote branch '{}' was not found on '{}'.\n\ngit stderr:\n{}",
+        branch,
+        remote,
+        stderr.trim()
+    );
+}
+
+fn create_tracking_branch(workdir: &Path, branch: &str, remote_ref: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["branch", "--track", branch, remote_ref])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to create local branch '{}'", branch))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    anyhow::bail!(
+        "Failed to create local tracking branch '{}': {}",
+        branch,
+        stderr.trim()
+    );
+}
+
+fn force_update_local_branch(workdir: &Path, branch: &str, remote_ref: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["branch", "--force", branch, remote_ref])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to reset local branch '{}'", branch))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    anyhow::bail!(
+        "Failed to reset local branch '{}': {}",
+        branch,
+        stderr.trim()
+    );
+}
+
+fn set_upstream(workdir: &Path, branch: &str, remote_ref: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["branch", "--set-upstream-to", remote_ref, branch])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to set upstream for '{}'", branch))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    anyhow::bail!("Failed to set upstream for '{}': {}", branch, stderr.trim());
+}
+
+fn local_branch_exists(workdir: &Path, branch: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ])
+        .current_dir(workdir)
+        .output()
+        .context("Failed to inspect local branches")?;
+    Ok(output.status.success())
+}
+
+fn rev_parse(workdir: &Path, rev: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", rev])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to resolve '{}'", rev))?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8(output.stdout)?.trim().to_string());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    anyhow::bail!("Failed to resolve '{}': {}", rev, stderr.trim());
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod doctor;
 pub mod draft;
 pub mod edit;
 pub mod generate;
+pub mod get;
 pub(crate) mod github_list;
 pub mod init;
 pub mod issue;

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -82,6 +82,19 @@ fn test_checkout_trunk_full_command() {
     assert_eq!(repo.current_branch(), "main");
 }
 
+#[test]
+fn test_get_help() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["get", "--help"]);
+    output
+        .assert_success()
+        .assert_stdout_contains("remote branch")
+        .assert_stdout_contains("--parent")
+        .assert_stdout_contains("--no-checkout")
+        .assert_stdout_contains("--force");
+}
+
 // =============================================================================
 // Sync Command Tests
 // =============================================================================

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -1,0 +1,177 @@
+//! Integration tests for `stax get`.
+
+mod common;
+
+use common::{OutputAssertions, TestRepo};
+
+fn push_remote_only_branch_from(
+    repo: &TestRepo,
+    branch: &str,
+    base: &str,
+    file: &str,
+    content: &str,
+) -> String {
+    repo.git(&["checkout", "-B", branch, base]).assert_success();
+    repo.create_file(file, content);
+    repo.commit(&format!("Commit {}", branch));
+    let sha = repo.head_sha();
+    repo.git(&["push", "-u", "origin", branch]).assert_success();
+    repo.git(&["checkout", "main"]).assert_success();
+    repo.git(&["branch", "-D", branch]).assert_success();
+    sha
+}
+
+fn push_remote_only_branch(repo: &TestRepo, branch: &str, file: &str, content: &str) -> String {
+    push_remote_only_branch_from(repo, branch, "main", file, content)
+}
+
+fn parent_for(repo: &TestRepo, branch: &str) -> Option<String> {
+    let json = repo.get_status_json();
+    json["branches"]
+        .as_array()
+        .and_then(|branches| {
+            branches
+                .iter()
+                .find(|entry| entry["name"].as_str() == Some(branch))
+        })
+        .and_then(|entry| entry["parent"].as_str())
+        .map(ToString::to_string)
+}
+
+#[test]
+fn get_fetches_remote_only_branch_and_tracks_it() {
+    let repo = TestRepo::new_with_remote();
+    let remote_sha = push_remote_only_branch(
+        &repo,
+        "remote-feature",
+        "remote.txt",
+        "remote branch content\n",
+    );
+
+    let out = repo.run_stax(&["get", "remote-feature"]);
+    out.assert_success()
+        .assert_stdout_contains("Created")
+        .assert_stdout_contains("remote-feature");
+
+    assert_eq!(repo.current_branch(), "remote-feature");
+    assert_eq!(repo.get_commit_sha("remote-feature"), remote_sha);
+    assert_eq!(repo.get_commit_sha("origin/remote-feature"), remote_sha);
+    assert_eq!(parent_for(&repo, "remote-feature").as_deref(), Some("main"));
+
+    repo.git(&["config", "branch.remote-feature.remote"])
+        .assert_success()
+        .assert_stdout_contains("origin");
+    repo.git(&["config", "branch.remote-feature.merge"])
+        .assert_success()
+        .assert_stdout_contains("refs/heads/remote-feature");
+}
+
+#[test]
+fn get_can_track_without_checkout_under_explicit_parent() {
+    let repo = TestRepo::new_with_remote();
+    let parent = repo.create_stack(&["review-base"]).remove(0);
+    repo.git(&["checkout", "main"]).assert_success();
+    let remote_sha = push_remote_only_branch_from(
+        &repo,
+        "remote-child",
+        &parent,
+        "child.txt",
+        "child branch content\n",
+    );
+
+    let out = repo.run_stax(&["get", "remote-child", "--parent", &parent, "--no-checkout"]);
+    out.assert_success()
+        .assert_stdout_contains("Tracked")
+        .assert_stdout_contains("remote-child");
+
+    assert_eq!(repo.current_branch(), "main");
+    assert_eq!(repo.get_commit_sha("remote-child"), remote_sha);
+    assert_eq!(
+        parent_for(&repo, "remote-child").as_deref(),
+        Some(parent.as_str())
+    );
+}
+
+#[test]
+fn get_accepts_remote_qualified_branch_name() {
+    let repo = TestRepo::new_with_remote();
+    let remote_sha = push_remote_only_branch(
+        &repo,
+        "qualified-feature",
+        "qualified.txt",
+        "qualified branch content\n",
+    );
+
+    let out = repo.run_stax(&["get", "origin/qualified-feature", "--no-checkout"]);
+    out.assert_success();
+
+    assert_eq!(repo.current_branch(), "main");
+    assert_eq!(repo.get_commit_sha("qualified-feature"), remote_sha);
+    assert_eq!(
+        parent_for(&repo, "qualified-feature").as_deref(),
+        Some("main")
+    );
+}
+
+#[test]
+fn get_missing_remote_branch_fails_clearly() {
+    let repo = TestRepo::new_with_remote();
+
+    let out = repo.run_stax(&["get", "does-not-exist"]);
+    out.assert_failure();
+
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("Remote branch 'does-not-exist' was not found"),
+        "expected missing-branch error, got:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn get_refuses_to_overwrite_divergent_local_branch_without_force() {
+    let repo = TestRepo::new_with_remote();
+    let remote_sha =
+        push_remote_only_branch(&repo, "divergent-feature", "remote.txt", "remote content\n");
+
+    repo.git(&["checkout", "-b", "divergent-feature", "main"])
+        .assert_success();
+    repo.create_file("local.txt", "local content\n");
+    repo.commit("Local divergent commit");
+    let local_sha = repo.head_sha();
+    repo.git(&["checkout", "main"]).assert_success();
+
+    let out = repo.run_stax(&["get", "divergent-feature", "--no-checkout"]);
+    out.assert_failure();
+
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("already exists and differs"),
+        "expected divergent-branch error, got:\n{}",
+        stderr
+    );
+    assert_eq!(repo.get_commit_sha("divergent-feature"), local_sha);
+    assert_ne!(repo.get_commit_sha("divergent-feature"), remote_sha);
+}
+
+#[test]
+fn get_force_resets_divergent_local_branch() {
+    let repo = TestRepo::new_with_remote();
+    let remote_sha =
+        push_remote_only_branch(&repo, "force-feature", "remote.txt", "remote content\n");
+
+    repo.git(&["checkout", "-b", "force-feature", "main"])
+        .assert_success();
+    repo.create_file("local.txt", "local content\n");
+    repo.commit("Local divergent commit");
+    repo.git(&["checkout", "main"]).assert_success();
+
+    let out = repo.run_stax(&["get", "force-feature", "--force", "--no-checkout"]);
+    out.assert_success()
+        .assert_stdout_contains("Reset")
+        .assert_stdout_contains("Tracked");
+
+    assert_eq!(repo.current_branch(), "main");
+    assert_eq!(repo.get_commit_sha("force-feature"), remote_sha);
+    assert_eq!(parent_for(&repo, "force-feature").as_deref(), Some("main"));
+}


### PR DESCRIPTION
## Summary

- add top-level `stax get <branch>` to fetch a configured-remote branch, create/update the local upstream-tracking branch, write stax metadata, and check it out by default
- support `--parent`, `--no-checkout`, `--force`, and remote-qualified branch names like `origin/feature`
- document the new Graphite-parity workflow in README, docs, compatibility mapping, and `skills.md`

Closes #448

## Tests

- `cargo fmt -- --check`
- `cargo test --test get_tests`
- `cargo test --test command_coverage_tests`
- `make test`

## Notes

- Local native `cargo test --test cli_tests` still has two unrelated shell setup auth failures that reproduce when run individually; Docker `make test` passes the full suite.