### PR TITLE
test: cover copy fallback without clipboard

### DIFF
--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -36,6 +36,8 @@ mod comprehensive_coverage_tests;
 mod conflict_handling_tests;
 #[path = "continue_tests.rs"]
 mod continue_tests;
+#[path = "copy_tests.rs"]
+mod copy_tests;
 #[path = "create_ai_tests.rs"]
 mod create_ai_tests;
 #[path = "create_below_tests.rs"]

--- a/tests/copy_tests.rs
+++ b/tests/copy_tests.rs
@@ -1,0 +1,53 @@
+use crate::common::{TestRepo, stax_bin};
+use std::process::{Command, Output};
+
+fn run_copy_without_clipboard(repo: &TestRepo) -> Output {
+    let null_path = if cfg!(windows) { "NUL" } else { "/dev/null" };
+    let home = repo.clean_home();
+
+    let mut cmd = Command::new(stax_bin());
+    cmd.args(["copy"])
+        .current_dir(repo.path())
+        .env("HOME", home)
+        .env("GIT_CONFIG_GLOBAL", null_path)
+        .env("GIT_CONFIG_SYSTEM", null_path)
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env("STAX_TEST_DISABLE_HEAD_SYNC", "1")
+        .env_remove("DISPLAY")
+        .env_remove("WAYLAND_DISPLAY")
+        .env_remove("XDG_SESSION_TYPE")
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("STAX_GITHUB_TOKEN")
+        .env_remove("GH_TOKEN")
+        .env_remove("STAX_SHELL_INTEGRATION");
+
+    cmd.output().expect("Failed to execute stax copy")
+}
+
+#[test]
+fn copy_prints_branch_and_succeeds_when_clipboard_is_unavailable() {
+    let repo = TestRepo::new();
+
+    let output = run_copy_without_clipboard(&repo);
+
+    assert!(
+        output.status.success(),
+        "expected stax copy to succeed without clipboard\nstderr:\n{}\nstdout:\n{}",
+        TestRepo::stderr(&output),
+        TestRepo::stdout(&output)
+    );
+
+    assert_eq!(TestRepo::stdout(&output), "main\n");
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("warning:") && stderr.contains("Clipboard unavailable"),
+        "expected clipboard warning, got:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("Branch name below:"),
+        "expected branch fallback label, got:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary
- add an end-to-end `stax copy` integration test for headless/no-clipboard environments
- verify the command exits successfully, prints the branch name to stdout, and emits a clipboard warning to stderr
- register the new test module in the consolidated integration test binary

Fixes #537

## Tests
- `cargo nextest run copy_tests::copy_prints_branch_and_succeeds_when_clipboard_is_unavailable --test all_tests --no-fail-fast`
- `cargo nextest run copy --lib --no-fail-fast`
- `make test`

## Docs
- Not updated: this PR only adds regression test coverage for existing user-visible behavior.

## Notes
- `cargo fmt --check` still reports pre-existing formatting diffs in `src/cli/tests.rs` and `src/commands/worktree/remove.rs`; the new test file is rustfmt-clean.
