### PR TITLE
perf(ci): use mold linker and test-container profile in Rust Tests

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   unit-tests:
     name: Unit Tests
@@ -19,6 +23,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-nextest
@@ -26,11 +32,11 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
-          key: ubuntu-latest
+          key: ubuntu-latest-test-container
       - name: Run unit tests
         env:
           RUST_MIN_STACK: 4194304
-        run: cargo nextest run --lib --bins
+        run: cargo nextest run --lib --bins --cargo-profile test-container
 
   integration-tests:
     name: Integration Tests
@@ -38,13 +44,17 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-latest-test-container
       - name: Run integration tests
         env:
           RUST_MIN_STACK: 4194304
-        run: cargo nextest run --tests
+        run: cargo nextest run --tests --cargo-profile test-container

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
   - `make test-local-ramdisk`
   - `make test-local-fast`
 - Targeted single-test runs via `cargo nextest run <pattern>` are fine and encouraged for tight feedback loops; switch to `make test` once changes are ready for verification.
-- Container test runs (`make test` / `make test-docker` / `make test-container`) use the pre-baked `stax-test` image (`make test-image`), the `test-container` Cargo profile (no debuginfo, mold linker), and shared env (`STAX_DISABLE_UPDATE_CHECK`, `RUST_MIN_STACK`, capped `NEXTEST_TEST_THREADS`). For tight iteration, prefer `cargo nextest run --lib --bins` or a module filter before a full container run.
+- Container test runs (`make test` / `make test-docker` / `make test-container`) use the pre-baked `stax-test` image (`make test-image`), the `test-container` Cargo profile (no debuginfo, mold linker), and shared env (`STAX_DISABLE_UPDATE_CHECK`, `RUST_MIN_STACK`, capped `NEXTEST_TEST_THREADS`). CI uses the same `test-container` profile and mold on `ubuntu-latest`. For tight iteration, prefer `cargo nextest run --lib --bins` or a module filter before a full container run.
 - All integration tests compile into a **single** binary (`tests/all_tests.rs`, with `autotests = false` in `Cargo.toml`) so cargo links one test binary instead of ~50 — this is what keeps test builds fast. Because of this, there is only one `[[test]]` target named `all_tests`: `cargo test --test status_tests` no longer works. To scope a run, filter by module path instead, e.g. `cargo nextest run status_tests::` (one former file) or `cargo nextest run status_tests::status_json_output` (one test). When adding a new `tests/*_tests.rs` file, register it with a `#[path = "..."] mod ...;` entry in `tests/all_tests.rs`.
 
 ## Why

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,8 @@ split-debuginfo = "unpacked"
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
 
-# Linux container test runs (Docker / Apple Container): skip debuginfo for faster
-# linking when target/ is bind-mounted from the macOS host.
+# Linux container test runs (Docker / Apple Container / CI): skip debuginfo for
+# faster linking when target/ is bind-mounted from the macOS host.
 [profile.test-container]
 inherits = "test"
 debug = 0


### PR DESCRIPTION
## Summary

- Install **mold** on `ubuntu-latest` and set `RUSTFLAGS="-C link-arg=-fuse-ld=mold"` in the Rust Tests workflow.
- Run both unit and integration jobs with `--cargo-profile test-container` (same no-debuginfo profile used by `make test-docker`).
- Bump `rust-cache` key to `ubuntu-latest-test-container` so the new profile gets a clean cache namespace.

## Why

PR #495 sped up local Docker runs (~64s → ~27s) but CI still used the default `test` profile and no mold linker. This wires the same fast-path settings into GitHub Actions.

## Expected impact

- Faster integration job links on warm cache (profile + mold).
- Test execution time unchanged (already improved in #495 via `STAX_TEST_DISABLE_HEAD_SYNC` and shorter TUI sleeps).
- First run after merge may be slower while the new cache key warms up.

## Test plan

- [ ] Rust Tests workflow passes on this PR
- [ ] Compare integration job "Run integration tests" step duration vs recent main runs (~100s baseline)

Made with [Cursor](https://cursor.com)