### PR TITLE
Treat st get branches as imported read-only bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ st config --set-ai
 | `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
-| `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax, and check it out |
+| `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax as imported, and check it out |
 | `st ss` | Submit the full stack, open/update linked PRs |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--remote`, `--all`) |
 | `st ready` | Interactive PR readiness dashboard for all tracked PRs, newest changed PR first: merge, ping, fix, wait, or draft (`--current`/`--stack` for current stack, `--plain` for table output) |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -12,7 +12,7 @@ Day-to-day commands you'll use most. For the exhaustive list of every command, s
 | `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
-| `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax, and check it out |
+| `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax as imported, and check it out |
 
 If you discover a hotfix while working upstack, keep the edits in place:
 

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -12,7 +12,7 @@
 | `st trunk <branch>` | Set trunk to `<branch>` |
 | `st prev` | Toggle to previous branch |
 | `st co` | Interactive branch picker |
-| `st get <branch>` | Fetch, checkout, and track a remote branch |
+| `st get <branch>` | Fetch, checkout, and track an imported remote branch |
 
 ## Checkout shortcuts
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -259,6 +259,7 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 - `--restack` · `--restack --auto-stash-pop`
 - `--delete-upstream-gone`
 - `--force` / `--safe` / `--continue` / `--quiet` / `--verbose`
+- Imported branches from `st get` are remote-delete exempt: once they are detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch.
 
 ### `st restack`
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -283,6 +283,8 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 - `--parent <branch>` records a non-trunk parent in stax metadata
 - `--no-checkout` fetches and tracks without switching branches
 - `--force` resets an existing divergent local branch to the remote tip
+- Imported branches are read-only support branches: submit uses them as stack bases but does not push them or update their PRs.
+- `st sync --restack` refreshes imported branches from their remote tips before restacking descendants; if an imported branch is checked out in a dirty worktree, sync skips it unless `--force` is used.
 
 ### `st ci`
 

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -40,6 +40,8 @@ st status   # your existing stack appears immediately
 | — | — | `st undo` · `st redo` |
 | — | `gt split -f <path>` | `st split --file <path>` |
 
+`st get` imports the remote branch as a read-only stack base: Stax can create and restack local branches on top of it, but submit skips pushing or updating the imported branch itself.
+
 ## Short alias: `st`
 
 stax also installs as `st`:

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -40,7 +40,7 @@ st status   # your existing stack appears immediately
 | — | — | `st undo` · `st redo` |
 | — | `gt split -f <path>` | `st split --file <path>` |
 
-`st get` imports the remote branch as a read-only stack base: Stax can create and restack local branches on top of it, but submit skips pushing or updating the imported branch itself. If the imported branch already has a PR, stack-link comments still include and sync that PR, with labels relative to the PR being rendered.
+`st get` imports the remote branch as a read-only stack base: Stax can create and restack local branches on top of it, but submit skips pushing or updating the imported branch itself. Sync cleanup may delete the imported local support branch after it is merged or upstream-gone, but it will not push-delete the imported remote branch. If the imported branch already has a PR, stack-link comments still include and sync that PR, with labels relative to the PR being rendered.
 
 ## Short alias: `st`
 

--- a/docs/compatibility/freephite-graphite.md
+++ b/docs/compatibility/freephite-graphite.md
@@ -40,7 +40,7 @@ st status   # your existing stack appears immediately
 | — | — | `st undo` · `st redo` |
 | — | `gt split -f <path>` | `st split --file <path>` |
 
-`st get` imports the remote branch as a read-only stack base: Stax can create and restack local branches on top of it, but submit skips pushing or updating the imported branch itself.
+`st get` imports the remote branch as a read-only stack base: Stax can create and restack local branches on top of it, but submit skips pushing or updating the imported branch itself. If the imported branch already has a PR, stack-link comments still include and sync that PR, with labels relative to the PR being rendered.
 
 ## Short alias: `st`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -165,6 +165,8 @@ single_stack = "on"    # "on" | "off"
 
 When body output is enabled, stax appends a managed block to the bottom of the PR body and only rewrites that managed block on future submits.
 
+Stack-link entries use compact PR/MR references and mark the PR being rendered with `👈`. On GitHub, stax keeps native `#123` PR references so GitHub renders its standard linked issue/PR styling; other forges use direct markdown links. The intro text is relative to the PR being rendered, so an imported base PR is described as an imported reference, while a local PR calls out any imported downstack context. Imported branches remain read-only for push and PR metadata updates, but their existing PRs still receive the managed stack links when they are part of the displayed stack.
+
 `single_stack` controls whether stack links are written when the stack contains only one PR. With the default `"on"`, links are always synced per `stack_links`. With `"off"`, stax skips link sync — and removes any stale links left over from a previous `"on"` setting — while the stack has a single PR. As soon as a second PR is submitted on the same stack, links populate on every PR (including the original) automatically.
 
 ## Forge type override

--- a/skills.md
+++ b/skills.md
@@ -30,7 +30,7 @@ stax sweep                     # Classify + optionally delete merged/gone/stale 
 stax restack                   # Rebase branch/stack onto parents
 stax cascade                   # Restack bottom-up and submit updates
 
-stax get <branch>              # Fetch, checkout, and track remote branch
+stax get <branch>              # Fetch, checkout, and track imported remote branch
 stax checkout|co|bco           # Checkout branch (interactive by default)
 stax trunk|t                   # Checkout trunk
 stax trunk <branch>            # Set trunk branch
@@ -287,6 +287,7 @@ stax p                             # Previous branch
 stax get teammate-branch           # Fetch remote branch, track under trunk, checkout
 stax get teammate-branch --parent base-branch  # Track fetched branch under explicit parent
 stax get teammate-branch --no-checkout  # Fetch and track without switching branches
+# Imported branches are read-only during submit; sync --restack refreshes clean imported bases before rebasing descendants.
 stax branch track --parent main    # Track existing branch under parent
 stax branch track --all-prs        # Import your open PRs
 stax branch untrack <branch>       # Remove stax metadata only

--- a/skills.md
+++ b/skills.md
@@ -287,7 +287,8 @@ stax p                             # Previous branch
 stax get teammate-branch           # Fetch remote branch, track under trunk, checkout
 stax get teammate-branch --parent base-branch  # Track fetched branch under explicit parent
 stax get teammate-branch --no-checkout  # Fetch and track without switching branches
-# Imported branches are read-only during submit; sync --restack refreshes clean imported bases before rebasing descendants.
+# Imported branches are read-only during submit; existing imported PRs still get stack-link comments with relative intro text. GitHub comments keep compact native PR references and mark the rendered PR with 👈.
+# sync --restack refreshes clean imported bases before rebasing descendants.
 stax branch track --parent main    # Track existing branch under parent
 stax branch track --all-prs        # Import your open PRs
 stax branch untrack <branch>       # Remove stax metadata only

--- a/skills.md
+++ b/skills.md
@@ -239,6 +239,7 @@ stax sync --force                  # Force sync without prompts
 stax sync --prune                  # Prune stale remotes
 stax sync --no-delete              # Keep merged branches
 stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
+# sync cleanup may delete merged/gone imported support branches locally, but never push-deletes their remotes.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
 stax sweep --delete                # Delete merged + upstream-gone branches with no unique work after confirmation
@@ -288,7 +289,7 @@ stax get teammate-branch           # Fetch remote branch, track under trunk, che
 stax get teammate-branch --parent base-branch  # Track fetched branch under explicit parent
 stax get teammate-branch --no-checkout  # Fetch and track without switching branches
 # Imported branches are read-only during submit; existing imported PRs still get stack-link comments with relative intro text. GitHub comments keep compact native PR references and mark the rendered PR with 👈.
-# sync --restack refreshes clean imported bases before rebasing descendants.
+# sync --restack refreshes clean imported bases before rebasing descendants; cleanup can remove them locally after merge/gone.
 stax branch track --parent main    # Track existing branch under parent
 stax branch track --all-prs        # Import your open PRs
 stax branch untrack <branch>       # Remove stax metadata only

--- a/src/commands/branch/track.rs
+++ b/src/commands/branch/track.rs
@@ -233,6 +233,7 @@ fn run_track_all_prs() -> Result<()> {
         let meta = BranchMetadata {
             parent_branch_name: parent_branch.clone(),
             parent_branch_revision: parent_rev,
+            source_remote: None,
             pr_info: Some(PrInfo {
                 number: pr.number,
                 state: pr.state.to_uppercase(),

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -72,7 +72,7 @@ pub fn run(branch: String, parent: Option<String>, no_checkout: bool, force: boo
     }
 
     let repo = GitRepo::open()?;
-    write_tracking_metadata(&repo, &branch, &parent_branch)?;
+    write_tracking_metadata(&repo, &branch, &parent_branch, &remote)?;
 
     if no_checkout {
         println!(
@@ -108,7 +108,12 @@ fn normalize_remote_branch(branch: &str, remote: &str) -> Result<String> {
     Ok(trimmed.to_string())
 }
 
-fn write_tracking_metadata(repo: &GitRepo, branch: &str, parent_branch: &str) -> Result<()> {
+fn write_tracking_metadata(
+    repo: &GitRepo,
+    branch: &str,
+    parent_branch: &str,
+    remote: &str,
+) -> Result<()> {
     if let Some(existing) = BranchMetadata::read(repo.inner(), branch)? {
         if existing.parent_branch_name != parent_branch {
             anyhow::bail!(
@@ -119,13 +124,23 @@ fn write_tracking_metadata(repo: &GitRepo, branch: &str, parent_branch: &str) ->
                 "stax branch reparent".cyan()
             );
         }
+        if existing.source_remote.as_deref() != Some(remote) {
+            let updated = BranchMetadata {
+                source_remote: Some(remote.to_string()),
+                ..existing
+            };
+            updated.write(repo.inner(), branch)?;
+        }
         return Ok(());
     }
 
     let parent_rev = repo
         .merge_base(parent_branch, branch)
         .or_else(|_| repo.branch_commit(parent_branch))?;
-    let meta = BranchMetadata::new(parent_branch, &parent_rev);
+    let meta = BranchMetadata {
+        source_remote: Some(remote.to_string()),
+        ..BranchMetadata::new(parent_branch, &parent_rev)
+    };
     meta.write(repo.inner(), branch)?;
     Ok(())
 }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -362,9 +362,12 @@ fn run_impl(
             RebaseResult::Success => {
                 // Update metadata with new parent revision
                 let new_parent_rev = repo.branch_commit(&parent_branch_name)?;
+                let source_remote =
+                    BranchMetadata::read(repo.inner(), branch)?.and_then(|meta| meta.source_remote);
                 let updated_meta = BranchMetadata {
                     parent_branch_name: parent_branch_name.clone(),
                     parent_branch_revision: new_parent_rev.clone(),
+                    source_remote,
                     pr_info: live_stack.branches.get(branch).and_then(|br| {
                         br.pr_number.map(|n| crate::engine::PrInfo {
                             number: n,

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1345,6 +1345,9 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let rt = rt.context("Internal error: missing runtime for PR submission")?;
     let client = client.context("Internal error: missing forge client for PR submission")?;
 
+    let imported_stack_branches =
+        imported_branches_for_stack(&repo, &stack, &current, &remote_info.name)?;
+
     let (open_pr_url, async_timings, async_full_scan_fallbacks) = rt.block_on(async {
         let mut pr_infos: Vec<StackPrInfo> = Vec::new();
         let mut created_pr_numbers: HashSet<u64> = HashSet::new();
@@ -1453,6 +1456,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     pr_infos.push(StackPrInfo {
                         branch: plan.branch.clone(),
                         pr_number: Some(pr.number),
+                        is_imported: plan.is_imported,
                     });
                 } else {
                     // Toggle draft status even when no other update is needed
@@ -1528,6 +1532,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     pr_infos.push(StackPrInfo {
                         branch: plan.branch.clone(),
                         pr_number: Some(existing_pr_number),
+                        is_imported: plan.is_imported,
                     });
                 }
             } else {
@@ -1587,6 +1592,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 pr_infos.push(StackPrInfo {
                     branch: plan.branch.clone(),
                     pr_number: Some(pr.number),
+                    is_imported: plan.is_imported,
                 });
             }
         }
@@ -1596,7 +1602,23 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         // from each PR branch's own stack context. When submitting from trunk,
         // a single trunk-wide context would flatten sibling stacks into a fake
         // linear chain.
-        let stack_link_contexts = stack_link_contexts_for_sync(&stack, &current, &pr_infos);
+        let mut stack_link_pr_infos = pr_infos.clone();
+        if stack_links_mode != StackLinksMode::Off {
+            discover_stack_link_pr_infos(
+                &client,
+                &stack,
+                &current,
+                &imported_stack_branches,
+                &mut stack_link_pr_infos,
+            )
+            .await?;
+        }
+        let stack_link_contexts = stack_link_contexts_for_sync(
+            &stack,
+            &current,
+            &stack_link_pr_infos,
+            &imported_stack_branches,
+        );
 
         let stack_links_started_at = Instant::now();
         let effective_stack_links_mode =
@@ -1856,10 +1878,11 @@ fn stack_pr_infos_for_links(
     stack: &Stack,
     current: &str,
     processed_pr_infos: &[StackPrInfo],
+    imported_branches: &HashSet<String>,
 ) -> Vec<StackPrInfo> {
-    let processed_pr_numbers: HashMap<&str, Option<u64>> = processed_pr_infos
+    let processed_pr_infos_by_branch: HashMap<&str, &StackPrInfo> = processed_pr_infos
         .iter()
-        .map(|info| (info.branch.as_str(), info.pr_number))
+        .map(|info| (info.branch.as_str(), info))
         .collect();
 
     stack
@@ -1867,27 +1890,94 @@ fn stack_pr_infos_for_links(
         .into_iter()
         .filter(|branch| branch != &stack.trunk)
         .map(|branch| {
-            let pr_number = processed_pr_numbers
-                .get(branch.as_str())
-                .copied()
-                .flatten()
+            let processed_info = processed_pr_infos_by_branch.get(branch.as_str()).copied();
+            let pr_number = processed_info
+                .and_then(|info| info.pr_number)
                 .or_else(|| stack.branches.get(&branch).and_then(|info| info.pr_number));
+            let is_imported = processed_info
+                .map(|info| info.is_imported)
+                .unwrap_or_else(|| imported_branches.contains(&branch));
 
-            StackPrInfo { branch, pr_number }
+            StackPrInfo {
+                branch,
+                pr_number,
+                is_imported,
+            }
         })
         .collect()
+}
+
+async fn discover_stack_link_pr_infos(
+    client: &ForgeClient,
+    stack: &Stack,
+    current: &str,
+    imported_branches: &HashSet<String>,
+    processed_pr_infos: &mut Vec<StackPrInfo>,
+) -> Result<()> {
+    let mut known_branches: HashSet<String> = processed_pr_infos
+        .iter()
+        .filter(|info| info.pr_number.is_some())
+        .map(|info| info.branch.clone())
+        .collect();
+
+    let missing_pr_infos =
+        stack_pr_infos_for_links(stack, current, processed_pr_infos, imported_branches);
+    for info in missing_pr_infos {
+        if info.pr_number.is_some() || known_branches.contains(&info.branch) {
+            continue;
+        }
+
+        if let Some(pr) = client.find_open_pr_by_head(&info.branch).await? {
+            known_branches.insert(info.branch.clone());
+            processed_pr_infos.push(StackPrInfo {
+                branch: info.branch,
+                pr_number: Some(pr.info.number),
+                is_imported: info.is_imported,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn imported_branches_for_stack(
+    repo: &GitRepo,
+    stack: &Stack,
+    current: &str,
+    remote: &str,
+) -> Result<HashSet<String>> {
+    let mut imported = HashSet::new();
+    for branch in stack
+        .current_stack(current)
+        .into_iter()
+        .filter(|branch| branch != &stack.trunk)
+    {
+        let Some(meta) = BranchMetadata::read(repo.inner(), &branch)? else {
+            continue;
+        };
+        if is_imported_from_remote(&meta, remote) {
+            imported.insert(branch);
+        }
+    }
+    Ok(imported)
 }
 
 fn stack_link_contexts_for_sync(
     stack: &Stack,
     current: &str,
     processed_pr_infos: &[StackPrInfo],
+    imported_branches: &HashSet<String>,
 ) -> Vec<(u64, String, Vec<StackPrInfo>)> {
-    stack_pr_infos_for_links(stack, current, processed_pr_infos)
+    stack_pr_infos_for_links(stack, current, processed_pr_infos, imported_branches)
         .into_iter()
         .filter_map(|info| {
             let pr_number = info.pr_number?;
-            let context = stack_pr_infos_for_links(stack, &info.branch, processed_pr_infos);
+            let context = stack_pr_infos_for_links(
+                stack,
+                &info.branch,
+                processed_pr_infos,
+                imported_branches,
+            );
             Some((pr_number, info.branch, context))
         })
         .collect()
@@ -2661,7 +2751,7 @@ mod tests {
     };
     use crate::engine::stack::StackBranch;
     use crate::engine::Stack;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn no_prompt_defaults_to_draft() {
@@ -2754,21 +2844,28 @@ mod tests {
             ]),
         };
 
+        let imported_branches = HashSet::from(["base".to_string()]);
         let infos = stack_pr_infos_for_links(
             &stack,
             "middle",
             &[StackPrInfo {
                 branch: "middle".to_string(),
                 pr_number: Some(22),
+                is_imported: false,
             }],
+            &imported_branches,
         );
 
         assert_eq!(
             infos
                 .iter()
-                .map(|info| (info.branch.as_str(), info.pr_number))
+                .map(|info| (info.branch.as_str(), info.pr_number, info.is_imported))
                 .collect::<Vec<_>>(),
-            vec![("base", Some(10)), ("middle", Some(22)), ("leaf", Some(30))]
+            vec![
+                ("base", Some(10), true),
+                ("middle", Some(22), false),
+                ("leaf", Some(30), false)
+            ]
         );
     }
 
@@ -2832,7 +2929,7 @@ mod tests {
             ]),
         };
 
-        let contexts = stack_link_contexts_for_sync(&stack, "main", &[]);
+        let contexts = stack_link_contexts_for_sync(&stack, "main", &[], &HashSet::new());
 
         let context_for = |branch: &str| {
             contexts

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -550,7 +550,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             let mut meta = BranchMetadata::read(repo.inner(), branch)?
                 .context(format!("No metadata for branch {}", branch))?;
             let is_empty = empty_set.contains(branch);
-            let is_imported = is_imported_from_remote(&meta, &remote_info.name);
+            let is_imported = is_imported_branch(&meta);
             let needs_push =
                 !is_imported && branch_needs_push(repo.workdir()?, &remote_info.name, branch);
             let mut existing_pr = None;
@@ -736,7 +736,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 .context(format!("No metadata for branch {}", branch))?;
 
             let is_empty = empty_set.contains(branch);
-            let is_imported = is_imported_from_remote(&meta, &remote_info.name);
+            let is_imported = is_imported_branch(&meta);
 
             // Check if PR exists (skip for empty branches)
             let existing_pr = lookups_by_branch
@@ -1345,8 +1345,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let rt = rt.context("Internal error: missing runtime for PR submission")?;
     let client = client.context("Internal error: missing forge client for PR submission")?;
 
-    let imported_stack_branches =
-        imported_branches_for_stack(&repo, &stack, &current, &remote_info.name)?;
+    let imported_stack_branches = imported_branches_for_stack(&repo, &stack, &current)?;
 
     let (open_pr_url, async_timings, async_full_scan_fallbacks) = rt.block_on(async {
         let mut pr_infos: Vec<StackPrInfo> = Vec::new();
@@ -1944,7 +1943,6 @@ fn imported_branches_for_stack(
     repo: &GitRepo,
     stack: &Stack,
     current: &str,
-    remote: &str,
 ) -> Result<HashSet<String>> {
     let mut imported = HashSet::new();
     for branch in stack
@@ -1955,7 +1953,7 @@ fn imported_branches_for_stack(
         let Some(meta) = BranchMetadata::read(repo.inner(), &branch)? else {
             continue;
         };
-        if is_imported_from_remote(&meta, remote) {
+        if is_imported_branch(&meta) {
             imported.insert(branch);
         }
     }
@@ -2212,8 +2210,8 @@ fn branch_needs_push(workdir: &Path, remote: &str, branch: &str) -> bool {
     }
 }
 
-fn is_imported_from_remote(meta: &BranchMetadata, remote: &str) -> bool {
-    meta.source_remote.as_deref() == Some(remote)
+fn is_imported_branch(meta: &BranchMetadata) -> bool {
+    meta.source_remote.is_some()
 }
 
 fn branch_matches_remote(workdir: &Path, remote: &str, branch: &str) -> bool {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -92,6 +92,8 @@ struct PrPlan {
     needs_pr_update: bool,
     // Empty branches get pushed but no PR created
     is_empty: bool,
+    // Branches imported with `stax get` are read-only support branches.
+    is_imported: bool,
 }
 
 struct ExistingPrLookup {
@@ -548,7 +550,9 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             let mut meta = BranchMetadata::read(repo.inner(), branch)?
                 .context(format!("No metadata for branch {}", branch))?;
             let is_empty = empty_set.contains(branch);
-            let needs_push = branch_needs_push(repo.workdir()?, &remote_info.name, branch);
+            let is_imported = is_imported_from_remote(&meta, &remote_info.name);
+            let needs_push =
+                !is_imported && branch_needs_push(repo.workdir()?, &remote_info.name, branch);
             let mut existing_pr = None;
             let had_metadata_pr = meta.pr_info.as_ref().filter(|p| p.number > 0).is_some();
 
@@ -651,6 +655,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 needs_push,
                 needs_pr_update: false,
                 is_empty,
+                is_imported,
             });
         }
     } else {
@@ -731,6 +736,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 .context(format!("No metadata for branch {}", branch))?;
 
             let is_empty = empty_set.contains(branch);
+            let is_imported = is_imported_from_remote(&meta, &remote_info.name);
 
             // Check if PR exists (skip for empty branches)
             let existing_pr = lookups_by_branch
@@ -793,10 +799,13 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             let base = meta.parent_branch_name.clone();
 
             // Check if we actually need to push
-            let needs_push = branch_needs_push(repo.workdir()?, &remote_info.name, branch);
+            let needs_push =
+                !is_imported && branch_needs_push(repo.workdir()?, &remote_info.name, branch);
 
             // Check if PR base needs updating (not for empty branches)
             let needs_pr_update = if is_empty {
+                false
+            } else if is_imported {
                 false
             } else if let Some(pr) = &existing_pr {
                 pr.info.base != base || needs_push
@@ -835,6 +844,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 needs_push,
                 needs_pr_update,
                 is_empty,
+                is_imported,
             });
         }
 
@@ -847,15 +857,21 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     // Show plan summary (exclude empty branches from PR counts)
     let creates: Vec<_> = plans
         .iter()
-        .filter(|p| p.existing_pr.is_none() && !p.is_empty)
+        .filter(|p| p.existing_pr.is_none() && !p.is_empty && !p.is_imported)
         .collect();
     let updates: Vec<_> = plans
         .iter()
-        .filter(|p| p.existing_pr.is_some() && p.needs_pr_update && !p.is_empty)
+        .filter(|p| p.existing_pr.is_some() && p.needs_pr_update && !p.is_empty && !p.is_imported)
         .collect();
     let noops: Vec<_> = plans
         .iter()
-        .filter(|p| p.existing_pr.is_some() && !p.needs_pr_update && !p.needs_push && !p.is_empty)
+        .filter(|p| {
+            p.existing_pr.is_some()
+                && !p.needs_pr_update
+                && !p.needs_push
+                && !p.is_empty
+                && !p.is_imported
+        })
         .collect();
 
     if !quiet {
@@ -896,7 +912,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         let mut ai_agent_selection: Option<AiAgentSelection> = None;
         let new_prs: Vec<_> = plans
             .iter()
-            .filter(|p| p.existing_pr.is_none() && !p.is_empty)
+            .filter(|p| p.existing_pr.is_none() && !p.is_empty && !p.is_imported)
             .collect();
         if !new_prs.is_empty() && !quiet {
             println!();
@@ -904,7 +920,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         }
 
         for plan in &mut plans {
-            if plan.existing_pr.is_some() || plan.is_empty {
+            if plan.existing_pr.is_some() || plan.is_empty || plan.is_imported {
                 continue;
             }
 
@@ -1066,7 +1082,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             if should_consider_existing_ai {
                 let existing_prs: Vec<_> = plans
                     .iter()
-                    .filter(|p| p.existing_pr.is_some() && !p.is_empty)
+                    .filter(|p| p.existing_pr.is_some() && !p.is_empty && !p.is_imported)
                     .collect();
                 if !existing_prs.is_empty() && !quiet {
                     println!();
@@ -1078,6 +1094,9 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                         continue;
                     };
                     if plan.is_empty {
+                        continue;
+                    }
+                    if plan.is_imported {
                         continue;
                     }
 
@@ -1296,7 +1315,9 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 || p.generated_body_update.is_some())
     });
 
-    let any_existing_prs = plans.iter().any(|p| !p.is_empty && p.existing_pr.is_some());
+    let any_existing_prs = plans
+        .iter()
+        .any(|p| !p.is_empty && !p.is_imported && p.existing_pr.is_some());
 
     if !any_pr_work && branches_needing_push.is_empty() && !any_existing_prs {
         if !quiet {
@@ -1333,7 +1354,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         let create_update_started_at = Instant::now();
         for plan in &plans {
             // Skip empty branches for PR operations
-            if plan.is_empty {
+            if plan.is_empty || plan.is_imported {
                 continue;
             }
 
@@ -2099,6 +2120,10 @@ fn branch_needs_push(workdir: &Path, remote: &str, branch: &str) -> bool {
         (Some(_), None) => true,      // Branch not on remote yet
         _ => true,                    // Default to push if unsure
     }
+}
+
+fn is_imported_from_remote(meta: &BranchMetadata, remote: &str) -> bool {
+    meta.source_remote.as_deref() == Some(remote)
 }
 
 fn branch_matches_remote(workdir: &Path, remote: &str, branch: &str) -> bool {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -143,6 +143,7 @@ pub fn run(
     let remote_name = config.remote_name().to_string();
     let remote_trunk_ref = format!("{}/{}", remote_name, stack.trunk);
     let imported_branches = imported_branches_for_remote(&repo, &stack, &remote_name)?;
+    let remote_delete_exempt_imported_branches = imported_branches_for_cleanup(&repo, &stack)?;
     let mut sync_extra_fetch_refs = extra_fetch_refs.to_vec();
     for branch in &imported_branches {
         if !sync_extra_fetch_refs.contains(branch) {
@@ -868,15 +869,21 @@ pub fn run(
                 let local_deleted = local_delete.deleted;
                 let local_worktree_blocked = local_delete.worktree_blocked;
 
-                // Delete remote branch
-                let remote_status = Command::new("git")
-                    .args(["push", &remote_name, "--delete", branch])
-                    .current_dir(&workdir)
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status();
+                // Imported branches are read-only remote references. Clean them
+                // up locally after merge, but never push-delete someone else's
+                // remote branch.
+                let remote_deleted = if remote_delete_exempt_imported_branches.contains(branch) {
+                    false
+                } else {
+                    let remote_status = Command::new("git")
+                        .args(["push", &remote_name, "--delete", branch])
+                        .current_dir(&workdir)
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .status();
 
-                let remote_deleted = remote_status.map(|s| s.success()).unwrap_or(false);
+                    remote_status.map(|s| s.success()).unwrap_or(false)
+                };
 
                 // Only delete metadata if branch no longer exists locally.
                 let local_still_exists = local_branch_exists(&workdir, branch);
@@ -1745,6 +1752,23 @@ fn imported_branches_for_remote(
         }
     }
     imported.sort();
+    Ok(imported)
+}
+
+fn imported_branches_for_cleanup(repo: &GitRepo, stack: &Stack) -> Result<HashSet<String>> {
+    let mut imported = HashSet::new();
+    for branch in stack.branches.keys() {
+        if branch == &stack.trunk {
+            continue;
+        }
+
+        let Some(meta) = BranchMetadata::read(repo.inner(), branch)? else {
+            continue;
+        };
+        if meta.source_remote.is_some() {
+            imported.insert(branch.clone());
+        }
+    }
     Ok(imported)
 }
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -142,6 +142,13 @@ pub fn run(
     let config = Config::load()?;
     let remote_name = config.remote_name().to_string();
     let remote_trunk_ref = format!("{}/{}", remote_name, stack.trunk);
+    let imported_branches = imported_branches_for_remote(&repo, &stack, &remote_name)?;
+    let mut sync_extra_fetch_refs = extra_fetch_refs.to_vec();
+    for branch in &imported_branches {
+        if !sync_extra_fetch_refs.contains(branch) {
+            sync_extra_fetch_refs.push(branch.clone());
+        }
+    }
 
     if r#continue {
         crate::commands::continue_cmd::run()?;
@@ -193,7 +200,7 @@ pub fn run(
     let output;
     // Remote branch names for merged detection (`None` when `--no-delete`: trunk-only fetch).
     let remote_branches_for_merged: Option<HashSet<String>>;
-    let remote_heads_for_extra_fetch = if !full && !extra_fetch_refs.is_empty() {
+    let remote_heads_for_extra_fetch = if !full && !sync_extra_fetch_refs.is_empty() {
         Some(
             remote::ls_remote_heads(&workdir, &remote_name)
                 .context("Failed to list remote heads before fetch")?,
@@ -203,7 +210,7 @@ pub fn run(
     };
     let fetch_refs = sync_fetch_refs(
         &stack.trunk,
-        extra_fetch_refs,
+        &sync_extra_fetch_refs,
         remote_heads_for_extra_fetch.as_ref(),
     );
 
@@ -512,6 +519,23 @@ pub fn run(
         format!("update {}", stack.trunk),
         update_trunk_started_at.elapsed(),
     ));
+
+    let imported_update_started_at = Instant::now();
+    let updated_imported_branches = refresh_imported_branches(
+        &repo,
+        &workdir,
+        &remote_name,
+        &imported_branches,
+        force,
+        quiet,
+        verbose,
+    )?;
+    if !imported_branches.is_empty() {
+        step_timings.push((
+            "update imported branches".to_string(),
+            imported_update_started_at.elapsed(),
+        ));
+    }
 
     // Kick off trunk diff stats now that trunk is updated. Runs in parallel with
     // merged-branch detection and optional restack (the expensive steps).
@@ -1273,6 +1297,24 @@ pub fn run(
         // Load stack once; orphaned parents are handled in Stack::load (parent → trunk,
         // needs_restack). Keep the stack in memory and update it after each rebase.
         let mut live_stack = Stack::load(&repo)?;
+        for branch in &updated_imported_branches {
+            if let Ok(parent_rev) = repo.branch_commit(branch) {
+                let children = live_stack
+                    .branches
+                    .get(branch.as_str())
+                    .map(|br| br.children.clone())
+                    .unwrap_or_default();
+                for child in &children {
+                    if let Some(child_br) = live_stack.branches.get_mut(child) {
+                        child_br.needs_restack = child_br
+                            .parent_revision
+                            .as_deref()
+                            .map(|rev| rev != parent_rev.as_str())
+                            .unwrap_or(true);
+                    }
+                }
+            }
+        }
         let branches_to_restack: Vec<String> = scope_order
             .iter()
             .filter(|branch| {
@@ -1360,9 +1402,12 @@ pub fn run(
                     RebaseResult::Success => {
                         let metadata_update_started_at = Instant::now();
                         let new_parent_rev = repo.branch_commit(&parent_branch_name)?;
+                        let source_remote = BranchMetadata::read(repo.inner(), branch)?
+                            .and_then(|meta| meta.source_remote);
                         let updated_meta = BranchMetadata {
                             parent_branch_name: parent_branch_name.clone(),
                             parent_branch_revision: new_parent_rev.clone(),
+                            source_remote,
                             pr_info: live_stack.branches.get(branch.as_str()).and_then(|br| {
                                 br.pr_number.map(|n| PrInfo {
                                     number: n,
@@ -1679,6 +1724,130 @@ fn sync_fetch_refs(
         }
     }
     refs
+}
+
+fn imported_branches_for_remote(
+    repo: &GitRepo,
+    stack: &Stack,
+    remote_name: &str,
+) -> Result<Vec<String>> {
+    let mut imported = Vec::new();
+    for branch in stack.branches.keys() {
+        if branch == &stack.trunk {
+            continue;
+        }
+
+        let Some(meta) = BranchMetadata::read(repo.inner(), branch)? else {
+            continue;
+        };
+        if meta.source_remote.as_deref() == Some(remote_name) {
+            imported.push(branch.clone());
+        }
+    }
+    imported.sort();
+    Ok(imported)
+}
+
+fn refresh_imported_branches(
+    repo: &GitRepo,
+    workdir: &Path,
+    remote_name: &str,
+    imported_branches: &[String],
+    force: bool,
+    quiet: bool,
+    verbose: bool,
+) -> Result<Vec<String>> {
+    let mut updated = Vec::new();
+    for branch in imported_branches {
+        let remote_ref = format!("{}/{}", remote_name, branch);
+        let Some(remote_oid) = resolve_ref_oid(workdir, &remote_ref) else {
+            if !quiet && verbose {
+                println!(
+                    "  {} skipped imported branch {} (missing {})",
+                    "!".yellow(),
+                    branch.cyan(),
+                    remote_ref.dimmed()
+                );
+            }
+            continue;
+        };
+
+        if resolve_ref_oid(workdir, branch).as_deref() == Some(remote_oid.as_str()) {
+            continue;
+        }
+
+        if let Some(branch_worktree) = repo.branch_worktree_path(branch)? {
+            if worktree_dirty(&branch_worktree)? && !force {
+                if !quiet {
+                    println!(
+                        "  {} skipped imported branch {} (checked out with local changes)",
+                        "!".yellow(),
+                        branch.cyan()
+                    );
+                }
+                continue;
+            }
+
+            let output = Command::new("git")
+                .args(["reset", "--hard", &remote_ref])
+                .current_dir(&branch_worktree)
+                .output()
+                .with_context(|| format!("Failed to update imported branch '{}'", branch))?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!(
+                    "Failed to update imported branch '{}' to '{}': {}",
+                    branch,
+                    remote_ref,
+                    stderr.trim()
+                );
+            }
+        } else {
+            let output = Command::new("git")
+                .args(["update-ref", &format!("refs/heads/{}", branch), &remote_ref])
+                .current_dir(workdir)
+                .output()
+                .with_context(|| format!("Failed to update imported branch '{}'", branch))?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!(
+                    "Failed to update imported branch '{}' to '{}': {}",
+                    branch,
+                    remote_ref,
+                    stderr.trim()
+                );
+            }
+        }
+
+        if !quiet {
+            println!(
+                "  {} updated imported branch {} from {}",
+                "↓".cyan(),
+                branch.cyan(),
+                remote_ref.dimmed()
+            );
+        }
+        updated.push(branch.clone());
+    }
+
+    Ok(updated)
+}
+
+fn worktree_dirty(workdir: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=all"])
+        .current_dir(workdir)
+        .output()
+        .context("Failed to inspect imported branch worktree")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git status failed: {}", stderr.trim());
+    }
+
+    Ok(!output.stdout.is_empty())
 }
 
 /// Drop stale `refs/remotes/<remote>/<branch>` for stax-tracked branches that no longer exist on the remote.

--- a/src/commands/upstack/restack.rs
+++ b/src/commands/upstack/restack.rs
@@ -119,9 +119,12 @@ pub fn run(auto_stash_pop: bool) -> Result<()> {
         )? {
             RebaseResult::Success => {
                 let new_parent_rev = repo.branch_commit(&parent_branch_name)?;
+                let source_remote =
+                    BranchMetadata::read(repo.inner(), branch)?.and_then(|meta| meta.source_remote);
                 let updated_meta = BranchMetadata {
                     parent_branch_name: parent_branch_name.clone(),
                     parent_branch_revision: new_parent_rev.clone(),
+                    source_remote,
                     pr_info: live_stack.branches.get(branch).and_then(|br| {
                         br.pr_number.map(|n| crate::engine::PrInfo {
                             number: n,

--- a/src/engine/metadata.rs
+++ b/src/engine/metadata.rs
@@ -13,6 +13,12 @@ pub struct BranchMetadata {
     /// Commit SHA of parent when this branch was last rebased
     #[serde(default)]
     pub parent_branch_revision: String,
+    /// Remote this branch was imported from with `stax get`.
+    ///
+    /// Imported branches are tracked so local branches can stack on top of
+    /// them, but submit should not push or update their PRs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_remote: Option<String>,
     /// PR information (if submitted)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_info: Option<PrInfo>,
@@ -35,6 +41,7 @@ impl BranchMetadata {
         Self {
             parent_branch_name: parent_name.to_string(),
             parent_branch_revision: parent_revision.to_string(),
+            source_remote: None,
             pr_info: None,
         }
     }
@@ -81,6 +88,10 @@ impl BranchMetadata {
 
     /// Check if the branch needs restacking (parent has moved)
     pub fn needs_restack(&self, repo: &Repository) -> Result<bool> {
+        if self.source_remote.is_some() {
+            return Ok(false);
+        }
+
         let parent_ref = repo.find_branch(&self.parent_branch_name, git2::BranchType::Local)?;
         let current_parent_rev = parent_ref.get().peel_to_commit()?.id().to_string();
         Ok(current_parent_rev != self.parent_branch_revision)
@@ -96,6 +107,7 @@ mod tests {
         let meta = BranchMetadata::new("main", "abc123");
         assert_eq!(meta.parent_branch_name, "main");
         assert_eq!(meta.parent_branch_revision, "abc123");
+        assert!(meta.source_remote.is_none());
         assert!(meta.pr_info.is_none());
     }
 

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -1261,6 +1261,31 @@ fn format_merge_error(err: octocrab::Error) -> anyhow::Error {
 pub struct StackPrInfo {
     pub branch: String,
     pub pr_number: Option<u64>,
+    pub is_imported: bool,
+}
+
+fn stack_links_intro(prs: &[StackPrInfo], current_index: Option<usize>, mr_label: &str) -> String {
+    let current = current_index.and_then(|index| prs.get(index).map(|pr| (index, pr)));
+
+    match current {
+        Some((_, current)) if current.is_imported => format!(
+            "This {} is an imported reference. Entries below it are local stack branches; Stax keeps these links in sync without pushing or updating the imported branch:",
+            mr_label
+        ),
+        Some((current, _))
+            if prs
+                .iter()
+                .enumerate()
+                .any(|(index, pr)| index < current && pr.is_imported) =>
+        {
+            format!(
+                "This {} is a local stack branch. Imported downstack entries are read-only context, and local stack branches are shown in stack order:",
+                mr_label
+            )
+        }
+        Some(_) => format!("This {} is part of a local stacked series:", mr_label),
+        None => format!("This {} is part of a stacked series:", mr_label),
+    }
 }
 
 /// Generate the stack links markdown shared by PR comments and PR bodies.
@@ -1279,10 +1304,14 @@ pub fn generate_stack_links_markdown(
         _ => "#",
     };
 
+    let current_index = prs
+        .iter()
+        .position(|pr_info| pr_info.pr_number == Some(current_pr_number));
+
     let mut lines = vec![
         "## Stack Links".to_string(),
         "".to_string(),
-        format!("This {} is part of a stacked series:", mr_label),
+        stack_links_intro(prs, current_index, mr_label),
         "".to_string(),
         format!("* `{}`", trunk),
     ];
@@ -1290,18 +1319,18 @@ pub fn generate_stack_links_markdown(
     // Build stack from bottom (trunk-adjacent) to top (leaf)
     // First PR is closest to trunk, last is the leaf
     for (i, pr_info) in prs.iter().enumerate() {
-        let is_current = pr_info.pr_number == Some(current_pr_number);
-        let pointer = if is_current { " 👈" } else { "" };
+        let pointer = if Some(i) == current_index {
+            " 👈"
+        } else {
+            ""
+        };
 
         let pr_text = match pr_info.pr_number {
             Some(num) => {
                 let label = format!("{} {}{}", mr_label, mr_prefix, num);
                 match remote.forge {
-                    // GitHub auto-links #N references; other forges need full URLs
                     ForgeType::GitHub => format!("**{}**{}", label, pointer),
-                    _ => {
-                        format!("[**{}**]({}){}", label, remote.pr_url(num), pointer)
-                    }
+                    _ => format!("[**{}**]({}){}", label, remote.pr_url(num), pointer),
                 }
             }
             None => format!("`{}`{}", pr_info.branch, pointer),
@@ -1710,14 +1739,17 @@ mod tests {
         let prs = vec![StackPrInfo {
             branch: "feature".to_string(),
             pr_number: Some(1),
+            is_imported: false,
         }];
 
         let comment = generate_stack_comment(&prs, 1, &remote, "main");
 
         assert!(comment.contains("## Stack Links"));
+        assert!(comment.contains("This PR is part of a local stacked series:"));
         assert!(comment.contains("`main`"));
         assert!(comment.contains("PR #1"));
-        assert!(comment.contains("👈")); // Current PR marker
+        assert!(comment.contains("**PR #1** 👈"));
+        assert!(!comment.contains("current local branch"));
         assert!(comment.contains("stax"));
     }
 
@@ -1737,14 +1769,17 @@ mod tests {
             StackPrInfo {
                 branch: "feature-a".to_string(),
                 pr_number: Some(1),
+                is_imported: false,
             },
             StackPrInfo {
                 branch: "feature-b".to_string(),
                 pr_number: Some(2),
+                is_imported: false,
             },
             StackPrInfo {
                 branch: "feature-c".to_string(),
                 pr_number: Some(3),
+                is_imported: false,
             },
         ];
 
@@ -1754,7 +1789,66 @@ mod tests {
         assert!(comment.contains("PR #2"));
         assert!(comment.contains("PR #3"));
         // Only PR #2 should have the pointer
-        assert!(comment.contains("PR #2** 👈"));
+        assert!(comment.contains("  * **PR #1**\n    * **PR #2** 👈\n      * **PR #3**"));
+        assert!(!comment.contains("current local branch"));
+        assert!(!comment.contains("local upstack"));
+    }
+
+    #[test]
+    fn test_generate_stack_comment_intro_relative_to_current_pr() {
+        let remote = crate::remote::RemoteInfo {
+            name: "origin".to_string(),
+            forge: crate::remote::ForgeType::GitHub,
+            host: "github.com".to_string(),
+            namespace: "user".to_string(),
+            repo: "repo".to_string(),
+            base_url: "https://github.com".to_string(),
+            api_base_url: Some("https://api.github.com".to_string()),
+        };
+
+        let prs = vec![
+            StackPrInfo {
+                branch: "imported-base".to_string(),
+                pr_number: Some(10),
+                is_imported: true,
+            },
+            StackPrInfo {
+                branch: "local-middle".to_string(),
+                pr_number: Some(20),
+                is_imported: false,
+            },
+            StackPrInfo {
+                branch: "local-tip".to_string(),
+                pr_number: Some(30),
+                is_imported: false,
+            },
+        ];
+
+        let base_comment = generate_stack_comment(&prs, 10, &remote, "main");
+        assert!(base_comment.contains(
+            "This PR is an imported reference. Entries below it are local stack branches; Stax keeps these links in sync without pushing or updating the imported branch:"
+        ));
+        assert!(base_comment.contains("  * **PR #10** 👈\n    * **PR #20**\n      * **PR #30**"));
+        assert!(!base_comment.contains("current imported reference"));
+        assert!(!base_comment.contains("local upstack"));
+
+        let middle_comment = generate_stack_comment(&prs, 20, &remote, "main");
+        assert!(middle_comment.contains(
+            "This PR is a local stack branch. Imported downstack entries are read-only context, and local stack branches are shown in stack order:"
+        ));
+        assert!(middle_comment.contains("  * **PR #10**\n    * **PR #20** 👈\n      * **PR #30**"));
+        assert!(!middle_comment.contains("imported reference downstack"));
+        assert!(!middle_comment.contains("current local branch"));
+        assert!(!middle_comment.contains("local upstack"));
+
+        let tip_comment = generate_stack_comment(&prs, 30, &remote, "main");
+        assert!(tip_comment.contains(
+            "This PR is a local stack branch. Imported downstack entries are read-only context, and local stack branches are shown in stack order:"
+        ));
+        assert!(tip_comment.contains("  * **PR #10**\n    * **PR #20**\n      * **PR #30** 👈"));
+        assert!(!tip_comment.contains("imported reference downstack"));
+        assert!(!tip_comment.contains("local downstack"));
+        assert!(!tip_comment.contains("current local branch"));
     }
 
     #[test]
@@ -1773,17 +1867,20 @@ mod tests {
             StackPrInfo {
                 branch: "feature-a".to_string(),
                 pr_number: Some(1),
+                is_imported: false,
             },
             StackPrInfo {
                 branch: "feature-b".to_string(),
                 pr_number: None, // No PR yet
+                is_imported: true,
             },
         ];
 
         let comment = generate_stack_comment(&prs, 1, &remote, "main");
 
         assert!(comment.contains("PR #1"));
-        assert!(comment.contains("`feature-b`")); // Branch name in backticks
+        assert!(comment.contains("`feature-b`"));
+        assert!(!comment.contains("imported reference upstack"));
     }
 
     #[test]
@@ -1802,21 +1899,24 @@ mod tests {
             StackPrInfo {
                 branch: "feature-a".to_string(),
                 pr_number: Some(10),
+                is_imported: false,
             },
             StackPrInfo {
                 branch: "feature-b".to_string(),
                 pr_number: Some(11),
+                is_imported: false,
             },
         ];
 
         let comment = generate_stack_comment(&prs, 11, &remote, "main");
 
         // GitLab uses MR terminology and !N prefix
-        assert!(comment.contains("This MR is part of a stacked series:"));
+        assert!(comment.contains("This MR is part of a local stacked series:"));
         assert!(comment.contains("[**MR !10**](https://gitlab.com/user/repo/-/merge_requests/10)"));
         assert!(
             comment.contains("[**MR !11**](https://gitlab.com/user/repo/-/merge_requests/11) 👈")
         );
+        assert!(!comment.contains("current local branch"));
     }
 
     #[test]
@@ -1834,12 +1934,13 @@ mod tests {
         let prs = vec![StackPrInfo {
             branch: "feature".to_string(),
             pr_number: Some(5),
+            is_imported: false,
         }];
 
         let comment = generate_stack_comment(&prs, 5, &remote, "main");
 
         // Gitea uses PR terminology but needs full URLs
-        assert!(comment.contains("This PR is part of a stacked series:"));
+        assert!(comment.contains("This PR is part of a local stacked series:"));
         assert!(comment.contains("[**PR #5**](https://gitea.example.com/org/project/pulls/5) 👈"));
     }
 
@@ -1858,6 +1959,7 @@ mod tests {
         let prs = vec![StackPrInfo {
             branch: "feature".to_string(),
             pr_number: Some(42),
+            is_imported: false,
         }];
 
         let comment = generate_stack_comment(&prs, 42, &remote, "main");
@@ -1943,10 +2045,12 @@ mod tests {
         let info = StackPrInfo {
             branch: "feature".to_string(),
             pr_number: Some(42),
+            is_imported: false,
         };
         let cloned = info.clone();
         assert_eq!(cloned.branch, "feature");
         assert_eq!(cloned.pr_number, Some(42));
+        assert!(!cloned.is_imported);
     }
 
     #[test]

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -3,6 +3,10 @@
 use crate::common;
 
 use common::{OutputAssertions, TestRepo};
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
 
 fn push_remote_only_branch_from(
     repo: &TestRepo,
@@ -38,6 +42,79 @@ fn parent_for(repo: &TestRepo, branch: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
+fn metadata_for(repo: &TestRepo, branch: &str) -> Value {
+    let output = repo.git(&["show", &format!("refs/branch-metadata/{}", branch)]);
+    output.assert_success();
+    serde_json::from_str(&TestRepo::stdout(&output)).expect("valid metadata JSON")
+}
+
+fn run_git_in(cwd: &Path, args: &[&str]) -> std::process::Output {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    output.assert_success();
+    output
+}
+
+fn configure_submit_remote(repo: &TestRepo) {
+    let remote_path = repo
+        .remote_path()
+        .expect("Expected remote path for repository with origin");
+    let remote_path_str = remote_path.to_string_lossy().to_string();
+
+    repo.git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://github.com/test-owner/test-repo.git",
+    ]);
+    repo.git(&["remote", "set-url", "--push", "origin", &remote_path_str]);
+
+    let file_url = format!("file://{}", remote_path_str);
+    repo.git(&[
+        "config",
+        "--local",
+        &format!("url.{}.insteadOf", file_url.trim_end_matches('/')),
+        "https://github.com/test-owner/test-repo.git",
+    ]);
+}
+
+fn update_remote_branch_in_clone(
+    repo: &TestRepo,
+    branch: &str,
+    file: &str,
+    content: &str,
+) -> String {
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let clone_dir = TempDir::new().expect("temp clone");
+
+    run_git_in(
+        clone_dir.path(),
+        &["clone", remote_path.to_str().unwrap(), "."],
+    );
+    run_git_in(
+        clone_dir.path(),
+        &["checkout", "-B", branch, &format!("origin/{}", branch)],
+    );
+    run_git_in(
+        clone_dir.path(),
+        &["config", "user.email", "other@test.com"],
+    );
+    run_git_in(clone_dir.path(), &["config", "user.name", "Other User"]);
+    std::fs::write(clone_dir.path().join(file), content).expect("write remote update");
+    run_git_in(clone_dir.path(), &["add", "-A"]);
+    run_git_in(
+        clone_dir.path(),
+        &["commit", "-m", "Update imported branch"],
+    );
+    let sha = run_git_in(clone_dir.path(), &["rev-parse", "HEAD"]);
+    run_git_in(clone_dir.path(), &["push", "origin", branch]);
+
+    String::from_utf8_lossy(&sha.stdout).trim().to_string()
+}
+
 #[test]
 fn get_fetches_remote_only_branch_and_tracks_it() {
     let repo = TestRepo::new_with_remote();
@@ -57,6 +134,10 @@ fn get_fetches_remote_only_branch_and_tracks_it() {
     assert_eq!(repo.get_commit_sha("remote-feature"), remote_sha);
     assert_eq!(repo.get_commit_sha("origin/remote-feature"), remote_sha);
     assert_eq!(parent_for(&repo, "remote-feature").as_deref(), Some("main"));
+    assert_eq!(
+        metadata_for(&repo, "remote-feature")["sourceRemote"],
+        "origin"
+    );
 
     repo.git(&["config", "branch.remote-feature.remote"])
         .assert_success()
@@ -174,4 +255,96 @@ fn get_force_resets_divergent_local_branch() {
     assert_eq!(repo.current_branch(), "main");
     assert_eq!(repo.get_commit_sha("force-feature"), remote_sha);
     assert_eq!(parent_for(&repo, "force-feature").as_deref(), Some("main"));
+}
+
+#[test]
+fn submit_does_not_push_imported_support_branch() {
+    let repo = TestRepo::new_with_remote();
+    configure_submit_remote(&repo);
+    let original_remote_sha =
+        push_remote_only_branch(&repo, "imported-parent", "parent.txt", "remote parent\n");
+
+    repo.run_stax(&["get", "imported-parent"]).assert_success();
+    repo.create_file("local-parent.txt", "local parent change\n");
+    repo.commit("Local parent change");
+    let local_parent_sha = repo.head_sha();
+
+    repo.run_stax(&["create", "my-child"]).assert_success();
+    repo.create_file("child.txt", "child\n");
+    repo.commit("Child change");
+    let child = repo.current_branch();
+
+    let out = repo.run_stax(&["downstack", "submit", "--no-pr", "--yes"]);
+    out.assert_success();
+
+    repo.git(&["fetch", "origin", "imported-parent"])
+        .assert_success();
+    assert_eq!(
+        repo.get_commit_sha("origin/imported-parent"),
+        original_remote_sha
+    );
+    assert_eq!(repo.get_commit_sha("imported-parent"), local_parent_sha);
+    assert_eq!(
+        repo.get_commit_sha(&format!("origin/{}", child)),
+        repo.get_commit_sha(&child)
+    );
+}
+
+#[test]
+fn sync_restack_updates_imported_parent_then_rebases_child() {
+    let repo = TestRepo::new_with_remote();
+    push_remote_only_branch(&repo, "review-base", "base.txt", "review base\n");
+
+    repo.run_stax(&["get", "review-base"]).assert_success();
+    repo.run_stax(&["create", "my-child"]).assert_success();
+    repo.create_file("child.txt", "child\n");
+    repo.commit("Child change");
+    let child = repo.current_branch();
+
+    let updated_parent_sha =
+        update_remote_branch_in_clone(&repo, "review-base", "base-2.txt", "review base 2\n");
+
+    let out = repo.run_stax(&["sync", "--restack", "--force"]);
+    out.assert_success()
+        .assert_stdout_contains("updated imported branch")
+        .assert_stdout_contains("restacked 1");
+
+    assert_eq!(repo.get_commit_sha("review-base"), updated_parent_sha);
+    assert_eq!(repo.current_branch(), child);
+    assert!(repo.path().join("base-2.txt").exists());
+}
+
+#[test]
+fn sync_restack_skips_dirty_imported_parent_worktree_without_force() {
+    let repo = TestRepo::new_with_remote();
+    let original_parent_sha =
+        push_remote_only_branch(&repo, "dirty-base", "base.txt", "review base\n");
+
+    repo.run_stax(&["get", "dirty-base"]).assert_success();
+    repo.run_stax(&["create", "my-child"]).assert_success();
+    repo.create_file("child.txt", "child\n");
+    repo.commit("Child change");
+
+    let imported_worktree = TempDir::new().expect("imported worktree");
+    run_git_in(
+        &repo.path(),
+        &[
+            "worktree",
+            "add",
+            imported_worktree.path().to_str().unwrap(),
+            "dirty-base",
+        ],
+    );
+    std::fs::write(imported_worktree.path().join("local.txt"), "local edit\n")
+        .expect("dirty imported worktree");
+
+    update_remote_branch_in_clone(&repo, "dirty-base", "base-2.txt", "review base 2\n");
+
+    let out = repo.run_stax(&["sync", "--restack"]);
+    out.assert_success()
+        .assert_stdout_contains("skipped imported branch")
+        .assert_stdout_contains("All branches up to date");
+
+    assert_eq!(repo.get_commit_sha("dirty-base"), original_parent_sha);
+    assert!(!repo.path().join("base-2.txt").exists());
 }

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -348,3 +348,65 @@ fn sync_restack_skips_dirty_imported_parent_worktree_without_force() {
     assert_eq!(repo.get_commit_sha("dirty-base"), original_parent_sha);
     assert!(!repo.path().join("base-2.txt").exists());
 }
+
+#[test]
+fn sync_deletes_merged_imported_branch_locally_without_deleting_remote() {
+    let repo = TestRepo::new_with_remote();
+    let imported_sha =
+        push_remote_only_branch(&repo, "borrowed-base", "base.txt", "borrowed base\n");
+
+    repo.run_stax(&["get", "borrowed-base"]).assert_success();
+    repo.git(&["checkout", "main"]).assert_success();
+    repo.merge_branch_on_remote("borrowed-base");
+
+    let out = repo.run_stax(&["sync", "--force"]);
+    out.assert_success();
+
+    let remote_branches = repo.list_remote_branches();
+    assert!(
+        remote_branches
+            .iter()
+            .any(|branch| branch == "borrowed-base"),
+        "sync must not delete imported remote branches, got: {:?}",
+        remote_branches
+    );
+    repo.git(&["fetch", "origin", "borrowed-base"])
+        .assert_success();
+    assert_eq!(repo.get_commit_sha("origin/borrowed-base"), imported_sha);
+
+    let local_branches = repo.list_branches();
+    assert!(
+        !local_branches
+            .iter()
+            .any(|branch| branch == "borrowed-base"),
+        "sync must clean up merged imported support branches locally, got: {:?}",
+        local_branches
+    );
+    repo.git(&["show-ref", "--verify", "refs/branch-metadata/borrowed-base"])
+        .assert_failure();
+}
+
+#[test]
+fn sync_delete_upstream_gone_deletes_imported_branch_locally() {
+    let repo = TestRepo::new_with_remote();
+    push_remote_only_branch(&repo, "borrowed-gone", "base.txt", "borrowed base\n");
+
+    repo.run_stax(&["get", "borrowed-gone"]).assert_success();
+    repo.git(&["checkout", "main"]).assert_success();
+    repo.git(&["push", "origin", "--delete", "borrowed-gone"])
+        .assert_success();
+
+    let out = repo.run_stax(&["sync", "--force", "--delete-upstream-gone"]);
+    out.assert_success();
+
+    let local_branches = repo.list_branches();
+    assert!(
+        !local_branches
+            .iter()
+            .any(|branch| branch == "borrowed-gone"),
+        "upstream-gone cleanup must delete imported support branches locally, got: {:?}",
+        local_branches
+    );
+    repo.git(&["show-ref", "--verify", "refs/branch-metadata/borrowed-gone"])
+        .assert_failure();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8422,10 +8422,234 @@ mod forge_mock_tests {
             body
         );
         assert!(
-            body.contains("PR #102** 👈"),
+            body.contains("  * **PR #101**\n    * **PR #102** 👈"),
             "current PR should keep the pointer, got: {}",
             body
         );
+        assert!(!body.contains("current local branch"));
+    }
+
+    #[tokio::test]
+    async fn test_branch_submit_syncs_imported_downstack_pr_comment() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        let _remote_root = remote_root.keep();
+
+        let checkout_base = git_with_env(
+            &repo,
+            home.path(),
+            &["checkout", "-B", "imported-base", "main"],
+        );
+        assert!(
+            checkout_base.status.success(),
+            "Failed to create imported base: {}",
+            TestRepo::stderr(&checkout_base)
+        );
+        repo.create_file("base.txt", "base\n");
+        repo.commit("Add imported base");
+        let push_base = git_with_env(
+            &repo,
+            home.path(),
+            &["push", "-u", "origin", "imported-base"],
+        );
+        assert!(
+            push_base.status.success(),
+            "Failed to push imported base: {}",
+            TestRepo::stderr(&push_base)
+        );
+        let checkout_main = git_with_env(&repo, home.path(), &["checkout", "main"]);
+        assert!(
+            checkout_main.status.success(),
+            "Failed to return to main: {}",
+            TestRepo::stderr(&checkout_main)
+        );
+        let delete_imported_base =
+            git_with_env(&repo, home.path(), &["branch", "-D", "imported-base"]);
+        assert!(
+            delete_imported_base.status.success(),
+            "Failed to delete local imported base: {}",
+            TestRepo::stderr(&delete_imported_base)
+        );
+
+        let output = run_stax_with_env(&repo, home.path(), &["get", "imported-base"]);
+        assert!(
+            output.status.success(),
+            "st get failed: {}",
+            TestRepo::stderr(&output)
+        );
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "local-child"]);
+        assert!(
+            output.status.success(),
+            "Failed to create child: {}",
+            TestRepo::stderr(&output)
+        );
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Add child");
+        let child = repo.current_branch();
+        let push_child = git_with_env(&repo, home.path(), &["push", "-u", "origin", &child]);
+        assert!(
+            push_child.status.success(),
+            "Failed to push child: {}",
+            TestRepo::stderr(&push_child)
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture_with_details(
+                    101,
+                    "imported-base",
+                    "main",
+                    "Imported base",
+                    "base body"
+                ),
+                github_pull_fixture_with_details(
+                    102,
+                    &child,
+                    "imported-base",
+                    "Child PR",
+                    "child body"
+                )
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/issues/101/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/repos/test/repo/issues/101/comments"))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
+                    901,
+                    "<!-- stax-stack-comment -->\ncreated",
+                )),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(
+                    101,
+                    "imported-base",
+                    "main",
+                    "Imported base",
+                    "base body",
+                ),
+            ))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/issues/102/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                issue_comment_fixture(902, "<!-- stax-stack-comment -->\nold")
+            ])))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/issues/comments/902"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(issue_comment_fixture(
+                    902,
+                    "<!-- stax-stack-comment -->\nupdated",
+                )),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                github_pull_fixture_with_details(
+                    102,
+                    &child,
+                    "imported-base",
+                    "Child PR",
+                    "child body",
+                ),
+            ))
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["branch", "submit", "--yes", "--no-prompt"],
+        );
+        assert!(
+            output.status.success(),
+            "branch submit failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let base_comment_create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST"
+                    && request.url.path() == "/repos/test/repo/issues/101/comments"
+            })
+            .expect("expected imported reference PR stack-comment create");
+        let payload: serde_json::Value = serde_json::from_slice(&base_comment_create.body).unwrap();
+        let body = payload["body"].as_str().expect("comment body");
+        assert!(
+            body.contains(
+                "This PR is an imported reference. Entries below it are local stack branches; Stax keeps these links in sync without pushing or updating the imported branch:"
+            ),
+            "imported base comment should use imported-reference intro, got: {}",
+            body
+        );
+        assert!(
+            body.contains("  * **PR #101** 👈"),
+            "imported base comment should mark the current imported PR, got: {}",
+            body
+        );
+        assert!(
+            body.contains("    * **PR #102**"),
+            "imported base comment should include local child PR, got: {}",
+            body
+        );
+        assert!(!body.contains("current imported reference"));
+        assert!(!body.contains("local upstack"));
+
+        let child_comment_patch = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "PATCH"
+                    && request.url.path() == "/repos/test/repo/issues/comments/902"
+            })
+            .expect("expected child stack-comment update");
+        let payload: serde_json::Value = serde_json::from_slice(&child_comment_patch.body).unwrap();
+        let body = payload["body"].as_str().expect("comment body");
+        assert!(
+            body.contains(
+                "This PR is a local stack branch. Imported downstack entries are read-only context, and local stack branches are shown in stack order:"
+            ),
+            "child comment should use local-stack intro, got: {}",
+            body
+        );
+        assert!(
+            body.contains("  * **PR #101**"),
+            "child comment should include imported reference PR, got: {}",
+            body
+        );
+        assert!(
+            body.contains("    * **PR #102** 👈"),
+            "child comment should mark the current PR with the pointer, got: {}",
+            body
+        );
+        assert!(!body.contains("imported reference downstack"));
+        assert!(!body.contains("current local branch"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #500

## Summary

- record the source remote in metadata for branches imported via `st get`
- treat imported branches as read-only support bases during submit so only user-owned upstack branches are pushed or updated
- keep imported branches remote-delete-exempt during sync cleanup: once an imported branch is detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch
- include existing imported PRs in managed stack-link sync so downstack imported bases get comments/body links too
- render stack-link comments with intro text relative to the PR being rendered while keeping the visible tree compact; GitHub comments use native `**PR #123** 👈` references for the rendered PR, and other forges keep explicit markdown links
- refresh imported branches during `st sync --restack` before restacking local descendants, while skipping dirty imported worktrees unless `--force` is used
- preserve imported-branch metadata across restack metadata rewrites
- update command docs and `skills.md` for the imported-branch workflow

## Tests

- `cargo nextest run get_tests::sync_`
- `cargo nextest run get_tests::submit_does_not_push_imported_support_branch`
- `cargo nextest run forge_mock_tests::test_branch_submit_syncs_imported_downstack_pr_comment`
- `cargo nextest run forge_mock_tests::test_branch_submit_stack_links_include_full_stack_context`
- `git diff --check`
- `make test` (`1658 tests run: 1658 passed, 0 skipped`)

Note: `cargo fmt --check` currently reports repo-wide rustfmt drift in many untouched files, so this PR leaves formatting scoped to the changed code instead of applying broad churn.