### PR TITLE
perf(build): cut test link time with line-tables-only debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,17 @@ tempfile = "3"
 serde_json = "1"
 wiremock = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+# Full debuginfo makes linking the ~50 integration-test binaries dominate
+# build time (each statically links the whole stax lib + octocrab/git2/ratatui).
+# `line-tables-only` keeps file/line numbers in panic backtraces while cutting
+# the per-binary relink from ~13s to ~5s. `unpacked` skips the dsymutil pack
+# step on macOS, which further speeds linking.
+[profile.dev]
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
+# `test` inherits from `dev`, but be explicit so test-binary links stay fast.
+[profile.test]
+debug = "line-tables-only"
+split-debuginfo = "unpacked"


### PR DESCRIPTION
## Motivation

Reduce local and test build time by cutting the cost of linking the many integration-test binaries. Full debuginfo was making relinks unnecessarily slow, especially on macOS.

## Description of changes / notes for reviewers

- Set `[profile.dev]` and `[profile.test]` to use `debug = "line-tables-only"` so panic backtraces keep file and line information without full debuginfo overhead.
- Set `split-debuginfo = "unpacked"` to skip the extra dsymutil packaging step on macOS and further reduce link time.