### PR TITLE
chore(deps): bump git2 from 0.20 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -1797,9 +1797,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ vendored-openssl = ["git2/vendored-openssl"]
 clap = { version = "4", features = ["derive"] }
 
 # Git (no ssh — we use HTTPS + token auth exclusively)
-git2 = { version = "0.20", default-features = false, features = ["https"] }
+git2 = { version = "0.21", default-features = false, features = ["https"] }
 
 # GitHub API
 octocrab = "0.49"

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -101,7 +101,7 @@ pub fn list_metadata_branches(repo: &Repository) -> Result<Vec<String>> {
 
     for reference in repo.references_glob(&format!("{}*", METADATA_REF_PREFIX))? {
         let reference = reference?;
-        if let Some(name) = reference.name() {
+        if let Ok(name) = reference.name() {
             let branch = name.strip_prefix(METADATA_REF_PREFIX).unwrap_or(name);
             branches.push(branch.to_string());
         }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -420,7 +420,7 @@ impl GitRepo {
         let mut entries: Vec<(PathBuf, Option<String>, bool)> = vec![(main_path, None, false)];
 
         let worktree_names = self.repo.worktrees()?;
-        for name in worktree_names.iter().flatten() {
+        for name in worktree_names.iter().filter_map(|r| r.ok().flatten()) {
             let worktree = self.repo.find_worktree(name)?;
             let is_prunable = worktree.is_prunable(None).unwrap_or(false);
             let path = Self::normalize_path(worktree.path());
@@ -428,7 +428,7 @@ impl GitRepo {
                 repo.head()
                     .ok()
                     .filter(|head| head.is_branch())
-                    .and_then(|head| head.shorthand().map(str::to_string))
+                    .and_then(|head| head.shorthand().ok().map(str::to_string))
             });
             entries.push((path, branch, is_prunable));
         }
@@ -979,7 +979,7 @@ impl GitRepo {
         for oid in revwalk {
             let oid = oid?;
             if let Ok(commit) = self.repo.find_commit(oid) {
-                if let Some(msg) = commit.summary() {
+                if let Ok(Some(msg)) = commit.summary() {
                     commits.push(msg.to_string());
                 }
             }
@@ -1689,7 +1689,7 @@ Use --auto-stash-pop or stash/commit changes first.",
             // Max 5 commits
             let oid = oid?;
             let commit = self.repo.find_commit(oid)?;
-            let message = commit.summary().unwrap_or("").to_string();
+            let message = commit.summary().ok().flatten().unwrap_or("").to_string();
             let short_id = &oid.to_string()[..10];
             commits.push(CommitInfo {
                 short_hash: short_id.to_string(),
@@ -1865,7 +1865,7 @@ Use --auto-stash-pop or stash/commit changes first.",
             .context("Failed to glob remote refs")?;
         let mut names = HashSet::new();
         for r in refs.flatten() {
-            if let Some(name) = r.name() {
+            if let Ok(name) = r.name() {
                 if let Some(branch) = name.strip_prefix(&prefix) {
                     names.insert(branch.to_string());
                 }

--- a/src/tui/split/app.rs
+++ b/src/tui/split/app.rs
@@ -126,7 +126,7 @@ impl SplitApp {
             let oid = oid?;
             let commit = repo.inner().find_commit(oid)?;
             let short_sha = &oid.to_string()[..7];
-            let message = commit.summary().unwrap_or("").to_string();
+            let message = commit.summary().ok().flatten().unwrap_or("").to_string();
 
             commits.push(CommitDisplay {
                 sha: oid.to_string(),


### PR DESCRIPTION
## Summary

Replaces dependabot PR #456 with the required code adaptations for git2 0.21's API changes.

git2 0.21 swapped several method return types from `Option` to `Result`:

| Method | 0.20 | 0.21 |
|---|---|---|
| `Reference::name()` | `Option<&str>` | `Result<&str, Error>` |
| `Reference::shorthand()` | `Option<&str>` | `Result<&str, Error>` |
| `Commit::summary()` | `Option<&str>` | `Result<Option<&str>, Error>` |
| `StringArray` iter `Item` | `Option<&str>` | `Result<Option<&str>, Error>` |

Touched 3 source files (refs.rs, repo.rs, split/app.rs) — 9 call sites updated to match.

## Test plan

- [x] `cargo check` clean
- [x] `cargo check --tests` clean
- [x] `make test` — all 1767 tests pass
- [ ] CI green on this branch
- [ ] Close dependabot #456 once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)