### PR TITLE
fix: show git push hook output on submit failure

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1848,27 +1848,23 @@ fn push_branches(
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         let rejected = rejected_push_branches(&stdout, branches);
-        let details = stderr.trim();
+        let details = push_failure_details(&stdout, &stderr);
+        let branch_list = branches.join(", ");
         if !rejected.is_empty() {
-            anyhow::bail!(
-                "Failed to push branches {}: rejected {}{}",
-                branches.join(", "),
-                rejected.join(", "),
-                if details.is_empty() {
-                    String::new()
-                } else {
-                    format!(" ({})", details)
-                }
+            let mut message = format!(
+                "Failed to push branches {branch_list}: rejected {}",
+                rejected.join(", ")
             );
+            if !details.is_empty() {
+                message.push('\n');
+                message.push_str(&details);
+            }
+            anyhow::bail!("{message}");
         }
         if details.is_empty() {
-            anyhow::bail!("Failed to push branches: {}", branches.join(", "));
+            anyhow::bail!("Failed to push branches: {branch_list}");
         }
-        anyhow::bail!(
-            "Failed to push branches {}: {}",
-            branches.join(", "),
-            details
-        );
+        anyhow::bail!("Failed to push branches {branch_list}:\n{details}");
     }
     Ok(())
 }
@@ -1991,6 +1987,18 @@ fn rejected_push_branches(porcelain: &str, branches: &[&str]) -> Vec<String> {
             branches.contains(&branch).then(|| branch.to_string())
         })
         .collect()
+}
+
+fn push_failure_details(stdout: &str, stderr: &str) -> String {
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => stdout.to_string(),
+        (true, false) => stderr.to_string(),
+        (false, false) => format!("stdout:\n{stdout}\nstderr:\n{stderr}"),
+    }
 }
 
 fn resolve_branches_for_scope(stack: &Stack, current: &str, scope: SubmitScope) -> Vec<String> {
@@ -2742,7 +2750,7 @@ fn format_duration(duration: Duration) -> String {
 mod tests {
     use super::{
         build_ai_pr_details_prompt, existing_ai_prompt_items, existing_ai_targets_for_auto_accept,
-        parse_ai_pr_details, rejected_push_branches, resolve_ai_targets,
+        parse_ai_pr_details, push_failure_details, rejected_push_branches, resolve_ai_targets,
         resolve_is_draft_without_prompt, stack_link_contexts_for_sync, stack_pr_infos_for_links,
         truncate_ai_diff, AiPrTargets, StackPrInfo, MAX_AI_DIFF_BYTES, PR_TYPE_DEFAULT_INDEX,
         PR_TYPE_OPTIONS,
@@ -2779,6 +2787,22 @@ mod tests {
         assert_eq!(
             rejected_push_branches(porcelain, &["feature", "feature-a"]),
             vec!["feature-a".to_string()]
+        );
+    }
+
+    #[test]
+    fn push_failure_details_preserves_stdout_when_stderr_is_empty() {
+        assert_eq!(
+            push_failure_details("pre-push hook blocked submit\n", ""),
+            "pre-push hook blocked submit"
+        );
+    }
+
+    #[test]
+    fn push_failure_details_labels_both_streams() {
+        assert_eq!(
+            push_failure_details("hook stdout\n", "hook stderr\n"),
+            "stdout:\nhook stdout\nstderr:\nhook stderr"
         );
     }
 

--- a/tests/submit_no_verify_tests.rs
+++ b/tests/submit_no_verify_tests.rs
@@ -50,7 +50,7 @@ mod unix {
         let hook = repo.path().join(".git/hooks/pre-push");
         fs::write(
             &hook,
-            "#!/bin/sh\necho 'pre-push hook blocked submit' >&2\nexit 1\n",
+            "#!/bin/sh\necho 'pre-push hook stdout blocked submit'\necho 'pre-push hook stderr blocked submit' >&2\nexit 1\n",
         )
         .expect("write pre-push hook");
         fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).expect("chmod pre-push hook");
@@ -91,7 +91,9 @@ mod unix {
         let (repo, branch) = repo_with_failing_pre_push_hook("submit-no-verify");
 
         repo.run_stax(&["ss", "--no-fetch", "--no-pr", "--no-prompt", "--yes"])
-            .assert_failure();
+            .assert_failure()
+            .assert_stderr_contains("pre-push hook stdout blocked submit")
+            .assert_stderr_contains("pre-push hook stderr blocked submit");
         assert!(
             !remote_has_branch(&repo, &branch),
             "branch should not exist after hook-blocked push"

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -284,11 +284,6 @@ fn wt_create_without_name_creates_random_lane() {
         "expected conductor-style creation message, got:\n{}",
         stderr
     );
-    assert!(
-        stderr.contains("and copied"),
-        "expected copied-files summary, got:\n{}",
-        stderr
-    );
 
     let worktrees = linked_worktree_dirs_default(&repo, &home);
     assert_eq!(worktrees.len(), 1, "expected one linked worktree");
@@ -314,6 +309,13 @@ fn wt_create_without_name_creates_random_lane() {
         "expected a branch ending with '{}', got {:?}",
         slug,
         repo.list_branches()
+    );
+    let stdout = TestRepo::stdout(&out);
+    let expected_path = default_worktree_root(&repo, &home).join(&slug);
+    assert!(
+        stdout.contains(expected_path.to_string_lossy().as_ref()),
+        "expected cd hint for generated worktree, got:\n{}",
+        stdout
     );
 
     let gitignore = fs::read_to_string(repo.path().join(".gitignore")).unwrap_or_default();


### PR DESCRIPTION
## Summary

- preserve both stdout and stderr from failed `git push` calls during submit
- keep rejected-branch detection while appending the underlying push/hook output
- cover stdout-only and mixed-stream hook diagnostics in tests
- update the worktree random-lane test for the current no-file-count creation output

Fixes #517.

## Tests

- `cargo nextest run submit_no_verify_tests:: push_failure_details`
- `cargo nextest run worktree_cli_tests::wt_create_without_name_creates_random_lane`
- `git diff --check`
- `make test` (Docker): 1684 tests passed

## Docs

No README/docs/skills update: this improves submit failure diagnostics and repairs a stale test assertion; it does not add or change commands, flags, workflows, concepts, or defaults.