### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/cesarferreira/stax/security/code-scanning/2](https://github.com/cesarferreira/stax/security/code-scanning/2)

Add an explicit top-level `permissions` block to `.github/workflows/rust-tests.yml` so all jobs inherit least-privilege token scopes by default.

Best fix here (without changing functionality): define workflow-level permissions as:

- `contents: read`

This is sufficient for `actions/checkout` and the shown test steps, and does not grant unnecessary write scopes.  
Edit region: near the top of `.github/workflows/rust-tests.yml`, directly after the `on:` trigger block (before `concurrency:` is a clean placement).

No imports, methods, or dependencies are needed—this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
