### PR TITLE
fix: correct misleading branch fold --keep help text (#496)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1460,7 +1460,8 @@ pub(crate) enum BranchCommands {
     /// Fold current branch into its parent
     #[command(visible_alias = "f")]
     Fold {
-        /// Keep the branch after folding (don't delete)
+        /// Keep the current branch's name as the surviving ref (delete the
+        /// parent ref instead)
         #[arg(short, long)]
         keep: bool,
         /// Skip confirmation prompt

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -357,6 +357,19 @@ fn test_branch_subcommands() {
 }
 
 #[test]
+fn test_branch_fold_keep_help_matches_top_level() {
+    let nested = stax(&["branch", "fold", "--help"]);
+    assert!(nested.status.success());
+    let nested_stdout = String::from_utf8_lossy(&nested.stdout);
+    assert!(nested_stdout.contains("Keep the current branch's name as the surviving ref"));
+
+    let top_level = stax(&["fold", "--help"]);
+    assert!(top_level.status.success());
+    let top_level_stdout = String::from_utf8_lossy(&top_level.stdout);
+    assert!(top_level_stdout.contains("Keep the current branch's name as the surviving ref"));
+}
+
+#[test]
 fn test_bc_shortcut() {
     // bc should work as hidden shortcut
     let output = stax(&["bc", "--help"]);


### PR DESCRIPTION
## Problem

`stax branch fold --help` described `--keep` as:

```
-k, --keep  Keep the branch after folding (don't delete)
```

This is misleading. As the top-level alias `stax fold --help` and the implementation (`src/commands/branch/fold.rs`) make clear, `--keep` keeps the *current* branch's name as the surviving ref and deletes the *parent* ref instead.

## Change

- Update `BranchCommands::Fold`'s `keep` help in `src/cli/args.rs` to match the clearer top-level wording: `Keep the current branch's name as the surviving ref (delete the parent ref instead)`. The nested and top-level help strings are now consistent.
- Add a CLI test (`test_branch_fold_keep_help_matches_top_level`) asserting both `stax branch fold --help` and `stax fold --help` contain the corrected phrasing, so they stay aligned.

## Verification

- `cargo check` passes.
- `cargo clippy` introduces no new warnings (the repo has pre-existing toolchain-version lints unrelated to this change; none reference the edited file).
- Targeted tests pass: `cargo nextest run test_branch_fold_keep_help_matches_top_level test_branch_subcommands` -> 2 passed.
- Manually confirmed `cargo run -- branch fold --help` and `cargo run -- fold --help` both show: `Keep the current branch's name as the surviving ref (delete the parent ref instead)`.

Closes #496