### PR TITLE
fix: actionable non-interactive error for dirty wt rm

### DIFF
--- a/src/commands/worktree/remove.rs
+++ b/src/commands/worktree/remove.rs
@@ -8,6 +8,7 @@ use crate::git::GitRepo;
 use anyhow::{bail, Result};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::io::IsTerminal;
 
 fn effective_remove_force(force: bool, confirmed_dirty_removal: bool) -> bool {
     force || confirmed_dirty_removal
@@ -78,6 +79,11 @@ pub fn run(name: Option<String>, force: bool, delete_branch: bool) -> Result<()>
             "Warning:".yellow().bold(),
             worktree.name
         );
+        if !std::io::stdin().is_terminal() {
+            bail!(
+                "`st wt rm` needs confirmation to remove a dirty worktree in non-interactive mode. Re-run with `--force`."
+            );
+        }
         let proceed = Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt("Remove anyway?")
             .default(false)

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -1205,6 +1205,53 @@ fn wt_remove_confirmed_dirty_worktree_uses_forced_git_remove() {
 }
 
 #[test]
+fn wt_remove_dirty_worktree_non_interactive_fails_with_force_guidance() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["create", "dirty-non-interactive"])
+        .assert_success();
+    let branch = repo.current_branch();
+    repo.run_stax(&["checkout", "main"]).assert_success();
+
+    let dirty_path = repo.path().join("wt-dirty-non-interactive");
+    repo.git(&["worktree", "add", dirty_path.to_str().unwrap(), &branch])
+        .assert_success();
+    fs::write(dirty_path.join("scratch.txt"), "dirty\n").expect("write dirty scratch file");
+
+    // `run_stax` uses a piped (non-terminal) stdin, exercising the
+    // non-interactive code path.
+    let out = repo.run_stax(&["wt", "rm", &branch]);
+    out.assert_failure().assert_stderr_contains("--force");
+
+    assert!(
+        dirty_path.exists(),
+        "dirty worktree should be preserved when confirmation cannot be obtained non-interactively"
+    );
+}
+
+#[test]
+fn wt_remove_dirty_worktree_force_removes_non_interactively() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["create", "dirty-force"]).assert_success();
+    let branch = repo.current_branch();
+    repo.run_stax(&["checkout", "main"]).assert_success();
+
+    let dirty_path = repo.path().join("wt-dirty-force");
+    repo.git(&["worktree", "add", dirty_path.to_str().unwrap(), &branch])
+        .assert_success();
+    fs::write(dirty_path.join("scratch.txt"), "dirty\n").expect("write dirty scratch file");
+
+    repo.run_stax(&["wt", "rm", "--force", &branch])
+        .assert_success();
+
+    assert!(
+        !dirty_path.exists(),
+        "expected --force to remove dirty worktree non-interactively"
+    );
+}
+
+#[test]
 fn wt_remove_without_name_removes_current_worktree() {
     let repo = TestRepo::new();
     let home = repo.clean_home();


### PR DESCRIPTION
Fixes #515

## Bug
`st wt rm <name>` on a dirty worktree (without `--force`) tried to prompt for confirmation via `dialoguer::Confirm::interact()`. When stdin is not a TTY — scripts, agents, cron, CI — this failed with a low-level, unactionable error:

```
Warning: Worktree 'dirty-lane' has uncommitted changes.
Error: IO error: not a terminal
```

This is inconsistent with `st wt cleanup`, which already checks `stdin().is_terminal()` and tells the caller to re-run with `--yes`.

## Fix
In `src/commands/worktree/remove.rs`, before prompting for dirty-worktree confirmation, check `std::io::stdin().is_terminal()`. If not interactive, bail with:

> `st wt rm` needs confirmation to remove a dirty worktree in non-interactive mode. Re-run with `--force`.

This mirrors the existing `cleanup` convention. The interactive prompt is unchanged for TTY users.

## Tests
Added two integration tests in `tests/worktree_cli_tests.rs`:
- `wt_remove_dirty_worktree_non_interactive_fails_with_force_guidance` — non-terminal stdin fails with `--force` guidance and the worktree is preserved.
- `wt_remove_dirty_worktree_force_removes_non_interactively` — `--force` removes the dirty worktree non-interactively.

Both pass, along with the existing `wt_remove_confirmed_dirty_worktree_uses_forced_git_remove`.