### PR TITLE
fix: replace stale `stax shell-setup --install` hints with `stax setup`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Test Command Policy
 
 - **AI agents:** for full-suite validation always run `make test`. On macOS this routes through Docker, which is the only sane way to run the entire integration suite — `cargo test` natively will be slow, flaky, and may exhaust file handles. Default to `make test` and only fall back to native runners when explicitly told to.
+- **Start Docker before running `make test`.** On macOS the Docker daemon is not always running; if `make test` fails with `failed to connect to the docker API at unix:///.../docker.sock`, ask the user to launch Docker Desktop (or run `open -a Docker`) and retry — do not silently fall back to `make test-native`.
 - Do not run the full suite via `cargo test` in this repo.
 - For full-suite validation, always use `make test`.
 - On macOS, `make test` intentionally routes to the Docker fast path.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM rust:1.95
+
+RUN cargo install cargo-nextest --locked
+
+WORKDIR /work

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ test-docker:
 		-w /work \
 		-e CARGO_HOME=/work/.docker-cache/cargo \
 		-v "$$(pwd)/.docker-cache/target:/work/target" \
-		rust:1.93 \
+		rust:1.95 \
 		bash -lc 'export PATH="$$CARGO_HOME/bin:/usr/local/cargo/bin:$$PATH"; if ! command -v cargo-nextest >/dev/null 2>&1; then cargo install cargo-nextest --locked; fi && cargo nextest run'
 
 # Run fast unit tests only

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -472,7 +472,7 @@ pub fn prompt_if_missing() -> Result<()> {
     eprintln!("{} Shell integration not detected.", "stax:".cyan().bold());
     eprintln!(
         "  Run {} for transparent worktree navigation (cd).",
-        "stax shell-setup --install".cyan()
+        "stax setup".cyan()
     );
     eprintln!();
 

--- a/src/commands/worktree/create.rs
+++ b/src/commands/worktree/create.rs
@@ -72,7 +72,7 @@ pub fn run(
                         "{}",
                         "Tip: add shell integration for automatic cd:".dimmed()
                     );
-                    println!("  {}", "stax shell-setup --install".cyan());
+                    println!("  {}", "stax setup".cyan());
                 }
             }
 
@@ -113,7 +113,7 @@ pub fn run(
                     "{}",
                     "Tip: add shell integration for automatic cd:".dimmed()
                 );
-                println!("  {}", "stax shell-setup --install".cyan());
+                println!("  {}", "stax setup".cyan());
             }
         }
         return Ok(());
@@ -192,7 +192,7 @@ pub fn run(
                 "{}",
                 "Tip: add shell integration for automatic cd:".dimmed()
             );
-            println!("  {}", "stax shell-setup --install".cyan());
+            println!("  {}", "stax setup".cyan());
         }
     }
 

--- a/src/commands/worktree/go.rs
+++ b/src/commands/worktree/go.rs
@@ -116,7 +116,7 @@ pub(crate) fn run_go_on_worktree(
                 "{}",
                 "Tip: add shell integration for automatic cd:".dimmed()
             );
-            println!("  {}", "stax shell-setup --install".cyan());
+            println!("  {}", "stax setup".cyan());
         }
     }
 

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -763,7 +763,7 @@ fn wt_create_without_shell_integration_suggests_install() {
         stdout
     );
     assert!(
-        stdout.contains("stax shell-setup --install"),
+        stdout.contains("stax setup"),
         "expected shell integration install hint, got:\n{}",
         stdout
     );
@@ -790,7 +790,7 @@ fn wt_go_without_shell_integration_suggests_install() {
         stdout
     );
     assert!(
-        stdout.contains("stax shell-setup --install"),
+        stdout.contains("stax setup"),
         "expected shell integration install hint, got:\n{}",
         stdout
     );


### PR DESCRIPTION
## Summary

- **Fixes #299**: replace 5 stale `stax shell-setup --install` hints (in `shell_setup.rs`, `worktree/go.rs`, `worktree/create.rs` ×3) with `stax setup`. The `--install` flag doesn't exist — only `--install-skills` does — so users who followed the hint hit `error: unexpected argument '--install' found` right after stax told them how to enable transparent `cd`. Updates the 2 worktree-CLI test assertions to match.
- **Docker test env**: bumps `make test-docker` from `rust:1.93` → `rust:1.95` to match the locally-installed toolchain, and adds a minimal `Dockerfile` (rust:1.95 + cargo-nextest) that captures the same env for future CI reuse. The Makefile still inlines the image for now so day-to-day usage is unchanged.
- **AGENTS.md**: notes that the Docker daemon must be running before `make test`, so agents stop silently falling back to native runs when the socket isn't available.

## Test plan

- [x] `cargo run -- setup` confirms `stax setup` is the working canonical command (the hint now points somewhere real).
- [x] `cargo test --test worktree_cli_tests suggests_install` — both hint-assertion tests pass.
- [x] `make test` on `rust:1.95` — full suite, 1767 tests, all green.
- [x] `grep -rn "shell-setup --install" src/ tests/ docs/ README.md` returns nothing.