### PR TITLE
test: use real trunk command in tests and assert success

### DIFF
--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -83,6 +83,27 @@ fn test_checkout_trunk_full_command() {
 }
 
 #[test]
+fn test_trunk_set_existing_branch() {
+    let repo = TestRepo::new();
+    repo.git(&["branch", "develop"]);
+
+    let output = repo.run_stax(&["trunk", "develop"]);
+    output
+        .assert_success()
+        .assert_stdout_contains("Trunk branch set to 'develop'");
+}
+
+#[test]
+fn test_trunk_set_nonexistent_branch_fails() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["trunk", "does-not-exist"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("does not exist locally");
+}
+
+#[test]
 fn test_get_help() {
     let repo = TestRepo::new();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -391,6 +391,16 @@ impl TestRepo {
             .expect("Failed to execute stax")
     }
 
+    /// Set the stax trunk branch, asserting the command succeeds.
+    ///
+    /// Wraps `stax trunk <branch>` so test setup fails loudly if the command
+    /// name changes or the trunk cannot be set, rather than silently
+    /// proceeding on an auto-detected trunk.
+    pub fn set_trunk(&self, branch: &str) -> &Self {
+        self.run_stax(&["trunk", branch]).assert_success();
+        self
+    }
+
     /// Run a stax command with additional environment variables.
     pub fn run_stax_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
         let mut cmd = sanitized_stax_command();

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -158,7 +158,7 @@ fn test_restack_with_non_ancestor_stored_revision_succeeds() {
     write_branch_metadata_raw(&repo, "my-feature", "main", &current_main_sha);
 
     // Initialize stax trunk
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
 
     repo.git(&["checkout", "my-feature"]);
 
@@ -281,7 +281,7 @@ fn test_restack_with_non_ancestor_revision_preserves_only_feature_commits() {
     // Store parentBranchRevision = M2 (not in feature history, not equal to current main)
     // This triggers needs_restack (M2 ≠ M3) and hits the non-ancestor path.
     write_branch_metadata_raw(&repo, "count-feature", "main", &mid_main_sha);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
 
     repo.git(&["checkout", "count-feature"]);
     let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
@@ -358,7 +358,7 @@ fn test_many_trunk_commits_linear_restack_only_replays_feature_commits() {
     );
 
     write_branch_metadata_raw(&repo, "busy-feature", "main", &old_main_tip);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
 
     assert_git_success(
         &repo,
@@ -408,7 +408,7 @@ fn test_sync_restack_many_trunk_commits_preserves_linear_feature_depth() {
     assert_git_success(&repo, &["push", "origin", "main"], "push main");
 
     write_branch_metadata_raw(&repo, "sync-busy", "main", &old_main_tip);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
 
     assert_git_success(&repo, &["checkout", "sync-busy"], "checkout sync-busy");
     let output = repo.run_stax(&["sync", "--restack", "--force", "--quiet", "--no-delete"]);
@@ -473,7 +473,7 @@ fn test_merging_main_into_feature_inflates_stored_replay_range() {
 
     // Stored boundary stayed at the original fork tip — the canonical mistake.
     write_branch_metadata_raw(&repo, "merged-feature", "main", &fork_point);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
 
     let stored_to_feature = rev_list_count(&repo, &format!("{fork_point}..merged-feature"));
     let merge_base_out = repo.git(&["merge-base", "main", "merged-feature"]);
@@ -538,7 +538,7 @@ fn build_merge_from_main_fixture(repo: &TestRepo) -> String {
     }
 
     write_branch_metadata_raw(repo, "preflight-feature", "main", &fork_point);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
     repo.git(&["checkout", "preflight-feature"]);
 
     "preflight-feature".to_string()
@@ -660,7 +660,7 @@ fn test_restack_preflight_silent_on_clean_linear_branch() {
     }
 
     write_branch_metadata_raw(&repo, "linear-quiet", "main", &fork_point);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
     repo.git(&["checkout", "linear-quiet"]);
 
     let output = repo.run_stax_with_env(
@@ -703,7 +703,7 @@ fn test_genuine_conflict_still_fails_after_fix() {
     // Write metadata with the pre-conflict main SHA as parentBranchRevision
     // (this is the correct merge-base — we want a real conflict, not metadata drift)
     write_branch_metadata_raw(&repo, "conflict-feature", "main", &pre_conflict_sha);
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
 
     repo.git(&["checkout", "conflict-feature"]);
 

--- a/tests/track_merge_base_tests.rs
+++ b/tests/track_merge_base_tests.rs
@@ -69,7 +69,7 @@ fn test_branch_track_stores_merge_base_not_parent_tip() {
     assert_ne!(divergence_sha, main_tip, "main must have advanced");
 
     // Initialize stax and track the feature branch
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
     repo.git(&["checkout", "my-feature"]);
 
     let output = repo.run_stax(&["branch", "track", "--parent", "main"]);
@@ -104,7 +104,7 @@ fn test_branch_track_at_current_tip_stores_tip_as_merge_base() {
     repo.create_file("feature.txt", "content");
     repo.commit("Feature commit");
 
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
     repo.git(&["checkout", "fresh-feature"]);
 
     let output = repo.run_stax(&["branch", "track", "--parent", "main"]);
@@ -144,7 +144,7 @@ fn test_track_then_restack_with_diverged_main_succeeds() {
     repo.commit("Main unrelated B");
 
     // Initialize stax and track
-    repo.run_stax(&["set-trunk", "main"]);
+    repo.set_trunk("main");
     repo.git(&["checkout", "long-feature"]);
 
     let track_out = repo.run_stax(&["branch", "track", "--parent", "main"]);


### PR DESCRIPTION
Fixes #494

## Bug

Several integration tests set up the trunk via `repo.run_stax(&["set-trunk", "main"])`, but `set-trunk` is not a real stax subcommand — the CLI exposes trunk setting through `stax trunk <branch>` (`src/cli/mod.rs:414-420`, dispatching to `commands::set_trunk::run`). Because these setup calls never asserted success, the invalid invocation failed silently and the tests passed only by relying on auto-detected trunk state — not the trunk-setting path they claimed to exercise. This weakens the regression suite for restack-provenance / merge-base correctness, where the intended trunk ref matters.

## Fix

- Add a `TestRepo::set_trunk` helper that runs `stax trunk <branch>` and asserts success, so setup fails loudly if the command name changes or trunk cannot be set.
- Replace all 11 `set-trunk` setup calls (`tests/restack_provenance_tests.rs` x8, `tests/track_merge_base_tests.rs` x3) with the helper.
- Add direct integration tests for `stax trunk <branch>`: a happy path (existing branch) and the nonexistent-branch error path.

## Verification

- `cargo fmt` clean on changed files; changes are test-only.
- Targeted run (18 tests) all pass:

```
cargo nextest run -E 'test(restack_provenance_tests) | test(track_merge_base_tests) | test(test_trunk_set_)'
18 tests run: 18 passed
```

Note: pre-existing whole-repo clippy/rustfmt drift under a newer toolchain (rust 1.96.0) is unrelated and intentionally left untouched.