### PR TITLE
fix: mark absorbed stack PRs explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Merge from the bottom of the stack up to your current branch, with CI and readin
 st merge                  # local cascade merge
 st merge --when-ready     # wait/poll until PRs are mergeable
 st merge --ds             # merge ancestors, rebase current branch
-st merge --stack          # validate current PR once, stack-merge through current
+st merge --stack          # validate current PR once; absorb lower PRs through current
 st merge --stack --full   # stack-merge the full stack even from the middle
 st merge --remote         # merge remotely on GitHub while you keep working
 st merge --all            # merge the whole stack regardless of position

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -35,7 +35,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
-| `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, and merge through current by default (`--full` includes descendants; GitHub only) |
+| `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, merge that PR, and mark lower PRs as absorbed (`--full` includes descendants; GitHub only) |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
 | `st cascade` | Restack, push, and create/update PRs in one shot |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -34,7 +34,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`
 - `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
-- `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, close selected downstack PRs with a back-reference comment, and rebase/retarget remaining descendants; defaults to `--method rebase`
+- `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, mark selected downstack PRs as absorbed with a back-reference comment, and rebase/retarget remaining descendants; defaults to `--method rebase`
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -75,11 +75,13 @@ st merge --stack --full
 st merge --stack --dry-run
 ```
 
-For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, validates CI/mergeability on selected tip PR `B`, retargets `B` to `main`, and merges only `B` through GitHub's merge API. PR `A` is then closed with a comment pointing at `B`; PR `C` remains open and is rebased/retargeted onto `main`.
+For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, validates CI/mergeability on selected tip PR `B`, retargets `B` to `main`, and merges only `B` through GitHub's merge API. PR `A` is then marked as absorbed with a comment pointing at `B`; PR `C` remains open and is rebased/retargeted onto `main`.
 
 Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `rebase`; pass `--method squash` only when you explicitly want GitHub to squash the selected range into one commit.
 
-This avoids re-running CI for every lower PR because the selected tip already contains that range. If trunk moves before the merge, stax aborts and asks you to restack and wait for fresh selected-tip CI.
+This avoids re-running CI for every lower PR because the selected tip already contains that range. The post-merge sync updates trunk and PR metadata without running generic merged-branch deletion; branch cleanup stays scoped to the stack range that was just landed. If trunk moves before the merge, stax aborts and asks you to restack and wait for fresh selected-tip CI.
+
+GitHub still displays absorbed lower PRs as closed rather than merged because only the selected tip PR is merged through GitHub. Stax leaves an explicit absorbed-by comment so the closure is intentional and traceable.
 
 For the no-extra-CI behavior, GitHub branch protection should require status checks but should not require branches to be up to date before merging. If GitHub requires up-to-date branches, it can force another revalidation at merge time.
 

--- a/skills.md
+++ b/skills.md
@@ -221,7 +221,7 @@ stax merge --downstack-only        # Merge ancestors below current, then rebase 
 stax merge --ds                    # Alias for --downstack-only
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
-stax merge --stack                 # GitHub only: validate selected tip once; default scope is bottom through current
+stax merge --stack                 # GitHub only: validate selected tip once, merge it, and mark lower PRs as absorbed
 stax merge --stack --downstack-only # Stack-merge ancestors below current; keep current open
 stax merge --stack --full          # Stack-merge full stack even from the middle
 stax merge --stack --when-ready    # Wait only for selected tip PR readiness before stack fast-forward merge

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -1,8 +1,8 @@
 //! Fast-forward stack merge through one GitHub PR merge.
 //!
 //! This is the serverless path from issue #293: validate the selected tip PR
-//! once, retarget that PR to trunk, merge it via GitHub's merge API, then close
-//! the selected lower PRs with a back-reference comment.
+//! once, retarget that PR to trunk, merge it via GitHub's merge API, then
+//! absorb the selected lower PRs with a back-reference comment.
 
 use crate::commands::merge::{
     PrBaseUpdate, rebase_and_finalize_remaining_branch, update_pr_base_unless_current,
@@ -267,7 +267,7 @@ pub fn run(
     }
     LiveTimer::maybe_finish_ok(merge_timer, "done");
 
-    reconcile_downstack_prs(&rt, &client, &resolved, tip, quiet)?;
+    absorb_downstack_prs(&rt, &client, &resolved, tip, quiet)?;
 
     rebase_remaining_branches(
         &repo,
@@ -284,7 +284,7 @@ pub fn run(
     }
 
     if !no_sync {
-        run_post_merge_sync(quiet, no_delete);
+        run_post_merge_sync(quiet);
     }
 
     if !quiet {
@@ -301,7 +301,7 @@ pub fn run(
             let action = if pr.pr_number == tip.pr_number {
                 "merged"
             } else {
-                "closed"
+                "absorbed"
             };
             println!(
                 "  {} #{} {} -> {}",
@@ -674,7 +674,7 @@ fn restore_tip_base(
     }
 }
 
-fn reconcile_downstack_prs(
+fn absorb_downstack_prs(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
     prs: &[ResolvedStackPr],
@@ -684,9 +684,9 @@ fn reconcile_downstack_prs(
     for pr in prs.iter().filter(|pr| pr.pr_number != tip.pr_number) {
         let timer = LiveTimer::maybe_new(
             !quiet,
-            &format!("Closing downstack PR #{}...", pr.pr_number),
+            &format!("Marking downstack PR #{} as absorbed...", pr.pr_number),
         );
-        let comment = downstack_landed_comment(tip.pr_number);
+        let comment = downstack_absorbed_comment(tip.pr_number);
         rt.block_on(async { client.create_issue_comment(pr.pr_number, &comment).await })?;
         rt.block_on(async { client.close_pr(pr.pr_number).await })?;
         LiveTimer::maybe_finish_ok(timer, "done");
@@ -735,8 +735,11 @@ fn rebase_remaining_branches(
     Ok(())
 }
 
-fn downstack_landed_comment(tip_pr_number: u64) -> String {
-    format!("Landed as part of stack merge of #{}.", tip_pr_number)
+fn downstack_absorbed_comment(tip_pr_number: u64) -> String {
+    format!(
+        "Absorbed into stack merge of #{}. This PR's commits landed through the selected tip PR.",
+        tip_pr_number
+    )
 }
 
 fn cleanup_local_stack(repo: &GitRepo, scope: &StackMergeScope, quiet: bool) -> Result<()> {
@@ -772,21 +775,24 @@ fn cleanup_local_stack(repo: &GitRepo, scope: &StackMergeScope, quiet: bool) -> 
     Ok(())
 }
 
-fn run_post_merge_sync(quiet: bool, no_delete: bool) {
+fn run_post_merge_sync(quiet: bool) {
     if !quiet {
         println!();
-        println!("{}", "Running post-merge sync...".dimmed());
+        println!(
+            "{}",
+            "Running post-merge sync (no branch deletion)...".dimmed()
+        );
     }
 
     if let Err(err) = crate::commands::sync::run(
-        false,      // restack
-        false,      // prune
-        false,      // full
-        !no_delete, // delete merged branches unless explicitly kept
-        false,      // delete upstream-gone branches
-        true,       // force
-        false,      // safe
-        false,      // continue
+        false, // restack
+        false, // prune
+        false, // full
+        false, // keep branch cleanup scoped to this stack merge
+        false, // delete upstream-gone branches
+        true,  // force
+        false, // safe
+        false, // continue
         quiet,
         false, // verbose
         false, // auto_stash_pop
@@ -842,7 +848,7 @@ fn print_stack_preview(
         let marker = if idx + 1 == prs.len() {
             "(tip, merged)"
         } else {
-            "(closed after tip merge)"
+            "(absorbed after tip merge)"
         };
         println!(
             "  {}. {} (#{}) {}",
@@ -1113,8 +1119,8 @@ mod tests {
     #[test]
     fn downstack_comment_links_to_tip() {
         assert_eq!(
-            downstack_landed_comment(42),
-            "Landed as part of stack merge of #42."
+            downstack_absorbed_comment(42),
+            "Absorbed into stack merge of #42. This PR's commits landed through the selected tip PR."
         );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9977,7 +9977,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_stack_retargets_tip_merges_once_and_closes_downstack_prs() {
+    async fn test_merge_stack_retargets_tip_merges_once_and_absorbs_downstack_prs() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -10059,7 +10059,7 @@ mod forge_mock_tests {
             .and(path("/repos/test/repo/issues/601/comments"))
             .respond_with(ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
                 9001,
-                "Landed as part of stack merge of #602.",
+                "Absorbed into stack merge of #602. This PR's commits landed through the selected tip PR.",
             )))
             .mount(&mock_server)
             .await;
@@ -10127,7 +10127,7 @@ mod forge_mock_tests {
         let comment_payload: Value = serde_json::from_slice(&comment_request.body).unwrap();
         assert_eq!(
             comment_payload["body"],
-            "Landed as part of stack merge of #602."
+            "Absorbed into stack merge of #602. This PR's commits landed through the selected tip PR."
         );
 
         let close_request = &requests[close_idx];
@@ -10244,7 +10244,7 @@ mod forge_mock_tests {
             .and(path("/repos/test/repo/issues/611/comments"))
             .respond_with(ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
                 9002,
-                "Landed as part of stack merge of #612.",
+                "Absorbed into stack merge of #612. This PR's commits landed through the selected tip PR.",
             )))
             .mount(&mock_server)
             .await;

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -285,8 +285,8 @@ fn wt_create_without_name_creates_random_lane() {
         stderr
     );
     assert!(
-        stderr.contains("and copied"),
-        "expected copied-files summary, got:\n{}",
+        stderr.contains("Branched") && stderr.contains("from main"),
+        "expected branch creation summary, got:\n{}",
         stderr
     );
 


### PR DESCRIPTION
## Summary

Closes #511.

This polishes the serverless `st merge --stack` flow so lower selected PRs are treated as intentionally absorbed into the selected tip merge instead of looking like ordinary closed/unmerged PRs.

Changes:
- rename the downstack reconciliation path in `merge_stack` from close/reconcile wording to absorb wording;
- post an explicit absorbed-by comment on lower selected PRs;
- show absorbed status in the preview and final summary;
- run the post-merge sync without generic merged-branch deletion so cleanup stays scoped to the stack range the command explicitly landed;
- document the GitHub limitation that absorbed lower PRs still display as closed because only the selected tip PR is actually merged;
- update a stale worktree-create integration assertion that still expected the removed copied-files summary.

## Validation

- `cargo nextest run worktree_cli_tests::wt_create_without_name_creates_random_lane`
- `cargo nextest run merge_stack`
- GitHub Actions: Unit Tests and Integration Tests passing on commit `840c0aa`

Full-suite local note:
- `make test` was attempted locally, but Docker failed while building the `stax-test` image before Rust tests ran: `failed to solve: write /var/lib/desktop-containerd/daemon/io.containerd.metadata.v1.bolt/meta.db: input/output error`.