### PR TITLE
Revert "[codex] Disable Windows release builds (#488)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,8 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-          # Windows builds are intentionally disabled to keep releases fast.
-          # Windows users can build from source with:
-          # cargo install stax --locked --features vendored-openssl
-          # - target: x86_64-pc-windows-msvc
-          #   os: windows-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ brew install cesarferreira/tap/stax
 ```
 
 <details>
-<summary><strong>Other installation methods</strong> — cargo-binstall, prebuilt binaries, Windows from source</summary>
+<summary><strong>Other installation methods</strong> — cargo-binstall, prebuilt binaries, Windows, from source</summary>
 
 ### cargo-binstall
 
@@ -76,21 +76,7 @@ mv stax st ~/.local/bin/
 # echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 ```
 
-**Windows (x86_64):** prebuilt Windows binaries are not published. Install Rust with the MSVC toolchain, then build and install from crates.io:
-
-```powershell
-cargo install stax --locked --features vendored-openssl
-```
-
-Or build from a local checkout:
-
-```powershell
-git clone https://github.com/cesarferreira/stax.git
-cd stax
-cargo install --path . --locked --features vendored-openssl
-```
-
-Cargo installs `stax.exe` and `st.exe` into `%USERPROFILE%\.cargo\bin`; make sure that directory is on your `PATH`. See [Windows notes](#windows-notes).
+**Windows (x86_64):** download `stax-x86_64-pc-windows-msvc.zip` from [Releases](https://github.com/cesarferreira/stax/releases), extract `stax.exe` and `st.exe`, and place them on your `PATH`. See [Windows notes](#windows-notes).
 
 ### Build from source
 
@@ -389,9 +375,7 @@ Use `--path` to scope either mode to a subdirectory.
 <details>
 <summary><strong>Windows notes</strong> — shell integration, worktrees, tmux</summary>
 
-stax runs on Windows (x86_64), but prebuilt Windows binaries are not published. Build it with Rust via `cargo install stax --locked --features vendored-openssl`; most commands work identically once `%USERPROFILE%\.cargo\bin` is on your `PATH`.
-
-Known limitations:
+stax runs on Windows (x86_64) with prebuilt binaries on [Releases](https://github.com/cesarferreira/stax/releases). Most commands work identically, with these limitations:
 
 - **Shell integration is not available.** `st setup` supports bash/zsh/fish only. On Windows:
   - `st wt c` / `st wt go` create and navigate worktrees but cannot auto-`cd` the parent shell. Manually `cd` to the printed path.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -40,21 +40,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
 
 ## Windows
 
-Prebuilt Windows binaries are not published. Install Rust with the MSVC toolchain, then build and install from crates.io:
-
-```powershell
-cargo install stax --locked --features vendored-openssl
-```
-
-Or build from a local checkout:
-
-```powershell
-git clone https://github.com/cesarferreira/stax.git
-cd stax
-cargo install --path . --locked --features vendored-openssl
-```
-
-Cargo installs `stax.exe` and `st.exe` into `%USERPROFILE%\.cargo\bin`; make sure that directory is on your `PATH`. See [Windows notes](../reference/windows.md) for shell and tmux limitations.
+Download `stax-x86_64-pc-windows-msvc.zip` from [Releases](https://github.com/cesarferreira/stax/releases/latest), extract `stax.exe` and `st.exe`, and place them on your `PATH`. See [Windows notes](../reference/windows.md) for shell and tmux limitations.
 
 ## Build from source
 

--- a/docs/reference/windows.md
+++ b/docs/reference/windows.md
@@ -1,26 +1,12 @@
 # Windows
 
-stax supports Windows (`x86_64-pc-windows-msvc`), but prebuilt Windows binaries are not published. Windows users should build and install from source with Rust.
+stax ships prebuilt Windows binaries (`x86_64-pc-windows-msvc`). Unit tests run on Windows in CI alongside Linux.
 
 ## Install
 
-Install Rust with the MSVC toolchain, then install from crates.io:
+Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract `stax.exe` and `st.exe`, and place them on your `PATH`.
 
-```powershell
-cargo install stax --locked --features vendored-openssl
-```
-
-Or build from a local checkout:
-
-```powershell
-git clone https://github.com/cesarferreira/stax.git
-cd stax
-cargo install --path . --locked --features vendored-openssl
-```
-
-Cargo installs `stax.exe` and `st.exe` into `%USERPROFILE%\.cargo\bin`; make sure that directory is on your `PATH`.
-
-If you install with `cargo install`, update notifications and `st cli upgrade` detect the Windows `.cargo\bin` path and show the matching cargo upgrade command.
+If you install with `cargo install` or `cargo binstall`, update notifications and `st cli upgrade` detect the Windows `.cargo\bin` path and show the matching cargo upgrade command.
 
 ## What works
 


### PR DESCRIPTION
## Motivation

Reverts #488, which disabled the Windows release build matrix and removed prebuilt Windows binaries from the published artifacts. This PR brings back first-class Windows support so users on `x86_64-pc-windows-msvc` can install stax by downloading a prebuilt zip from Releases instead of having to build from source.

## Description of changes / notes for reviewers

- Re-enable the `x86_64-pc-windows-msvc` target in `.github/workflows/release.yml`.
- Restore the original Windows install instructions in `README.md`, `docs/getting-started/install.md`, and `docs/reference/windows.md` pointing to `stax-x86_64-pc-windows-msvc.zip` on GitHub Releases.
- Restore the "stax ships prebuilt Windows binaries" wording in the Windows notes section.