### PR TITLE
fix: print value when clipboard unavailable in copy command

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -16,13 +16,25 @@ pub enum CopyTarget {
     Pr,
 }
 
-/// Copy branch name or PR URL to clipboard
-pub fn run(target: CopyTarget) -> Result<()> {
+impl CopyTarget {
+    /// Human-readable label for the resolved value.
+    fn label(self) -> &'static str {
+        match self {
+            CopyTarget::Branch => "Branch name",
+            CopyTarget::Pr => "PR URL",
+        }
+    }
+}
+
+/// Resolve the value to copy (branch name or PR URL) without touching the
+/// clipboard. Kept separate from clipboard writing so that value resolution
+/// fails (or succeeds) independently of clipboard availability.
+fn resolve_value(target: CopyTarget) -> Result<String> {
     let repo = GitRepo::open()?;
     let current = repo.current_branch()?;
 
     let text = match target {
-        CopyTarget::Branch => current.clone(),
+        CopyTarget::Branch => current,
         CopyTarget::Pr => {
             let stack = Stack::load(&repo)?;
             let config = Config::load()?;
@@ -53,19 +65,50 @@ pub fn run(target: CopyTarget) -> Result<()> {
         }
     };
 
-    // Copy to clipboard
+    Ok(text)
+}
+
+/// Attempt to write `text` to the system clipboard.
+///
+/// Returns an error describing why the clipboard could not be used (e.g. no
+/// desktop clipboard in a headless/SSH/CI session).
+fn write_to_clipboard(text: &str) -> Result<()> {
     let mut clipboard =
         Clipboard::new().map_err(|e| anyhow::anyhow!("Failed to access clipboard: {}", e))?;
     clipboard
-        .set_text(&text)
+        .set_text(text)
         .map_err(|e| anyhow::anyhow!("Failed to copy to clipboard: {}", e))?;
+    Ok(())
+}
 
-    let label = match target {
-        CopyTarget::Branch => "Branch name",
-        CopyTarget::Pr => "PR URL",
-    };
+/// Copy branch name or PR URL to clipboard.
+///
+/// In headless/SSH/CI environments where no desktop clipboard is available the
+/// resolved value is still printed (with a warning on stderr) and the command
+/// exits successfully, so callers always get the value instead of only a
+/// clipboard backend error.
+pub fn run(target: CopyTarget) -> Result<()> {
+    // Resolve the value first; this is what the user actually wants and must
+    // not be gated behind clipboard availability.
+    let text = resolve_value(target)?;
+    let label = target.label();
 
-    println!("{} copied to clipboard: {}", label, text.cyan());
+    match write_to_clipboard(&text) {
+        Ok(()) => {
+            println!("{} copied to clipboard: {}", label, text.cyan());
+        }
+        Err(e) => {
+            // No clipboard available (headless/SSH/CI). Still give the user the
+            // value and exit successfully instead of hard-failing.
+            eprintln!(
+                "{} Clipboard unavailable ({}). {} below:",
+                "warning:".yellow().bold(),
+                e,
+                label
+            );
+            println!("{}", text);
+        }
+    }
 
     Ok(())
 }
@@ -108,5 +151,11 @@ mod tests {
         let target = CopyTarget::Branch;
         let copied = target; // Copy, not move
         assert_eq!(target, copied); // Original still accessible
+    }
+
+    #[test]
+    fn test_copy_target_label() {
+        assert_eq!(CopyTarget::Branch.label(), "Branch name");
+        assert_eq!(CopyTarget::Pr.label(), "PR URL");
     }
 }


### PR DESCRIPTION
## Problem

`stax copy` (and `stax copy --pr`) hard-failed in headless/SSH/CI sessions where no desktop clipboard is available:

```
$ stax copy
Error: Failed to access clipboard: Unknown error while interacting with the clipboard: X11 server connection timed out because it was unreachable
# exit code: 1
```

The command resolved the branch name / PR URL first, but treated clipboard access as mandatory (`Clipboard::new()?`), so users in exactly the environments where this command is most useful got neither a copied value nor a printed fallback.

## Fix

- Split value resolution (`resolve_value`) from clipboard writing (`write_to_clipboard`).
- When the clipboard is unavailable, print a warning to stderr and the resolved value to stdout, then exit `0` so callers always get the value.
- Happy path (clipboard available) is unchanged.

## Tests

- Added a unit test for the new `CopyTarget::label()` helper.
- All existing `copy` unit tests pass (`cargo nextest run copy`: 6 passed).
- `cargo check` passes. Pre-existing repo-wide clippy lints (`collapsible_if` etc., from a newer host toolchain) are unrelated to this change; copy.rs introduces none.

Fixes #479