### PR TITLE
Show remote indicator for pushed branches

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -296,7 +296,9 @@ pub fn run(
         let branch = &db.name;
         let is_current = branch == &current;
         let entry = branch_status_map.get(branch);
-        let has_remote = entry.and_then(|e| e.pr_number).is_some();
+        let has_remote = entry
+            .map(|e| e.has_remote || e.pr_number.is_some())
+            .unwrap_or(false);
 
         // Check if we need a corner connector - this happens when the PREVIOUS branch was at a higher column
         // The corner shows that a side branch joins back to this level

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3677,6 +3677,35 @@ fn test_status_shows_remote_indicator() {
 }
 
 #[test]
+fn test_status_text_shows_remote_indicator_without_pr_metadata() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature/remote-without-pr"]);
+    let branch_name = repo.current_branch();
+    repo.create_file("f.txt", "content");
+    repo.commit("Feature");
+    repo.git(&["push", "-u", "origin", &branch_name]);
+
+    let output = repo.run_stax(&["ls"]);
+    assert!(
+        output.status.success(),
+        "Failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let line = stdout
+        .lines()
+        .find(|line| line.contains(&branch_name))
+        .expect("Expected branch in status output");
+    assert!(
+        line.contains("☁"),
+        "Expected remote indicator in status output line: {}",
+        line
+    );
+}
+
+#[test]
 fn test_force_push_after_amend() {
     let repo = TestRepo::new_with_remote();
 


### PR DESCRIPTION
## Motivation

Show the remote indicator for branches that have been pushed, even when PR metadata is unavailable, so branch listings stay accurate.

## Description of changes / notes for reviewers

- Treat a branch as having a remote when it has either remote tracking or PR metadata.
- Adds an integration test covering `ls` output for a pushed branch without PR metadata.