### PR TITLE
[codex] fix sweep upstream-gone safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ st config --set-ai
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
-| `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` to remove safe-to-delete ones |
+| `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` removes merged branches and upstream-gone branches with no unique work |
 | `st update` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs |
 | `st update --force --yes --no-prompt` | Run update without sync or submit prompts |
 | `st update --verbose` | Include detailed sync/restack/submit timing |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -56,7 +56,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | Command | What it does |
 |---|---|
 | `st sweep` | Classify all local branches: merged, upstream-gone, stale, active (read-only) |
-| `st sweep --delete` | Delete all merged and upstream-gone branches after confirmation |
+| `st sweep --delete` | Delete merged branches and upstream-gone branches with no unique work after confirmation |
 | `st sweep --delete --include-stale` | Also delete stale branches (older than threshold) |
 | `st sweep --delete --force` | Skip confirmation prompt |
 | `st sweep --stale-days 60` | Override stale threshold (default 30, or `branch.stale_days` in config) |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -16,7 +16,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
 | `st sweep` | | Classify all local branches as merged / upstream-gone / stale / active (read-only by default) |
-| `st sweep --delete` | | Delete merged and upstream-gone branches after confirmation |
+| `st sweep --delete` | | Delete merged branches and upstream-gone branches with no unique work after confirmation |
 | `st sweep --delete --include-stale` | | Also delete stale branches (older than `--stale-days` / `branch.stale_days` config key) |
 | `st sweep --delete --force` | | Skip confirmation prompt |
 | `st sweep --stale-days <N>` | | Override stale threshold in days (default: 30) |

--- a/docs/commands/sweep.md
+++ b/docs/commands/sweep.md
@@ -17,11 +17,11 @@ Over time a repo accumulates branches that were merged, whose PR was closed, or 
 | Status | Meaning |
 |---|---|
 | `merged` | Ancestor of trunk, or confirmed merged via remote state |
-| `upstream-gone` | Remote tracking ref is `[gone]` (upstream branch deleted) |
+| `upstream-gone` | Remote tracking ref is `[gone]` and the branch has no commits unique to local or remote trunk |
 | `stale` | Last commit older than the configured threshold (default 30 days) |
 | `active` | Everything else |
 
-Precedence when a branch matches multiple: **merged > upstream-gone > stale > active**.
+Precedence when a branch matches multiple: **merged > safe upstream-gone > stale > active**. Upstream-gone branches with unique commits are treated as active so cleanup cannot delete local-only work.
 
 ## Usage
 
@@ -29,7 +29,7 @@ Precedence when a branch matches multiple: **merged > upstream-gone > stale > ac
 # Read-only: classify all local branches and print a grouped summary
 stax sweep
 
-# Delete merged and upstream-gone branches (safe to remove), with confirmation
+# Delete merged branches and upstream-gone branches with no unique work, with confirmation
 stax sweep --delete
 
 # Also include stale branches in the deletion set
@@ -49,7 +49,7 @@ stax sweep --json
 
 | Flag | Description |
 |---|---|
-| `--delete` | Delete merged and upstream-gone branches after confirmation |
+| `--delete` | Delete merged branches and upstream-gone branches with no unique work after confirmation |
 | `--include-stale` | Extend deletion to stale branches (requires `--delete`) |
 | `--force` | Skip confirmation prompt (requires `--delete`) |
 | `--stale-days <N>` | Override stale threshold in days (default: 30) |
@@ -70,6 +70,7 @@ stale_days = 60
 
 - Trunk and the current branch are always excluded.
 - `--delete` without `--include-stale` never touches stale branches; unmerged work is safe.
+- Upstream-gone branches with commits not reachable from local or remote trunk are classified as active and are not deleted by `--delete`.
 - Stax-tracked children of deleted branches are reparented to trunk before deletion so `stax status` stays clean.
 - `--json` is always read-only (conflicts with `--delete`).
 

--- a/skills.md
+++ b/skills.md
@@ -241,7 +241,7 @@ stax sync --no-delete              # Keep merged branches
 stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
-stax sweep --delete                # Delete merged + upstream-gone branches after confirmation
+stax sweep --delete                # Delete merged + upstream-gone branches with no unique work after confirmation
 stax sweep --delete --include-stale  # Also delete stale branches
 stax sweep --delete --force        # Skip confirmation prompt
 stax sweep --stale-days 60         # Override stale threshold in days (default 30, or branch.stale_days config)

--- a/src/commands/sweep.rs
+++ b/src/commands/sweep.rs
@@ -1,13 +1,13 @@
 use crate::config::Config;
 use crate::engine::branch_detect::{
-    MergeType, StaleBranchInfo, find_merged_branches_all, find_stale_branches,
-    find_upstream_gone_branches,
+    find_merged_branches_all, find_stale_branches, find_upstream_gone_branches, MergeType,
+    StaleBranchInfo,
 };
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
 use anyhow::{Context, Result};
 use colored::Colorize;
-use dialoguer::{Confirm, theme::ColorfulTheme};
+use dialoguer::{theme::ColorfulTheme, Confirm};
 use serde::Serialize;
 use std::collections::HashSet;
 use std::process::Command;
@@ -45,14 +45,27 @@ pub fn run(
     // 2. Upstream-gone
     let gone_branches = find_upstream_gone_branches(&workdir, &trunk)?;
     // Merged takes precedence over upstream-gone; trunk/current are never candidates.
-    let gone_set: HashSet<String> = gone_branches
-        .into_iter()
-        .filter(|b| b != &trunk && b != &current && !merged_set.contains(b))
-        .collect();
+    let mut gone_set: HashSet<String> = HashSet::new();
+    let mut protected_gone_set: HashSet<String> = HashSet::new();
+    for branch in gone_branches {
+        if branch == trunk || branch == current || merged_set.contains(&branch) {
+            continue;
+        }
+
+        if has_unique_commits_since_any_base(&workdir, &branch, &[&trunk, &remote_trunk_ref])? {
+            protected_gone_set.insert(branch);
+        } else {
+            gone_set.insert(branch);
+        }
+    }
 
     // 3. Stale (old commits, not merged or gone)
-    let already_classified: HashSet<String> =
-        merged_set.iter().chain(gone_set.iter()).cloned().collect();
+    let already_classified: HashSet<String> = merged_set
+        .iter()
+        .chain(gone_set.iter())
+        .chain(protected_gone_set.iter())
+        .cloned()
+        .collect();
     let stale_infos = find_stale_branches(
         &workdir,
         &trunk,
@@ -438,6 +451,33 @@ fn format_age(days: u64) -> String {
         let years = days / 365;
         format!("({} year{})", years, if years == 1 { "" } else { "s" })
     }
+}
+
+fn has_unique_commits_since_any_base(
+    workdir: &std::path::Path,
+    branch: &str,
+    bases: &[&str],
+) -> Result<bool> {
+    for base in bases {
+        let range = format!("{}..{}", base, branch);
+        let output = Command::new("git")
+            .args(["rev-list", "--count", &range])
+            .current_dir(workdir)
+            .output()
+            .with_context(|| format!("Failed to count unique commits for '{}'", branch))?;
+
+        if !output.status.success() {
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let unique_count = stdout.trim().parse::<u64>().unwrap_or(u64::MAX);
+        if unique_count == 0 {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 /// Reparent stax-tracked children of `branch` to trunk before deleting it.

--- a/tests/sweep_tests.rs
+++ b/tests/sweep_tests.rs
@@ -245,6 +245,109 @@ fn sweep_shows_active_unmerged_branch() {
     );
 }
 
+#[test]
+fn sweep_does_not_treat_upstream_gone_with_local_work_as_deletable() {
+    let repo = TestRepo::new_with_remote();
+    repo.run_stax(&["init"]).assert_success();
+
+    assert!(repo
+        .git(&["checkout", "-b", "gone-with-local-work"])
+        .status
+        .success());
+    repo.create_file("pushed.txt", "pushed");
+    repo.commit("pushed work");
+    assert!(repo
+        .git(&["push", "-u", "origin", "gone-with-local-work"])
+        .status
+        .success());
+
+    repo.create_file("local-only.txt", "local only");
+    repo.commit("local-only work");
+
+    assert!(repo.git(&["checkout", "main"]).status.success());
+    assert!(repo
+        .git(&["push", "origin", "--delete", "gone-with-local-work"])
+        .status
+        .success());
+    assert!(repo.git(&["fetch", "--prune", "origin"]).status.success());
+
+    let out = repo.run_stax(&["sweep", "--json"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("sweep --json should output valid JSON: {}\n{}", e, stdout));
+    let branch = parsed["branches"]
+        .as_array()
+        .expect("JSON should have branches array")
+        .iter()
+        .find(|b| b["name"].as_str() == Some("gone-with-local-work"))
+        .expect("gone-with-local-work should appear in sweep JSON");
+    assert!(
+        branch["status"].as_str() == Some("active"),
+        "branch with local-only commits should be classified as active:\n{}",
+        stdout
+    );
+
+    let delete_out = repo.run_stax(&["sweep", "--delete", "--force"]);
+    delete_out.assert_success();
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&"gone-with-local-work".to_string()),
+        "gone-with-local-work should survive sweep --delete --force:\n{:?}",
+        branches
+    );
+}
+
+#[test]
+fn sweep_delete_removes_gone_branch_without_unique_work() {
+    let repo = TestRepo::new_with_remote();
+    repo.run_stax(&["init"]).assert_success();
+
+    assert!(repo
+        .git(&["checkout", "-b", "gone-without-local-work"])
+        .status
+        .success());
+    assert!(repo
+        .git(&["push", "-u", "origin", "gone-without-local-work"])
+        .status
+        .success());
+
+    assert!(repo.git(&["checkout", "main"]).status.success());
+    assert!(repo
+        .git(&["push", "origin", "--delete", "gone-without-local-work"])
+        .status
+        .success());
+    assert!(repo.git(&["fetch", "--prune", "origin"]).status.success());
+
+    let out = repo.run_stax(&["sweep", "--json"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("sweep --json should output valid JSON: {}\n{}", e, stdout));
+    let branch = parsed["branches"]
+        .as_array()
+        .expect("JSON should have branches array")
+        .iter()
+        .find(|b| b["name"].as_str() == Some("gone-without-local-work"))
+        .expect("gone-without-local-work should appear in sweep JSON");
+    assert_eq!(
+        branch["status"].as_str(),
+        Some("merged"),
+        "branch without unique commits should remain a safe deletion candidate"
+    );
+
+    let delete_out = repo.run_stax(&["sweep", "--delete", "--force"]);
+    delete_out.assert_success();
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.contains(&"gone-without-local-work".to_string()),
+        "gone-without-local-work should be deleted:\n{:?}",
+        branches
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Phase 2 — opt-in deletion
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Protect upstream-gone branches from `stax sweep --delete` when they have commits not reachable from local or remote trunk
- Keep protected upstream-gone branches classified as active so they are not deleted by default or via `--include-stale`
- Update sweep docs and agent-facing command notes to describe the narrowed deletion set

## Root cause
`sweep` treated every `[gone]` upstream as safe to delete and later used `git branch -D`, which could remove local-only work after a remote branch disappeared.

Fixes #475.

## Verification
- `cargo test --test sweep_tests -- --nocapture`
- `make test` (Docker nextest: 1793 tests run, 1793 passed, 0 skipped)