### PR TITLE
fix: add TUI pane visibility toggles

### DIFF
--- a/docs/interface/tui.md
+++ b/docs/interface/tui.md
@@ -13,6 +13,7 @@ stax
 - Full-height stack tree with PR status, sync indicators, and ahead/behind counts
 - Selected-branch summary with recommended next actions and live CI progress
 - Patch viewer with a compact diffstat header and scrollable body
+- Runtime pane toggles for small terminals (`1` Stack, `2` Summary, `3` Patch)
 - Keyboard-driven checkout, restack, submit, create, rename, delete
 - Reorder mode for reparenting branches
 
@@ -36,6 +37,7 @@ The main `st` TUI is focused on stacks and patches. Worktree management lives in
 | `d` | Delete branch |
 | `/` | Search / filter branches |
 | `Tab` | Toggle focus between stack and patch panes |
+| `1` / `2` / `3` | Show/hide Stack, Summary, and Patch panes |
 | `?` | Show keybindings |
 | `q`/`Esc` | Quit |
 

--- a/skills.md
+++ b/skills.md
@@ -609,7 +609,7 @@ Symbols:
 
 ## Tips
 
-- Run `stax` with no args to launch the interactive TUI; selected-branch CI hydrates in the background, and unchanged branch diffs can be reused from the repo-local TUI cache on reopen.
+- Run `stax` with no args to launch the interactive TUI; selected-branch CI hydrates in the background, unchanged branch diffs can be reused from the repo-local TUI cache on reopen, and `1`/`2`/`3` toggle the Stack/Summary/Patch panes for small terminals.
 - Use `stax --help` or `stax <command> --help` for exact flags.
 - Hidden convenience shortcuts: `stax bc`, `stax bu`, `stax bd`, `stax bs`, `stax w`, `stax wtc`, `stax wtgo`, `stax wtrm`.
 - Use `--yes` for non-interactive scripting.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -290,11 +290,62 @@ impl BranchDisplay {
 }
 
 /// Which pane is focused
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FocusedPane {
     #[default]
     Stack,
+    Summary,
     Diff,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiPane {
+    Stack,
+    Summary,
+    Patch,
+}
+
+/// Runtime visibility for dashboard panes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneVisibility {
+    pub stack: bool,
+    pub summary: bool,
+    pub patch: bool,
+}
+
+impl Default for PaneVisibility {
+    fn default() -> Self {
+        Self {
+            stack: true,
+            summary: true,
+            patch: true,
+        }
+    }
+}
+
+impl PaneVisibility {
+    pub fn is_visible(self, pane: TuiPane) -> bool {
+        match pane {
+            TuiPane::Stack => self.stack,
+            TuiPane::Summary => self.summary,
+            TuiPane::Patch => self.patch,
+        }
+    }
+
+    fn set_visible(&mut self, pane: TuiPane, visible: bool) {
+        match pane {
+            TuiPane::Stack => self.stack = visible,
+            TuiPane::Summary => self.summary = visible,
+            TuiPane::Patch => self.patch = visible,
+        }
+    }
+
+    pub fn visible_count(self) -> usize {
+        [self.stack, self.summary, self.patch]
+            .into_iter()
+            .filter(|visible| *visible)
+            .count()
+    }
 }
 
 /// Application mode
@@ -389,6 +440,7 @@ pub struct App {
     pub selected_diff: Vec<DiffLine>,
     pub diff_scroll: usize,
     pub focused_pane: FocusedPane,
+    pub pane_visibility: PaneVisibility,
     pub diff_stat: Vec<DiffStatLine>,
     pub status_message: Option<String>,
     pub status_set_at: Option<Instant>,
@@ -449,6 +501,7 @@ impl App {
             selected_diff: Vec::new(),
             diff_scroll: 0,
             focused_pane: FocusedPane::Stack,
+            pane_visibility: PaneVisibility::default(),
             diff_stat: Vec::new(),
             status_message: initial_status,
             status_set_at,
@@ -830,6 +883,68 @@ impl App {
     /// Calculate total scrollable lines in diff view (stats header + diff content)
     pub fn total_diff_lines(&self) -> usize {
         self.selected_diff.len()
+    }
+
+    pub fn toggle_pane_visibility(&mut self, pane: TuiPane) {
+        let currently_visible = self.pane_visibility.is_visible(pane);
+        if currently_visible && self.pane_visibility.visible_count() == 1 {
+            self.set_status("At least one pane must remain visible");
+            return;
+        }
+
+        self.pane_visibility.set_visible(pane, !currently_visible);
+        self.ensure_focus_visible();
+
+        let pane_name = match pane {
+            TuiPane::Stack => "Stack",
+            TuiPane::Summary => "Summary",
+            TuiPane::Patch => "Patch",
+        };
+        let state = if currently_visible { "hidden" } else { "shown" };
+        self.set_status(format!("{} pane {}", pane_name, state));
+    }
+
+    fn focused_pane_is_visible(&self) -> bool {
+        match self.focused_pane {
+            FocusedPane::Stack => self.pane_visibility.stack,
+            FocusedPane::Summary => self.pane_visibility.summary,
+            FocusedPane::Diff => self.pane_visibility.patch,
+        }
+    }
+
+    fn ensure_focus_visible(&mut self) {
+        if self.focused_pane_is_visible() {
+            return;
+        }
+
+        self.focused_pane = if self.pane_visibility.stack {
+            FocusedPane::Stack
+        } else if self.pane_visibility.patch {
+            FocusedPane::Diff
+        } else {
+            FocusedPane::Summary
+        };
+    }
+
+    pub fn focus_next_visible_pane(&mut self) {
+        let panes = [FocusedPane::Stack, FocusedPane::Summary, FocusedPane::Diff];
+        let current = panes
+            .iter()
+            .position(|pane| *pane == self.focused_pane)
+            .unwrap_or(0);
+
+        for offset in 1..=panes.len() {
+            let next = panes[(current + offset) % panes.len()].clone();
+            let is_visible = match next {
+                FocusedPane::Stack => self.pane_visibility.stack,
+                FocusedPane::Summary => self.pane_visibility.summary,
+                FocusedPane::Diff => self.pane_visibility.patch,
+            };
+            if is_visible {
+                self.focused_pane = next;
+                return;
+            }
+        }
     }
 
     /// Set a status message (auto-clears after timeout)
@@ -1799,8 +1914,8 @@ fn spawn_ci_loader(repo_path: PathBuf, branch: String) -> Receiver<CiUpdate> {
 mod tests {
     use super::{
         App, BranchCiSummary, BranchDisplay, DiffLineType, DiffRequest, DiffUpdate, FocusedPane,
-        Mode, live_ci_summary_text, run_in_tokio_runtime, spawn_diff_loader,
-        substring_filter_indices,
+        Mode, PaneVisibility, TuiPane, live_ci_summary_text, run_in_tokio_runtime,
+        spawn_diff_loader, substring_filter_indices,
     };
     use crate::cache::{CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache};
     use crate::engine::Stack;
@@ -1895,6 +2010,7 @@ mod tests {
             selected_diff: Vec::new(),
             diff_scroll: 0,
             focused_pane: FocusedPane::Stack,
+            pane_visibility: PaneVisibility::default(),
             diff_stat: Vec::new(),
             status_message: None,
             status_set_at: None,
@@ -1952,6 +2068,49 @@ mod tests {
         );
         assert!(app.selected_diff.is_empty());
         assert!(app.diff_stat.is_empty());
+    }
+
+    #[test]
+    fn toggling_patch_hides_it_and_moves_focus_to_stack() {
+        let (_tempdir, repo) = test_repo();
+        let mut app = minimal_app(repo, vec![skeleton_branch("main", None, true)]);
+        app.focused_pane = FocusedPane::Diff;
+
+        app.toggle_pane_visibility(TuiPane::Patch);
+
+        assert!(!app.pane_visibility.patch);
+        assert_eq!(app.focused_pane, FocusedPane::Stack);
+        assert_eq!(app.status_message.as_deref(), Some("Patch pane hidden"));
+    }
+
+    #[test]
+    fn toggling_does_not_hide_last_visible_pane() {
+        let (_tempdir, repo) = test_repo();
+        let mut app = minimal_app(repo, vec![skeleton_branch("main", None, true)]);
+        app.pane_visibility = PaneVisibility {
+            stack: true,
+            summary: false,
+            patch: false,
+        };
+
+        app.toggle_pane_visibility(TuiPane::Stack);
+
+        assert!(app.pane_visibility.stack);
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("At least one pane must remain visible")
+        );
+    }
+
+    #[test]
+    fn tab_skips_hidden_patch_pane() {
+        let (_tempdir, repo) = test_repo();
+        let mut app = minimal_app(repo, vec![skeleton_branch("main", None, true)]);
+        app.pane_visibility.patch = false;
+
+        app.focus_next_visible_pane();
+
+        assert_eq!(app.focused_pane, FocusedPane::Summary);
     }
 
     #[test]

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -36,6 +36,9 @@ pub enum KeyAction {
     Quit,
     ReorderMode,
     MovePicker,
+    ToggleStackPane,
+    ToggleSummaryPane,
+    TogglePatchPane,
 
     // Reorder mode actions
     MoveUp,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod ui;
 mod widgets;
 pub mod worktree;
 
-use app::{App, ConfirmAction, FocusedPane, InputAction, Mode, PendingCommand};
+use app::{App, ConfirmAction, FocusedPane, InputAction, Mode, PendingCommand, TuiPane};
 use event::{KeyAction, KeyContext, poll_event};
 
 use crate::engine::BranchMetadata;
@@ -170,6 +170,9 @@ fn handle_normal_action(app: &mut App, action: KeyAction) -> Result<()> {
                 'q' => Some(KeyAction::Quit),
                 'o' => Some(KeyAction::ReorderMode),
                 'm' => Some(KeyAction::MovePicker),
+                '1' => Some(KeyAction::ToggleStackPane),
+                '2' => Some(KeyAction::ToggleSummaryPane),
+                '3' => Some(KeyAction::TogglePatchPane),
                 _ => None,
             };
 
@@ -177,14 +180,13 @@ fn handle_normal_action(app: &mut App, action: KeyAction) -> Result<()> {
                 return handle_normal_action(app, mapped_action);
             }
         }
-        KeyAction::Tab => {
-            app.focused_pane = match app.focused_pane {
-                FocusedPane::Stack => FocusedPane::Diff,
-                FocusedPane::Diff => FocusedPane::Stack,
-            };
-        }
+        KeyAction::Tab => app.focus_next_visible_pane(),
+        KeyAction::ToggleStackPane => app.toggle_pane_visibility(TuiPane::Stack),
+        KeyAction::ToggleSummaryPane => app.toggle_pane_visibility(TuiPane::Summary),
+        KeyAction::TogglePatchPane => app.toggle_pane_visibility(TuiPane::Patch),
         KeyAction::Up => match app.focused_pane {
             FocusedPane::Stack => app.select_previous(),
+            FocusedPane::Summary => {}
             FocusedPane::Diff => {
                 if app.diff_scroll > 0 {
                     app.diff_scroll -= 1;
@@ -193,6 +195,7 @@ fn handle_normal_action(app: &mut App, action: KeyAction) -> Result<()> {
         },
         KeyAction::Down => match app.focused_pane {
             FocusedPane::Stack => app.select_next(),
+            FocusedPane::Summary => {}
             FocusedPane::Diff => {
                 if app.diff_scroll < app.total_diff_lines().saturating_sub(1) {
                     app.diff_scroll += 1;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,4 +1,4 @@
-use crate::tui::app::{App, ConfirmAction, FocusedPane, InputAction, Mode};
+use crate::tui::app::{App, ConfirmAction, FocusedPane, InputAction, Mode, PaneVisibility};
 use crate::tui::widgets::{render_details, render_diff, render_reorder_preview, render_stack_tree};
 use ratatui::{
     Frame,
@@ -11,13 +11,13 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DashboardLayout {
-    stack: Rect,
-    summary: Rect,
-    patch: Rect,
+    stack: Option<Rect>,
+    summary: Option<Rect>,
+    patch: Option<Rect>,
     status: Rect,
 }
 
-fn dashboard_layout(area: Rect) -> DashboardLayout {
+fn dashboard_layout(area: Rect, visibility: PaneVisibility) -> DashboardLayout {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -26,40 +26,121 @@ fn dashboard_layout(area: Rect) -> DashboardLayout {
         ])
         .split(area);
 
-    let main_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
-        .split(chunks[0]);
+    let main = chunks[0];
+    let status = chunks[1];
 
-    let left_chunks = Layout::default()
+    match (visibility.stack, visibility.summary, visibility.patch) {
+        (true, true, true) => {
+            let main_chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
+                .split(main);
+
+            let left_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Min(8),     // stack
+                    Constraint::Length(10), // branch summary
+                ])
+                .split(main_chunks[0]);
+
+            DashboardLayout {
+                stack: Some(left_chunks[0]),
+                summary: Some(left_chunks[1]),
+                patch: Some(main_chunks[1]),
+                status,
+            }
+        }
+        (true, true, false) => {
+            let chunks = stack_summary_layout(main);
+            DashboardLayout {
+                stack: Some(chunks[0]),
+                summary: Some(chunks[1]),
+                patch: None,
+                status,
+            }
+        }
+        (true, false, true) => {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
+                .split(main);
+            DashboardLayout {
+                stack: Some(chunks[0]),
+                summary: None,
+                patch: Some(chunks[1]),
+                status,
+            }
+        }
+        (false, true, true) => {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
+                .split(main);
+            DashboardLayout {
+                stack: None,
+                summary: Some(chunks[0]),
+                patch: Some(chunks[1]),
+                status,
+            }
+        }
+        (true, false, false) => DashboardLayout {
+            stack: Some(main),
+            summary: None,
+            patch: None,
+            status,
+        },
+        (false, true, false) => DashboardLayout {
+            stack: None,
+            summary: Some(main),
+            patch: None,
+            status,
+        },
+        (false, false, true) => DashboardLayout {
+            stack: None,
+            summary: None,
+            patch: Some(main),
+            status,
+        },
+        (false, false, false) => DashboardLayout {
+            stack: Some(main),
+            summary: None,
+            patch: None,
+            status,
+        },
+    }
+}
+
+fn stack_summary_layout(area: Rect) -> [Rect; 2] {
+    let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(8),     // stack
             Constraint::Length(10), // branch summary
         ])
-        .split(main_chunks[0]);
-
-    DashboardLayout {
-        stack: left_chunks[0],
-        summary: left_chunks[1],
-        patch: main_chunks[1],
-        status: chunks[1],
-    }
+        .split(area);
+    [chunks[0], chunks[1]]
 }
 
 /// Main UI render function
 pub fn render(f: &mut Frame, app: &App) {
     let show_reorder_preview = matches!(app.mode, Mode::Reorder)
         || matches!(app.mode, Mode::Confirm(ConfirmAction::ApplyReorder));
-    let layout = dashboard_layout(f.area());
+    let layout = dashboard_layout(f.area(), app.pane_visibility);
 
-    render_stack_tree(f, app, layout.stack);
-    render_details(f, app, layout.summary);
+    if let Some(area) = layout.stack {
+        render_stack_tree(f, app, area);
+    }
+    if let Some(area) = layout.summary {
+        render_details(f, app, area);
+    }
 
-    if show_reorder_preview {
-        render_reorder_preview(f, app, layout.patch);
-    } else {
-        render_diff(f, app, layout.patch);
+    if let Some(area) = layout.patch {
+        if show_reorder_preview {
+            render_reorder_preview(f, app, area);
+        } else {
+            render_diff(f, app, area);
+        }
     }
 
     // Status bar
@@ -89,6 +170,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
             Mode::Normal => {
                 let (focus_label, focus_color, focus_hint) = match app.focused_pane {
                     FocusedPane::Stack => (" STACK ", Color::Cyan, "browse branches"),
+                    FocusedPane::Summary => (" SUMMARY ", Color::Blue, "inspect branch"),
                     FocusedPane::Diff => (" PATCH ", Color::Green, "scroll patch"),
                 };
                 let branch_count = app.branches.len();
@@ -242,6 +324,8 @@ fn build_normal_shortcuts(app: &App) -> Line<'static> {
 
     spans.push(key_hint("/", Color::Cyan));
     spans.push(Span::raw(" search  "));
+    spans.push(key_hint("1/2/3", Color::Blue));
+    spans.push(Span::raw(" panes  "));
     spans.push(key_hint("m", Color::Magenta));
     spans.push(Span::raw(" move  "));
     spans.push(key_hint("?", Color::Yellow));
@@ -282,6 +366,9 @@ fn render_help_modal(f: &mut Frame) {
         Line::from("  ↓/j      Move selection down"),
         Line::from("  Enter    Checkout selected branch"),
         Line::from("  Tab      Switch focus to patch scrolling"),
+        Line::from("  1        Show/hide Stack pane"),
+        Line::from("  2        Show/hide Summary pane"),
+        Line::from("  3        Show/hide Patch pane"),
         Line::from(""),
         Line::from(vec![Span::styled(
             "Actions",
@@ -604,29 +691,72 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::{build_tree_prefix, dashboard_layout};
+    use crate::tui::app::PaneVisibility;
     use ratatui::layout::Rect;
 
     #[test]
     fn dashboard_layout_places_summary_under_stack() {
-        let layout = dashboard_layout(Rect::new(0, 0, 100, 40));
+        let layout = dashboard_layout(Rect::new(0, 0, 100, 40), PaneVisibility::default());
+        let stack = layout.stack.expect("stack pane");
+        let summary = layout.summary.expect("summary pane");
+        let patch = layout.patch.expect("patch pane");
 
-        assert_eq!(layout.stack.x, 0);
-        assert_eq!(layout.summary.x, 0);
-        assert_eq!(layout.summary.y, layout.stack.y + layout.stack.height);
-        assert_eq!(layout.summary.width, layout.stack.width);
-        assert!(layout.patch.x > layout.stack.x);
-        assert_eq!(layout.patch.y, 0);
-        assert_eq!(layout.patch.height, 36);
+        assert_eq!(stack.x, 0);
+        assert_eq!(summary.x, 0);
+        assert_eq!(summary.y, stack.y + stack.height);
+        assert_eq!(summary.width, stack.width);
+        assert!(patch.x > stack.x);
+        assert_eq!(patch.y, 0);
+        assert_eq!(patch.height, 36);
     }
 
     #[test]
     fn dashboard_layout_keeps_reorder_preview_on_right() {
-        let layout = dashboard_layout(Rect::new(0, 0, 100, 40));
+        let layout = dashboard_layout(Rect::new(0, 0, 100, 40), PaneVisibility::default());
+        let summary = layout.summary.expect("summary pane");
+        let patch = layout.patch.expect("patch pane");
 
-        assert_eq!(layout.summary.x, layout.stack.x);
-        assert!(layout.patch.x > layout.summary.x);
-        assert_eq!(layout.patch.y, 0);
-        assert_eq!(layout.patch.height, 36);
+        assert_eq!(summary.x, layout.stack.expect("stack pane").x);
+        assert!(patch.x > summary.x);
+        assert_eq!(patch.y, 0);
+        assert_eq!(patch.height, 36);
+    }
+
+    #[test]
+    fn dashboard_layout_expands_stack_when_summary_and_patch_are_hidden() {
+        let layout = dashboard_layout(
+            Rect::new(0, 0, 100, 40),
+            PaneVisibility {
+                stack: true,
+                summary: false,
+                patch: false,
+            },
+        );
+
+        assert_eq!(layout.stack, Some(Rect::new(0, 0, 100, 36)));
+        assert_eq!(layout.summary, None);
+        assert_eq!(layout.patch, None);
+        assert_eq!(layout.status, Rect::new(0, 36, 100, 4));
+    }
+
+    #[test]
+    fn dashboard_layout_expands_stack_and_summary_when_patch_is_hidden() {
+        let layout = dashboard_layout(
+            Rect::new(0, 0, 100, 40),
+            PaneVisibility {
+                stack: true,
+                summary: true,
+                patch: false,
+            },
+        );
+        let stack = layout.stack.expect("stack pane");
+        let summary = layout.summary.expect("summary pane");
+
+        assert_eq!(stack.width, 100);
+        assert_eq!(summary.width, 100);
+        assert_eq!(summary.y, 26);
+        assert_eq!(summary.height, 10);
+        assert_eq!(layout.patch, None);
     }
 
     #[test]

--- a/src/tui/widgets/details.rs
+++ b/src/tui/widgets/details.rs
@@ -1,4 +1,4 @@
-use crate::tui::app::{App, BranchDisplay};
+use crate::tui::app::{App, BranchDisplay, FocusedPane};
 use ratatui::{
     Frame,
     layout::Rect,
@@ -10,6 +10,7 @@ use ratatui::{
 /// Render the details panel (bottom left)
 pub fn render_details(f: &mut Frame, app: &App, area: Rect) {
     let branch = app.selected_branch();
+    let is_focused = app.focused_pane == FocusedPane::Summary;
 
     let content = if let Some(branch) = branch {
         build_details_content(app, branch)
@@ -17,16 +18,22 @@ pub fn render_details(f: &mut Frame, app: &App, area: Rect) {
         vec![Line::from("No branch selected")]
     };
 
+    let (border_color, title_style) = if is_focused {
+        (
+            Color::Cyan,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+    } else {
+        (Color::DarkGray, Style::default().fg(Color::DarkGray))
+    };
+
     let paragraph = Paragraph::new(content).block(
         Block::default()
             .borders(Borders::ALL)
-            .title(Span::styled(
-                " Summary ",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ))
-            .border_style(Style::default().fg(Color::Cyan)),
+            .title(Span::styled(" [2] Summary ", title_style))
+            .border_style(Style::default().fg(border_color)),
     );
 
     f.render_widget(paragraph, area);

--- a/src/tui/widgets/diff.rs
+++ b/src/tui/widgets/diff.rs
@@ -14,12 +14,12 @@ pub fn render_diff(f: &mut Frame, app: &App, area: Rect) {
 
     let title = if let Some(b) = branch {
         if let Some(parent) = &b.parent {
-            format!(" Patch: {} ← {} ", b.name, parent)
+            format!(" [3] Patch: {} ← {} ", b.name, parent)
         } else {
-            format!(" {} ", b.name)
+            format!(" [3] {} ", b.name)
         }
     } else {
-        " Patch ".to_string()
+        " [3] Patch ".to_string()
     };
 
     let (border_color, title_style) = if is_focused {

--- a/src/tui/widgets/stack_tree.rs
+++ b/src/tui/widgets/stack_tree.rs
@@ -274,11 +274,15 @@ pub fn render_stack_tree(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let title = if search_active && !app.search_query.is_empty() {
-        format!(" Stack /{} ({} matches) ", app.search_query, branches.len())
+        format!(
+            " [1] Stack /{} ({} matches) ",
+            app.search_query,
+            branches.len()
+        )
     } else if search_active {
-        format!(" Stack (filter: all {}) ", branches.len())
+        format!(" [1] Stack (filter: all {}) ", branches.len())
     } else {
-        format!(" Stack ({}) ", app.branches.len())
+        format!(" [1] Stack ({}) ", app.branches.len())
     };
 
     let (border_color, title_style) = if is_focused {


### PR DESCRIPTION
## Summary
- add runtime TUI pane visibility state for Stack, Summary, and Patch
- wire `1` / `2` / `3` keybindings, pane-title hints, help text, and dynamic dashboard layout resizing
- keep focus on a visible pane and prevent hiding the last remaining pane
- document the new shortcuts in the TUI docs and agent-facing skills map

Fixes #549

## Tests
- `rustfmt --edition 2024 --check src/tui/app.rs src/tui/event.rs src/tui/mod.rs src/tui/ui.rs src/tui/widgets/stack_tree.rs src/tui/widgets/details.rs src/tui/widgets/diff.rs`
- `cargo check`
- `cargo nextest run dashboard_layout toggling_patch_hides_it_and_moves_focus_to_stack toggling_does_not_hide_last_visible_pane tab_skips_hidden_patch_pane --no-fail-fast`
- `make test`