### PR TITLE
feat: add stack fast-forward merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Merge from the bottom of the stack up to your current branch, with CI and readin
 st merge                  # local cascade merge
 st merge --when-ready     # wait/poll until PRs are mergeable
 st merge --ds             # merge ancestors, rebase current branch
+st merge --stack          # validate current PR once, stack-merge through current
+st merge --stack --full   # stack-merge the full stack even from the middle
 st merge --remote         # merge remotely on GitHub while you keep working
 st merge --all            # merge the whole stack regardless of position
 ```
@@ -271,7 +273,7 @@ st config --set-ai
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
 | `st get <branch>` | Fetch a remote branch, create a local upstream-tracking branch, track it in stax, and check it out |
 | `st ss` | Submit the full stack, open/update linked PRs |
-| `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--remote`, `--all`) |
+| `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--stack`, `--stack --full`, `--remote`, `--all`) |
 | `st ready` | Interactive PR readiness dashboard for all tracked PRs, newest changed PR first: merge, ping, fix, wait, or draft (`--current`/`--stack` for current stack, `--plain` for table output) |
 | `st ci` / `st ci --oneline` | CI status — full per-check table, or one compact line per branch across the stack (multi-branch defaults to the roll-up) |
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -35,6 +35,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
+| `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, and merge through current by default (`--full` includes descendants; GitHub only) |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
 | `st cascade` | Restack, push, and create/update PRs in one shot |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -33,7 +33,9 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`
-- `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; incompatible with `--all`, `--remote`, and `--queue`
+- `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
+- `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, close selected downstack PRs with a back-reference comment, and rebase/retarget remaining descendants; defaults to `--method rebase`
+- `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains
 
@@ -248,7 +250,7 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 ### `st merge`
 
 - `--dry-run` / `--yes`
-- `--all` / `--downstack-only` (`--ds`) / `--method squash|merge|rebase`
+- `--all` / `--downstack-only` (`--ds`) / `--stack` / `--stack --full` / `--method squash|merge|rebase`
 - `--when-ready` · `--when-ready --interval 10`
 - `--remote` · `--remote --all` · `--remote --timeout 60 --interval 10`
 - `--queue` · `--queue --all --yes`

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -23,15 +23,21 @@ st merge --dry-run
 st merge --all
 st merge --downstack-only                 # alias: --ds
 st merge --method squash|merge|rebase
+st merge --stack                           # validate current PR once, land through current
+st merge --stack --downstack-only          # land ancestors below current through one PR
+st merge --stack --full                    # land the full stack even from the middle
+st merge --stack --when-ready              # wait only for the selected tip PR, then land
 st merge --when-ready                       # wait for readiness explicitly
 st merge --when-ready --interval 10
 st merge --no-wait --no-delete --no-sync
 st merge --timeout 60 --yes
 ```
 
-`--downstack-only` (`--ds`) merges only ancestors below the current branch, then rebases the current branch onto trunk and keeps descendants stacked above it. It is incompatible with `--all`, `--remote`, and `--queue`.
+`--downstack-only` (`--ds`) merges only ancestors below the current branch, then rebases the current branch onto trunk and keeps descendants stacked above it. It composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`.
 
-`--when-ready` is incompatible with `--dry-run`, `--no-wait`, and `--remote`.
+`--full` is only valid with `--stack`; it includes descendants above the current branch in the selected stack merge.
+
+`--when-ready` is incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`. With `--stack`, it waits only for the selected tip PR.
 
 ### Partial stack merge
 
@@ -56,6 +62,26 @@ st merge --ds
 ```
 
 Merges `auth` and `auth-api`; `auth-ui` is rebased onto `main`, and `auth-tests` remains stacked on `auth-ui`.
+
+## `st merge --stack` (GitHub only)
+
+Fast-forwards the selected stack range through one GitHub PR merge. By default the selected range is stack bottom through the current branch:
+
+```bash
+st merge --stack
+st merge --stack --when-ready
+st merge --stack --downstack-only
+st merge --stack --full
+st merge --stack --dry-run
+```
+
+For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, validates CI/mergeability on selected tip PR `B`, retargets `B` to `main`, and merges only `B` through GitHub's merge API. PR `A` is then closed with a comment pointing at `B`; PR `C` remains open and is rebased/retargeted onto `main`.
+
+Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `rebase`; pass `--method squash` only when you explicitly want GitHub to squash the selected range into one commit.
+
+This avoids re-running CI for every lower PR because the selected tip already contains that range. If trunk moves before the merge, stax aborts and asks you to restack and wait for fresh selected-tip CI.
+
+For the no-extra-CI behavior, GitHub branch protection should require status checks but should not require branches to be up to date before merging. If GitHub requires up-to-date branches, it can force another revalidation at merge time.
 
 ## `st merge --remote` (GitHub only)
 

--- a/skills.md
+++ b/skills.md
@@ -221,10 +221,14 @@ stax merge --downstack-only        # Merge ancestors below current, then rebase 
 stax merge --ds                    # Alias for --downstack-only
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
+stax merge --stack                 # GitHub only: validate selected tip once; default scope is bottom through current
+stax merge --stack --downstack-only # Stack-merge ancestors below current; keep current open
+stax merge --stack --full          # Stack-merge full stack even from the middle
+stax merge --stack --when-ready    # Wait only for selected tip PR readiness before stack fast-forward merge
 stax merge --when-ready            # Wait for CI + approval before each merge
 stax merge --remote                # Merge via GitHub API only — no local checkout/rebase/push
 stax merge --remote --all          # Include full stack (GitHub only)
-stax merge --interval 30           # Poll interval in seconds for --when-ready / --remote
+stax merge --interval 30           # Poll interval in seconds for --when-ready / --remote / --stack --when-ready
 stax merge --no-wait               # Fail fast if CI is pending
 stax merge --timeout 60            # Max wait minutes per PR
 stax merge --no-delete             # Keep branches after merge
@@ -456,6 +460,7 @@ stax ss --rerequest-review
 ```bash
 stax ready
 stax merge --when-ready --interval 15
+stax merge --stack --when-ready    # GitHub stack fast-forward: selected tip CI only, defaults to rebase
 ```
 
 ### After Base PR Merges

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -277,15 +277,18 @@ pub(crate) enum Commands {
         /// Merge entire stack (ignore current position)
         #[arg(long)]
         all: bool,
+        /// With --stack, merge the full stack even when current is in the middle
+        #[arg(long, requires = "stack", conflicts_with_all = ["all", "downstack_only"])]
+        full: bool,
         /// Merge ancestors below current, then rebase current branch
-        #[arg(long, visible_alias = "ds", conflicts_with_all = ["all", "remote", "queue"])]
+        #[arg(long, visible_alias = "ds", conflicts_with_all = ["all", "full", "remote", "queue"])]
         downstack_only: bool,
         /// Show merge plan without merging
         #[arg(long)]
         dry_run: bool,
-        /// Merge method: squash, merge, rebase
-        #[arg(long, default_value = "squash")]
-        method: String,
+        /// Merge method: squash, merge, rebase (default: squash; rebase with --stack)
+        #[arg(long)]
+        method: Option<String>,
         /// Keep branches after merge (don't delete)
         #[arg(long)]
         no_delete: bool,
@@ -299,13 +302,16 @@ pub(crate) enum Commands {
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "remote", "queue"])]
         when_ready: bool,
         /// Merge via GitHub API only (no local checkout/rebase/push); GitHub updates branches remotely
-        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "queue"])]
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "queue", "stack"])]
         remote: bool,
+        /// Validate the selected tip PR, retarget it to trunk, and merge the selected stack range once
+        #[arg(long, conflicts_with_all = ["no_wait", "remote", "queue"])]
+        stack: bool,
         /// Enqueue PRs into the forge's merge queue instead of merging one-by-one.
         /// Supported on GitHub (merge queue) and GitLab (merge trains). Not available on Gitea.
-        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote"])]
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote", "stack"])]
         queue: bool,
-        /// Polling interval in seconds for --when-ready, --remote, and --queue
+        /// Polling interval in seconds for --when-ready, --remote, --queue, and --stack --when-ready
         #[arg(long, default_value = "15")]
         interval: u64,
         /// Skip post-merge sync (`stax rs`)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -203,6 +203,7 @@ pub fn run() -> Result<()> {
         Commands::Submit { submit } => run_submit(submit, commands::submit::SubmitScope::Stack),
         Commands::Merge {
             all,
+            full,
             downstack_only,
             dry_run,
             method,
@@ -211,18 +212,34 @@ pub fn run() -> Result<()> {
             timeout,
             when_ready,
             remote,
+            stack,
             queue,
             interval,
             no_sync,
             yes,
             quiet,
         } => {
-            let merge_method = method.parse().unwrap_or_default();
+            let default_method = if stack { "rebase" } else { "squash" };
+            let merge_method = method.as_deref().unwrap_or(default_method).parse()?;
             if queue {
                 commands::merge_queue::run(all, timeout, interval, no_sync, yes, quiet)
             } else if remote {
                 commands::merge_remote::run(
                     all,
+                    merge_method,
+                    timeout,
+                    interval,
+                    no_delete,
+                    no_sync,
+                    yes,
+                    quiet,
+                )
+            } else if stack {
+                commands::merge_stack::run(
+                    all || full,
+                    downstack_only,
+                    dry_run,
+                    when_ready,
                     merge_method,
                     timeout,
                     interval,

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -1,0 +1,1120 @@
+//! Fast-forward stack merge through one GitHub PR merge.
+//!
+//! This is the serverless path from issue #293: validate the selected tip PR
+//! once, retarget that PR to trunk, merge it via GitHub's merge API, then close
+//! the selected lower PRs with a back-reference comment.
+
+use crate::commands::merge::{
+    PrBaseUpdate, rebase_and_finalize_remaining_branch, update_pr_base_unless_current,
+};
+use crate::config::Config;
+use crate::engine::Stack;
+use crate::forge::ForgeClient;
+use crate::git::GitRepo;
+use crate::github::pr::{CiStatus, MergeMethod, PrMergeStatus};
+use crate::progress::LiveTimer;
+use crate::remote::{ForgeType, RemoteInfo};
+use anyhow::{Context, Result};
+use colored::Colorize;
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use std::io::Write;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StackMergeBranch {
+    branch: String,
+    pr_number: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct StackMergeScope {
+    to_merge: Vec<StackMergeBranch>,
+    remaining: Vec<StackMergeBranch>,
+    trunk: String,
+    current: String,
+    downstack_only: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedStackPr {
+    branch: String,
+    pr_number: u64,
+    base: String,
+}
+
+#[derive(Debug, Clone)]
+struct RemainingStackBranch {
+    branch: String,
+    pr_number: Option<u64>,
+}
+
+enum WaitResult {
+    Ready(PrMergeStatus),
+    Failed(String),
+    Timeout,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    full: bool,
+    downstack_only: bool,
+    dry_run: bool,
+    when_ready: bool,
+    method: MergeMethod,
+    timeout_mins: u64,
+    interval_secs: u64,
+    no_delete: bool,
+    no_sync: bool,
+    yes: bool,
+    quiet: bool,
+) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let current = repo.current_branch()?;
+    let stack = Stack::load(&repo)?;
+    let config = Config::load()?;
+
+    if current == stack.trunk {
+        if !quiet {
+            println!(
+                "{}",
+                "You are on trunk. Checkout a tracked stack branch to merge.".yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    if !stack.branches.contains_key(&current) {
+        if !quiet {
+            println!(
+                "{}",
+                format!(
+                    "Branch '{}' is not tracked. Run 'stax branch track' first.",
+                    current
+                )
+                .yellow()
+            );
+        }
+        return Ok(());
+    }
+
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax merge --stack` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+
+    let scope = calculate_stack_merge_scope(&repo, &stack, &current, full, downstack_only)?;
+    if scope.to_merge.is_empty() {
+        if !quiet {
+            println!("{}", "No branches to stack merge.".yellow());
+        }
+        return Ok(());
+    }
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+    let client = ForgeClient::new(&remote_info).context(
+        "Failed to connect to the configured forge. Check your token and remote configuration.",
+    )?;
+
+    let fetch_timer = LiveTimer::maybe_new(!quiet, "Fetching latest trunk...");
+    let trunk_sha = fetch_and_verify_trunk_current(&repo, &remote_info, &scope.trunk)?;
+    LiveTimer::maybe_finish_ok(fetch_timer, "done");
+
+    verify_linear_stack(&repo, &scope)?;
+
+    let pr_timer = LiveTimer::maybe_new(!quiet, "Fetching stack PRs...");
+    let resolved = resolve_stack_prs(&rt, &client, &scope)?;
+    let remaining = resolve_remaining_branches(&rt, &client, &scope.remaining)?;
+    LiveTimer::maybe_finish_ok(pr_timer, "done");
+
+    let status_timer = LiveTimer::maybe_new(!quiet, "Checking stack eligibility...");
+    let statuses = fetch_stack_statuses(&rt, &client, &resolved)?;
+    check_downstack_eligibility(&resolved, &statuses)?;
+    LiveTimer::maybe_finish_ok(status_timer, "done");
+
+    let tip = resolved.last().context("stack merge scope is empty")?;
+    let mut tip_status = statuses.last().context("missing tip status")?.clone();
+
+    if !when_ready {
+        if let Some(reason) = tip_blocker(&tip_status) {
+            anyhow::bail!(
+                "Selected tip PR #{} ({}) is not ready: {}.\n\nRun `stax merge --stack --when-ready` to wait.",
+                tip.pr_number,
+                tip.branch,
+                reason
+            );
+        }
+    }
+
+    if !quiet {
+        println!();
+        print_stack_preview(
+            &resolved,
+            &remaining,
+            &scope.trunk,
+            method,
+            when_ready,
+            scope.downstack_only,
+        );
+    }
+
+    if dry_run {
+        if !quiet {
+            println!();
+            println!("{}", "Dry run - no changes made.".dimmed());
+        }
+        return Ok(());
+    }
+
+    if !yes && !quiet {
+        let confirm = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Proceed with fast-forward stack merge?")
+            .default(false)
+            .interact()?;
+
+        if !confirm {
+            println!("{}", "Aborted.".dimmed());
+            return Ok(());
+        }
+    }
+
+    if !quiet {
+        println!();
+        print_header("Stack Fast-Forward Merge");
+    }
+
+    if when_ready {
+        let timeout = Duration::from_secs(timeout_mins * 60);
+        let poll_interval = Duration::from_secs(interval_secs);
+        match wait_for_tip_ready(&rt, &client, tip.pr_number, timeout, poll_interval, quiet)? {
+            WaitResult::Ready(status) => tip_status = status,
+            WaitResult::Failed(reason) => {
+                anyhow::bail!(
+                    "Selected tip PR #{} ({}) is not ready: {}",
+                    tip.pr_number,
+                    tip.branch,
+                    reason
+                )
+            }
+            WaitResult::Timeout => {
+                anyhow::bail!(
+                    "Timed out waiting for selected tip PR #{} ({}) to become ready",
+                    tip.pr_number,
+                    tip.branch
+                )
+            }
+        }
+    }
+
+    verify_tip_head_matches_local(&repo, tip, &tip_status)?;
+    ensure_trunk_unchanged(&repo, &remote_info, &scope.trunk, &trunk_sha)?;
+
+    let original_tip_base = tip.base.clone();
+    let retarget_timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!(
+            "Retargeting selected tip PR #{} to {}...",
+            tip.pr_number, scope.trunk
+        ),
+    );
+    let retargeted =
+        match update_pr_base_unless_current(&rt, &client, tip.pr_number, &scope.trunk, &tip.branch)
+        {
+            Ok(PrBaseUpdate::Updated) => {
+                LiveTimer::maybe_finish_ok(retarget_timer, "done");
+                true
+            }
+            Ok(PrBaseUpdate::AlreadyTargeted) => {
+                LiveTimer::maybe_finish_ok(retarget_timer, "already on base");
+                false
+            }
+            Err(e) => {
+                LiveTimer::maybe_finish_err(retarget_timer, "failed");
+                return Err(e);
+            }
+        };
+
+    if let Err(e) = ensure_trunk_unchanged(&repo, &remote_info, &scope.trunk, &trunk_sha) {
+        if retargeted {
+            restore_tip_base(&rt, &client, tip, &original_tip_base, quiet);
+        }
+        return Err(e);
+    }
+
+    let merge_timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!(
+            "Merging selected tip PR #{} ({})...",
+            tip.pr_number,
+            method.as_str()
+        ),
+    );
+    let merge_result = rt.block_on(async {
+        client
+            .merge_pr(tip.pr_number, method, None, Some(&tip_status.head_sha))
+            .await
+    });
+
+    if let Err(e) = merge_result {
+        LiveTimer::maybe_finish_err(merge_timer, "failed");
+        if retargeted {
+            restore_tip_base(&rt, &client, tip, &original_tip_base, quiet);
+        }
+        return Err(e);
+    }
+    LiveTimer::maybe_finish_ok(merge_timer, "done");
+
+    reconcile_downstack_prs(&rt, &client, &resolved, tip, quiet)?;
+
+    rebase_remaining_branches(
+        &repo,
+        &rt,
+        &client,
+        &remote_info.name,
+        &scope.trunk,
+        &remaining,
+        quiet,
+    )?;
+
+    if !no_delete {
+        cleanup_local_stack(&repo, &scope, quiet)?;
+    }
+
+    if !no_sync {
+        run_post_merge_sync(quiet, no_delete);
+    }
+
+    if !quiet {
+        println!();
+        print_header_success("Stack Merged");
+        println!();
+        println!(
+            "Merged {} PRs through tip #{} into {}:",
+            resolved.len(),
+            tip.pr_number,
+            scope.trunk.cyan()
+        );
+        for pr in &resolved {
+            let action = if pr.pr_number == tip.pr_number {
+                "merged"
+            } else {
+                "closed"
+            };
+            println!(
+                "  {} #{} {} -> {}",
+                "✓".green(),
+                pr.pr_number,
+                pr.branch,
+                action
+            );
+        }
+        if !remaining.is_empty() {
+            println!();
+            println!("Remaining in stack (rebased onto {}):", scope.trunk.cyan());
+            for branch in &remaining {
+                if let Some(pr_number) = branch.pr_number {
+                    println!("  {} #{} {}", "○".dimmed(), pr_number, branch.branch);
+                } else {
+                    println!("  {} {}", "○".dimmed(), branch.branch);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn calculate_stack_merge_scope(
+    repo: &GitRepo,
+    stack: &Stack,
+    current: &str,
+    full: bool,
+    downstack_only: bool,
+) -> Result<StackMergeScope> {
+    let mut to_merge = stack.ancestors(current);
+    to_merge.reverse();
+    to_merge.retain(|branch| branch != &stack.trunk);
+
+    let mut remaining = stack.descendants(current);
+    if downstack_only {
+        remaining.insert(0, current.to_string());
+    } else {
+        to_merge.push(current.to_string());
+    }
+
+    if full && !remaining.is_empty() {
+        to_merge.extend(std::mem::take(&mut remaining));
+    }
+
+    let to_merge = to_merge
+        .into_iter()
+        .map(|branch| stack_merge_branch(repo, stack, branch))
+        .collect::<Result<Vec<_>>>()?;
+    let remaining = remaining
+        .into_iter()
+        .map(|branch| stack_merge_branch(repo, stack, branch))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(StackMergeScope {
+        to_merge,
+        remaining,
+        trunk: stack.trunk.clone(),
+        current: current.to_string(),
+        downstack_only,
+    })
+}
+
+fn stack_merge_branch(repo: &GitRepo, stack: &Stack, branch: String) -> Result<StackMergeBranch> {
+    let pr_number = stack.branches.get(&branch).and_then(|info| info.pr_number);
+
+    repo.branch_commit(&branch)
+        .with_context(|| format!("Local branch '{}' does not exist", branch))?;
+
+    Ok(StackMergeBranch { branch, pr_number })
+}
+
+fn fetch_and_verify_trunk_current(
+    repo: &GitRepo,
+    remote: &RemoteInfo,
+    trunk: &str,
+) -> Result<String> {
+    if !repo.fetch_remote(&remote.name)? {
+        anyhow::bail!("Failed to fetch remote '{}'", remote.name);
+    }
+
+    let local = repo.rev_parse(trunk)?;
+    let remote_ref = format!("{}/{}", remote.name, trunk);
+    let remote_sha = repo
+        .rev_parse(&remote_ref)
+        .with_context(|| format!("Failed to resolve remote trunk '{}'", remote_ref))?;
+
+    if local != remote_sha {
+        anyhow::bail!(
+            "Local trunk '{}' is not current with '{}'. Run `stax sync --restack` and wait for the new tip CI before stack merging.",
+            trunk,
+            remote_ref
+        );
+    }
+
+    Ok(local)
+}
+
+fn ensure_trunk_unchanged(
+    repo: &GitRepo,
+    remote: &RemoteInfo,
+    trunk: &str,
+    expected_sha: &str,
+) -> Result<()> {
+    if !repo.fetch_remote(&remote.name)? {
+        anyhow::bail!("Failed to fetch remote '{}'", remote.name);
+    }
+
+    let remote_ref = format!("{}/{}", remote.name, trunk);
+    let remote_sha = repo.rev_parse(&remote_ref)?;
+    if remote_sha != expected_sha {
+        anyhow::bail!(
+            "Remote trunk '{}' moved while preparing the stack merge. Run `stax sync --restack` and wait for the new tip CI.",
+            remote_ref
+        );
+    }
+
+    Ok(())
+}
+
+fn verify_linear_stack(repo: &GitRepo, scope: &StackMergeScope) -> Result<()> {
+    let mut parent = scope.trunk.as_str();
+    for branch in scope.to_merge.iter().chain(scope.remaining.iter()) {
+        if !repo.is_ancestor(parent, &branch.branch)? {
+            anyhow::bail!(
+                "Branch '{}' is not based on '{}'. Run `stax restack` and wait for tip CI before stack merging.",
+                branch.branch,
+                parent
+            );
+        }
+        parent = &branch.branch;
+    }
+
+    Ok(())
+}
+
+fn resolve_stack_prs(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    scope: &StackMergeScope,
+) -> Result<Vec<ResolvedStackPr>> {
+    let mut resolved = Vec::with_capacity(scope.to_merge.len());
+
+    for branch in &scope.to_merge {
+        let pr_number = match branch.pr_number {
+            Some(pr_number) => pr_number,
+            None => rt
+                .block_on(async { client.find_pr(&branch.branch).await })?
+                .map(|pr| pr.number)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Branch '{}' has no PR. Run 'stax submit' first.",
+                        branch.branch
+                    )
+                })?,
+        };
+
+        let pr = rt.block_on(async { client.get_pr_with_head(pr_number).await })?;
+        if pr.head != branch.branch {
+            anyhow::bail!(
+                "PR #{} is for head branch '{}', expected '{}'",
+                pr_number,
+                pr.head,
+                branch.branch
+            );
+        }
+
+        resolved.push(ResolvedStackPr {
+            branch: branch.branch.clone(),
+            pr_number,
+            base: pr.info.base,
+        });
+    }
+
+    Ok(resolved)
+}
+
+fn resolve_remaining_branches(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    branches: &[StackMergeBranch],
+) -> Result<Vec<RemainingStackBranch>> {
+    branches
+        .iter()
+        .map(|branch| {
+            let pr_number = match branch.pr_number {
+                Some(pr_number) => Some(pr_number),
+                None => rt
+                    .block_on(async { client.find_pr(&branch.branch).await })?
+                    .map(|pr| pr.number),
+            };
+
+            Ok(RemainingStackBranch {
+                branch: branch.branch.clone(),
+                pr_number,
+            })
+        })
+        .collect()
+}
+
+fn fetch_stack_statuses(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    prs: &[ResolvedStackPr],
+) -> Result<Vec<PrMergeStatus>> {
+    prs.iter()
+        .map(|pr| rt.block_on(async { client.get_pr_merge_status(pr.pr_number).await }))
+        .collect()
+}
+
+fn check_downstack_eligibility(prs: &[ResolvedStackPr], statuses: &[PrMergeStatus]) -> Result<()> {
+    for (pr, status) in prs
+        .iter()
+        .zip(statuses.iter())
+        .take(prs.len().saturating_sub(1))
+    {
+        if let Some(reason) = downstack_blocker(status) {
+            anyhow::bail!(
+                "Downstack PR #{} ({}) is not eligible for stack merge: {}",
+                pr.pr_number,
+                pr.branch,
+                reason
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn downstack_blocker(status: &PrMergeStatus) -> Option<&'static str> {
+    if status.state.to_lowercase() != "open" {
+        return Some("PR is closed");
+    }
+    if status.is_draft {
+        return Some("PR is draft");
+    }
+    if status.changes_requested {
+        return Some("changes requested");
+    }
+    if status.review_decision.as_deref() == Some("REVIEW_REQUIRED") {
+        return Some("review required");
+    }
+    if status.mergeable == Some(false) {
+        return Some("has merge conflicts");
+    }
+    None
+}
+
+fn tip_blocker(status: &PrMergeStatus) -> Option<&'static str> {
+    downstack_blocker(status).or_else(|| match status.ci_status {
+        CiStatus::Failure => Some("CI failed"),
+        CiStatus::Pending => Some("CI is still pending"),
+        CiStatus::Success | CiStatus::NoCi => {
+            if status.mergeable.is_none() {
+                Some("mergeability is still being checked")
+            } else {
+                None
+            }
+        }
+    })
+}
+
+fn wait_for_tip_ready(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    pr_number: u64,
+    timeout: Duration,
+    poll_interval: Duration,
+    quiet: bool,
+) -> Result<WaitResult> {
+    let start = Instant::now();
+    let mut last_status: Option<String> = None;
+
+    loop {
+        let status = rt.block_on(async { client.get_pr_merge_status(pr_number).await })?;
+        if let Some(reason) = tip_blocker(&status) {
+            if matches!(
+                reason,
+                "CI is still pending" | "mergeability is still being checked"
+            ) {
+                if start.elapsed() > timeout {
+                    if !quiet && last_status.is_some() {
+                        println!();
+                    }
+                    return Ok(WaitResult::Timeout);
+                }
+
+                if !quiet {
+                    let elapsed = start.elapsed().as_secs();
+                    let status_text = format!(
+                        "      {} Waiting for selected tip PR: {}... ({}s)",
+                        "⏳".yellow(),
+                        reason,
+                        elapsed
+                    );
+                    if last_status.is_some() {
+                        print!("\r{}\r", " ".repeat(96));
+                    }
+                    print!("{}", status_text);
+                    std::io::stdout().flush().ok();
+                    last_status = Some(status_text);
+                }
+
+                std::thread::sleep(poll_interval);
+                continue;
+            }
+
+            if !quiet && last_status.is_some() {
+                println!();
+            }
+            return Ok(WaitResult::Failed(reason.to_string()));
+        }
+
+        if !quiet && last_status.is_some() {
+            println!();
+        }
+        return Ok(WaitResult::Ready(status));
+    }
+}
+
+fn verify_tip_head_matches_local(
+    repo: &GitRepo,
+    tip: &ResolvedStackPr,
+    tip_status: &PrMergeStatus,
+) -> Result<()> {
+    let local_sha = repo.rev_parse(&tip.branch)?;
+    if local_sha != tip_status.head_sha {
+        anyhow::bail!(
+            "Selected tip PR #{} head SHA ({}) does not match local branch '{}' ({}). Run `stax submit` or fetch the branch before stack merging.",
+            tip.pr_number,
+            tip_status.head_sha,
+            tip.branch,
+            local_sha
+        );
+    }
+
+    Ok(())
+}
+
+fn restore_tip_base(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    tip: &ResolvedStackPr,
+    original_base: &str,
+    quiet: bool,
+) {
+    let timer = LiveTimer::maybe_new(
+        !quiet,
+        &format!(
+            "Restoring selected tip PR #{} base to {}...",
+            tip.pr_number, original_base
+        ),
+    );
+    match rt.block_on(async { client.update_pr_base(tip.pr_number, original_base).await }) {
+        Ok(()) => LiveTimer::maybe_finish_ok(timer, "done"),
+        Err(e) => {
+            LiveTimer::maybe_finish_err(timer, "failed");
+            if !quiet {
+                eprintln!(
+                    "{} failed to restore PR #{} base to {}: {:#}",
+                    "warning:".yellow().bold(),
+                    tip.pr_number,
+                    original_base,
+                    e
+                );
+            }
+        }
+    }
+}
+
+fn reconcile_downstack_prs(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    prs: &[ResolvedStackPr],
+    tip: &ResolvedStackPr,
+    quiet: bool,
+) -> Result<()> {
+    for pr in prs.iter().filter(|pr| pr.pr_number != tip.pr_number) {
+        let timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!("Closing downstack PR #{}...", pr.pr_number),
+        );
+        let comment = downstack_landed_comment(tip.pr_number);
+        rt.block_on(async { client.create_issue_comment(pr.pr_number, &comment).await })?;
+        rt.block_on(async { client.close_pr(pr.pr_number).await })?;
+        LiveTimer::maybe_finish_ok(timer, "done");
+    }
+
+    Ok(())
+}
+
+fn rebase_remaining_branches(
+    repo: &GitRepo,
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    remote_name: &str,
+    trunk: &str,
+    remaining: &[RemainingStackBranch],
+    quiet: bool,
+) -> Result<()> {
+    if remaining.is_empty() {
+        return Ok(());
+    }
+
+    if !quiet {
+        println!();
+        println!("{}", "Rebasing remaining stack branches...".dimmed());
+    }
+
+    for (idx, branch) in remaining.iter().enumerate() {
+        let previous = if idx == 0 {
+            None
+        } else {
+            Some(remaining[idx - 1].branch.as_str())
+        };
+        rebase_and_finalize_remaining_branch(
+            repo,
+            rt,
+            client,
+            remote_name,
+            trunk,
+            &branch.branch,
+            branch.pr_number,
+            previous,
+            quiet,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn downstack_landed_comment(tip_pr_number: u64) -> String {
+    format!("Landed as part of stack merge of #{}.", tip_pr_number)
+}
+
+fn cleanup_local_stack(repo: &GitRepo, scope: &StackMergeScope, quiet: bool) -> Result<()> {
+    if !quiet {
+        println!();
+        println!("{}", "Cleaning up local stack branches...".dimmed());
+    }
+
+    let checkout_after_cleanup = if scope.downstack_only {
+        &scope.current
+    } else {
+        &scope.trunk
+    };
+    let _ = repo.checkout(checkout_after_cleanup);
+
+    for branch in &scope.to_merge {
+        let local_deleted = repo.delete_branch(&branch.branch, true).is_ok();
+        let _ = crate::git::refs::delete_metadata(repo.inner(), &branch.branch);
+
+        if !quiet {
+            if local_deleted {
+                println!("  {} {} deleted", "✓".green(), branch.branch.dimmed());
+            } else {
+                println!(
+                    "  {} {} kept (checked out elsewhere or already removed)",
+                    "○".yellow(),
+                    branch.branch.dimmed()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run_post_merge_sync(quiet: bool, no_delete: bool) {
+    if !quiet {
+        println!();
+        println!("{}", "Running post-merge sync...".dimmed());
+    }
+
+    if let Err(err) = crate::commands::sync::run(
+        false,      // restack
+        false,      // prune
+        false,      // full
+        !no_delete, // delete merged branches unless explicitly kept
+        false,      // delete upstream-gone branches
+        true,       // force
+        false,      // safe
+        false,      // continue
+        quiet,
+        false, // verbose
+        false, // auto_stash_pop
+        &[],
+    ) {
+        if !quiet {
+            println!();
+            println!(
+                "{} {}",
+                "warning:".yellow().bold(),
+                format!("post-merge sync failed: {}", err).yellow()
+            );
+            println!(
+                "{}",
+                "Run 'stax rs --force' manually to sync local state.".dimmed()
+            );
+        }
+    }
+}
+
+fn print_stack_preview(
+    prs: &[ResolvedStackPr],
+    remaining: &[RemainingStackBranch],
+    trunk: &str,
+    method: MergeMethod,
+    when_ready: bool,
+    downstack_only: bool,
+) {
+    print_header("Stack Fast-Forward Merge");
+    println!();
+    let tip = prs
+        .last()
+        .expect("stack merge preview requires a selected tip PR");
+    println!(
+        "Will validate PR #{} once, retarget it to {}, then merge one PR:",
+        tip.pr_number,
+        trunk.cyan()
+    );
+    if downstack_only {
+        println!(
+            "{}",
+            "Only branches below the current branch are included.".dimmed()
+        );
+    } else if !remaining.is_empty() {
+        println!(
+            "{}",
+            "Branches above the current branch stay open and will be rebased/retargeted.".dimmed()
+        );
+    }
+    println!();
+
+    for (idx, pr) in prs.iter().enumerate() {
+        let marker = if idx + 1 == prs.len() {
+            "(tip, merged)"
+        } else {
+            "(closed after tip merge)"
+        };
+        println!(
+            "  {}. {} (#{}) {}",
+            (idx + 1).to_string().bold(),
+            pr.branch.bold(),
+            pr.pr_number,
+            marker.dimmed()
+        );
+    }
+
+    if !remaining.is_empty() {
+        println!();
+        println!("{}", "Remaining after stack merge:".dimmed());
+        for (idx, branch) in remaining.iter().enumerate() {
+            let target = if idx == 0 {
+                trunk
+            } else {
+                &remaining[idx - 1].branch
+            };
+            let pr_text = branch
+                .pr_number
+                .map(|number| format!(" (#{})", number))
+                .unwrap_or_default();
+            println!(
+                "  {} {}{} -> {}",
+                "○".dimmed(),
+                branch.branch.bold(),
+                pr_text.dimmed(),
+                target.cyan()
+            );
+        }
+    }
+
+    println!();
+    println!(
+        "Merge method: {} {}",
+        method.as_str().cyan(),
+        if matches!(method, MergeMethod::Rebase) {
+            "(default for --stack)".dimmed()
+        } else {
+            "(explicit)".dimmed()
+        }
+    );
+    if when_ready {
+        println!(
+            "{}",
+            "Will wait only for the selected tip PR's CI and mergeability; downstack PRs are checked for review blockers."
+                .dimmed()
+        );
+    } else {
+        println!(
+            "{}",
+            "Requires the selected tip PR to already be green; downstack PRs are checked for review blockers."
+                .dimmed()
+        );
+    }
+}
+
+fn display_width(s: &str) -> usize {
+    s.chars()
+        .map(|c| match c {
+            '\x00'..='\x1f' | '\x7f' => 0,
+            '\x20'..='\x7e' => 1,
+            '─' | '│' | '┌' | '┐' | '└' | '┘' | '├' | '┤' | '┬' | '┴' | '┼' | '╭' | '╮' | '╯'
+            | '╰' | '║' | '═' => 1,
+            '←' | '→' | '↑' | '↓' => 1,
+            '✓' | '✗' | '✔' | '✘' => 1,
+            _ => 2,
+        })
+        .sum()
+}
+
+fn print_header(title: &str) {
+    let width: usize = 56;
+    let title_width = display_width(title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        title.bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}
+
+fn print_header_success(title: &str) {
+    let width: usize = 56;
+    let full_title = format!("✓ {}", title);
+    let title_width = display_width(&full_title);
+    let padding = width.saturating_sub(title_width) / 2;
+    println!("╭{}╮", "─".repeat(width));
+    println!(
+        "│{}{}{}│",
+        " ".repeat(padding),
+        full_title.green().bold(),
+        " ".repeat(width.saturating_sub(padding + title_width))
+    );
+    println!("╰{}╯", "─".repeat(width));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::stack::StackBranch;
+    use std::collections::HashMap;
+
+    fn status(ci_status: CiStatus) -> PrMergeStatus {
+        PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "open".to_string(),
+            updated_at: None,
+            is_draft: false,
+            mergeable: Some(true),
+            mergeable_state: "clean".to_string(),
+            ci_status,
+            review_decision: Some("APPROVED".to_string()),
+            approvals: 1,
+            changes_requested: false,
+            head_sha: "abc123".to_string(),
+        }
+    }
+
+    fn tracked_stack() -> Stack {
+        let mut branches = HashMap::new();
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                parent_revision: None,
+                children: vec!["feature-a".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "feature-a".to_string(),
+            StackBranch {
+                name: "feature-a".to_string(),
+                parent: Some("main".to_string()),
+                parent_revision: None,
+                children: vec!["feature-b".to_string()],
+                needs_restack: false,
+                pr_number: Some(1),
+                pr_state: Some("OPEN".to_string()),
+                pr_is_draft: Some(false),
+            },
+        );
+        branches.insert(
+            "feature-b".to_string(),
+            StackBranch {
+                name: "feature-b".to_string(),
+                parent: Some("feature-a".to_string()),
+                parent_revision: None,
+                children: vec!["feature-c".to_string()],
+                needs_restack: false,
+                pr_number: Some(2),
+                pr_state: Some("OPEN".to_string()),
+                pr_is_draft: Some(false),
+            },
+        );
+        branches.insert(
+            "feature-c".to_string(),
+            StackBranch {
+                name: "feature-c".to_string(),
+                parent: Some("feature-b".to_string()),
+                parent_revision: None,
+                children: vec![],
+                needs_restack: false,
+                pr_number: Some(3),
+                pr_state: Some("OPEN".to_string()),
+                pr_is_draft: Some(false),
+            },
+        );
+
+        Stack {
+            branches,
+            trunk: "main".to_string(),
+        }
+    }
+
+    fn scope_without_repo(
+        stack: &Stack,
+        current: &str,
+        full: bool,
+        downstack_only: bool,
+    ) -> (Vec<String>, Vec<String>) {
+        let mut to_merge = stack.ancestors(current);
+        to_merge.reverse();
+        to_merge.retain(|branch| branch != &stack.trunk);
+
+        let mut remaining = stack.descendants(current);
+        if downstack_only {
+            remaining.insert(0, current.to_string());
+        } else {
+            to_merge.push(current.to_string());
+        }
+
+        if full && !remaining.is_empty() {
+            to_merge.extend(std::mem::take(&mut remaining));
+        }
+
+        (to_merge, remaining)
+    }
+
+    #[test]
+    fn stack_scope_defaults_to_current_branch() {
+        let stack = tracked_stack();
+        let (to_merge, remaining) = scope_without_repo(&stack, "feature-b", false, false);
+        assert_eq!(to_merge, vec!["feature-a", "feature-b"]);
+        assert_eq!(remaining, vec!["feature-c"]);
+    }
+
+    #[test]
+    fn stack_scope_full_includes_descendants() {
+        let stack = tracked_stack();
+        let (to_merge, remaining) = scope_without_repo(&stack, "feature-b", true, false);
+        assert_eq!(to_merge, vec!["feature-a", "feature-b", "feature-c"]);
+        assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn stack_scope_downstack_only_excludes_current() {
+        let stack = tracked_stack();
+        let (to_merge, remaining) = scope_without_repo(&stack, "feature-b", false, true);
+        assert_eq!(to_merge, vec!["feature-a"]);
+        assert_eq!(remaining, vec!["feature-b", "feature-c"]);
+    }
+
+    #[test]
+    fn stack_scope_downstack_only_direct_child_has_no_merge_targets() {
+        let stack = tracked_stack();
+        let (to_merge, remaining) = scope_without_repo(&stack, "feature-a", false, true);
+        assert!(to_merge.is_empty());
+        assert_eq!(remaining, vec!["feature-a", "feature-b", "feature-c"]);
+    }
+
+    #[test]
+    fn downstack_blocker_ignores_redundant_ci_failure() {
+        let mut status = status(CiStatus::Failure);
+        status.review_decision = Some("APPROVED".to_string());
+
+        assert_eq!(downstack_blocker(&status), None);
+    }
+
+    #[test]
+    fn downstack_blocker_rejects_missing_required_review() {
+        let mut status = status(CiStatus::Success);
+        status.review_decision = Some("REVIEW_REQUIRED".to_string());
+
+        assert_eq!(downstack_blocker(&status), Some("review required"));
+    }
+
+    #[test]
+    fn tip_blocker_checks_tip_ci() {
+        assert_eq!(
+            tip_blocker(&status(CiStatus::Pending)),
+            Some("CI is still pending")
+        );
+        assert_eq!(tip_blocker(&status(CiStatus::Failure)), Some("CI failed"));
+        assert_eq!(tip_blocker(&status(CiStatus::Success)), None);
+    }
+
+    #[test]
+    fn downstack_comment_links_to_tip() {
+        assert_eq!(
+            downstack_landed_comment(42),
+            "Landed as part of stack merge of #42."
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod merge;
 pub mod merge_queue;
 pub(crate) mod merge_rebase;
 pub mod merge_remote;
+pub mod merge_stack;
 pub mod merge_when_ready;
 pub mod modify;
 pub mod navigate;

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -1,10 +1,10 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
 use reqwest::Client;
-use serde::de::DeserializeOwned;
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -220,6 +220,24 @@ impl ForgeClient {
         dispatch!(self, create_stack_comment(number, stack_comment))
     }
 
+    pub async fn create_issue_comment(&self, number: u64, body: &str) -> Result<()> {
+        match self {
+            Self::GitHub(client) => client.create_issue_comment(number, body).await,
+            Self::GitLab(_) | Self::Gitea(_) => {
+                bail!("creating plain PR comments is currently only supported for GitHub")
+            }
+        }
+    }
+
+    pub async fn close_pr(&self, number: u64) -> Result<()> {
+        match self {
+            Self::GitHub(client) => client.close_pr(number).await,
+            Self::GitLab(_) | Self::Gitea(_) => {
+                bail!("closing PRs from stack merge is currently only supported for GitHub")
+            }
+        }
+    }
+
     pub async fn delete_stack_comment(&self, number: u64) -> Result<()> {
         dispatch!(self, delete_stack_comment(number))
     }
@@ -236,12 +254,15 @@ impl ForgeClient {
         sha: Option<&str>,
     ) -> Result<()> {
         match self {
-            // GitHub's merge_pr takes (number, method, commit_title, commit_message).
-            // The `sha` merge-guard is not exposed by the current GitHub client,
-            // so we pass None for commit_message rather than forwarding sha there.
             Self::GitHub(client) => {
                 client
-                    .merge_pr(number, method, commit_title.map(str::to_string), None)
+                    .merge_pr(
+                        number,
+                        method,
+                        commit_title.map(str::to_string),
+                        None,
+                        sha.map(str::to_string),
+                    )
                     .await
             }
             Self::GitLab(client) => client.merge_pr(number, method, commit_title, sha).await,

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -798,6 +798,32 @@ impl GitHubClient {
         Ok(())
     }
 
+    /// Add a plain issue comment to a PR conversation.
+    pub async fn create_issue_comment(&self, pr_number: u64, body: &str) -> Result<()> {
+        self.record_api_call("issues.comments.create");
+        self.octocrab
+            .issues(&self.owner, &self.repo)
+            .create_comment(pr_number, body)
+            .await
+            .context("Failed to create comment")?;
+
+        Ok(())
+    }
+
+    /// Close a PR without merging it.
+    pub async fn close_pr(&self, pr_number: u64) -> Result<()> {
+        self.record_api_call("pulls.update.state");
+        self.octocrab
+            .pulls(&self.owner, &self.repo)
+            .update(pr_number)
+            .state(octocrab::params::pulls::State::Closed)
+            .send()
+            .await
+            .context("Failed to close PR")?;
+
+        Ok(())
+    }
+
     /// Delete the stax-managed stack comment on a PR, if present.
     pub async fn delete_stack_comment(&self, pr_number: u64) -> Result<()> {
         let Some(comment_id) = self.find_stack_comment_id(pr_number).await? else {
@@ -911,6 +937,7 @@ impl GitHubClient {
         method: MergeMethod,
         commit_title: Option<String>,
         commit_message: Option<String>,
+        sha: Option<String>,
     ) -> Result<()> {
         let merge_method = match method {
             MergeMethod::Squash => octocrab::params::pulls::MergeMethod::Squash,
@@ -927,6 +954,10 @@ impl GitHubClient {
 
         if let Some(ref message) = commit_message {
             merge_builder = merge_builder.message(message);
+        }
+
+        if let Some(ref sha) = sha {
+            merge_builder = merge_builder.sha(sha);
         }
 
         merge_builder.send().await.map_err(format_merge_error)?;
@@ -2629,7 +2660,9 @@ mod tests {
             .await;
 
         let client = create_test_client(&mock_server).await;
-        let result = client.merge_pr(42, MergeMethod::Squash, None, None).await;
+        let result = client
+            .merge_pr(42, MergeMethod::Squash, None, None, None)
+            .await;
 
         let err = result.expect_err("merge_pr should fail on 405");
         let msg = format!("{:#}", err);
@@ -2662,7 +2695,9 @@ mod tests {
             .await;
 
         let client = create_test_client(&mock_server).await;
-        let result = client.merge_pr(7, MergeMethod::Merge, None, None).await;
+        let result = client
+            .merge_pr(7, MergeMethod::Merge, None, None, None)
+            .await;
 
         let err = result.expect_err("merge_pr should fail on 422");
         let msg = format!("{:#}", err);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5885,6 +5885,35 @@ fn test_merge_downstack_only_conflicts_with_queue() {
 }
 
 #[test]
+fn test_merge_stack_downstack_only_is_allowed() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--stack", "--downstack-only", "--dry-run"]);
+    let stderr = TestRepo::stderr(&output);
+
+    assert!(
+        output.status.success(),
+        "Expected --stack --downstack-only to parse, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_merge_full_requires_stack() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--full"]);
+    let stderr = TestRepo::stderr(&output);
+
+    assert!(!output.status.success(), "Expected --full to require --stack");
+    assert!(
+        stderr.contains("required") || stderr.contains("requires"),
+        "Expected clap requires error, got: {}",
+        stderr
+    );
+}
+
+#[test]
 fn test_merge_ds_alias_conflicts_with_all() {
     let repo = TestRepo::new();
 
@@ -6247,7 +6276,7 @@ fn test_merge_method_options() {
 }
 
 #[test]
-fn test_merge_invalid_method_defaults_to_squash() {
+fn test_merge_invalid_method_fails() {
     let repo = TestRepo::new_with_remote();
 
     // Create a branch
@@ -6255,14 +6284,13 @@ fn test_merge_invalid_method_defaults_to_squash() {
     repo.create_file("test.txt", "content");
     repo.commit("Test");
 
-    // Invalid method should fall back to default (squash)
     let output = repo.run_stax(&["merge", "--method", "invalid", "--dry-run"]);
-    // Should not panic, should handle gracefully
-    // The command will fail due to no PR, but shouldn't crash
     let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(!output.status.success(), "Invalid method should fail");
     assert!(
-        !combined.is_empty(),
-        "Should produce some output even with invalid method"
+        combined.contains("Invalid merge method"),
+        "Expected invalid method error, got: {}",
+        combined
     );
 }
 
@@ -6906,7 +6934,15 @@ mod forge_mock_tests {
     }
 
     async fn mount_github_review_status(mock_server: &MockServer, number: u64, decision: &str) {
-        mount_github_merge_status(mock_server, number, "OPEN", decision).await;
+        let head_sha = format!("sha-{}", number);
+        mount_github_merge_status_with_head(
+            mock_server,
+            number,
+            "OPEN",
+            decision,
+            &head_sha,
+        )
+        .await;
     }
 
     async fn mount_github_merge_status(
@@ -6914,6 +6950,24 @@ mod forge_mock_tests {
         number: u64,
         state: &str,
         decision: &str,
+    ) {
+        let head_sha = format!("sha-{}", number);
+        mount_github_merge_status_with_head(
+            mock_server,
+            number,
+            state,
+            decision,
+            &head_sha,
+        )
+        .await;
+    }
+
+    async fn mount_github_merge_status_with_head(
+        mock_server: &MockServer,
+        number: u64,
+        state: &str,
+        decision: &str,
+        head_sha: &str,
     ) {
         let nodes = if decision == "APPROVED" {
             serde_json::json!([{ "state": "APPROVED" }])
@@ -6939,7 +6993,7 @@ mod forge_mock_tests {
                             "isDraft": false,
                             "mergeable": "MERGEABLE",
                             "reviewDecision": decision,
-                            "headRefOid": format!("sha-{}", number),
+                            "headRefOid": head_sha,
                             "statusCheckRollup": { "state": "SUCCESS" },
                             "reviews": { "nodes": nodes }
                         }
@@ -9695,6 +9749,353 @@ mod forge_mock_tests {
                 && combined.contains("Merge Stopped"),
             "Expected duplicate PR base error to surface. Output:\n{}",
             combined
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_retargets_tip_merges_once_and_closes_downstack_prs() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-ff-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-ff-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let branch_b_sha = repo.get_commit_sha(&branch_b);
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        write_branch_pr_metadata(&repo, &branch_a, "main", 601, Some(false));
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 602, Some(false));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/601"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(601, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/602"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(602, &branch_b, &branch_a, &branch_b_sha)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        mount_github_merge_status_with_head(&mock_server, 601, "OPEN", "APPROVED", "sha-a").await;
+        mount_github_merge_status_with_head(
+            &mock_server,
+            602,
+            "OPEN",
+            "APPROVED",
+            &branch_b_sha,
+        )
+        .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/602"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                602,
+                &branch_b,
+                "main",
+                &branch_b_sha,
+            )))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/602/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test/repo/issues/601/comments"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
+                9001,
+                "Landed as part of stack merge of #602.",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/601"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                601, &branch_a, "main", "sha-a",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "merge --stack failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        assert!(
+            requests.iter().all(|request| {
+                request.method.as_str() != "PUT"
+                    || request.url.path() != "/repos/test/repo/pulls/601/merge"
+            }),
+            "Expected no merge call for downstack PR #601, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+
+        let tip_patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/602");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/602/merge");
+        let comment_idx =
+            find_request_index(&requests, "POST", "/repos/test/repo/issues/601/comments");
+        let close_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/601");
+        assert!(
+            tip_patch_idx < merge_idx && merge_idx < comment_idx && comment_idx < close_idx,
+            "Expected retarget -> tip merge -> comment -> close order, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+
+        let tip_patch = &requests[tip_patch_idx];
+        let tip_patch_payload: Value = serde_json::from_slice(&tip_patch.body).unwrap();
+        assert_eq!(tip_patch_payload["base"], "main");
+
+        let merge_request = &requests[merge_idx];
+        let merge_payload: Value = serde_json::from_slice(&merge_request.body).unwrap();
+        assert_eq!(merge_payload["merge_method"], "rebase");
+        assert_eq!(merge_payload["sha"], branch_b_sha);
+
+        let comment_request = &requests[comment_idx];
+        let comment_payload: Value = serde_json::from_slice(&comment_request.body).unwrap();
+        assert_eq!(
+            comment_payload["body"],
+            "Landed as part of stack merge of #602."
+        );
+
+        let close_request = &requests[close_idx];
+        let close_payload: Value = serde_json::from_slice(&close_request.body).unwrap();
+        assert_eq!(close_payload["state"], "closed");
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_from_middle_retargets_remaining_child_pr() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-mid-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-mid-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("middle.txt", "middle\n");
+        repo.commit("Middle commit");
+        let branch_b_sha = repo.get_commit_sha(&branch_b);
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-mid-c"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_c = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let branch_c_sha = repo.get_commit_sha(&branch_c);
+        let push_c = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_c]);
+        assert!(push_c.status.success(), "{}", TestRepo::stderr(&push_c));
+
+        let checkout_b = git_with_env(&repo, home.path(), &["checkout", &branch_b]);
+        assert!(
+            checkout_b.status.success(),
+            "{}",
+            TestRepo::stderr(&checkout_b)
+        );
+
+        write_branch_pr_metadata(&repo, &branch_a, "main", 611, Some(false));
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 612, Some(false));
+        write_branch_pr_metadata(&repo, &branch_c, &branch_b, 613, Some(false));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/611"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(611, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/612"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(612, &branch_b, &branch_a, &branch_b_sha)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/613"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(613, &branch_c, &branch_b, &branch_c_sha)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        mount_github_merge_status_with_head(&mock_server, 611, "OPEN", "APPROVED", "sha-a").await;
+        mount_github_merge_status_with_head(
+            &mock_server,
+            612,
+            "OPEN",
+            "APPROVED",
+            &branch_b_sha,
+        )
+        .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/612"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                612,
+                &branch_b,
+                "main",
+                &branch_b_sha,
+            )))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/612/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test/repo/issues/611/comments"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
+                9002,
+                "Landed as part of stack merge of #612.",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/611"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                611, &branch_a, "main", "sha-a",
+            )))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/613"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                613, &branch_c, "main", &branch_c_sha,
+            )))
+            .mount(&mock_server)
+            .await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "merge --stack failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        assert!(
+            requests.iter().all(|request| {
+                request.method.as_str() != "PUT"
+                    || request.url.path() != "/repos/test/repo/pulls/611/merge"
+            }),
+            "Expected no merge call for downstack PR #611"
+        );
+        assert!(
+            requests.iter().all(|request| {
+                request.method.as_str() != "PUT"
+                    || request.url.path() != "/repos/test/repo/pulls/613/merge"
+            }),
+            "Expected no merge call for remaining PR #613"
+        );
+
+        let tip_patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/612");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/612/merge");
+        let remaining_patch_idx =
+            find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/613");
+        assert!(
+            tip_patch_idx < merge_idx && merge_idx < remaining_patch_idx,
+            "Expected tip retarget -> merge -> remaining retarget order, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+
+        let remaining_patch = &requests[remaining_patch_idx];
+        let remaining_payload: Value = serde_json::from_slice(&remaining_patch.body).unwrap();
+        assert_eq!(remaining_payload["base"], "main");
+
+        let branch_b_is_still_ancestor = repo
+            .git(&["merge-base", "--is-ancestor", &branch_b, &branch_c])
+            .status
+            .success();
+        assert!(
+            !branch_b_is_still_ancestor,
+            "remaining branch should be rebased off the merged current branch"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add GitHub-only `st merge --stack` fast-forward merge: validate the selected tip PR, retarget it to trunk, merge once with a head-SHA guard, then comment/close selected downstack PRs.
- Scope `--stack` through the current branch by default, support `--stack --downstack-only`, and add `--stack --full` for including descendants from the middle of a stack.
- Rebase/push/retarget remaining descendants after a partial stack merge, and document the branch-protection caveat for no-extra-CI behavior.

## Testing
- `cargo check`
- `cargo nextest run merge_stack`
- `cargo nextest run merge_method`
- `cargo nextest run merge_downstack_only`
- `cargo nextest run merge_full_requires_stack`
- `cargo nextest run invalid_method`
- `make test` (Docker; 1663 passed)

Addresses the fast-forward stack merge proposal from https://github.com/cesarferreira/stax/issues/293#issuecomment-4699088493.


## details

Scope & limits — what needs a server and what doesn't

The dividing line is concurrency and asynchrony, not authorship:

    Who wrote the code → no server. Path 2 handles it.
    Who lands code at the same time, when no human is online, or across many stacks competing for the same trunk → needs the https://github.com/cesarferreira/stax/issues/293 server/queue.

Works on Path 2 today (no infrastructure):

    Single-author stacks.
    Multi-author / shared stacks — including stacks built on st get-imported read-only bases (https://github.com/cesarferreira/stax/pull/501). Multi-authorship does not require a server; it only requires one coordinator with merge rights on every PR running the merge atomically while the tip is green. (See the multi-author edge cases above.)
    Any case where one person is willing to be online to trigger and watch the merge.

Needs the https://github.com/cesarferreira/stax/issues/293 server/queue (genuinely server-shaped):

    Concurrent submitters racing for trunk. Two people merge stacks against the same trunk tip at once; the first lands, the second's green is now stale. Serializing this (lock + "rebase and revalidate only what changed") is the actual queue and needs an always-on arbiter.
    "Land it later, when I'm offline." Submit-and-walk-away across timezones needs something running when CI finishes. A laptop polling st merge --when-ready works only while that laptop is awake (Option B in https://github.com/cesarferreira/stax/issues/293); a server removes the "a human's machine must stay on" requirement.
    Speculative CI / cross-stack batching — keeping candidate N+1 warm while N merges. Pure throughput optimization; needs persistent state.

This issue deliberately covers only the first bucket. The second bucket stays in https://github.com/cesarferreira/stax/issues/293.