### PR TITLE
fix: correct misleading `branch fold --keep` help text

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1460,7 +1460,8 @@ pub(crate) enum BranchCommands {
     /// Fold current branch into its parent
     #[command(visible_alias = "f")]
     Fold {
-        /// Keep the branch after folding (don't delete)
+        /// Keep the current branch's name as the surviving ref (delete the
+        /// parent ref instead)
         #[arg(short, long)]
         keep: bool,
         /// Skip confirmation prompt

--- a/tests/fold_tests.rs
+++ b/tests/fold_tests.rs
@@ -130,6 +130,23 @@ fn test_fold_help_surfaces() {
             args,
             stdout
         );
+        // The `--keep` help must accurately describe the destructive behaviour
+        // (it deletes the parent ref) and stay aligned between the nested
+        // `branch fold` and the top-level `fold` alias. The old wording
+        // ("Keep the branch after folding (don't delete)") misleadingly
+        // implied the operation was non-destructive.
+        assert!(
+            stdout.contains("surviving ref"),
+            "expected `--keep` help to describe the surviving ref in `{:?}` help: {}",
+            args,
+            stdout
+        );
+        assert!(
+            !stdout.contains("Keep the branch after folding"),
+            "found stale misleading `--keep` help in `{:?}` help: {}",
+            args,
+            stdout
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #496

## Bug

`stax branch fold --help` described `--keep` as:

```
-k, --keep  Keep the branch after folding (don't delete)
```

This implies `--keep` is non-destructive. In reality, keep mode keeps the **current** branch's name as the surviving ref and **deletes the parent ref** (`src/commands/branch/fold.rs:10-12`, `:101-104`). The top-level `fold` alias already had the accurate wording, so the nested subcommand help was both misleading and inconsistent — exactly the kind of mismatch that can make a destructive stack operation feel safer than it is.

## Fix

- Update the nested `BranchCommands::Fold` `keep` help in `src/cli/args.rs` to match the accurate top-level wording: "Keep the current branch's name as the surviving ref (delete the parent ref instead)".
- Extend `test_fold_help_surfaces` in `tests/fold_tests.rs` to assert that all three help surfaces (`branch fold`, `b f`, `fold`) describe the surviving ref and no longer contain the stale "Keep the branch after folding" text, keeping the nested and top-level help aligned.

## Verification

- `cargo check` passes.
- `cargo nextest run fold_tests::test_fold_help_surfaces` passes.
- `rustfmt --check` clean on the two changed files.

Note: `cargo clippy -- -D warnings` surfaces 138 pre-existing `collapsible_if` warnings across the repo from the local clippy 1.96 toolchain; none are in the changed files and they are unrelated to this change.