### PR TITLE
chore: bump to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stax"
 version = "0.85.1"
-edition = "2021"
+edition = "2024"
 default-run = "stax"
 description = "Fast stacked Git branches and PRs"
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95
+FROM rust:latest
 
 RUN cargo install cargo-nextest --locked
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -36,9 +36,9 @@ fn interactive_terminal_requires_both_stdio_streams() {
 fn interactive_stdio_can_be_forced_for_tests() {
     #[cfg(debug_assertions)]
     {
-        std::env::set_var("STAX_TEST_FORCE_INTERACTIVE_TERMINAL", "1");
+        unsafe { std::env::set_var("STAX_TEST_FORCE_INTERACTIVE_TERMINAL", "1") };
         assert_eq!(detect_interactive_stdio(), (true, true));
-        std::env::remove_var("STAX_TEST_FORCE_INTERACTIVE_TERMINAL");
+        unsafe { std::env::remove_var("STAX_TEST_FORCE_INTERACTIVE_TERMINAL") };
     }
 }
 

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -197,7 +197,7 @@ fn load_commits(
     ];
 
     // Add path filter if specified
-    if let Some(ref p) = resolved_path {
+    if let Some(p) = &resolved_path {
         args.push("--".to_string());
         args.push(p.clone());
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -31,8 +31,8 @@ fn write_auth_config(
 
 fn restore_env_var(name: &str, value: Option<String>) {
     match value {
-        Some(value) => env::set_var(name, value),
-        None => env::remove_var(name),
+        Some(value) => unsafe { env::set_var(name, value) },
+        None => unsafe { env::remove_var(name) },
     }
 }
 
@@ -80,8 +80,8 @@ fn config_load_overlays_repo_stax_toml_when_present() {
     )
     .unwrap();
 
-    env::set_var("HOME", &home_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     Command::new("git")
         .arg("init")
         .current_dir(&repo_dir)
@@ -131,8 +131,8 @@ fn config_load_discovers_repo_stax_toml_from_nested_directory() {
     fs::write(global_config_dir.join("config.toml"), "[ui]\ntips = true\n").unwrap();
     fs::write(repo_dir.join("stax.toml"), "[ui]\ntips = false\n").unwrap();
 
-    env::set_var("HOME", &home_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     Command::new("git")
         .arg("init")
         .current_dir(&repo_dir)
@@ -163,8 +163,8 @@ fn config_path_uses_global_config_when_repo_local_config_is_absent() {
     fs::create_dir_all(&repo_dir).unwrap();
     fs::create_dir_all(&home_dir).unwrap();
 
-    env::set_var("HOME", &home_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     Command::new("git")
         .arg("init")
         .current_dir(&repo_dir)
@@ -206,8 +206,8 @@ fn config_path_env_override_wins_over_repo_local_config() {
     )
     .unwrap();
 
-    env::set_var("HOME", temp_dir.join("home"));
-    env::set_var("STAX_CONFIG_DIR", &override_config_dir);
+    unsafe { env::set_var("HOME", temp_dir.join("home")) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", &override_config_dir) };
     Command::new("git")
         .arg("init")
         .current_dir(&repo_dir)
@@ -244,8 +244,8 @@ fn config_load_ignores_old_repo_dot_config_path() {
     fs::create_dir_all(&home_dir).unwrap();
     fs::write(old_config_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
 
-    env::set_var("HOME", &home_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     Command::new("git")
         .arg("init")
         .current_dir(&repo_dir)
@@ -280,8 +280,8 @@ fn config_save_writes_global_config_when_repo_stax_toml_exists() {
     fs::create_dir_all(&home_dir).unwrap();
     fs::write(repo_dir.join("stax.toml"), "[ui]\ntips = false\n").unwrap();
 
-    env::set_var("HOME", &home_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     Command::new("git")
         .arg("init")
         .current_dir(&repo_dir)
@@ -649,13 +649,13 @@ fn test_token_priority_stax_env_first() {
     let temp_dir =
         std::env::temp_dir().join(format!("stax-test-stax-first-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
     write_auth_config(&temp_dir, false, true, None);
 
     // Set both env vars
-    env::set_var("STAX_GITHUB_TOKEN", "stax-token");
-    env::set_var("GITHUB_TOKEN", "github-token");
+    unsafe { env::set_var("STAX_GITHUB_TOKEN", "stax-token") };
+    unsafe { env::set_var("GITHUB_TOKEN", "github-token") };
 
     // STAX_GITHUB_TOKEN should take priority
     let token = Config::github_token();
@@ -663,18 +663,18 @@ fn test_token_priority_stax_env_first() {
 
     // Restore original values
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -691,31 +691,31 @@ fn test_github_token_env_ignored_by_default() {
     let temp_dir =
         std::env::temp_dir().join(format!("stax-test-env-ignored-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
     write_auth_config(&temp_dir, false, false, None);
 
     // Only set GITHUB_TOKEN
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::set_var("GITHUB_TOKEN", "github-token");
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::set_var("GITHUB_TOKEN", "github-token") };
 
     let token = Config::github_token();
     assert_eq!(token, None);
 
     // Restore original values
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -732,29 +732,29 @@ fn test_github_token_env_opt_in_fallback() {
     let temp_dir =
         std::env::temp_dir().join(format!("stax-test-env-opt-in-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
     write_auth_config(&temp_dir, false, true, None);
 
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::set_var("GITHUB_TOKEN", "github-token");
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::set_var("GITHUB_TOKEN", "github-token") };
 
     let token = Config::github_token();
     assert_eq!(token, Some("github-token".to_string()));
 
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -774,28 +774,28 @@ fn test_empty_stax_token_falls_back_to_credentials() {
     write_auth_config(&temp_dir, false, true, None);
     fs::write(config_dir.join(".credentials"), "file-token").unwrap();
 
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::set_var("STAX_GITHUB_TOKEN", "");
-    env::set_var("GITHUB_TOKEN", "github-token");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::set_var("STAX_GITHUB_TOKEN", "") };
+    unsafe { env::set_var("GITHUB_TOKEN", "github-token") };
 
     let token = Config::github_token();
     assert_eq!(token, Some("file-token".to_string()));
 
     // Restore original values
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -842,8 +842,8 @@ fn test_set_github_token_writes_to_file() {
     fs::create_dir_all(&temp_dir).unwrap();
 
     // Override HOME to use temp directory
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
 
     // Write token
     let test_token = "ghp_test_token_12345";
@@ -871,10 +871,10 @@ fn test_set_github_token_writes_to_file() {
 
     // Cleanup
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
 }
 
@@ -896,10 +896,10 @@ fn test_github_token_reads_from_credentials_file() {
     fs::write(config_dir.join(".credentials"), test_token).unwrap();
 
     // Override HOME and clear env vars
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::remove_var("GITHUB_TOKEN");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::remove_var("GITHUB_TOKEN") };
 
     // Read token - should come from file
     let token = Config::github_token();
@@ -907,18 +907,18 @@ fn test_github_token_reads_from_credentials_file() {
 
     // Cleanup
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -939,8 +939,8 @@ fn test_github_token_roundtrip() {
     fs::create_dir_all(&temp_dir).unwrap();
 
     // Override HOME
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
 
     // Write token
     let test_token = "ghp_roundtrip_token_abcdef";
@@ -953,10 +953,10 @@ fn test_github_token_roundtrip() {
 
     // Cleanup
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
 }
 
@@ -980,10 +980,10 @@ fn test_github_token_credentials_take_priority_over_env_when_enabled() {
     write_auth_config(&temp_dir, false, true, None);
 
     // Set HOME and env var
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::set_var("GITHUB_TOKEN", env_token);
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::set_var("GITHUB_TOKEN", env_token) };
 
     // Credentials file should take priority over ambient GITHUB_TOKEN
     let token = Config::github_token();
@@ -991,18 +991,18 @@ fn test_github_token_credentials_take_priority_over_env_when_enabled() {
 
     // Cleanup
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -1024,10 +1024,10 @@ fn test_github_token_trims_whitespace_from_file() {
     fs::write(config_dir.join(".credentials"), token_with_whitespace).unwrap();
 
     // Override HOME and clear env vars
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::remove_var("GITHUB_TOKEN");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::remove_var("GITHUB_TOKEN") };
 
     // Token should be trimmed
     let token = Config::github_token();
@@ -1035,18 +1035,18 @@ fn test_github_token_trims_whitespace_from_file() {
 
     // Cleanup
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -1064,37 +1064,37 @@ fn test_github_token_falls_back_to_gh_cli() {
         std::env::temp_dir().join(format!("stax-test-gh-fallback-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
     write_auth_config(&temp_dir, true, false, None);
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::remove_var("GITHUB_TOKEN");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::remove_var("GITHUB_TOKEN") };
 
     let mock_path = write_mock_gh(
         &temp_dir,
         "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  echo \"gh-cli-token\"\n  exit 0\nfi\nexit 1\n",
     );
-    env::set_var("PATH", mock_path);
+    unsafe { env::set_var("PATH", mock_path) };
 
     let token = Config::github_token();
     assert_eq!(token, Some("gh-cli-token".to_string()));
 
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_path {
-        Some(v) => env::set_var("PATH", v),
-        None => env::remove_var("PATH"),
+        Some(v) => unsafe { env::set_var("PATH", v) },
+        None => unsafe { env::remove_var("PATH") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -1112,34 +1112,34 @@ fn test_github_token_skips_gh_cli_when_disabled() {
         std::env::temp_dir().join(format!("stax-test-gh-disabled-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
     write_auth_config(&temp_dir, false, false, None);
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::remove_var("GITHUB_TOKEN");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::remove_var("GITHUB_TOKEN") };
 
     let mock_path = write_mock_gh(&temp_dir, "#!/bin/sh\necho \"gh-cli-token\"\n");
-    env::set_var("PATH", mock_path);
+    unsafe { env::set_var("PATH", mock_path) };
 
     let token = Config::github_token();
     assert_eq!(token, None);
 
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_path {
-        Some(v) => env::set_var("PATH", v),
-        None => env::remove_var("PATH"),
+        Some(v) => unsafe { env::set_var("PATH", v) },
+        None => unsafe { env::remove_var("PATH") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -1157,37 +1157,37 @@ fn test_github_token_passes_gh_hostname() {
         std::env::temp_dir().join(format!("stax-test-gh-hostname-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
     write_auth_config(&temp_dir, true, false, Some("github.example.com"));
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::remove_var("GITHUB_TOKEN");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::remove_var("GITHUB_TOKEN") };
 
     let mock_path = write_mock_gh(
         &temp_dir,
         "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ] && [ \"$3\" = \"--hostname\" ] && [ \"$4\" = \"github.example.com\" ]; then\n  echo \"gh-host-token\"\n  exit 0\nfi\nexit 1\n",
     );
-    env::set_var("PATH", mock_path);
+    unsafe { env::set_var("PATH", mock_path) };
 
     let token = Config::github_token();
     assert_eq!(token, Some("gh-host-token".to_string()));
 
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_path {
-        Some(v) => env::set_var("PATH", v),
-        None => env::remove_var("PATH"),
+        Some(v) => unsafe { env::set_var("PATH", v) },
+        None => unsafe { env::remove_var("PATH") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 
@@ -1205,34 +1205,34 @@ fn test_github_token_gh_failure_falls_back_to_opt_in_env() {
         std::env::temp_dir().join(format!("stax-test-gh-fallback-env-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
     write_auth_config(&temp_dir, true, true, None);
-    env::set_var("HOME", &temp_dir);
-    env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-    env::remove_var("STAX_GITHUB_TOKEN");
-    env::set_var("GITHUB_TOKEN", "env-token");
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::set_var("GITHUB_TOKEN", "env-token") };
 
     let mock_path = write_mock_gh(&temp_dir, "#!/bin/sh\nexit 1\n");
-    env::set_var("PATH", mock_path);
+    unsafe { env::set_var("PATH", mock_path) };
 
     let token = Config::github_token();
     assert_eq!(token, Some("env-token".to_string()));
 
     let _ = fs::remove_dir_all(&temp_dir);
-    env::remove_var("STAX_CONFIG_DIR");
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
     match orig_home {
-        Some(v) => env::set_var("HOME", v),
-        None => env::remove_var("HOME"),
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
     }
     match orig_path {
-        Some(v) => env::set_var("PATH", v),
-        None => env::remove_var("PATH"),
+        Some(v) => unsafe { env::set_var("PATH", v) },
+        None => unsafe { env::remove_var("PATH") },
     }
     match orig_stax {
-        Some(v) => env::set_var("STAX_GITHUB_TOKEN", v),
-        None => env::remove_var("STAX_GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
     }
     match orig_github {
-        Some(v) => env::set_var("GITHUB_TOKEN", v),
-        None => env::remove_var("GITHUB_TOKEN"),
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
     }
 }
 

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -720,7 +720,7 @@ mod tests {
     async fn test_list_open_prs_by_head() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -754,7 +754,7 @@ mod tests {
     async fn test_fetch_checks_maps_gitea_statuses() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -789,7 +789,7 @@ mod tests {
     async fn test_list_open_pull_requests() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -829,7 +829,7 @@ mod tests {
     async fn test_list_open_issues() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -862,7 +862,7 @@ mod tests {
     async fn test_get_current_user() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -882,7 +882,7 @@ mod tests {
     async fn test_get_user_open_prs_filters_by_author() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -924,7 +924,7 @@ mod tests {
     async fn test_get_recent_merged_prs() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -967,7 +967,7 @@ mod tests {
     async fn test_get_recent_opened_prs() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("Authorization", "token test-token"))
@@ -1010,7 +1010,7 @@ mod tests {
     async fn test_get_reviews_received() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITEA_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITEA_TOKEN", "test-token") };
 
         // Mock: user's open PRs
         Mock::given(method("GET"))

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -793,7 +793,7 @@ mod tests {
     async fn test_list_open_prs_by_head() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -829,7 +829,7 @@ mod tests {
     async fn test_fetch_checks_maps_gitlab_statuses() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -866,7 +866,7 @@ mod tests {
     async fn test_list_open_pull_requests() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -907,7 +907,7 @@ mod tests {
     async fn test_list_open_issues() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -941,7 +941,7 @@ mod tests {
     async fn test_get_current_user() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -962,7 +962,7 @@ mod tests {
     async fn test_get_user_open_prs() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -996,7 +996,7 @@ mod tests {
     async fn test_get_recent_merged_prs() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -1030,7 +1030,7 @@ mod tests {
     async fn test_get_recent_opened_prs() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         Mock::given(method("GET"))
             .and(header("PRIVATE-TOKEN", "test-token"))
@@ -1062,7 +1062,7 @@ mod tests {
     async fn test_get_reviews_received() {
         ensure_crypto_provider();
         let server = MockServer::start().await;
-        std::env::set_var("STAX_GITLAB_TOKEN", "test-token");
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
 
         // Mock: user's open MRs
         Mock::given(method("GET"))

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -542,8 +542,8 @@ mod tests {
 
     fn restore_env(var: &str, value: Option<String>) {
         match value {
-            Some(value) => env::set_var(var, value),
-            None => env::remove_var(var),
+            Some(value) => unsafe { env::set_var(var, value) },
+            None => unsafe { env::remove_var(var) },
         }
     }
 
@@ -603,11 +603,11 @@ mod tests {
             env::temp_dir().join(format!("stax-forge-token-gitlab-{}", std::process::id()));
         fs::create_dir_all(&temp_dir).unwrap();
 
-        env::set_var("HOME", &temp_dir);
-        env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-        env::remove_var("STAX_GITLAB_TOKEN");
-        env::remove_var("GITLAB_TOKEN");
-        env::remove_var("STAX_FORGE_TOKEN");
+        unsafe { env::set_var("HOME", &temp_dir) };
+        unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+        unsafe { env::remove_var("STAX_GITLAB_TOKEN") };
+        unsafe { env::remove_var("GITLAB_TOKEN") };
+        unsafe { env::remove_var("STAX_FORGE_TOKEN") };
 
         Config::set_github_token("saved-token").unwrap();
 
@@ -638,11 +638,11 @@ mod tests {
             env::temp_dir().join(format!("stax-forge-token-gitea-{}", std::process::id()));
         fs::create_dir_all(&temp_dir).unwrap();
 
-        env::set_var("HOME", &temp_dir);
-        env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax"));
-        env::remove_var("STAX_GITEA_TOKEN");
-        env::remove_var("GITEA_TOKEN");
-        env::remove_var("STAX_FORGE_TOKEN");
+        unsafe { env::set_var("HOME", &temp_dir) };
+        unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+        unsafe { env::remove_var("STAX_GITEA_TOKEN") };
+        unsafe { env::remove_var("GITEA_TOKEN") };
+        unsafe { env::remove_var("STAX_FORGE_TOKEN") };
 
         Config::set_github_token("saved-token").unwrap();
 

--- a/src/tui/ready/mod.rs
+++ b/src/tui/ready/mod.rs
@@ -257,7 +257,7 @@ mod tests {
     fn ready_tui_constructs_forge_client_with_entered_runtime() {
         let _guard = ENV_LOCK.lock().unwrap();
         let original_token = env::var("STAX_GITHUB_TOKEN").ok();
-        env::set_var("STAX_GITHUB_TOKEN", "test-token");
+        unsafe { env::set_var("STAX_GITHUB_TOKEN", "test-token") };
 
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         let remote = RemoteInfo {
@@ -273,8 +273,8 @@ mod tests {
         let result = create_loader_forge_client(&runtime, &remote);
 
         match original_token {
-            Some(token) => env::set_var("STAX_GITHUB_TOKEN", token),
-            None => env::remove_var("STAX_GITHUB_TOKEN"),
+            Some(token) => unsafe { env::set_var("STAX_GITHUB_TOKEN", token) },
+            None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
         }
         assert!(result.is_ok());
     }

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -394,7 +394,7 @@ impl HunkSplitApp {
             let hunks: Vec<usize> = file_sel
                 .iter()
                 .enumerate()
-                .filter(|(_, &s)| s)
+                .filter(|&(_, &s)| s)
                 .map(|(hi, _)| hi)
                 .collect();
             if !hunks.is_empty() {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1211,12 +1211,12 @@ fn test_generate_help_includes_no_prompt_flag() {
 
 #[test]
 fn test_gen_alias_matches_generate_help() {
-    let gen = stax(&["gen", "--help"]);
+    let gen_out = stax(&["gen", "--help"]);
     let generate = stax(&["generate", "--help"]);
-    assert!(gen.status.success(), "gen --help should succeed");
+    assert!(gen_out.status.success(), "gen --help should succeed");
     assert!(generate.status.success(), "generate --help should succeed");
     assert_eq!(
-        String::from_utf8_lossy(&gen.stdout),
+        String::from_utf8_lossy(&gen_out.stdout),
         String::from_utf8_lossy(&generate.stdout),
         "gen and generate help should match"
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7204,7 +7204,7 @@ mod forge_mock_tests {
         let repo = TestRepo::new_with_remote();
 
         // Set environment variables for the mock
-        std::env::set_var("STAX_GITHUB_TOKEN", "mock-token");
+        unsafe { std::env::set_var("STAX_GITHUB_TOKEN", "mock-token") };
 
         (repo, mock_server)
     }

--- a/tests/track_all_prs_tests.rs
+++ b/tests/track_all_prs_tests.rs
@@ -44,8 +44,8 @@ fn test_track_all_prs_no_token() {
     let repo = TestRepo::new_with_remote();
 
     // Ensure no token is set
-    std::env::remove_var("GITHUB_TOKEN");
-    std::env::remove_var("STAX_GITHUB_TOKEN");
+    unsafe { std::env::remove_var("GITHUB_TOKEN") };
+    unsafe { std::env::remove_var("STAX_GITHUB_TOKEN") };
 
     let output = repo.run_stax(&["branch", "track", "--all-prs"]);
 


### PR DESCRIPTION
## Motivation

Bumps the crate to Rust **edition 2024** (stabilized in Rust 1.85).

## Changes

- `Cargo.toml`: `edition = "2021"` → `edition = "2024"`
- `Dockerfile`: `rust:1.95` → `rust:latest`

### Edition 2024 fixes required

- **Unsafe env mutation** — `std::env::set_var` and `std::env::remove_var` are now `unsafe` in edition 2024. Wrapped 195 call sites in \`unsafe { ... }\` blocks across:
  - \`src/config/tests.rs\`, \`src/cli/tests.rs\`, \`src/forge/{mod,gitea,gitlab}.rs\`, \`src/tui/ready/mod.rs\`, \`tests/integration_tests.rs\`, \`tests/track_all_prs_tests.rs\`
- **Match ergonomics** — stricter rules on explicit \`ref\` / \`&\` patterns:
  - \`src/commands/changelog.rs:200\` — \`if let Some(ref p) = resolved_path\` → \`if let Some(p) = &resolved_path\`
  - \`src/tui/split_hunk/app.rs:397\` — \`.filter(|(_, &s)| s)\` → \`.filter(|&(_, &s)| s)\`
- **Reserved keyword** — \`gen\` is now reserved. Renamed local variable in \`tests/cli_tests.rs\`: \`gen\` → \`gen_out\`.

## Testing

- \`cargo build --all-targets\` ✅
- \`make test\` ✅ — all 1789 tests pass