### PR TITLE
docs: document branch.stale_days and git.rerere config keys (#510)

### DIFF
--- a/docs/commands/sweep.md
+++ b/docs/commands/sweep.md
@@ -65,7 +65,7 @@ Set the stale threshold globally in `~/.config/stax/config.toml`:
 stale_days = 60
 ```
 
-`--stale-days` overrides this per-run.
+`--stale-days` overrides this per-run. See the [configuration reference](../configuration/index.md#stale-branch-threshold) for details.
 
 ## Safety
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -21,6 +21,10 @@ Config is loaded as follows:
 # user = "cesar"
 # date_format = "%m-%d"
 # replacement = "-"
+# stale_days = 30 # days without commits before `stax sweep` calls a branch stale
+
+[git]
+# rerere = true # auto-enable git rerere on `stax init`
 
 [remote]
 # name = "origin"
@@ -152,6 +156,24 @@ date_format = "%m-%d"
 ```
 
 The legacy `prefix` field still works when `format` is unset.
+
+## Stale-branch threshold
+
+```toml
+[branch]
+stale_days = 60
+```
+
+`stale_days` is the number of days without new commits before [`stax sweep`](../commands/sweep.md) classifies a branch as `stale` (default: `30`). The `stax sweep --stale-days <N>` flag overrides this per run.
+
+## Git rerere
+
+```toml
+[git]
+rerere = false
+```
+
+When `rerere` is `true` (the default), `stax init` enables Git's [rerere](https://git-scm.com/docs/git-rerere) ("reuse recorded resolution") so previously resolved merge conflicts are replayed automatically during restacks. Set it to `false` to leave your global Git configuration untouched on init.
 
 ## Stack-links placement
 


### PR DESCRIPTION
The configuration reference omitted two config keys that exist in the code:

- `branch.stale_days` — days without commits before `stax sweep` classifies a branch as stale (default `30`).
- `git.rerere` — whether `stax init` auto-enables Git rerere (default `true`).

## Changes

- Added commented `stale_days` example to the `[branch]` section and a new `[git]` section with `rerere` in the sample config in `docs/configuration/index.md`.
- Added a **Stale-branch threshold** prose section (linking to the sweep docs) and a **Git rerere** prose section explaining both keys, matching the page's existing style.
- Cross-linked `docs/commands/sweep.md` to the new configuration section.

Verified the docs build cleanly with `zensical build` ("No issues found").

Closes #510