### PR TITLE
docs: fix status alias reference

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -6,7 +6,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 
 | Command | Alias | Description |
 |---|---|---|
-| `st status` | `s`, `ls` | Show stack |
+| `st status` | `ls` | Show stack |
 | `st ll` | | Show stack with PR URLs and full details |
 | `st log` | `l` | Show stack with commits and PR info |
 | `st submit` | `ss` | Submit full current stack |

--- a/skills.md
+++ b/skills.md
@@ -19,7 +19,7 @@ Stax manages stacked branches: small focused branches layered on top of each oth
 ## Command Map
 
 ```bash
-stax status|s|ls              # Stack status (tree)
+stax status|ls                # Stack status (tree)
 stax ll                        # Stack status with PR URLs/details
 stax log|l                     # Stack status with commits + PR info
 


### PR DESCRIPTION
## Motivation

Fixes #504. The command reference and agent skills file still listed `s` as a `status` alias, but `s` now opens the `stack` command group.

## Description of changes / notes for reviewers

- Update `docs/commands/reference.md` so `st status` lists only `ls` as an alias.
- Update `skills.md` so agent-facing command guidance matches the CLI.

Validation:

- Source check: `src/cli/args.rs` defines `status` with `visible_alias = "ls"` and `stack` with `visible_alias = "s"`.
- Targeted stale-reference search across `README.md`, `docs`, `skills.md`, and `src/cli/args.rs`.
- `git diff --check`
- `cargo run --features vendored-openssl --quiet --bin stax -- --help`
- `cargo run --features vendored-openssl --quiet --bin stax -- s --help`

Notes:

- `cargo run --quiet --bin stax -- --help` without `vendored-openssl` failed before project code because local `pkg-config`/OpenSSL discovery is unavailable.
- `make test` did not run locally because `cargo-nextest` is not installed in this environment.
- `cargo fmt --check` reports pre-existing rustfmt drift across unrelated Rust files; this PR changes Markdown only.