### PR TITLE
fix: reject zero merge polling interval

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -312,7 +312,7 @@ pub(crate) enum Commands {
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote", "stack"])]
         queue: bool,
         /// Polling interval in seconds for --when-ready, --remote, --queue, and --stack --when-ready
-        #[arg(long, default_value = "15")]
+        #[arg(long, default_value_t = 15, value_parser = clap::value_parser!(u64).range(1..))]
         interval: u64,
         /// Skip post-merge sync (`stax rs`)
         #[arg(long)]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -413,3 +413,40 @@ fn status_requires_clean_repo_state() {
     assert_eq!(cmd.policy(), CommandPolicy::RequiresCleanRepoState);
     assert!(!cmd.allows_during_rebase());
 }
+
+#[test]
+fn merge_when_ready_rejects_zero_interval() {
+    assert!(try_parse_cli(&["stax", "merge", "--when-ready", "--interval", "0"]).is_err());
+}
+
+#[test]
+fn merge_remote_rejects_zero_interval() {
+    assert!(try_parse_cli(&["stax", "merge", "--remote", "--interval", "0"]).is_err());
+}
+
+#[test]
+fn merge_queue_rejects_zero_interval() {
+    assert!(try_parse_cli(&["stax", "merge", "--queue", "--interval", "0"]).is_err());
+}
+
+#[test]
+fn merge_stack_when_ready_rejects_zero_interval() {
+    assert!(try_parse_cli(&[
+        "stax",
+        "merge",
+        "--stack",
+        "--when-ready",
+        "--interval",
+        "0"
+    ])
+    .is_err());
+}
+
+#[test]
+fn merge_accepts_interval_of_one() {
+    let cli = parse_cli(&["stax", "merge", "--when-ready", "--interval", "1"]);
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Merge { interval: 1, .. })
+    ));
+}


### PR DESCRIPTION
Fixes #519

## Bug

`stax merge` accepted `--interval` as an unconstrained `u64`. With `--interval 0`, the parsed value flowed directly into `Duration::from_secs(0)` in the readiness/queue polling loops:

- `src/commands/merge_stack.rs` (`--stack --when-ready`)
- `src/commands/merge_when_ready.rs` (`--when-ready`)
- `src/commands/merge_remote.rs` (`--remote`)
- `src/commands/merge_queue.rs` (`--queue`)

While CI/mergeability is pending, a zero-second sleep turns the polite readiness watcher into a tight loop that polls GitHub as fast as the process can run — CPU churn, noisy redraws, and API rate-limit abuse during exactly the long-running, unattended watch flows.

## Fix

Add a clap `value_parser` to `Merge::interval` requiring `>= 1` second (`range(1..)`), mirroring the existing bounded GitHub list-limit parsers in `src/cli/args.rs`. Invalid values are now rejected with a clap validation error before any network work begins.

## Tests

Added CLI parser tests in `src/cli/tests.rs`:
- `--when-ready --interval 0` → validation error
- `--remote --interval 0` → validation error
- `--queue --interval 0` → validation error
- `--stack --when-ready --interval 0` → validation error
- `--interval 1` still parses

## Verification

- `cargo check` passes
- `cargo nextest run` on the 5 new tests: all pass
- `rustfmt --check` clean on changed files

Note: `--timeout` was left unchanged; `timeout = 0` has defined semantics (single check, no wait) in the existing flows, unlike a zero interval.