### PR TITLE
Fix scoped submit PR default ranges

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -74,6 +74,7 @@ pub struct SubmitOptions {
 struct PrPlan {
     branch: String,
     parent: String,
+    commit_range_base: String,
     publish_ref: String,
     publish_oid: Option<String>,
     uses_temporary_publish_ref: bool,
@@ -108,6 +109,7 @@ struct ExistingPrLookup {
 #[derive(Debug, Clone)]
 struct PublishSource {
     source_ref: String,
+    commit_range_base: String,
     oid: Option<String>,
     is_temporary: bool,
 }
@@ -643,10 +645,9 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 .context(format!("No metadata for branch {}", branch))?;
             let is_empty = empty_set.contains(branch);
             let is_imported = is_imported_branch(&meta);
-            let publish_source = publish_sources
-                .get(branch)
-                .cloned()
-                .unwrap_or_else(|| default_publish_source(repo.workdir().ok(), branch));
+            let publish_source = publish_sources.get(branch).cloned().unwrap_or_else(|| {
+                default_publish_source(repo.workdir().ok(), branch, &meta.parent_branch_name)
+            });
             let needs_push = !is_imported
                 && ref_needs_push(
                     repo.workdir()?,
@@ -743,6 +744,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             plans.push(PrPlan {
                 branch: branch.clone(),
                 parent: meta.parent_branch_name,
+                commit_range_base: publish_source.commit_range_base,
                 publish_ref: publish_source.source_ref,
                 publish_oid: publish_source.oid,
                 uses_temporary_publish_ref: publish_source.is_temporary,
@@ -841,10 +843,12 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
 
             let is_empty = empty_set.contains(branch);
             let is_imported = is_imported_branch(&meta);
+            // Determine the base branch for PR
+            let base = meta.parent_branch_name.clone();
             let publish_source = publish_sources
                 .get(branch)
                 .cloned()
-                .unwrap_or_else(|| default_publish_source(repo.workdir().ok(), branch));
+                .unwrap_or_else(|| default_publish_source(repo.workdir().ok(), branch, &base));
 
             // Check if PR exists (skip for empty branches)
             let existing_pr = lookups_by_branch
@@ -903,9 +907,6 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 }
             }
 
-            // Determine the base branch for PR
-            let base = meta.parent_branch_name.clone();
-
             // Check if we actually need to push
             let needs_push = !is_imported
                 && ref_needs_push(
@@ -944,6 +945,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             plans.push(PrPlan {
                 branch: branch.clone(),
                 parent: base,
+                commit_range_base: publish_source.commit_range_base,
                 publish_ref: publish_source.source_ref,
                 publish_oid: publish_source.oid,
                 uses_temporary_publish_ref: publish_source.is_temporary,
@@ -1070,8 +1072,11 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 select_template_interactive(&discovered_templates)?
             };
 
-            let commit_messages =
-                collect_commit_messages(repo.workdir()?, &plan.parent, &plan.publish_ref);
+            let commit_messages = collect_commit_messages(
+                repo.workdir()?,
+                &plan.commit_range_base,
+                &plan.publish_ref,
+            );
             let default_title = default_pr_title(&commit_messages, &plan.branch);
 
             // Use selected template content if available
@@ -1086,7 +1091,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             let ai_details = if let Some(targets) = ai_targets {
                 match generate_ai_pr_details(
                     repo.workdir()?,
-                    &plan.parent,
+                    &plan.commit_range_base,
                     &plan.publish_ref,
                     template_content,
                     targets,
@@ -1261,7 +1266,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
 
                     match generate_ai_pr_details(
                         repo.workdir()?,
-                        &plan.parent,
+                        &plan.commit_range_base,
                         &plan.publish_ref,
                         template_content,
                         selected_targets,
@@ -2387,6 +2392,7 @@ fn prepare_publish_sources_for_submit(
             branch.clone(),
             PublishSource {
                 source_ref: temp_ref,
+                commit_range_base: onto_ref,
                 oid: Some(oid),
                 is_temporary: true,
             },
@@ -2517,9 +2523,10 @@ fn hex_ref_component(value: &str) -> String {
         .collect::<String>()
 }
 
-fn default_publish_source(workdir: Option<&Path>, branch: &str) -> PublishSource {
+fn default_publish_source(workdir: Option<&Path>, branch: &str, parent: &str) -> PublishSource {
     PublishSource {
         source_ref: format!("refs/heads/{branch}"),
+        commit_range_base: parent.to_string(),
         oid: rev_parse_ref(workdir, branch),
         is_temporary: false,
     }

--- a/tests/scoped_submit_tests.rs
+++ b/tests/scoped_submit_tests.rs
@@ -1,4 +1,10 @@
 use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 struct BranchSnapshot {
     name: String,
@@ -52,6 +58,59 @@ fn fetch_origin(repo: &TestRepo) {
     repo.git(&["fetch", "origin"]).assert_success();
 }
 
+fn run_git(cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    output.assert_success();
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn push_remote_only_branch(repo: &TestRepo, branch: &str, file: &str, content: &str) {
+    repo.git(&["checkout", "-B", branch, "main"])
+        .assert_success();
+    repo.create_file(file, content);
+    repo.commit(&format!("Commit {branch}"));
+    repo.git(&["push", "-u", "origin", branch]).assert_success();
+    repo.git(&["checkout", "main"]).assert_success();
+    repo.git(&["branch", "-D", branch]).assert_success();
+}
+
+fn remote_branch_sha(repo: &TestRepo, branch: &str) -> String {
+    let output = repo.git(&["ls-remote", "origin", &format!("refs/heads/{branch}")]);
+    output.assert_success();
+    TestRepo::stdout(&output)
+        .split_whitespace()
+        .next()
+        .expect("remote branch sha")
+        .to_string()
+}
+
+fn simulate_remote_owner_update(
+    repo: &TestRepo,
+    branch: &str,
+    file: &str,
+    content: &str,
+) -> String {
+    let remote_path = repo.remote_path().expect("remote path");
+    let clone = TempDir::new().expect("temp clone");
+
+    run_git(clone.path(), &["clone", remote_path.to_str().unwrap(), "."]);
+    run_git(
+        clone.path(),
+        &["checkout", "-B", branch, &format!("origin/{branch}")],
+    );
+    run_git(clone.path(), &["config", "user.email", "other@test.com"]);
+    run_git(clone.path(), &["config", "user.name", "Other User"]);
+    fs::write(clone.path().join(file), content).expect("write remote update");
+    run_git(clone.path(), &["add", "-A"]);
+    run_git(clone.path(), &["commit", "-m", "Update imported branch"]);
+    run_git(clone.path(), &["push", "origin", branch]);
+    run_git(clone.path(), &["rev-parse", branch])
+}
+
 fn assert_contains_commit(repo: &TestRepo, ancestor: &str, descendant: &str, message: &str) {
     let output = repo.git(&["merge-base", "--is-ancestor", ancestor, descendant]);
     assert!(
@@ -92,6 +151,64 @@ fn assert_no_temporary_submit_worktrees(repo: &TestRepo) {
         !TestRepo::stdout(&worktrees).contains("stax-submit-"),
         "temporary submit worktrees should be cleaned up"
     );
+}
+
+fn write_test_config(home: &Path, api_base_url: &str) {
+    let config_dir = home.join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("failed to create test config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"off\"\n"),
+    )
+    .expect("failed to write test config");
+}
+
+async fn mock_github_pr_create(mock_server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/test-owner/test-repo/pulls"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
+            "id": 42,
+            "number": 42,
+            "state": "open",
+            "title": "created",
+            "body": "",
+            "draft": false,
+            "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
+            "base": { "ref": "main", "sha": "bbbb" },
+            "html_url": "https://github.com/test-owner/test-repo/pull/42"
+        })))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/issues/42/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/pulls/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
+            "id": 42,
+            "number": 42,
+            "state": "open",
+            "title": "created",
+            "body": "",
+            "draft": false,
+            "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
+            "base": { "ref": "main", "sha": "bbbb" },
+            "html_url": "https://github.com/test-owner/test-repo/pull/42"
+        })))
+        .mount(mock_server)
+        .await;
 }
 
 #[test]
@@ -137,6 +254,152 @@ fn branch_submit_temporarily_restacks_when_parent_is_remote_synced() {
     );
     assert_no_temporary_submit_refs(&repo);
     assert_no_temporary_submit_worktrees(&repo);
+}
+
+#[tokio::test]
+async fn upstack_submit_pr_defaults_exclude_parent_commits_from_temporary_parent() {
+    let mock_server = MockServer::start().await;
+    mock_github_pr_create(&mock_server).await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+
+    let stack =
+        remote_synced_parent_stack(&repo, &["temp-pr-parent", "temp-pr-middle", "temp-pr-leaf"]);
+    let leaf = stack.leaf.as_ref().expect("fixture should include a leaf");
+
+    let output = repo.run_stax_with_env(
+        &[
+            "upstack",
+            "submit",
+            "--yes",
+            "--no-prompt",
+            "--publish",
+            "--no-template",
+        ],
+        &[("STAX_GITHUB_TOKEN", "test-token")],
+    );
+    assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+    let requests = mock_server.received_requests().await.unwrap();
+    let payloads = requests
+        .iter()
+        .filter(|request| {
+            request.method.as_str() == "POST"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls"
+        })
+        .map(|request| serde_json::from_slice::<serde_json::Value>(&request.body).unwrap())
+        .collect::<Vec<_>>();
+
+    let middle = payloads
+        .iter()
+        .find(|payload| payload["head"].as_str() == Some(stack.submitted.name.as_str()))
+        .expect("missing middle PR create payload");
+    assert_eq!(middle["title"], "Commit for temp-pr-middle");
+    assert!(
+        !middle["body"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Parent update"),
+        "middle PR body should not include excluded parent commits: {middle}"
+    );
+
+    let leaf_payload = payloads
+        .iter()
+        .find(|payload| payload["head"].as_str() == Some(leaf.name.as_str()))
+        .expect("missing leaf PR create payload");
+    assert_eq!(leaf_payload["title"], "Commit for temp-pr-leaf");
+    let leaf_body = leaf_payload["body"].as_str().unwrap_or_default();
+    assert!(
+        !leaf_body.contains("Parent update"),
+        "leaf PR body should not include excluded grandparent commits: {leaf_payload}"
+    );
+    assert!(
+        !leaf_body.contains("Commit for temp-pr-middle"),
+        "leaf PR body should not include its temporary parent commit: {leaf_payload}"
+    );
+}
+
+#[tokio::test]
+async fn branch_submit_pr_defaults_exclude_imported_parent_commits_after_temporary_restack() {
+    let mock_server = MockServer::start().await;
+    mock_github_pr_create(&mock_server).await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+
+    push_remote_only_branch(
+        &repo,
+        "imported-pr-parent",
+        "imported-parent.txt",
+        "remote parent\n",
+    );
+    repo.run_stax(&["get", "imported-pr-parent"])
+        .assert_success();
+    repo.run_stax(&["create", "imported-pr-child"])
+        .assert_success();
+    repo.create_file("child.txt", "child\n");
+    repo.commit("Child change");
+    let child = repo.current_branch();
+
+    let imported_parent_remote_after = simulate_remote_owner_update(
+        &repo,
+        "imported-pr-parent",
+        "imported-parent-update.txt",
+        "remote parent update\n",
+    );
+    fetch_origin(&repo);
+    repo.git(&[
+        "branch",
+        "-f",
+        "imported-pr-parent",
+        "origin/imported-pr-parent",
+    ])
+    .assert_success();
+
+    let output = repo.run_stax_with_env(
+        &[
+            "branch",
+            "submit",
+            "--yes",
+            "--no-prompt",
+            "--publish",
+            "--no-template",
+        ],
+        &[("STAX_GITHUB_TOKEN", "test-token")],
+    );
+    assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+    assert_eq!(
+        remote_branch_sha(&repo, "imported-pr-parent"),
+        imported_parent_remote_after,
+        "branch submit should not push or rewrite the imported parent remote"
+    );
+
+    let requests = mock_server.received_requests().await.unwrap();
+    let payload = requests
+        .iter()
+        .find(|request| {
+            request.method.as_str() == "POST"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls"
+        })
+        .map(|request| serde_json::from_slice::<serde_json::Value>(&request.body).unwrap())
+        .expect("missing child PR create payload");
+
+    assert_eq!(payload["head"], child);
+    assert_eq!(payload["title"], "Child change");
+    let body = payload["body"].as_str().unwrap_or_default();
+    assert!(
+        !body.contains("Commit imported-pr-parent"),
+        "child PR body should not include imported parent commit: {payload}"
+    );
+    assert!(
+        !body.contains("Update imported branch"),
+        "child PR body should not include imported parent update: {payload}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #543.

## Summary
- carry the effective commit-range base with each submit publish source
- use that range for generated PR titles/bodies and AI PR context when scoped submit uses temporary refs
- add a mocked GitHub integration test for `upstack submit` PR creation with a temporary parent ref

## Tests
- `cargo nextest run scoped_submit_tests::`
- `make test` (Docker, 1708 passed)

Docs not updated: this fixes incorrect PR defaults without changing commands, flags, or documented behavior.