### PR TITLE
fix: detect squash-merged branches in sweep

### DIFF
--- a/src/commands/sweep.rs
+++ b/src/commands/sweep.rs
@@ -37,7 +37,7 @@ pub fn run(
 
     // 1. Merged (git ancestry plus tracked PR cleanup signals)
     let mut merged_infos: Vec<_> =
-        find_merged_branches_all(&workdir, &trunk, Some(remote_trunk_ref.as_str()))?
+        find_merged_branches_all(&repo, &workdir, &trunk, Some(remote_trunk_ref.as_str()))?
             .into_iter()
             .filter(|m| m.branch != trunk && m.branch != current)
             .collect();

--- a/src/engine/branch_detect.rs
+++ b/src/engine/branch_detect.rs
@@ -1,3 +1,4 @@
+use crate::git::GitRepo;
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::path::Path;
@@ -9,7 +10,6 @@ pub enum MergeType {
     /// Branch is an ancestor of trunk (git branch --merged).
     Ancestor,
     /// Branch patches are a subset of trunk's patches (squash/rebase merge).
-    #[allow(dead_code)]
     SquashMerge,
 }
 
@@ -32,8 +32,16 @@ pub struct StaleBranchInfo {
 /// branches — not just stax-tracked ones. It uses only git-level merge detection
 /// (no metadata-based heuristics), so it works equally well for untracked branches.
 ///
+/// Detection runs in two passes:
+///   1. `git branch --merged` against local trunk and (optionally) remote trunk —
+///      catches plain (fast-forward / merge-commit) integrations via ancestry.
+///   2. Patch-id provenance (`is_branch_merged_equivalent_to_trunk`) for branches
+///      not caught by ancestry — catches squash- and rebase-merges where the
+///      branch's commits were rewritten into trunk and are no longer ancestors.
+///
 /// `remote_trunk_ref` is e.g. `"origin/main"` — pass it if available for method 1b.
 pub fn find_merged_branches_all(
+    repo: &GitRepo,
     workdir: &Path,
     trunk: &str,
     remote_trunk_ref: Option<&str>,
@@ -77,6 +85,30 @@ pub fn find_merged_branches_all(
                     });
                 }
             }
+        }
+    }
+
+    // Method 2: patch-id provenance for squash/rebase merges.
+    //
+    // `git branch --merged` only finds branches whose tip is an ancestor of
+    // trunk. Squash- and rebase-merges rewrite the branch's commits into trunk,
+    // so the original branch tip is never an ancestor. We detect these by
+    // comparing patch ids: a branch whose patches are all present in trunk is
+    // integrated even though it is not an ancestor.
+    let already_merged: HashSet<String> = merged.iter().map(|m| m.branch.clone()).collect();
+    for branch in repo.list_branches()? {
+        if branch == trunk || already_merged.contains(&branch) {
+            continue;
+        }
+        // Conservative: only classify when patch equivalence is unambiguous.
+        if repo
+            .is_branch_merged_equivalent_to_trunk(&branch)
+            .unwrap_or(false)
+        {
+            merged.push(MergedBranchInfo {
+                branch,
+                merge_type: MergeType::SquashMerge,
+            });
         }
     }
 

--- a/tests/sweep_tests.rs
+++ b/tests/sweep_tests.rs
@@ -216,6 +216,52 @@ fn sweep_json_does_not_list_current_merged_branch() {
 }
 
 #[test]
+fn sweep_classifies_squash_merged_branch() {
+    // A branch whose commits were applied to trunk via `git merge --squash`
+    // (and then committed) is integrated even though its tip is not an ancestor
+    // of trunk. sweep must classify it as merged, not active.
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["bc", "feature-squashed"]).assert_success();
+    repo.create_file("squashed.txt", "squashed contents");
+    repo.commit("feature work to be squashed");
+
+    // Squash-merge the feature into main, leaving the original branch in place.
+    repo.run_stax(&["t"]).assert_success();
+    let squash = repo.git(&["merge", "--squash", "feature-squashed"]);
+    assert!(
+        squash.status.success(),
+        "git merge --squash failed: {}",
+        TestRepo::stderr(&squash)
+    );
+    let commit = repo.git(&["commit", "-m", "Squash merge feature-squashed"]);
+    assert!(
+        commit.status.success(),
+        "commit of squashed changes failed: {}",
+        TestRepo::stderr(&commit)
+    );
+
+    let out = repo.run_stax(&["sweep", "--json"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("sweep --json should output valid JSON: {}\n{}", e, stdout));
+    let branch = parsed["branches"]
+        .as_array()
+        .expect("JSON should have branches array")
+        .iter()
+        .find(|b| b["name"].as_str() == Some("feature-squashed"))
+        .expect("feature-squashed should appear in sweep JSON");
+    assert_eq!(
+        branch["status"].as_str(),
+        Some("merged"),
+        "squash-merged branch should be classified as merged, not active:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn sweep_classifies_untracked_merged_branch() {
     // A branch created with plain git (not stax track) and then merged should
     // still be classified as merged by sweep.


### PR DESCRIPTION
Fixes #471

## Bug

`stax sweep` classified squash- and rebase-merged branches as `active` instead of `merged`. `find_merged_branches_all` (in `src/engine/branch_detect.rs`) only used `git branch --merged`, which detects integration via **ancestry**. A squash or rebase merge rewrites the branch's commits into trunk, so the original branch tip is never an ancestor of trunk and was therefore never detected. In GitHub repos that use squash merge (the common case), this left already-integrated branches in the `active` bucket, defeating the purpose of branch cleanup.

The `MergeType::SquashMerge` variant already existed but was never constructed (it carried `#[allow(dead_code)]`), and the doc comment advertised squash-merge awareness that the code did not implement.

## Fix

Add a second detection pass to `find_merged_branches_all` using patch-id provenance via `GitRepo::is_branch_merged_equivalent_to_trunk` — the same patch-id strategy `stax sync` already uses to detect squash/rebase merges. Branches not caught by the ancestry pass are checked for patch-equivalence against trunk and, when all of their patches are present in trunk, classified as merged with `MergeType::SquashMerge` (shown as ` squash` in the human-readable output).

The check is conservative: a branch is only marked merged when its patch set is unambiguously a subset of trunk's, and it reuses the existing `PATCH_ID_TRUNK_COMMIT_CAP` guard to bound cost on large repos.

## Tests

Added `sweep_classifies_squash_merged_branch` to `tests/sweep_tests.rs`: creates a branch, integrates it via `git merge --squash` + commit, and asserts `stax sweep --json` reports it as `merged`. Verified the new test plus the existing sweep merged/active/json/delete tests pass; `cargo check` is clean.