### PR TITLE
perf(test): consolidate integration tests into a single binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@
   - `make test-native`
   - `make test-local-ramdisk`
   - `make test-local-fast`
-- Targeted single-test or single-crate runs via `cargo test --test <name>` / `cargo nextest run <pattern>` are fine and encouraged for tight feedback loops; switch to `make test` once changes are ready for verification.
+- Targeted single-test runs via `cargo nextest run <pattern>` are fine and encouraged for tight feedback loops; switch to `make test` once changes are ready for verification.
+- All integration tests compile into a **single** binary (`tests/all_tests.rs`, with `autotests = false` in `Cargo.toml`) so cargo links one test binary instead of ~50 — this is what keeps test builds fast. Because of this, there is only one `[[test]]` target named `all_tests`: `cargo test --test status_tests` no longer works. To scope a run, filter by module path instead, e.g. `cargo nextest run status_tests::` (one former file) or `cargo nextest run status_tests::status_json_output` (one test). When adding a new `tests/*_tests.rs` file, register it with a `#[path = "..."] mod ...;` entry in `tests/all_tests.rs`.
 
 ## Why
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ description = "Fast stacked Git branches and PRs"
 license = "MIT"
 authors = ["Cesar Ferreira"]
 repository = "https://github.com/cesarferreira/stax"
+# Integration tests are consolidated into a single binary (tests/all_tests.rs)
+# instead of one binary per file. Linking ~50 separate test binaries (each
+# statically linking the whole stax lib + octocrab/git2/ratatui) dominated build
+# time; one binary links once. Disable auto-discovery so the per-file targets
+# are not also built.
+autotests = false
 
 [lib]
 name = "stax"
@@ -19,6 +25,11 @@ path = "src/main.rs"
 [[bin]]
 name = "st"
 path = "src/bin/st.rs"
+
+# Single consolidated integration-test binary. See `autotests = false` above.
+[[test]]
+name = "all_tests"
+path = "tests/all_tests.rs"
 
 [features]
 default = []

--- a/tests/abort_tests.rs
+++ b/tests/abort_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/absorb_tests.rs
+++ b/tests/absorb_tests.rs
@@ -3,7 +3,7 @@
 //! Verifies that staged changes are attributed to the correct stack branches
 //! based on which branch last modified each file.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::fs;

--- a/tests/additional_coverage_tests.rs
+++ b/tests/additional_coverage_tests.rs
@@ -1,7 +1,7 @@
 //! Additional integration tests for code coverage
 //! Targeting edge cases and less-tested code paths
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use serde_json::Value;

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -1,0 +1,114 @@
+//! Consolidated integration-test binary.
+//!
+//! Every `tests/*_tests.rs` file is included here as a module instead of being
+//! compiled into its own separate test binary. Cargo links one binary instead
+//! of ~50 (each of which statically links the whole stax lib plus heavy deps
+//! like octocrab, git2, and ratatui), which is the dominant cost of building
+//! the test suite. See `autotests = false` and the `[[test]]` target in
+//! `Cargo.toml`.
+//!
+//! Shared helpers live in `tests/common/`; it is declared once here and each
+//! suite module reaches it via `use crate::common;`.
+
+mod common;
+
+#[path = "abort_tests.rs"]
+mod abort_tests;
+#[path = "absorb_tests.rs"]
+mod absorb_tests;
+#[path = "additional_coverage_tests.rs"]
+mod additional_coverage_tests;
+#[path = "auth_tests.rs"]
+mod auth_tests;
+#[path = "changelog_tests.rs"]
+mod changelog_tests;
+#[path = "ci_tests.rs"]
+mod ci_tests;
+#[path = "cli_tests.rs"]
+mod cli_tests;
+#[path = "command_coverage_tests.rs"]
+mod command_coverage_tests;
+#[path = "comments_tests.rs"]
+mod comments_tests;
+#[path = "comprehensive_coverage_tests.rs"]
+mod comprehensive_coverage_tests;
+#[path = "conflict_handling_tests.rs"]
+mod conflict_handling_tests;
+#[path = "continue_tests.rs"]
+mod continue_tests;
+#[path = "create_ai_tests.rs"]
+mod create_ai_tests;
+#[path = "create_below_tests.rs"]
+mod create_below_tests;
+#[path = "create_insert_tests.rs"]
+mod create_insert_tests;
+#[path = "create_rollback_tests.rs"]
+mod create_rollback_tests;
+#[path = "demo_tests.rs"]
+mod demo_tests;
+#[path = "detach_tests.rs"]
+mod detach_tests;
+#[path = "doctor_fix_tests.rs"]
+mod doctor_fix_tests;
+#[path = "downstack_tests.rs"]
+mod downstack_tests;
+#[path = "edge_cases_tests.rs"]
+mod edge_cases_tests;
+#[path = "edit_tests.rs"]
+mod edit_tests;
+#[path = "fix_tests.rs"]
+mod fix_tests;
+#[path = "fold_tests.rs"]
+mod fold_tests;
+#[path = "get_tests.rs"]
+mod get_tests;
+#[path = "github_list_tests.rs"]
+mod github_list_tests;
+#[path = "integration_tests.rs"]
+mod integration_tests;
+#[path = "navigation_tests.rs"]
+mod navigation_tests;
+#[path = "pr_body_tests.rs"]
+mod pr_body_tests;
+#[path = "pr_template_tests.rs"]
+mod pr_template_tests;
+#[path = "release_prep_tests.rs"]
+mod release_prep_tests;
+#[path = "reorder_tests.rs"]
+mod reorder_tests;
+#[path = "rerequest_review_tests.rs"]
+mod rerequest_review_tests;
+#[path = "resolve_tests.rs"]
+mod resolve_tests;
+#[path = "restack_provenance_tests.rs"]
+mod restack_provenance_tests;
+#[path = "split_hunk_tests.rs"]
+mod split_hunk_tests;
+#[path = "split_tests.rs"]
+mod split_tests;
+#[path = "stack_test_tests.rs"]
+mod stack_test_tests;
+#[path = "staging_menu_tests.rs"]
+mod staging_menu_tests;
+#[path = "status_tests.rs"]
+mod status_tests;
+#[path = "submit_fetch_failure_tests.rs"]
+mod submit_fetch_failure_tests;
+#[path = "submit_no_verify_tests.rs"]
+mod submit_no_verify_tests;
+#[path = "sweep_tests.rs"]
+mod sweep_tests;
+#[path = "track_all_prs_tests.rs"]
+mod track_all_prs_tests;
+#[path = "track_merge_base_tests.rs"]
+mod track_merge_base_tests;
+#[path = "tui_commands_tests.rs"]
+mod tui_commands_tests;
+#[path = "upstack_onto_tests.rs"]
+mod upstack_onto_tests;
+#[path = "validate_tests.rs"]
+mod validate_tests;
+#[path = "worktree_cli_tests.rs"]
+mod worktree_cli_tests;
+#[path = "worktree_tests.rs"]
+mod worktree_tests;

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for `stax auth` command flags and behavior.
 
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/changelog_tests.rs
+++ b/tests/changelog_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/ci_tests.rs
+++ b/tests/ci_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify the CI status display functionality.
 
-mod common;
+use crate::common;
 use common::TestRepo;
 
 /// Test that ci command shows "no tracked branches" when there are none

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{run_stax_in_script_with_env, TestRepo};
 use std::fs;

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -1,7 +1,7 @@
 //! Additional integration tests to increase code coverage
 //! Tests for: checkout, sync, restack, undo, redo, doctor, log, diff
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/comments_tests.rs
+++ b/tests/comments_tests.rs
@@ -4,7 +4,7 @@
 //! Note: Full functionality requires GitHub API access, so we test
 //! pre-condition validation that exits before API calls.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/comprehensive_coverage_tests.rs
+++ b/tests/comprehensive_coverage_tests.rs
@@ -1,7 +1,7 @@
 //! Comprehensive integration tests targeting additional code paths
 //! These tests focus on edge cases and less common execution paths
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/conflict_handling_tests.rs
+++ b/tests/conflict_handling_tests.rs
@@ -4,7 +4,7 @@
 //! Bug 2: Non-rebase-aware commands during active rebase should give clear error
 //! Bug 3: restack --continue should resume from checkpoint, not restart
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests for the `continue` command that resumes after conflict resolution.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use serde_json::Value;

--- a/tests/create_ai_tests.rs
+++ b/tests/create_ai_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::TestRepo;
 use std::fs;

--- a/tests/create_below_tests.rs
+++ b/tests/create_below_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/create_insert_tests.rs
+++ b/tests/create_insert_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/create_rollback_tests.rs
+++ b/tests/create_rollback_tests.rs
@@ -13,7 +13,7 @@
 //!
 //! Most tests require Unix (pre-commit hooks use `#!/bin/sh` and chmod).
 
-mod common;
+use crate::common;
 
 #[cfg(unix)]
 use common::stax_bin;

--- a/tests/demo_tests.rs
+++ b/tests/demo_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 use std::process::Command;
 

--- a/tests/detach_tests.rs
+++ b/tests/detach_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/doctor_fix_tests.rs
+++ b/tests/doctor_fix_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{run_stax_in_script_with_env, TestRepo};
 

--- a/tests/downstack_tests.rs
+++ b/tests/downstack_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests for the `downstack get` command that shows branches below current.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/edge_cases_tests.rs
+++ b/tests/edge_cases_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify that various edge cases are handled correctly.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/edit_tests.rs
+++ b/tests/edit_tests.rs
@@ -3,7 +3,7 @@
 //! Verifies interactive commit editing (reword, drop, squash, fixup)
 //! within a branch's own commits.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/fix_tests.rs
+++ b/tests/fix_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/fold_tests.rs
+++ b/tests/fold_tests.rs
@@ -5,7 +5,7 @@
 //! surviving branch, siblings are rebased, and `--keep` lets the current
 //! branch's name survive while the parent ref is deleted.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `stax get`.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/github_list_tests.rs
+++ b/tests/github_list_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use serde_json::Value;

--- a/tests/navigation_tests.rs
+++ b/tests/navigation_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests for top, bottom, up, down commands that navigate the branch stack.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/pr_body_tests.rs
+++ b/tests/pr_body_tests.rs
@@ -1,6 +1,6 @@
 //! PR body command integration tests.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::fs;

--- a/tests/pr_template_tests.rs
+++ b/tests/pr_template_tests.rs
@@ -4,7 +4,7 @@
 //! Note: Full submit tests require GitHub API access, so we test
 //! template discovery in real repo contexts without API calls.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::fs;

--- a/tests/release_prep_tests.rs
+++ b/tests/release_prep_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::TestRepo;
 use std::fs;

--- a/tests/reorder_tests.rs
+++ b/tests/reorder_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/rerequest_review_tests.rs
+++ b/tests/rerequest_review_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/resolve_tests.rs
+++ b/tests/resolve_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::fs;

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -11,7 +11,7 @@
 //!   `git rebase --onto <parentBranchName> <parentBranchRevision> <branch>`
 //! without any ancestor check.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::io::Write;

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::collections::{HashMap, HashSet};

--- a/tests/split_tests.rs
+++ b/tests/split_tests.rs
@@ -4,7 +4,7 @@
 //! Note: The split command launches an interactive TUI, so we test
 //! pre-condition validation that exits before the TUI launches.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/stack_test_tests.rs
+++ b/tests/stack_test_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/staging_menu_tests.rs
+++ b/tests/staging_menu_tests.rs
@@ -9,7 +9,7 @@
 //! - `-a/--all`: bypass the menu entirely and force-stage.
 //! - Pre-staged index: skip the menu and commit what's staged.
 //!
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/status_tests.rs
+++ b/tests/status_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use serde_json::Value;

--- a/tests/submit_fetch_failure_tests.rs
+++ b/tests/submit_fetch_failure_tests.rs
@@ -5,7 +5,7 @@
 //! must NOT silently fall through to a `--force-with-lease` push against
 //! stale remote-tracking refs (which the remote rejects as `(stale info)`).
 
-mod common;
+use crate::common;
 
 use common::TestRepo;
 

--- a/tests/submit_no_verify_tests.rs
+++ b/tests/submit_no_verify_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 #[cfg(unix)]
 mod unix {

--- a/tests/sweep_tests.rs
+++ b/tests/sweep_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use serde_json::Value;

--- a/tests/track_all_prs_tests.rs
+++ b/tests/track_all_prs_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `stax branch track --all-prs` command
 
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 /// Test that --all-prs flag is recognized by the CLI

--- a/tests/track_merge_base_tests.rs
+++ b/tests/track_merge_base_tests.rs
@@ -5,7 +5,7 @@
 //! `git rebase --onto` to scope the replay incorrectly when the branch was created
 //! from an older parent commit.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/tui_commands_tests.rs
+++ b/tests/tui_commands_tests.rs
@@ -3,7 +3,7 @@
 //! The TUI runs stax commands via subprocess. These tests verify that
 //! the commands work correctly when called with the arguments the TUI uses.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/upstack_onto_tests.rs
+++ b/tests/upstack_onto_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for `st upstack onto` -- mass reparent current + descendants onto new parent.
 
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 

--- a/tests/validate_tests.rs
+++ b/tests/validate_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 use common::{OutputAssertions, TestRepo};
 
 #[test]

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use std::fs;

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -1,4 +1,4 @@
-mod common;
+use crate::common;
 
 use common::{OutputAssertions, TestRepo};
 use serde_json::Value;


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Reduce integration test build time by avoiding the cost of compiling and linking ~50 separate test binaries. This also standardizes how the suite is run locally now that all integration tests live under one consolidated target.

## Description of changes / notes for reviewers

- Disable Cargo’s integration-test auto-discovery and register a single `all_tests` target in `Cargo.toml`, so the full suite compiles into one binary instead of one binary per file.
- Add `tests/all_tests.rs` as the central integration-test entrypoint and include each `tests/*_tests.rs` module there, with shared helpers exposed once through `crate::common`.
- Update every integration test file to import `common` from the consolidated test crate instead of declaring its own local `mod common;`.
- Refresh the repo guidance in `AGENTS.md` to reflect the new test layout and the recommended `cargo nextest run <pattern>` workflow for targeted runs.