### PR TITLE
fix: exclude current branch from sweep candidates

### DIFF
--- a/src/commands/sweep.rs
+++ b/src/commands/sweep.rs
@@ -1,13 +1,13 @@
 use crate::config::Config;
 use crate::engine::branch_detect::{
-    find_merged_branches_all, find_stale_branches, find_upstream_gone_branches, MergeType,
-    StaleBranchInfo,
+    MergeType, StaleBranchInfo, find_merged_branches_all, find_stale_branches,
+    find_upstream_gone_branches,
 };
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use anyhow::{Context, Result};
 use colored::Colorize;
-use dialoguer::{theme::ColorfulTheme, Confirm};
+use dialoguer::{Confirm, theme::ColorfulTheme};
 use serde::Serialize;
 use std::collections::HashSet;
 use std::process::Command;
@@ -35,19 +35,19 @@ pub fn run(
     // --- Classify all local branches ---
 
     // 1. Merged (ancestor or squash-merged)
-    let merged_infos = find_merged_branches_all(
-        &workdir,
-        &trunk,
-        Some(remote_trunk_ref.as_str()),
-    )?;
+    let merged_infos: Vec<_> =
+        find_merged_branches_all(&workdir, &trunk, Some(remote_trunk_ref.as_str()))?
+            .into_iter()
+            .filter(|m| m.branch != trunk && m.branch != current)
+            .collect();
     let merged_set: HashSet<String> = merged_infos.iter().map(|m| m.branch.clone()).collect();
 
     // 2. Upstream-gone
     let gone_branches = find_upstream_gone_branches(&workdir, &trunk)?;
-    // Merged takes precedence over upstream-gone
+    // Merged takes precedence over upstream-gone; trunk/current are never candidates.
     let gone_set: HashSet<String> = gone_branches
         .into_iter()
-        .filter(|b| !merged_set.contains(b))
+        .filter(|b| b != &trunk && b != &current && !merged_set.contains(b))
         .collect();
 
     // 3. Stale (old commits, not merged or gone)
@@ -95,7 +95,10 @@ pub fn run(
     // --- Human-readable output ---
 
     if total_classified == 0 {
-        println!("{}", "No local branches found (other than trunk and current).".dimmed());
+        println!(
+            "{}",
+            "No local branches found (other than trunk and current).".dimmed()
+        );
         return Ok(());
     }
 
@@ -147,7 +150,9 @@ pub fn run(
         sorted.sort();
         println!(
             "{} {}",
-            format!("  upstream-gone  ({})", sorted.len()).yellow().bold(),
+            format!("  upstream-gone  ({})", sorted.len())
+                .yellow()
+                .bold(),
             "— remote deleted, safe to delete".dimmed()
         );
         for b in &sorted {
@@ -192,10 +197,7 @@ pub fn run(
     if !active_branches.is_empty() {
         let mut sorted = active_branches.clone();
         sorted.sort();
-        println!(
-            "{}",
-            format!("  active  ({})", sorted.len()).cyan().bold()
-        );
+        println!("{}", format!("  active  ({})", sorted.len()).cyan().bold());
         for b in &sorted {
             let tracked_marker = if stack.branches.contains_key(b) {
                 " tracked".dimmed()
@@ -208,7 +210,13 @@ pub fn run(
     }
 
     // Summary / hints
-    print_summary(&merged_set, &gone_set, &stale_set, effective_stale_days, delete);
+    print_summary(
+        &merged_set,
+        &gone_set,
+        &stale_set,
+        effective_stale_days,
+        delete,
+    );
 
     // --- Deletion ---
     if delete {

--- a/tests/sweep_tests.rs
+++ b/tests/sweep_tests.rs
@@ -9,7 +9,13 @@ use serde_json::Value;
 
 /// Merge a branch into the current branch using git (fast-forward).
 fn merge_branch(repo: &TestRepo, branch: &str) {
-    let out = repo.git(&["merge", "--no-ff", branch, "-m", &format!("Merge {}", branch)]);
+    let out = repo.git(&[
+        "merge",
+        "--no-ff",
+        branch,
+        "-m",
+        &format!("Merge {}", branch),
+    ]);
     assert!(
         out.status.success(),
         "Failed to merge branch {}: {}",
@@ -80,6 +86,73 @@ fn sweep_does_not_list_trunk_or_current() {
     assert!(
         lines_with_main.is_empty(),
         "trunk 'main' should not appear as a deletable branch:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn sweep_does_not_list_current_merged_branch_as_deletable() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["bc", "current-merged"]).assert_success();
+    repo.create_file("current.txt", "current");
+    repo.commit("current branch commit");
+
+    repo.run_stax(&["t"]).assert_success();
+    merge_branch(&repo, "current-merged");
+    repo.git(&["checkout", "current-merged"]);
+
+    let out = repo.run_stax(&["sweep"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+
+    let candidate_lines: Vec<&str> = stdout
+        .lines()
+        .filter(|l| {
+            l.contains("current-merged") && (l.contains("✓") || l.contains("⚑") || l.contains("○"))
+        })
+        .collect();
+    assert!(
+        candidate_lines.is_empty(),
+        "current branch must not appear as a sweep candidate:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("delete 1 merged/gone branch"),
+        "summary tip must not count the current branch as deletable:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn sweep_json_does_not_list_current_merged_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["bc", "current-json-merged"])
+        .assert_success();
+    repo.create_file("current-json.txt", "current");
+    repo.commit("current json branch commit");
+
+    repo.run_stax(&["t"]).assert_success();
+    merge_branch(&repo, "current-json-merged");
+    repo.git(&["checkout", "current-json-merged"]);
+
+    let out = repo.run_stax(&["sweep", "--json"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("sweep --json should output valid JSON: {}\n{}", e, stdout));
+    let branches = parsed["branches"]
+        .as_array()
+        .expect("JSON should have branches array");
+
+    assert!(
+        branches
+            .iter()
+            .all(|b| b["name"].as_str() != Some("current-json-merged")),
+        "current branch must not appear in sweep JSON:\n{}",
         stdout
     );
 }


### PR DESCRIPTION
## Summary
- exclude trunk/current from `stax sweep` merged/upstream-gone candidate sets before output/summary/JSON generation
- keep the existing delete-time guard as a final safety net
- add regression coverage for a checked-out merged non-trunk branch in human and JSON output

Fixes #473

## Tests
- `cargo test --test sweep_tests current_merged_branch`
- `cargo test --test sweep_tests`
- `make test` — 1791 passed

## Docs
No docs update needed: existing docs already state trunk and current branch are excluded; this PR makes implementation match that behavior.
