### PR TITLE
fix(test): stabilize scripted TUI delays

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -78,9 +78,13 @@ fn sh_quote(value: &str) -> String {
 }
 
 /// Delay before the first TUI keystrokes in `script`-based integration tests.
-pub const TUI_SCRIPT_LEAD_DELAY: &str = "sleep 0.2";
+///
+/// Keep this conservative: the `script` PTY helper does not provide a readiness
+/// signal, so sending input too early races the TUI startup/re-render path and
+/// can make multi-round flows silently accept the wrong branch name.
+pub const TUI_SCRIPT_LEAD_DELAY: &str = "sleep 1";
 /// Pause between TUI interaction rounds.
-pub const TUI_SCRIPT_STEP_DELAY: &str = "sleep 0.2";
+pub const TUI_SCRIPT_STEP_DELAY: &str = "sleep 2";
 
 #[allow(dead_code)]
 pub fn run_stax_in_script(cwd: &Path, args: &[&str], input_script: &str) -> Output {


### PR DESCRIPTION
## Summary
- restore conservative PTY script delays for TUI integration tests
- document why the delay cannot be too aggressive without a readiness signal

## Why
Main was failing in CI because `split_hunk_tests::test_split_hunk_two_files_into_two_branches` raced the scripted TUI startup/round transition and only created `feature-a_split_1`, deleting the original `feature-a` branch.

## Tests
- `STAX_SPLIT_DEBUG=1 cargo nextest run split_hunk_tests::test_split_hunk_two_files_into_two_branches --no-fail-fast`
- `make test`

Docs: not needed; test-only stabilization.