### PR TITLE
fix: protect upstream-gone branches with local-only commits in sync

### DIFF
--- a/src/commands/sweep.rs
+++ b/src/commands/sweep.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::engine::branch_detect::{
     MergeType, MergedBranchInfo, StaleBranchInfo, find_merged_branches_all, find_stale_branches,
-    find_upstream_gone_branches,
+    find_upstream_gone_branches, has_unique_commits_since_any_base,
 };
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
@@ -485,33 +485,6 @@ fn format_age(days: u64) -> String {
         let years = days / 365;
         format!("({} year{})", years, if years == 1 { "" } else { "s" })
     }
-}
-
-fn has_unique_commits_since_any_base(
-    workdir: &std::path::Path,
-    branch: &str,
-    bases: &[&str],
-) -> Result<bool> {
-    for base in bases {
-        let range = format!("{}..{}", base, branch);
-        let output = Command::new("git")
-            .args(["rev-list", "--count", &range])
-            .current_dir(workdir)
-            .output()
-            .with_context(|| format!("Failed to count unique commits for '{}'", branch))?;
-
-        if !output.status.success() {
-            continue;
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let unique_count = stdout.trim().parse::<u64>().unwrap_or(u64::MAX);
-        if unique_count == 0 {
-            return Ok(false);
-        }
-    }
-
-    Ok(true)
 }
 
 /// Reparent stax-tracked children of `branch` to trunk before deleting it.

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -6,6 +6,7 @@ use crate::commands::worktree::{
     shared::{compute_worktree_details, worktree_removal_blockers_for_cleanup},
 };
 use crate::config::Config;
+use crate::engine::branch_detect::has_unique_commits_since_any_base;
 use crate::engine::{BranchMetadata, PrInfo, Stack};
 use crate::errors::ConflictStopped;
 use crate::forge::ForgeClient;
@@ -981,12 +982,56 @@ pub fn run(
     if delete_upstream_gone {
         let detect_gone_started_at = Instant::now();
         let detect_timer = LiveTimer::maybe_new(!quiet, "Detect upstream-gone branches");
-        let gone = find_upstream_gone_branches(&workdir, &stack.trunk)?;
+        let detected_gone = find_upstream_gone_branches(&workdir, &stack.trunk)?;
+
+        // Protect upstream-gone branches that still carry local-only work
+        // (commits unique relative to BOTH local trunk and origin/<trunk>).
+        // A branch's remote upstream disappearing does not mean its commits
+        // were integrated — users routinely add local commits after the last
+        // push — so deleting such a branch would lose un-pushed work. This
+        // mirrors `stax sweep`, which already classifies these branches as
+        // active rather than deletable (see commands/sweep.rs).
+        let mut gone: Vec<String> = Vec::with_capacity(detected_gone.len());
+        let mut protected_gone: Vec<String> = Vec::new();
+        for branch in detected_gone {
+            if has_unique_commits_since_any_base(
+                &workdir,
+                &branch,
+                &[stack.trunk.as_str(), remote_trunk_ref.as_str()],
+            )? {
+                protected_gone.push(branch);
+            } else {
+                gone.push(branch);
+            }
+        }
+
         step_timings.push((
             "detect upstream-gone branches".to_string(),
             detect_gone_started_at.elapsed(),
         ));
         LiveTimer::maybe_finish_timed(detect_timer);
+
+        if !quiet && !protected_gone.is_empty() {
+            let branch_word = if protected_gone.len() == 1 {
+                "branch"
+            } else {
+                "branches"
+            };
+            println!(
+                "    Protected {} upstream-gone {} with local-only commits:",
+                protected_gone.len().to_string().cyan(),
+                branch_word
+            );
+            for branch in &protected_gone {
+                println!(
+                    "      {} {} {}",
+                    "▸".bright_black(),
+                    branch,
+                    "(has unpushed work)".dimmed()
+                );
+            }
+            println!();
+        }
 
         let delete_gone_started_at = Instant::now();
 

--- a/src/engine/branch_detect.rs
+++ b/src/engine/branch_detect.rs
@@ -147,6 +147,43 @@ pub fn find_upstream_gone_branches(workdir: &Path, trunk: &str) -> Result<Vec<St
     Ok(branches.into_iter().collect())
 }
 
+/// Returns `true` if `branch` has at least one commit unique relative to
+/// EVERY base in `bases` (e.g. local trunk and `origin/<trunk>`).
+///
+/// This is the safety predicate used to protect upstream-gone branches that
+/// still carry local-only work from being deleted. A branch is only considered
+/// "safe to delete" (returns `false`) when it has zero unique commits relative
+/// to at least one reachable base. Unresolvable bases (e.g. a missing
+/// `origin/<trunk>` ref) are skipped rather than treated as "no unique work",
+/// so a branch is never classified as deletable on the basis of a base that
+/// could not be evaluated.
+pub fn has_unique_commits_since_any_base(
+    workdir: &Path,
+    branch: &str,
+    bases: &[&str],
+) -> Result<bool> {
+    for base in bases {
+        let range = format!("{}..{}", base, branch);
+        let output = Command::new("git")
+            .args(["rev-list", "--count", &range])
+            .current_dir(workdir)
+            .output()
+            .with_context(|| format!("Failed to count unique commits for '{}'", branch))?;
+
+        if !output.status.success() {
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let unique_count = stdout.trim().parse::<u64>().unwrap_or(u64::MAX);
+        if unique_count == 0 {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
 /// Find local branches whose most recent commit is older than `stale_days` days.
 ///
 /// Excludes `trunk`, the current branch, and any branches already in

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -393,6 +393,14 @@ fn sync_delete_upstream_gone_deletes_imported_branch_locally() {
 
     repo.run_stax(&["get", "borrowed-gone"]).assert_success();
     repo.git(&["checkout", "main"]).assert_success();
+
+    // Land the imported branch's work on trunk and publish it so it carries no
+    // commits unique relative to origin/main and stays a legitimate deletion
+    // candidate under the #478 local-only-work safety guard.
+    repo.git(&["merge", "--ff-only", "borrowed-gone"])
+        .assert_success();
+    repo.git(&["push", "origin", "main"]).assert_success();
+
     repo.git(&["push", "origin", "--delete", "borrowed-gone"])
         .assert_success();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4704,11 +4704,19 @@ fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
     let repo = TestRepo::new_with_remote();
 
     // Create an untracked branch (no stax metadata), push, then delete remote.
+    // Its work is also merged into the remote trunk, so it carries no commits
+    // unique relative to origin/main and remains a legitimate deletion
+    // candidate under the local-only-work safety guard.
     repo.git(&["checkout", "-b", "manual-upstream-gone"]);
     repo.create_file("manual.txt", "manual branch content");
     repo.commit("Manual branch commit");
     repo.git(&["push", "-u", "origin", "manual-upstream-gone"]);
+
+    // Land the branch's work on trunk and publish it.
     repo.git(&["checkout", "main"]);
+    repo.git(&["merge", "--ff-only", "manual-upstream-gone"]);
+    repo.git(&["push", "origin", "main"]);
+
     repo.git(&["push", "origin", "--delete", "manual-upstream-gone"]);
 
     let output = repo.run_stax(&["sync", "--force", "--delete-upstream-gone"]);
@@ -4722,6 +4730,41 @@ fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
     assert!(
         !branches.iter().any(|b| b == "manual-upstream-gone"),
         "Expected --delete-upstream-gone to delete the stale local branch"
+    );
+}
+
+#[test]
+fn test_sync_delete_upstream_gone_protects_branch_with_local_only_commits() {
+    // Regression test for #478: a branch whose remote upstream was deleted but
+    // which still carries commits never integrated into trunk must NOT be
+    // deleted by `sync --delete-upstream-gone`. This mirrors the `sweep`
+    // safety guard (sweep_does_not_treat_upstream_gone_with_local_work_as_deletable).
+    let repo = TestRepo::new_with_remote();
+
+    repo.git(&["checkout", "-b", "gone-with-local-work"]);
+    repo.create_file("pushed.txt", "pushed");
+    repo.commit("pushed work");
+    repo.git(&["push", "-u", "origin", "gone-with-local-work"]);
+
+    // Add a commit AFTER the last push — never published anywhere.
+    repo.create_file("local-only.txt", "local only");
+    repo.commit("local-only work");
+
+    repo.git(&["checkout", "main"]);
+    repo.git(&["push", "origin", "--delete", "gone-with-local-work"]);
+
+    let output = repo.run_stax(&["sync", "--force", "--delete-upstream-gone"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|b| b == "gone-with-local-work"),
+        "Expected sync to protect upstream-gone branch with local-only commits, got: {:?}",
+        branches
     );
 }
 
@@ -4745,8 +4788,14 @@ fn test_sync_delete_upstream_gone_reparents_tracked_children() {
     repo.commit("Child commit");
     repo.git(&["push", "-u", "origin", &child_branch]);
 
-    // Delete the parent on the remote so its upstream is gone
+    // Land the parent's work on trunk and publish it so the parent has no
+    // commits unique relative to origin/main and stays a legitimate deletion
+    // candidate under the #478 local-only-work safety guard.
     repo.git(&["checkout", "main"]);
+    repo.git(&["merge", "--ff-only", &parent_branch]);
+    repo.git(&["push", "origin", "main"]);
+
+    // Delete the parent on the remote so its upstream is gone
     repo.git(&["push", "origin", "--delete", &parent_branch]);
 
     // Run sync --delete-upstream-gone; parent should be deleted and the
@@ -4820,8 +4869,15 @@ fn test_sync_delete_upstream_gone_reparents_across_multiple_doomed_ancestors() {
     repo.commit("leaf");
     repo.git(&["push", "-u", "origin", &leaf]);
 
-    // Delete both grand AND mid on the remote. Leaf survives remotely.
+    // Land grand+mid work on trunk and publish it so neither carries commits
+    // unique relative to origin/main; they stay legitimate deletion candidates
+    // under the #478 local-only-work safety guard. Leaf keeps its own unique
+    // commit and survives.
     repo.git(&["checkout", "main"]);
+    repo.git(&["merge", "--ff-only", &mid]);
+    repo.git(&["push", "origin", "main"]);
+
+    // Delete both grand AND mid on the remote. Leaf survives remotely.
     repo.git(&["push", "origin", "--delete", &grand]);
     repo.git(&["push", "origin", "--delete", &mid]);
 

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -791,6 +791,13 @@ fn sync_delete_upstream_gone_removes_safe_linked_worktree() {
     let wt_lane = repo.path().join("wt-stale");
     repo.git(&["worktree", "add", wt_lane.to_str().unwrap(), &branch])
         .assert_success();
+
+    // Land the branch's work on trunk and publish it so it carries no commits
+    // unique relative to origin/main and stays a legitimate deletion candidate
+    // under the #478 local-only-work safety guard.
+    repo.git(&["merge", "--ff-only", &branch]).assert_success();
+    repo.git(&["push", "origin", "main"]).assert_success();
+
     repo.git(&["push", "origin", "--delete", &branch])
         .assert_success();
 


### PR DESCRIPTION
## Summary

`stax sync --delete-upstream-gone` deleted **any** branch whose remote upstream was gone (`[gone]`), even when the branch carried commits that were never integrated into trunk — for example, local commits added after the last push. This is a data-loss footgun: the same branch that `stax sweep` correctly classifies as `active` was silently removed by `sync`.

## The bug

The sync upstream-gone path (`src/commands/sync.rs`) deleted every `[gone]` branch returned by `find_upstream_gone_branches`, with no check for unique local work. `sweep` already guards this case via `has_unique_commits_since_any_base`, but `sync` did not.

## The fix

- Promote sweep's `has_unique_commits_since_any_base` predicate into `engine::branch_detect` so both commands share one implementation.
- In `sync --delete-upstream-gone`, partition detected `[gone]` branches: those with commits unique relative to **both** local trunk and `origin/<trunk>` are now protected (and reported), exactly like `sweep`. Branches with no unique work are still deleted.

## Tests

- New regression test `test_sync_delete_upstream_gone_protects_branch_with_local_only_commits` reproduces the issue scenario (push, add a local-only commit, delete remote) and asserts the branch survives.
- Existing "branch gets deleted" tests now land the branch's work on trunk before deleting the remote, so they remain legitimate deletion candidates under the new safety guard while preserving their reparenting assertions (#200).
- `sweep` safety tests continue to pass against the shared predicate.

All 9 affected sync/sweep/worktree/get tests pass; `cargo check` is clean.

Fixes #478