### PR TITLE
apple container testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Cargo.lock
 /.venv
 /.test-tmp
 /.docker-cache
+/.container-cache
 .worktrees/
 .claude
 .serena
@@ -16,4 +17,3 @@ __pycache__/
 
 .playwright-mcp/
 .superpowers/
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   - `make test-local-ramdisk`
   - `make test-local-fast`
 - Targeted single-test runs via `cargo nextest run <pattern>` are fine and encouraged for tight feedback loops; switch to `make test` once changes are ready for verification.
+- Container test runs (`make test` / `make test-docker` / `make test-container`) use the pre-baked `stax-test` image (`make test-image`), the `test-container` Cargo profile (no debuginfo, mold linker), and shared env (`STAX_DISABLE_UPDATE_CHECK`, `RUST_MIN_STACK`, capped `NEXTEST_TEST_THREADS`). For tight iteration, prefer `cargo nextest run --lib --bins` or a module filter before a full container run.
 - All integration tests compile into a **single** binary (`tests/all_tests.rs`, with `autotests = false` in `Cargo.toml`) so cargo links one test binary instead of ~50 — this is what keeps test builds fast. Because of this, there is only one `[[test]]` target named `all_tests`: `cargo test --test status_tests` no longer works. To scope a run, filter by module path instead, e.g. `cargo nextest run status_tests::` (one former file) or `cargo nextest run status_tests::status_json_output` (one test). When adding a new `tests/*_tests.rs` file, register it with a `#[path = "..."] mod ...;` entry in `tests/all_tests.rs`.
 
 ## Why

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ make test
 # Full suite natively (slower on macOS)
 make test-native
 
+# Rebuild the pre-baked Linux test image (after Dockerfile changes)
+make test-image
+
+# Experimental Apple Container path (builds into container's local image store)
+make test-container
+
 # Run a single test by name
 cargo nextest run test_name
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,9 @@ split-debuginfo = "unpacked"
 [profile.test]
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
+
+# Linux container test runs (Docker / Apple Container): skip debuginfo for faster
+# linking when target/ is bind-mounted from the macOS host.
+[profile.test-container]
+inherits = "test"
+debug = 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
-FROM rust:latest
+FROM rust:1
 
-RUN cargo install cargo-nextest --locked
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends mold curl ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& case "$(uname -m)" in \
+		aarch64 | arm64) nextest_platform=linux-arm ;; \
+		x86_64 | amd64) nextest_platform=linux ;; \
+		*) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+	esac \
+	&& curl -LsSf "https://get.nexte.st/latest/${nextest_platform}" | tar zxf - -C /usr/local/cargo/bin
 
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 WORKDIR /work

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build build-release release install clean test test-native test-local-fast test-local-ramdisk test-docker ramdisk-up ramdisk-down test-unit test-integration check fmt lint all
+.PHONY: build build-release release install clean test test-native test-local-fast test-local-ramdisk test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint all
 
 RAMDISK_NAME ?= STAXRAM
 RAMDISK_SIZE_MB ?= 2048
 RAMDISK_MOUNT ?= /Volumes/$(RAMDISK_NAME)
 MAC_LOCAL_TEST_THREADS ?= 8
 LEVEL ?= minor
+CONTAINER ?= $(shell if [ -x /opt/homebrew/opt/container/bin/container ]; then printf '%s\n' /opt/homebrew/opt/container/bin/container; else printf '%s\n' container; fi)
+CONTAINER_MEMORY ?= 8G
+CONTAINER_CARGO_BUILD_JOBS ?= 4
 
 # Default target
 all: check build test
@@ -111,6 +114,20 @@ test-docker:
 		-v "$$(pwd)/.docker-cache/target:/work/target" \
 		rust:1 \
 		bash -lc 'export PATH="$$CARGO_HOME/bin:/usr/local/cargo/bin:$$PATH"; if ! command -v cargo-nextest >/dev/null 2>&1; then cargo install cargo-nextest --locked; fi && cargo nextest run'
+
+# Run tests with Apple container (experimental macOS fast path)
+test-container:
+	mkdir -p .container-cache/cargo .container-cache/target
+	$(CONTAINER) run --rm -t \
+		-u "$$(id -u):$$(id -g)" \
+		-m "$(CONTAINER_MEMORY)" \
+		-v "$$(pwd):/work" \
+		-w /work \
+		-e CARGO_HOME=/work/.container-cache/cargo \
+		-e CARGO_BUILD_JOBS="$(CONTAINER_CARGO_BUILD_JOBS)" \
+		-v "$$(pwd)/.container-cache/target:/work/target" \
+		rust:1 \
+		bash -lc 'export PATH="$$CARGO_HOME/bin:/usr/local/cargo/bin:$$PATH"; if ! command -v cargo-nextest >/dev/null 2>&1; then mkdir -p "$$CARGO_HOME/bin"; case "$$(uname -m)" in aarch64|arm64) nextest_platform=linux-arm ;; x86_64|amd64) nextest_platform=linux ;; *) echo "unsupported container architecture: $$(uname -m)" >&2; exit 1 ;; esac; curl -LsSf "https://get.nexte.st/latest/$$nextest_platform" | tar zxf - -C "$$CARGO_HOME/bin"; fi && cargo nextest run'
 
 # Run fast unit tests only
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-.PHONY: build build-release release install clean test test-native test-local-fast test-local-ramdisk test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint all
+.PHONY: build build-release release install clean test test-native test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint all
 
 RAMDISK_NAME ?= STAXRAM
 RAMDISK_SIZE_MB ?= 2048
 RAMDISK_MOUNT ?= /Volumes/$(RAMDISK_NAME)
 MAC_LOCAL_TEST_THREADS ?= 8
 LEVEL ?= minor
+STAX_TEST_IMAGE ?= stax-test
 CONTAINER ?= $(shell if [ -x /opt/homebrew/opt/container/bin/container ]; then printf '%s\n' /opt/homebrew/opt/container/bin/container; else printf '%s\n' container; fi)
 CONTAINER_MEMORY ?= 8G
 CONTAINER_CARGO_BUILD_JOBS ?= 4
+CONTAINER_CARGO_PROFILE ?= test-container
 
 # Default target
 all: check build test
@@ -103,31 +105,42 @@ test-local-ramdisk: ramdisk-up
 	fi; \
 	env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$(RAMDISK_MOUNT)/tmp" TMPDIR="$(RAMDISK_MOUNT)/tmp" NEXTEST_TEST_THREADS="$$threads" cargo nextest run
 
-# Run tests in Linux Docker (fast path on macOS)
-test-docker:
-	mkdir -p .docker-cache/cargo .docker-cache/target
-	docker run --rm -t \
+# Build the pre-baked Linux test image (nextest + mold linker).
+test-image:
+	docker build -t $(STAX_TEST_IMAGE) -f Dockerfile .
+
+# Build the same image into Apple Container's local store.
+test-container-image:
+	$(CONTAINER) build -t $(STAX_TEST_IMAGE) -f Dockerfile .
+
+# Shared container test env (Docker and Apple Container).
+define CONTAINER_TEST_RUN
+	@threads="$${NEXTEST_TEST_THREADS:-$(MAC_LOCAL_TEST_THREADS)}"; \
+	$(1) run --rm -t \
 		-u "$$(id -u):$$(id -g)" \
+		$(2) \
 		-v "$$(pwd):/work" \
 		-w /work \
-		-e CARGO_HOME=/work/.docker-cache/cargo \
-		-v "$$(pwd)/.docker-cache/target:/work/target" \
-		rust:1 \
-		bash -lc 'export PATH="$$CARGO_HOME/bin:/usr/local/cargo/bin:$$PATH"; if ! command -v cargo-nextest >/dev/null 2>&1; then cargo install cargo-nextest --locked; fi && cargo nextest run'
+		-e CARGO_HOME=/work/$(3)/cargo \
+		-e CARGO_INCREMENTAL=0 \
+		-e CARGO_BUILD_JOBS="$(CONTAINER_CARGO_BUILD_JOBS)" \
+		-e STAX_CONTAINER_CARGO_PROFILE="$(CONTAINER_CARGO_PROFILE)" \
+		-e NEXTEST_TEST_THREADS="$$threads" \
+		-e RUST_MIN_STACK=4194304 \
+		-v "$$(pwd)/$(3)/target:/work/target" \
+		$(STAX_TEST_IMAGE) \
+		bash /work/scripts/container-nextest.sh $(4)
+endef
+
+# Run tests in Linux Docker (fast path on macOS)
+test-docker: test-image
+	mkdir -p .docker-cache/cargo .docker-cache/target
+	$(call CONTAINER_TEST_RUN,docker,,.docker-cache,)
 
 # Run tests with Apple container (experimental macOS fast path)
-test-container:
+test-container: test-container-image
 	mkdir -p .container-cache/cargo .container-cache/target
-	$(CONTAINER) run --rm -t \
-		-u "$$(id -u):$$(id -g)" \
-		-m "$(CONTAINER_MEMORY)" \
-		-v "$$(pwd):/work" \
-		-w /work \
-		-e CARGO_HOME=/work/.container-cache/cargo \
-		-e CARGO_BUILD_JOBS="$(CONTAINER_CARGO_BUILD_JOBS)" \
-		-v "$$(pwd)/.container-cache/target:/work/target" \
-		rust:1 \
-		bash -lc 'export PATH="$$CARGO_HOME/bin:/usr/local/cargo/bin:$$PATH"; if ! command -v cargo-nextest >/dev/null 2>&1; then mkdir -p "$$CARGO_HOME/bin"; case "$$(uname -m)" in aarch64|arm64) nextest_platform=linux-arm ;; x86_64|amd64) nextest_platform=linux ;; *) echo "unsupported container architecture: $$(uname -m)" >&2; exit 1 ;; esac; curl -LsSf "https://get.nexte.st/latest/$$nextest_platform" | tar zxf - -C "$$CARGO_HOME/bin"; fi && cargo nextest run'
+	$(call CONTAINER_TEST_RUN,$(CONTAINER),-m "$(CONTAINER_MEMORY)",.container-cache,)
 
 # Run fast unit tests only
 test-unit:

--- a/scripts/container-nextest.sh
+++ b/scripts/container-nextest.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Shared entrypoint for Linux container test runs (Docker and Apple Container).
+set -euo pipefail
+
+export PATH="${CARGO_HOME:-/usr/local/cargo}/bin:/usr/local/cargo/bin:${PATH}"
+
+ensure_nextest() {
+	if command -v cargo-nextest >/dev/null 2>&1; then
+		return 0
+	fi
+	mkdir -p "${CARGO_HOME}/bin"
+	case "$(uname -m)" in
+	aarch64 | arm64) nextest_platform=linux-arm ;;
+	x86_64 | amd64) nextest_platform=linux ;;
+	*)
+		echo "unsupported container architecture: $(uname -m)" >&2
+		exit 1
+		;;
+	esac
+	curl -LsSf "https://get.nexte.st/latest/${nextest_platform}" | tar zxf - -C "${CARGO_HOME}/bin"
+}
+
+ensure_nextest
+
+profile="${STAX_CONTAINER_CARGO_PROFILE:-test-container}"
+
+exec env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN \
+	STAX_DISABLE_UPDATE_CHECK=1 \
+	cargo nextest run --cargo-profile "${profile}" "$@"

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1272,6 +1272,9 @@ pub(crate) fn sync_head_after_push(
     repo: &GitRepo,
     branch: &str,
 ) {
+    if std::env::var_os("STAX_TEST_DISABLE_HEAD_SYNC").is_some() {
+        return;
+    }
     if let Ok(pushed_sha) = repo.rev_parse(branch) {
         wait_for_github_head_sync(rt, client, pr_number, &pushed_sha, Duration::from_secs(15));
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -65,7 +65,9 @@ fn apply_sanitized_test_env(cmd: &mut Command) {
         .env_remove("GH_TOKEN")
         .env("GIT_CONFIG_GLOBAL", null_path)
         .env("GIT_CONFIG_SYSTEM", null_path)
-        .env("STAX_DISABLE_UPDATE_CHECK", "1");
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        // Forge mocks return static PR head SHAs; skip the post-push head-sync poll.
+        .env("STAX_TEST_DISABLE_HEAD_SYNC", "1");
 }
 
 // Used by `tui_commands_tests` and `worktree_tests`; other integration test crates
@@ -74,6 +76,11 @@ fn apply_sanitized_test_env(cmd: &mut Command) {
 fn sh_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
+
+/// Delay before the first TUI keystrokes in `script`-based integration tests.
+pub const TUI_SCRIPT_LEAD_DELAY: &str = "sleep 0.2";
+/// Pause between TUI interaction rounds.
+pub const TUI_SCRIPT_STEP_DELAY: &str = "sleep 0.2";
 
 #[allow(dead_code)]
 pub fn run_stax_in_script(cwd: &Path, args: &[&str], input_script: &str) -> Output {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -37,7 +37,8 @@ fn sanitized_stax_command() -> Command {
         .env_remove("GH_TOKEN")
         .env("GIT_CONFIG_GLOBAL", null_path)
         .env("GIT_CONFIG_SYSTEM", null_path)
-        .env("STAX_DISABLE_UPDATE_CHECK", "1");
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env("STAX_TEST_DISABLE_HEAD_SYNC", "1");
     cmd
 }
 
@@ -7105,7 +7106,8 @@ mod forge_mock_tests {
             .env("GIT_CONFIG_GLOBAL", &gitconfig)
             .env("GIT_CONFIG_SYSTEM", &gitconfig)
             .env(token_env, "mock-token")
-            .env("STAX_DISABLE_UPDATE_CHECK", "1");
+            .env("STAX_DISABLE_UPDATE_CHECK", "1")
+            .env("STAX_TEST_DISABLE_HEAD_SYNC", "1");
         command.output().expect("Failed to execute stax")
     }
 
@@ -7132,7 +7134,8 @@ mod forge_mock_tests {
             .env("GIT_CONFIG_SYSTEM", &gitconfig)
             .env(token_env, "mock-token")
             .env("PATH", path)
-            .env("STAX_DISABLE_UPDATE_CHECK", "1");
+            .env("STAX_DISABLE_UPDATE_CHECK", "1")
+            .env("STAX_TEST_DISABLE_HEAD_SYNC", "1");
         command.output().expect("Failed to execute stax")
     }
 
@@ -7151,7 +7154,8 @@ mod forge_mock_tests {
             .env("GIT_CONFIG_GLOBAL", &gitconfig)
             .env("GIT_CONFIG_SYSTEM", &gitconfig)
             .env(token_env, "mock-token")
-            .env("STAX_DISABLE_UPDATE_CHECK", "1");
+            .env("STAX_DISABLE_UPDATE_CHECK", "1")
+            .env("STAX_TEST_DISABLE_HEAD_SYNC", "1");
         command
             .output()
             .expect("Failed to execute stax in custom cwd")

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -93,10 +93,10 @@ fn test_split_hunk_requires_terminal() {
 
 /// Each round: j(down to hunk), Space(select), Enter(finish round), Enter(accept name).
 fn split_hunk_script(rounds: usize) -> String {
-    let mut parts = vec!["sleep 1".to_string()];
+    let mut parts = vec![common::TUI_SCRIPT_LEAD_DELAY.to_string()];
     for _ in 0..rounds {
         parts.push("printf 'j \\r\\r'".to_string());
-        parts.push("sleep 2".to_string());
+        parts.push(common::TUI_SCRIPT_STEP_DELAY.to_string());
     }
     parts.join("; ")
 }
@@ -281,8 +281,12 @@ fn test_split_hunk_abort_with_dirty_workdir_preserves_changes() {
     repo.create_file("dirty.txt", "dirty content\n");
 
     // Abort immediately: q(quit) y(confirm)
-    let script = "sleep 1; printf 'qy'; sleep 2";
-    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    let script = format!(
+        "{}; printf 'qy'; {}",
+        common::TUI_SCRIPT_LEAD_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY
+    );
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
 
     assert!(
         output.status.success(),
@@ -504,13 +508,13 @@ fn test_split_hunk_line_additions_partial_select() {
     // Round 3: select hunks 2 and 3 (j, space, j, space, Enter, Enter)
 
     let script = [
-        "sleep 1",
+        common::TUI_SCRIPT_LEAD_DELAY,
         "printf 'j \\r\\r'",
-        "sleep 3",
+        common::TUI_SCRIPT_STEP_DELAY,
         "printf 'j \\r\\r'",
-        "sleep 3",
+        common::TUI_SCRIPT_STEP_DELAY,
         "printf 'j j \\r\\r'",
-        "sleep 2",
+        common::TUI_SCRIPT_STEP_DELAY,
     ]
     .join("; ");
     let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
@@ -618,7 +622,12 @@ fn test_split_hunk_partial_file_selection_gets_second_round() {
     //   j=A:2(now idx 0), space=select, j=A:3(now idx 1), space=select
     //   Enter=commit, Enter=accept name
 
-    let script = "sleep 1; printf 'j j jjja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let script = format!(
+        "{}; printf 'j j jjja\\r\\r'; {}; printf 'j j \\r\\r'; {}",
+        common::TUI_SCRIPT_LEAD_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY
+    );
     let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
     assert!(
         output.status.success(),
@@ -785,8 +794,13 @@ fn test_split_hunk_toggle_file_then_deselect() {
     // Round 2 (list mode): file_a with 2 remaining hunks
     //   j → first hunk, space, j → second hunk, space, Enter, Enter
 
-    let script = "sleep 1; printf 'ajjj j ja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
-    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    let script = format!(
+        "{}; printf 'ajjj j ja\\r\\r'; {}; printf 'j j \\r\\r'; {}",
+        common::TUI_SCRIPT_LEAD_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY
+    );
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
     assert!(
         output.status.success(),
         "Split failed: {}",
@@ -828,8 +842,13 @@ fn test_split_hunk_select_later_hunks_first() {
     // Round 2: file_a with A:0 and A:1 remaining
     //   j → first hunk, space, j → second hunk, space, Enter, Enter
 
-    let script = "sleep 1; printf 'jjj j ja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
-    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    let script = format!(
+        "{}; printf 'jjj j ja\\r\\r'; {}; printf 'j j \\r\\r'; {}",
+        common::TUI_SCRIPT_LEAD_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY
+    );
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
     assert!(
         output.status.success(),
         "Split failed: {}",
@@ -891,8 +910,13 @@ fn test_split_hunk_sequential_mode_partial() {
     // Round 2 (list mode): remaining A:2, A:3
     //   j, space, j, space, Enter, Enter
 
-    let script = "sleep 1; printf '\\tyyynnna\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
-    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], script);
+    let script = format!(
+        "{}; printf '\\tyyynnna\\r'; {}; printf 'j j \\r\\r'; {}",
+        common::TUI_SCRIPT_LEAD_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY
+    );
+    let output = common::run_stax_in_script(&repo.path(), &["split", "--hunk"], &script);
     assert!(
         output.status.success(),
         "Split failed: {}",
@@ -918,11 +942,16 @@ fn test_split_hunk_debug_log_captures_selections() {
     let (repo, original) = setup_two_file_four_two_hunks();
 
     // Same as partial-select: select A:0, A:1 + all B, expect round 2 with A:2, A:3
-    let script = "sleep 1; printf 'j j jjja\\r\\r'; sleep 3; printf 'j j \\r\\r'; sleep 2";
+    let script = format!(
+        "{}; printf 'j j jjja\\r\\r'; {}; printf 'j j \\r\\r'; {}",
+        common::TUI_SCRIPT_LEAD_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY,
+        common::TUI_SCRIPT_STEP_DELAY
+    );
     let output = common::run_stax_in_script_with_env(
         &repo.path(),
         &["split", "--hunk"],
-        script,
+        &script,
         &[("STAX_SPLIT_DEBUG", "1")],
     );
     assert!(

--- a/tests/staging_menu_tests.rs
+++ b/tests/staging_menu_tests.rs
@@ -15,12 +15,20 @@ use common::{OutputAssertions, TestRepo};
 
 fn select_menu_option(index: usize) -> String {
     let downs = "\\033[B".repeat(index);
-    format!("sleep 1; printf '{}\\r'", downs)
+    format!(
+        "{}; printf '{}\\r'",
+        common::TUI_SCRIPT_LEAD_DELAY, downs
+    )
 }
 
 fn select_patch_and_stage_first_hunk() -> String {
     let downs = "\\033[B";
-    format!("sleep 1; printf '{}\\r'; sleep 1; printf 'y\\n'", downs)
+    format!(
+        "{lead}; printf '{downs}\\r'; {step}; printf 'y\\n'",
+        lead = common::TUI_SCRIPT_LEAD_DELAY,
+        step = common::TUI_SCRIPT_STEP_DELAY,
+        downs = downs
+    )
 }
 
 fn head_file(repo: &TestRepo, path: &str) -> String {

--- a/tests/tui_commands_tests.rs
+++ b/tests/tui_commands_tests.rs
@@ -77,7 +77,14 @@ fn test_tui_delete_branch_via_dashboard() {
     let branch_name = repo.current_branch();
     repo.run_stax(&["checkout", "main"]).assert_success();
 
-    let output = common::run_stax_in_script(&repo.path(), &[], "printf 'kdy'; sleep 1; printf 'q'");
+    let output = common::run_stax_in_script(
+        &repo.path(),
+        &[],
+        &format!(
+            "printf 'kdy'; {}; printf 'q'",
+            common::TUI_SCRIPT_STEP_DELAY
+        ),
+    );
     assert!(
         output.status.success(),
         "Scripted TUI session failed: {}",

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -378,7 +378,7 @@ fn restack_interactive_stash_propagates_to_target_worktree() {
     // but didn't enable auto_stash_pop for the rebase layer, so wt_a's dirty state
     // caused: "Cannot restack: worktree has uncommitted changes".
     let output =
-        common::run_stax_in_script(&wt_b, &["restack", "--all"], "printf 'y\\n'; sleep 10");
+        common::run_stax_in_script(&wt_b, &["restack", "--all"], "printf 'y\\n'; sleep 2");
     assert!(
         output.status.success(),
         "Interactive restack should succeed when target worktree is also dirty.\n\
@@ -552,7 +552,7 @@ fn interactive_checkout_selector_routes_to_worktree() {
     let output = common::run_stax_in_script(
         &repo.path(),
         &["checkout"],
-        "printf '\\033[A'; sleep 1; printf '\\r'",
+        "printf '\\033[A'; sleep 0.2; printf '\\r'",
     );
 
     assert!(


### PR DESCRIPTION
## Summary

- Add `make test-container` as an experimental Apple Container path alongside `make test-docker`, with separate cargo/target caches (`.container-cache/`).
- Speed up container test runs with a pre-baked `stax-test` image (nextest + mold linker), a `test-container` Cargo profile for faster bind-mounted relinks, and shared test env via `scripts/container-nextest.sh`.
- Cut integration suite wall time by fixing test-only bottlenecks: forge mocks no longer hit the 15s post-push head-sync timeout, and scripted TUI tests use 200ms delays instead of multi-second sleeps.

## Result (Docker, cached build)

| Metric | Before | After |
|---|---|---|
| Full suite | ~64s | ~27s |
| `test_merge_retargets_...` | ~15s | ~0.7s |
| `split_hunk` TUI tests | 5–9s | ~0.7–0.9s |
| `restack_interactive_stash_...` | ~10s | ~2.2s |

## Notes

- Production behavior is unchanged. `STAX_TEST_DISABLE_HEAD_SYNC` is only set in integration tests; real merges still wait for forge head sync.
- Apple Container builds its own `stax-test` image (`make test-container-image`) because it cannot pull Docker-local images from the host store.
- First run after pulling may rebuild `target/` under the new `test-container` profile; subsequent incremental relinks are ~2× faster (~9s vs ~19s).

## Test plan

- [x] `make test-docker` — 1651 passed
- [x] `make test-container` — 1651 passed
- [x] Targeted slow-test subsets (forge merge mocks, split_hunk, worktree restack) pass with new timings