### PR TITLE
fix: don't flag empty never-pushed branches as merged

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1953,6 +1953,32 @@ struct MergedBranchInfo {
     merge_type: MergeType,
 }
 
+fn should_spare_empty_never_submitted_branch(
+    workdir: &Path,
+    stack: &Stack,
+    branch: &str,
+) -> Result<bool> {
+    let Some(info) = stack.branches.get(branch) else {
+        return Ok(false);
+    };
+    if info.pr_number.is_some() {
+        return Ok(false);
+    }
+
+    // Use the recorded parent revision so branches with real commits that were
+    // later merged into trunk are not mistaken for never-started branches.
+    let parent = info
+        .parent_revision
+        .as_deref()
+        .or(info.parent.as_deref())
+        .unwrap_or(&stack.trunk);
+    Ok(!has_unique_commits_since_any_base(
+        workdir,
+        branch,
+        &[parent],
+    )?)
+}
+
 fn find_merged_branches(
     repo: &GitRepo,
     workdir: &std::path::Path,
@@ -1981,7 +2007,9 @@ fn find_merged_branches(
         }
 
         // Only include branches we're tracking
-        if stack.branches.contains_key(branch) {
+        if stack.branches.contains_key(branch)
+            && !should_spare_empty_never_submitted_branch(workdir, stack, branch)?
+        {
             merged.push(MergedBranchInfo {
                 branch: branch.to_string(),
                 merge_type: MergeType::Ancestor,
@@ -2009,6 +2037,7 @@ fn find_merged_branches(
             // Only include branches we're tracking (and avoid duplicates)
             if stack.branches.contains_key(branch)
                 && !merged.iter().any(|info| info.branch == branch)
+                && !should_spare_empty_never_submitted_branch(workdir, stack, branch)?
             {
                 merged.push(MergedBranchInfo {
                     branch: branch.to_string(),
@@ -2117,6 +2146,9 @@ fn find_merged_branches(
 
     for branch in stack.branches.keys() {
         if branch == &stack.trunk || merged.iter().any(|m| &m.branch == branch) {
+            continue;
+        }
+        if should_spare_empty_never_submitted_branch(workdir, stack, branch)? {
             continue;
         }
         // Remote still exists -> not merged via squash-delete; skip expensive check.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -473,6 +473,52 @@ fn list_remote_heads(repo: &TestRepo) -> Vec<String> {
         .collect()
 }
 
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, parent_branch: &str, pr_number: u64) {
+    let metadata = serde_json::json!({
+        "parentBranchName": parent_branch,
+        "parentBranchRevision": repo.get_commit_sha(parent_branch),
+        "prInfo": {
+            "number": pr_number,
+            "state": "OPEN"
+        }
+    });
+
+    let mut child = Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("Failed to hash metadata blob");
+    use std::io::Write;
+    child
+        .stdin
+        .as_mut()
+        .expect("metadata hash stdin")
+        .write_all(metadata.to_string().as_bytes())
+        .expect("Failed to write metadata JSON");
+    let output = child.wait_with_output().expect("Failed to hash metadata");
+    assert!(
+        output.status.success(),
+        "git hash-object failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let blob_hash = String::from_utf8(output.stdout)
+        .expect("metadata hash UTF-8")
+        .trim()
+        .to_string();
+    let update_ref = repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{}", branch),
+        &blob_hash,
+    ]);
+    assert!(
+        update_ref.status.success(),
+        "git update-ref failed: {}",
+        TestRepo::stderr(&update_ref)
+    );
+}
+
 // =============================================================================
 // Test Infrastructure Tests
 // =============================================================================
@@ -4967,6 +5013,82 @@ fn test_sync_detects_branch_with_empty_diff_against_trunk() {
             || stdout.contains("feature-empty-diff")
             || stdout.contains("deleted"),
         "Expected sync to detect branch with empty diff, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_sync_preserves_empty_never_pushed_branch() {
+    let repo = TestRepo::new_with_remote();
+
+    let create = repo.run_stax(&["bc", "empty-never-pushed"]);
+    assert!(
+        create.status.success(),
+        "Failed to create empty branch: {}",
+        TestRepo::stderr(&create)
+    );
+    let branch_name = repo.current_branch();
+    assert_eq!(
+        repo.get_commit_sha("main"),
+        repo.get_commit_sha(&branch_name),
+        "test branch should have no commits beyond main"
+    );
+
+    repo.run_stax(&["t"]);
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let branches = repo.list_branches();
+    assert!(
+        branches.contains(&branch_name),
+        "empty never-pushed branch should not be deleted by sync.\nstdout:\n{}\nbranches: {:?}",
+        stdout,
+        branches
+    );
+    assert!(
+        !stdout.contains(&branch_name),
+        "empty never-pushed branch should not be reported as merged.\nstdout:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn test_sync_deletes_empty_branch_with_pr_metadata() {
+    let repo = TestRepo::new_with_remote();
+
+    let create = repo.run_stax(&["bc", "empty-with-pr"]);
+    assert!(
+        create.status.success(),
+        "Failed to create empty branch: {}",
+        TestRepo::stderr(&create)
+    );
+    let branch_name = repo.current_branch();
+    write_branch_pr_metadata(&repo, &branch_name, "main", 4242);
+
+    repo.run_stax(&["t"]);
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let branches = repo.list_branches();
+    assert!(
+        !branches.contains(&branch_name),
+        "empty branch with PR metadata should still be deleted by sync.\nstdout:\n{}\nbranches: {:?}",
+        stdout,
+        branches
+    );
+    assert!(
+        stdout.contains("cleaned 1 merged") || stdout.contains(&branch_name),
+        "Expected sync to report the PR-backed branch cleanup, got:\n{}",
         stdout
     );
 }


### PR DESCRIPTION
## Summary

- Prevent `stax sync` / `stax rs --restack` from treating empty, never-pushed branches as merged just because their tip is reachable from trunk.
- Keep PR-backed cleanup and real merged-branch cleanup working by sparing only branches with no PR metadata and no commits beyond their recorded parent revision.
- Add sync integration coverage for empty never-pushed branches, empty PR-backed branches, and the existing empty-diff merged branch path.

## Test plan

- `cargo nextest run integration_tests::test_sync_preserves_empty_never_pushed_branch integration_tests::test_sync_deletes_empty_branch_with_pr_metadata integration_tests::test_sync_detects_branch_with_empty_diff_against_trunk`
- `cargo nextest run integration_tests::test_sync --no-fail-fast`
- `make test` attempted, but Docker image build failed while downloading nextest due `curl: (60) SSL certificate problem: self-signed certificate in certificate chain`
- Native full fallback: `cargo nextest run --no-fail-fast` with the repo's local-fast env completed 1718 tests: 1716 passed, with 2 unrelated existing native failures in `copy_tests::copy_prints_branch_and_succeeds_when_clipboard_is_unavailable` and `staging_menu_tests::modify_interactive_patch_amends_selected_hunk`

## Notes

- `stax sweep` is intentionally unchanged in this PR; its current tests classify no-unique-work branches as safe deletion candidates.