### PR TITLE
Add native GitHub Stacked PR integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ st merge --all            # merge the whole stack regardless of position
 
 → [Merge and cascade](docs/workflows/merge-and-cascade.md)
 
+### Native GitHub Stacked PRs
+
+When a GitHub repo has native Stacked PRs enabled and you have the `github/gh-stack` extension installed, `st ss` automatically registers the submitted PRs as a native GitHub Stack. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
+
+```bash
+gh extension install github/gh-stack
+st doctor --fix          # can offer the install when missing
+st ss                    # auto-links native stack when available
+st stack link            # manually re-link the current stack
+st stack unlink          # remove the native GitHub Stack object
+```
+
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior.
+
 ### AI conflict resolution
 
 When a rebase stops on a conflict, `st resolve` sends only the conflicted text files to your configured AI agent, applies the result, and resumes the rebase automatically. If the AI returns invalid output, touches a non-conflicted file, or leaves extra conflicts behind, stax bails out and preserves the in-progress rebase so you can inspect or continue manually.

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -29,6 +29,8 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | Command | What it does |
 |---|---|
 | `st ss` | Submit the whole stack — open or update linked PRs |
+| `st stack link` | Register the current PR stack as a native GitHub Stack when `gh-stack` is available |
+| `st stack unlink` | Remove the native GitHub Stack object for the current stack |
 | `st branch submit` | Submit only the current branch; if its parent is already synced to the remote, Stax may publish a temporary rebased head without moving your local branch |
 | `st upstack submit` | Submit current branch and descendants; descendants are temporarily chained onto any temporary parent publish heads |
 | `st draft [branch]` | Convert the current (or named) branch's PR to draft |
@@ -43,6 +45,8 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st cascade` | Restack, push, and create/update PRs in one shot |
 
 Scoped submit keeps local branch metadata unchanged when it prepares a temporary publish head. Plain `git commit` work on the branch is included; `st restack` remains the command that updates local branch tips and parent revisions.
+
+On GitHub repos with native Stacked PRs enabled, `st ss` auto-registers the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change.
 
 ## Sync, restack, update
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -10,6 +10,8 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st ll` | | Show stack with PR URLs and full details |
 | `st log` | `l` | Show stack with commits and PR info |
 | `st submit` | `ss` | Submit full current stack |
+| `st stack link` | | Register the current PR stack as a native GitHub Stack via `gh stack link` |
+| `st stack unlink` | | Remove the native GitHub Stack object via `gh stack unstack` |
 | `st merge` | | Cascade-merge from bottom to current (see flags below) |
 | `st merge-when-ready` | `mwr` | Backward-compatible alias for `st merge --when-ready` |
 | `st sync` | `rs` | Pull trunk, delete merged branches (incl. squash merges), reparent children |
@@ -35,6 +37,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`
 - `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
 - `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, mark selected downstack PRs as absorbed with a back-reference comment, and rebase/retarget remaining descendants; defaults to `--method rebase`
+- When native GitHub Stacked PRs are active for the repo, regular `st merge` lets GitHub handle dependent-PR retargeting after each merge.
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains
@@ -149,7 +152,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st init` | Initialize stax or reconfigure trunk (`--trunk <branch>`) |
 | `st cli upgrade` | Detect install method and run the matching upgrade |
 | `st doctor` | Check repo health |
-| `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config and stale AI skills) |
+| `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config, stale AI skills, and optional `gh-stack` install) |
 | `st continue` | Continue after conflicts |
 | `st open` | Open repository in browser |
 | `st demo` | Interactive tutorial — no auth or repo required |
@@ -243,9 +246,10 @@ If the stash cannot apply cleanly while committing below, Stax restores the orig
 - `--ai` generate PR title and body with AI; narrow with `--title` or `--body`
 - `--template <name>` / `--no-template` / `--edit`
 - `--rerequest-review` / `--update-title`
+- `--native-stack` force-attempt native GitHub Stack registration for this submit; `--no-native-stack` skips it
 - `--yes` / `--no-prompt`
 
-Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.config/stax/config.toml`.
+Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` and `native_stack = "auto" | "off" | "link"` in `~/.config/stax/config.toml`.
 
 ### `st merge`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -35,6 +35,8 @@ Config is loaded as follows:
 [submit]
 # stack_links = "comment" # "comment" | "body" | "both" | "off"
 # single_stack = "on"     # "on" | "off" — when "off", skip stack-link sync while the stack has only one PR
+# native_stack = "auto"   # "auto" | "off" | "link" — auto-register native GitHub Stacked PRs when available
+# stack_links_when_native = "keep" # "keep" | "off" — keep stax body/comment links even when native registration succeeds
 
 [ci]
 # alert = false
@@ -190,6 +192,22 @@ When body output is enabled, stax appends a managed block to the bottom of the P
 Stack-link entries use compact PR/MR references and mark the PR being rendered with `👈`. On GitHub, stax keeps native `#123` PR references so GitHub renders its standard linked issue/PR styling; other forges use direct markdown links. The intro text is relative to the PR being rendered, so an imported base PR is described as an imported reference, while a local PR calls out any imported downstack context. Imported branches remain read-only for push and PR metadata updates, but their existing PRs still receive the managed stack links when they are part of the displayed stack.
 
 `single_stack` controls whether stack links are written when the stack contains only one PR. With the default `"on"`, links are always synced per `stack_links`. With `"off"`, stax skips link sync — and removes any stale links left over from a previous `"on"` setting — while the stack has a single PR. As soon as a second PR is submitted on the same stack, links populate on every PR (including the original) automatically.
+
+## Native GitHub Stacked PRs
+
+```toml
+[submit]
+native_stack = "auto"              # "auto" | "off" | "link"
+stack_links_when_native = "keep"   # "keep" | "off"
+```
+
+`native_stack = "auto"` is the default. On GitHub remotes, stax checks for the `github/gh-stack` extension and tries to register submitted multi-PR stacks with GitHub's native Stacked PRs feature. If the extension is missing, the repo does not have private-preview access, or the remote is not GitHub, submit silently keeps the existing stax behavior.
+
+Use `native_stack = "off"` to disable native registration. Use `"link"` to force an attempt even when the repo's feature cache is unknown or disabled. Per run, `st submit --native-stack` forces an attempt and `st submit --no-native-stack` skips it.
+
+`stack_links_when_native = "keep"` preserves stax's body/comment stack links when native registration succeeds. Set it to `"off"` only if you want the GitHub native stack map without stax-managed PR body/comment links.
+
+`st doctor` reports whether `gh-stack` is installed and `st doctor --fix` can install it with `gh extension install github/gh-stack` after confirmation.
 
 ## Forge type override
 

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -1,0 +1,58 @@
+# GitHub native Stacked PRs
+
+GitHub's native Stacked PRs feature adds a stack map, final-target branch protection, and native stack rebase/merge controls to the GitHub PR UI. stax can register its existing stacked PRs with that native feature when the repo has access.
+
+## How it works
+
+stax still owns local stack management: branch creation, parent metadata, restack, submit, PR bodies, and body/comment stack links. After `st submit` creates or updates the PRs, stax can run:
+
+```bash
+gh stack link <bottom-pr> <next-pr> ... --base <trunk> --remote <remote>
+```
+
+That registers the already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order and keeps its own body/comment stack links unless you opt out.
+
+## Requirements
+
+- GitHub remote.
+- Repo has GitHub native Stacked PRs enabled.
+- GitHub CLI `gh` is installed.
+- `github/gh-stack` extension is installed:
+
+```bash
+gh extension install github/gh-stack
+```
+
+`st doctor` reports this status. `st doctor --fix` can offer to install the extension when `gh` is available.
+
+## Default behavior
+
+The default is zero-config:
+
+```toml
+[submit]
+native_stack = "auto"
+stack_links_when_native = "keep"
+```
+
+With `auto`, stax attempts native registration only when the extension is installed and the repo is eligible. If the repo is not enabled for the private preview, stax caches that result locally and stops retrying. Submit still succeeds and behaves like normal stax.
+
+`stack_links_when_native = "keep"` means PR body/comment links continue to sync even when GitHub native registration succeeds.
+
+## Manual commands
+
+```bash
+st stack link
+st stack unlink
+```
+
+Use `st stack link` to re-register the current stack manually. Use `st stack unlink` to remove the native GitHub Stack object without deleting branches or stax metadata.
+
+## Submit overrides
+
+```bash
+st submit --native-stack     # force an attempt for this run
+st submit --no-native-stack  # skip native registration for this run
+```
+
+These only affect native GitHub registration. PR creation, branch pushes, and stax-managed stack links continue to follow the normal submit options.

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -7,10 +7,10 @@ GitHub's native Stacked PRs feature adds a stack map, final-target branch protec
 stax still owns local stack management: branch creation, parent metadata, restack, submit, PR bodies, and body/comment stack links. After `st submit` creates or updates the PRs, stax can run:
 
 ```bash
-gh stack link <bottom-pr> <next-pr> ... --base <trunk> --remote <remote>
+gh stack link <pr> [<next-pr> ...] --base <trunk> --remote <remote>
 ```
 
-That registers the already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order and keeps its own body/comment stack links unless you opt out.
+That registers one or more already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order and keeps its own body/comment stack links unless you opt out.
 
 ## Requirements
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - Configuration:
       - Config Reference: configuration/index.md
   - Integrations:
+      - GitHub Native Stacked PRs: integrations/github-native-stacks.md
       - PR Templates and AI: integrations/pr-templates-and-ai.md
       - Claude Code: integrations/claude-code.md
       - Codex: integrations/codex.md

--- a/skills.md
+++ b/skills.md
@@ -24,6 +24,8 @@ stax ll                        # Stack status with PR URLs/details
 stax log|l                     # Stack status with commits + PR info
 
 stax submit|ss                 # Submit full stack
+stax stack link                # Register current PR stack as native GitHub Stack (GitHub + gh-stack)
+stax stack unlink              # Remove native GitHub Stack object
 stax merge                     # Merge PRs from stack bottom upward
 stax sync|rs                   # Sync trunk + clean merged branches
 stax sweep                     # Classify + optionally delete merged/gone/stale branches
@@ -206,11 +208,19 @@ stax submit --ai --title           # Generate/update PR title only
 stax submit --ai --body            # Generate/update PR body only
 stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
+stax submit --native-stack         # Force-attempt native GitHub Stack registration for this run
+stax submit --no-native-stack      # Skip native GitHub Stack registration for this run
 
 # ~/.config/stax/config.toml; repo-root stax.toml overlays shared values
 [submit]
 stack_links = "body"               # "comment" | "body" | "both" | "off"
 single_stack = "on"                # "on" | "off" — when "off", skip stack-link sync while only one PR exists; populates on all PRs as soon as the stack reaches 2
+native_stack = "auto"              # "auto" | "off" | "link" — auto-register native GitHub Stacked PRs when gh-stack + repo access are available
+stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment links when native registration succeeds
+
+# Native GitHub Stacked PRs are additive. Repos/users without access or without
+# `github/gh-stack` installed behave exactly as normal stax. `stax doctor --fix`
+# can offer `gh extension install github/gh-stack` when `gh` is installed.
 
 stax branch submit                 # Submit current branch only
 stax bs                            # Hidden shortcut alias for branch submit

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -78,6 +78,12 @@ pub(crate) struct SubmitOptions {
     /// Re-request review from existing reviewers when updating PRs
     #[arg(long)]
     pub(crate) rerequest_review: bool,
+    /// Force-attempt native GitHub Stack registration via `gh stack`
+    #[arg(long, conflicts_with = "no_native_stack")]
+    pub(crate) native_stack: bool,
+    /// Skip native GitHub Stack registration for this submit
+    #[arg(long, conflicts_with = "native_stack")]
+    pub(crate) no_native_stack: bool,
     /// Squash all commits on each branch into one before pushing
     #[arg(long)]
     pub(crate) squash: bool,
@@ -111,6 +117,13 @@ impl From<SubmitOptions> for commands::submit::SubmitOptions {
             title: submit.title,
             body: submit.body,
             rerequest_review: submit.rerequest_review,
+            native_stack_override: if submit.no_native_stack {
+                Some(crate::config::NativeStackMode::Off)
+            } else if submit.native_stack {
+                Some(crate::config::NativeStackMode::Link)
+            } else {
+                None
+            },
             squash: submit.squash,
             update_title: submit.update_title,
         }
@@ -1342,6 +1355,12 @@ pub(crate) enum StackCommands {
         #[arg(long, value_enum, default_value_t = RestackSubmitAfter::No)]
         submit_after: RestackSubmitAfter,
     },
+
+    /// Register the current stack as a native GitHub Stack via `gh stack`
+    Link,
+
+    /// Remove the native GitHub Stack object via `gh stack`
+    Unlink,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -713,6 +713,8 @@ pub fn run() -> Result<()> {
                 auto_stash_pop,
                 submit_after.into(),
             ),
+            StackCommands::Link => commands::stack_cmd::run_link(),
+            StackCommands::Unlink => commands::stack_cmd::run_unlink(),
         },
         // Hidden shortcuts
         Commands::Bc {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge;
 use crate::git::{GitRepo, refs};
+use crate::github::gh_stack::{self, ExtensionStatus, FeatureState};
 use crate::remote::{self, RemoteInfo};
 use anyhow::{Result, bail};
 use colored::Colorize;
@@ -33,6 +34,7 @@ enum RepairAction {
         key: &'static str,
         value: &'static str,
     },
+    InstallGhStackExtension,
     UpdateSkills,
 }
 
@@ -41,6 +43,9 @@ impl RepairAction {
         match self {
             RepairAction::SetGitConfig { key, value } => {
                 format!("Set git config {key}={value}")
+            }
+            RepairAction::InstallGhStackExtension => {
+                "Install GitHub gh-stack extension".to_string()
             }
             RepairAction::UpdateSkills => "Update stale AI agent skill files".to_string(),
         }
@@ -123,6 +128,44 @@ pub fn run(fix: bool) -> Result<()> {
             )
             .yellow()
         );
+    }
+
+    if remote_info
+        .as_ref()
+        .map(|info| info.forge == crate::remote::ForgeType::GitHub)
+        .unwrap_or(false)
+    {
+        match gh_stack::extension_status() {
+            ExtensionStatus::Installed => {
+                let feature = gh_stack::feature_enabled(repo.workdir()?);
+                let feature_label = match feature {
+                    FeatureState::Enabled => "repo feature cache: enabled",
+                    FeatureState::Disabled => "repo feature cache: disabled",
+                    FeatureState::Unknown => "repo feature cache: unknown",
+                };
+                println!(
+                    "{} {} {}",
+                    "✓".green(),
+                    "GitHub native stacks: gh-stack extension installed".dimmed(),
+                    format!("({feature_label})").dimmed()
+                );
+            }
+            ExtensionStatus::NoExtension => {
+                repair_plan.push(RepairAction::InstallGhStackExtension);
+                println!(
+                    "{} {}",
+                    "⚠".yellow(),
+                    "GitHub native stacks: gh-stack extension missing (run `gh extension install github/gh-stack`)".yellow()
+                );
+            }
+            ExtensionStatus::NoGh => {
+                println!(
+                    "{} {}",
+                    "⚠".yellow(),
+                    "GitHub native stacks: GitHub CLI `gh` not found (optional)".yellow()
+                );
+            }
+        }
     }
 
     if repo.is_dirty()? {
@@ -389,6 +432,10 @@ fn apply_repair_action(action: &RepairAction) -> Result<()> {
         }
         RepairAction::UpdateSkills => {
             skills::run_update(false)?;
+        }
+        RepairAction::InstallGhStackExtension => {
+            gh_stack::install_extension()?;
+            println!("{} {}", "✓".green(), action.description().dimmed());
         }
     }
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -3,7 +3,8 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, PrInfo, Stack};
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
-use crate::remote::RemoteInfo;
+use crate::github::gh_stack::{self, ExtensionStatus, NativeStackEntry};
+use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use std::collections::{HashMap, HashSet};
@@ -81,7 +82,14 @@ pub fn run(options: GetOptions) -> Result<()> {
     let requested_branch = target.branch.clone();
 
     let stack = Stack::load(&repo)?;
-    let targets = collect_targets(&repo, &workdir, &config, &stack, target, &options, &trunk)?;
+    let targets = if let Some(native_targets) =
+        native_stack_targets(&config, requested, &target, &trunk)
+            .filter(|targets| !targets.is_empty())
+    {
+        native_targets
+    } else {
+        collect_targets(&repo, &workdir, &config, &stack, target, &options, &trunk)?
+    };
     let mut skipped = Vec::new();
 
     for target in &targets {
@@ -328,6 +336,122 @@ fn collect_targets(
     }
 
     Ok(targets)
+}
+
+fn native_stack_targets(
+    config: &Config,
+    requested: &str,
+    requested_target: &GetTarget,
+    trunk: &str,
+) -> Option<Vec<GetTarget>> {
+    if requested.parse::<u64>().is_err()
+        || gh_stack::extension_status() != ExtensionStatus::Installed
+    {
+        return None;
+    }
+
+    let repo = GitRepo::open().ok()?;
+    let remote_info = RemoteInfo::from_repo(&repo, config).ok()?;
+    if remote_info.forge != ForgeType::GitHub {
+        return None;
+    }
+
+    let entries = gh_stack::view_stack(requested).ok()?;
+    if entries.len() < 2 {
+        return None;
+    }
+
+    let targets = native_entries_to_targets(config, &entries, requested_target, trunk);
+    if targets
+        .iter()
+        .any(|target| target.branch == requested_target.branch)
+    {
+        Some(targets)
+    } else {
+        None
+    }
+}
+
+fn native_entries_to_targets(
+    config: &Config,
+    entries: &[NativeStackEntry],
+    requested_target: &GetTarget,
+    trunk: &str,
+) -> Vec<GetTarget> {
+    let mut targets = Vec::new();
+    let mut previous_branch: Option<String> = None;
+
+    for entry in ordered_native_entries(config, entries) {
+        let Ok(branch) = normalize_remote_branch(&entry.branch, config.remote_name()) else {
+            continue;
+        };
+        let parent = entry
+            .base
+            .as_deref()
+            .and_then(|base| normalize_remote_branch(base, config.remote_name()).ok())
+            .or_else(|| previous_branch.clone())
+            .unwrap_or_else(|| trunk.to_string());
+        let pr_info = entry.pr_number.map(|number| PrInfo {
+            number,
+            state: "OPEN".to_string(),
+            is_draft: None,
+        });
+
+        targets.push(GetTarget {
+            required_remote: branch == requested_target.branch,
+            branch: branch.clone(),
+            parent,
+            pr_info,
+        });
+        previous_branch = Some(branch);
+    }
+
+    targets
+}
+
+fn ordered_native_entries(config: &Config, entries: &[NativeStackEntry]) -> Vec<NativeStackEntry> {
+    let mut normalized = Vec::new();
+    for entry in entries {
+        let Ok(branch) = normalize_remote_branch(&entry.branch, config.remote_name()) else {
+            continue;
+        };
+        let base = entry
+            .base
+            .as_deref()
+            .and_then(|base| normalize_remote_branch(base, config.remote_name()).ok());
+        normalized.push(NativeStackEntry {
+            branch,
+            pr_number: entry.pr_number,
+            base,
+        });
+    }
+
+    if normalized.iter().any(|entry| entry.base.is_none()) {
+        return normalized;
+    }
+
+    let by_branch = normalized
+        .iter()
+        .map(|entry| (entry.branch.clone(), entry.clone()))
+        .collect::<HashMap<_, _>>();
+    let mut ordered = Vec::new();
+    let mut remaining = normalized;
+
+    while !remaining.is_empty() {
+        let Some(index) = remaining.iter().position(|entry| {
+            entry.base.as_ref().is_none_or(|base| {
+                !by_branch.contains_key(base)
+                    || ordered
+                        .iter()
+                        .any(|seen: &NativeStackEntry| &seen.branch == base)
+            })
+        }) else {
+            return entries.to_vec();
+        };
+        ordered.push(remaining.remove(index));
+    }
+
+    ordered
 }
 
 fn add_existing_stack_target(

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -83,7 +83,7 @@ pub fn run(options: GetOptions) -> Result<()> {
 
     let stack = Stack::load(&repo)?;
     let targets = if let Some(native_targets) =
-        native_stack_targets(&config, requested, &target, &trunk)
+        native_stack_targets(&repo, &config, requested, &target, &trunk)
             .filter(|targets| !targets.is_empty())
     {
         native_targets
@@ -339,20 +339,24 @@ fn collect_targets(
 }
 
 fn native_stack_targets(
+    repo: &GitRepo,
     config: &Config,
     requested: &str,
     requested_target: &GetTarget,
     trunk: &str,
 ) -> Option<Vec<GetTarget>> {
-    if requested.parse::<u64>().is_err()
-        || gh_stack::extension_status() != ExtensionStatus::Installed
-    {
+    // Cheap gating before spawning any `gh` subprocess: only numeric PR requests
+    // on GitHub remotes can resolve to a native stack.
+    if requested.parse::<u64>().is_err() {
         return None;
     }
 
-    let repo = GitRepo::open().ok()?;
-    let remote_info = RemoteInfo::from_repo(&repo, config).ok()?;
+    let remote_info = RemoteInfo::from_repo(repo, config).ok()?;
     if remote_info.forge != ForgeType::GitHub {
+        return None;
+    }
+
+    if gh_stack::extension_status() != ExtensionStatus::Installed {
         return None;
     }
 
@@ -446,7 +450,10 @@ fn ordered_native_entries(config: &Config, entries: &[NativeStackEntry]) -> Vec<
                         .any(|seen: &NativeStackEntry| &seen.branch == base)
             })
         }) else {
-            return entries.to_vec();
+            // Cycle / unresolvable base: fall back to the normalized entries in
+            // their original order rather than the raw (un-normalized) input.
+            ordered.extend(remaining);
+            return ordered;
         };
         ordered.push(remaining.remove(index));
     }

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -7,9 +7,10 @@ use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::{GitRepo, RebaseResult};
+use crate::github::gh_stack::{self, ExtensionStatus, FeatureState};
 use crate::github::pr::{MergeMethod, PrMergeStatus};
 use crate::progress::LiveTimer;
-use crate::remote::RemoteInfo;
+use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use std::io::Write;
@@ -149,6 +150,8 @@ pub fn run(
             "Failed to connect to the configured forge. Check your token and remote configuration."
         )
     })?;
+    let native_stack_capable = remote_info.forge == ForgeType::GitHub
+        && gh_stack::feature_enabled(repo.workdir()?) == FeatureState::Enabled;
 
     let fetch_status_timer = LiveTimer::maybe_new(!quiet, "Fetching PR status...");
 
@@ -271,6 +274,20 @@ pub fn run(
             // Retarget next PR to trunk after successful merge
             if let Some(next_branch) = next_branch {
                 let next_pr = next_branch.pr_number.unwrap();
+                if native_stack_covers_dependency(pr_number, next_pr, native_stack_capable) {
+                    if !quiet {
+                        println!(
+                            "  {} {}",
+                            "skip:".dimmed(),
+                            format!(
+                                "native GitHub Stack will retarget dependent PR #{}",
+                                next_pr
+                            )
+                            .dimmed()
+                        );
+                    }
+                    continue;
+                }
                 let update_base_timer = LiveTimer::maybe_new(
                     !quiet,
                     &format!("Retargeting #{} to {}...", next_pr, scope.trunk),
@@ -531,6 +548,26 @@ pub fn run(
     }
 
     Ok(())
+}
+
+fn native_stack_covers_dependency(
+    current_pr: u64,
+    next_pr: u64,
+    native_stack_capable: bool,
+) -> bool {
+    if !native_stack_capable || gh_stack::extension_status() != ExtensionStatus::Installed {
+        return false;
+    }
+
+    gh_stack::view_stack(&current_pr.to_string())
+        .map(|entries| {
+            let numbers = entries
+                .iter()
+                .filter_map(|entry| entry.pr_number)
+                .collect::<Vec<_>>();
+            numbers.contains(&current_pr) && numbers.contains(&next_pr)
+        })
+        .unwrap_or(false)
 }
 
 /// Calculate which branches to merge based on current position
@@ -1092,7 +1129,11 @@ fn local_trunk_reset_is_safe(workdir: &Path, trunk: &str) -> bool {
     let remote_trunk = format!("origin/{}", trunk);
 
     let diverged = Command::new("git")
-        .args(["rev-list", "--count", &format!("{}..{}", remote_trunk, trunk)])
+        .args([
+            "rev-list",
+            "--count",
+            &format!("{}..{}", remote_trunk, trunk),
+        ])
         .current_dir(workdir)
         .output();
     match diverged {

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -31,8 +31,8 @@ pub fn run_link() -> Result<()> {
     let stack = Stack::load(&repo)?;
     let current = repo.current_branch()?;
     let pr_numbers = current_stack_pr_numbers(&stack, &current)?;
-    if pr_numbers.len() < 2 {
-        anyhow::bail!("Native GitHub Stacks require at least two PRs in the current stack");
+    if pr_numbers.is_empty() {
+        anyhow::bail!("Native GitHub Stacks require at least one PR in the current stack");
     }
 
     match gh_stack::link_stack(&pr_numbers, &stack.trunk, &remote_info.name) {
@@ -48,6 +48,9 @@ pub fn run_link() -> Result<()> {
         LinkOutcome::FeatureDisabled { message } => {
             gh_stack::set_feature_enabled(repo.workdir()?, false)?;
             anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::SinglePrValidationRejected { message } => {
+            anyhow::bail!("GitHub rejected the native Stack link: {message}");
         }
         LinkOutcome::Failed { message } => {
             anyhow::bail!("Failed to link native GitHub Stack: {message}");
@@ -74,6 +77,9 @@ pub fn run_unlink() -> Result<()> {
         }
         LinkOutcome::FeatureDisabled { message } => {
             anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::SinglePrValidationRejected { message } => {
+            anyhow::bail!("GitHub rejected the native Stack unlink: {message}");
         }
         LinkOutcome::Failed { message } => {
             anyhow::bail!("Failed to remove native GitHub Stack: {message}");

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -1,8 +1,11 @@
 use crate::commands::worktree::shared::platform_shell;
+use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::{GitRepo, refs};
+use crate::github::gh_stack::{self, ExtensionStatus, LinkOutcome};
 use crate::ops::receipt::OpKind;
 use crate::ops::tx::Transaction;
+use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::Result;
 use colored::Colorize;
 use git2::BranchType;
@@ -12,6 +15,100 @@ use std::io::{self, Write};
 // =========================================================================
 // validate
 // =========================================================================
+
+pub fn run_link() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax stack link` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+    ensure_gh_stack_extension()?;
+
+    let stack = Stack::load(&repo)?;
+    let current = repo.current_branch()?;
+    let pr_numbers = current_stack_pr_numbers(&stack, &current)?;
+    if pr_numbers.len() < 2 {
+        anyhow::bail!("Native GitHub Stacks require at least two PRs in the current stack");
+    }
+
+    match gh_stack::link_stack(&pr_numbers, &stack.trunk, &remote_info.name) {
+        LinkOutcome::Linked => {
+            gh_stack::set_feature_enabled(repo.workdir()?, true)?;
+            println!(
+                "{} {}",
+                "✓".green(),
+                format!("Linked {} PRs as a native GitHub Stack", pr_numbers.len()).dimmed()
+            );
+            Ok(())
+        }
+        LinkOutcome::FeatureDisabled { message } => {
+            gh_stack::set_feature_enabled(repo.workdir()?, false)?;
+            anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::Failed { message } => {
+            anyhow::bail!("Failed to link native GitHub Stack: {message}");
+        }
+    }
+}
+
+pub fn run_unlink() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax stack unlink` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+    ensure_gh_stack_extension()?;
+
+    match gh_stack::unlink_stack() {
+        LinkOutcome::Linked => {
+            println!("{}", "✓ Native GitHub Stack removed".green());
+            Ok(())
+        }
+        LinkOutcome::FeatureDisabled { message } => {
+            anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::Failed { message } => {
+            anyhow::bail!("Failed to remove native GitHub Stack: {message}");
+        }
+    }
+}
+
+fn ensure_gh_stack_extension() -> Result<()> {
+    match gh_stack::extension_status() {
+        ExtensionStatus::Installed => Ok(()),
+        ExtensionStatus::NoExtension => {
+            anyhow::bail!(
+                "`gh-stack` extension is not installed. Run `gh extension install github/gh-stack`."
+            )
+        }
+        ExtensionStatus::NoGh => {
+            anyhow::bail!("GitHub CLI `gh` is not installed or not available on PATH.")
+        }
+    }
+}
+
+fn current_stack_pr_numbers(stack: &Stack, current: &str) -> Result<Vec<u64>> {
+    stack
+        .current_stack(current)
+        .into_iter()
+        .filter(|branch| branch != &stack.trunk)
+        .map(|branch| {
+            stack
+                .branches
+                .get(&branch)
+                .and_then(|info| info.pr_number)
+                .ok_or_else(|| anyhow::anyhow!("Branch '{branch}' does not have PR metadata"))
+        })
+        .collect()
+}
 
 pub fn run_validate() -> Result<()> {
     let repo = GitRepo::open()?;

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -2154,7 +2154,7 @@ fn maybe_link_native_stack(
         .iter()
         .map(|(pr_number, _, _)| *pr_number)
         .collect::<Vec<_>>();
-    if pr_numbers.len() < 2 {
+    if pr_numbers.is_empty() {
         return Ok(false);
     }
 
@@ -2179,6 +2179,7 @@ fn maybe_link_native_stack(
             gh_stack::set_feature_enabled(workdir, false)?;
             Ok(false)
         }
+        LinkOutcome::SinglePrValidationRejected { .. } => Ok(false),
         LinkOutcome::Failed { message } => {
             if !quiet {
                 println!(

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,8 +1,11 @@
 use crate::commands::open::open_url_in_browser;
-use crate::config::{Config, SingleStackMode, StackLinksMode};
+use crate::config::{
+    Config, NativeStackMode, SingleStackMode, StackLinksMode, StackLinksWhenNative,
+};
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
+use crate::github::gh_stack::{self, ExtensionStatus, FeatureState, LinkOutcome};
 use crate::github::pr::{
     PrInfoWithHead, StackPrInfo, generate_stack_links_markdown, remove_stack_links_from_body,
     upsert_stack_links_in_body,
@@ -11,7 +14,7 @@ use crate::github::pr_template::{discover_pr_templates, select_template_interact
 use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
-use crate::remote::{self, RemoteInfo};
+use crate::remote::{self, ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{Editor, Input, Select, theme::ColorfulTheme};
@@ -67,6 +70,7 @@ pub struct SubmitOptions {
     pub title: bool,
     pub body: bool,
     pub rerequest_review: bool,
+    pub native_stack_override: Option<NativeStackMode>,
     pub squash: bool,
     pub update_title: bool,
 }
@@ -359,6 +363,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         title: ai_title,
         body: body_scope,
         rerequest_review,
+        native_stack_override,
         squash,
         update_title,
     } = options;
@@ -378,6 +383,8 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let config = Config::load()?;
     let stack_links_mode = config.submit.stack_links;
     let single_stack_mode = config.submit.single_stack;
+    let stack_links_when_native = config.submit.stack_links_when_native;
+    let native_stack_mode = native_stack_override.unwrap_or(config.submit.native_stack);
 
     // Track if --draft was explicitly passed (we'll ask interactively if not)
     let draft_flag_set = draft;
@@ -1752,12 +1759,25 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             &imported_stack_branches,
         );
 
+        let native_stack_linked = maybe_link_native_stack(
+            repo.workdir()?,
+            &remote_info,
+            &stack.trunk,
+            native_stack_mode,
+            &stack_link_contexts,
+            quiet,
+        )?;
+
         let stack_links_started_at = Instant::now();
         let effective_stack_links_mode =
-            if single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1 {
+            if native_stack_linked && stack_links_when_native == StackLinksWhenNative::Off {
                 StackLinksMode::Off
             } else {
-                stack_links_mode
+                if single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1 {
+                    StackLinksMode::Off
+                } else {
+                    stack_links_mode
+                }
             };
         for (pr_number, _branch, stack_link_pr_infos) in &stack_link_contexts {
             let sync_timer =
@@ -2116,6 +2136,60 @@ fn stack_link_contexts_for_sync(
             Some((pr_number, info.branch, context))
         })
         .collect()
+}
+
+fn maybe_link_native_stack(
+    workdir: &Path,
+    remote_info: &RemoteInfo,
+    trunk: &str,
+    mode: NativeStackMode,
+    stack_link_contexts: &[(u64, String, Vec<StackPrInfo>)],
+    quiet: bool,
+) -> Result<bool> {
+    if mode == NativeStackMode::Off || remote_info.forge != ForgeType::GitHub {
+        return Ok(false);
+    }
+
+    let pr_numbers = stack_link_contexts
+        .iter()
+        .map(|(pr_number, _, _)| *pr_number)
+        .collect::<Vec<_>>();
+    if pr_numbers.len() < 2 {
+        return Ok(false);
+    }
+
+    if gh_stack::extension_status() != ExtensionStatus::Installed {
+        return Ok(false);
+    }
+
+    if mode == NativeStackMode::Auto && gh_stack::feature_enabled(workdir) == FeatureState::Disabled
+    {
+        return Ok(false);
+    }
+
+    match gh_stack::link_stack(&pr_numbers, trunk, &remote_info.name) {
+        LinkOutcome::Linked => {
+            gh_stack::set_feature_enabled(workdir, true)?;
+            if !quiet {
+                println!("{} {}", "✓".green(), "Native GitHub Stack linked".dimmed());
+            }
+            Ok(true)
+        }
+        LinkOutcome::FeatureDisabled { .. } => {
+            gh_stack::set_feature_enabled(workdir, false)?;
+            Ok(false)
+        }
+        LinkOutcome::Failed { message } => {
+            if !quiet {
+                println!(
+                    "  {} {}",
+                    "note:".dimmed(),
+                    format!("native GitHub Stack link skipped: {message}").dimmed()
+                );
+            }
+            Ok(false)
+        }
+    }
 }
 
 fn rejected_push_branches(porcelain: &str, specs: &[PushSpec]) -> Vec<String> {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1769,16 +1769,15 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         )?;
 
         let stack_links_started_at = Instant::now();
-        let effective_stack_links_mode =
-            if native_stack_linked && stack_links_when_native == StackLinksWhenNative::Off {
-                StackLinksMode::Off
-            } else {
-                if single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1 {
-                    StackLinksMode::Off
-                } else {
-                    stack_links_mode
-                }
-            };
+        let native_forces_links_off =
+            native_stack_linked && stack_links_when_native == StackLinksWhenNative::Off;
+        let single_stack_skips_links =
+            single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1;
+        let effective_stack_links_mode = if native_forces_links_off || single_stack_skips_links {
+            StackLinksMode::Off
+        } else {
+            stack_links_mode
+        };
         for (pr_number, _branch, stack_link_pr_infos) in &stack_link_contexts {
             let sync_timer =
                 LiveTimer::maybe_new(!quiet, &format!("Syncing stack links on #{}...", pr_number));
@@ -2158,12 +2157,15 @@ fn maybe_link_native_stack(
         return Ok(false);
     }
 
-    if gh_stack::extension_status() != ExtensionStatus::Installed {
+    // Cheap cached check before spawning any `gh` subprocess: if this repo has
+    // already been marked feature-disabled, `auto` mode stays quiet without
+    // probing the extension on every submit.
+    if mode == NativeStackMode::Auto && gh_stack::feature_enabled(workdir) == FeatureState::Disabled
+    {
         return Ok(false);
     }
 
-    if mode == NativeStackMode::Auto && gh_stack::feature_enabled(workdir) == FeatureState::Disabled
-    {
+    if gh_stack::extension_status() != ExtensionStatus::Installed {
         return Ok(false);
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,6 +110,13 @@ pub struct SubmitConfig {
     /// Where stax-managed stack links should be synced on submit.
     #[serde(default)]
     pub stack_links: StackLinksMode,
+    /// Whether to register a native GitHub Stack via `gh stack` after submit.
+    #[serde(default)]
+    pub native_stack: NativeStackMode,
+    /// Whether stax-managed stack links should still sync when native stack
+    /// registration succeeds.
+    #[serde(default)]
+    pub stack_links_when_native: StackLinksWhenNative,
     /// Whether to sync stack links when the stack has only one PR.
     /// `On` (default) always syncs per `stack_links`. `Off` skips link sync
     /// (and cleans up stale links) while the stack has <= 1 PRs; once a 2nd
@@ -138,6 +145,23 @@ pub enum StackLinksMode {
     Comment,
     Body,
     Both,
+    Off,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NativeStackMode {
+    Off,
+    Link,
+    #[default]
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum StackLinksWhenNative {
+    #[default]
+    Keep,
     Off,
 }
 

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -1,0 +1,304 @@
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::{Command, Output};
+
+const FEATURE_ENABLED_KEY: &str = "stax.nativeStack.enabled";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionStatus {
+    NoGh,
+    NoExtension,
+    Installed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureState {
+    Unknown,
+    Disabled,
+    Enabled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkOutcome {
+    Linked,
+    FeatureDisabled { message: String },
+    Failed { message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeStackEntry {
+    pub branch: String,
+    pub pr_number: Option<u64>,
+    pub base: Option<String>,
+}
+
+pub fn extension_status() -> ExtensionStatus {
+    extension_status_with_env(&[])
+}
+
+pub fn extension_status_with_path(path: &str) -> ExtensionStatus {
+    extension_status_with_env(&[("PATH", path)])
+}
+
+fn extension_status_with_env(env: &[(&str, &str)]) -> ExtensionStatus {
+    let version = gh_command(env).arg("--version").output();
+    match version {
+        Ok(output) if output.status.success() => {}
+        Ok(_) => return ExtensionStatus::NoGh,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return ExtensionStatus::NoGh,
+        Err(_) => return ExtensionStatus::NoGh,
+    }
+
+    let extensions = gh_command(env).args(["extension", "list"]).output();
+    match extensions {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.lines().any(|line| line.contains("github/gh-stack")) {
+                ExtensionStatus::Installed
+            } else {
+                ExtensionStatus::NoExtension
+            }
+        }
+        _ => ExtensionStatus::NoExtension,
+    }
+}
+
+pub fn feature_enabled(repo_path: impl AsRef<Path>) -> FeatureState {
+    let output = Command::new("git")
+        .args(["config", "--get", FEATURE_ENABLED_KEY])
+        .current_dir(repo_path.as_ref())
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => match String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .to_lowercase()
+            .as_str()
+        {
+            "true" => FeatureState::Enabled,
+            "false" => FeatureState::Disabled,
+            _ => FeatureState::Unknown,
+        },
+        _ => FeatureState::Unknown,
+    }
+}
+
+pub fn set_feature_enabled(repo_path: impl AsRef<Path>, enabled: bool) -> Result<()> {
+    let value = if enabled { "true" } else { "false" };
+    let output = Command::new("git")
+        .args(["config", FEATURE_ENABLED_KEY, value])
+        .current_dir(repo_path.as_ref())
+        .output()
+        .context("Failed to run git config for native stack feature cache")?;
+
+    if !output.status.success() {
+        bail!(
+            "failed to set native stack feature cache: {}",
+            output_details(&output)
+        );
+    }
+
+    Ok(())
+}
+
+pub fn link_stack(pr_numbers: &[u64], base: &str, remote: &str) -> LinkOutcome {
+    link_stack_with_env(pr_numbers, base, remote, &[])
+}
+
+pub fn link_stack_with_path(
+    pr_numbers: &[u64],
+    base: &str,
+    remote: &str,
+    path: &str,
+) -> LinkOutcome {
+    link_stack_with_env(pr_numbers, base, remote, &[("PATH", path)])
+}
+
+pub fn link_stack_with_env(
+    pr_numbers: &[u64],
+    base: &str,
+    remote: &str,
+    env: &[(&str, &str)],
+) -> LinkOutcome {
+    let mut command = gh_command(env);
+    command.args(["stack", "link"]);
+    for number in pr_numbers {
+        command.arg(number.to_string());
+    }
+    command.args(["--base", base, "--remote", remote]);
+
+    match command.output() {
+        Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
+            message: command_message(&output),
+        },
+        Ok(output) => LinkOutcome::Failed {
+            message: command_message(&output),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => LinkOutcome::Failed {
+            message: "`gh` executable not found".to_string(),
+        },
+        Err(err) => LinkOutcome::Failed {
+            message: err.to_string(),
+        },
+    }
+}
+
+pub fn install_extension() -> Result<()> {
+    install_extension_with_env(&[])
+}
+
+pub fn unlink_stack() -> LinkOutcome {
+    unlink_stack_with_env(&[])
+}
+
+pub fn view_stack(target: &str) -> Result<Vec<NativeStackEntry>> {
+    view_stack_with_env(target, &[])
+}
+
+pub fn view_stack_with_env(target: &str, env: &[(&str, &str)]) -> Result<Vec<NativeStackEntry>> {
+    let output = gh_command(env)
+        .args(["stack", "view", "--json", target])
+        .output()
+        .context("Failed to execute `gh stack view --json`")?;
+
+    if !output.status.success() {
+        bail!("`gh stack view --json` failed: {}", output_details(&output));
+    }
+
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("Failed to parse `gh stack view --json`")?;
+    Ok(parse_native_stack_entries(&value))
+}
+
+pub fn unlink_stack_with_env(env: &[(&str, &str)]) -> LinkOutcome {
+    match gh_command(env).args(["stack", "unstack"]).output() {
+        Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
+            message: command_message(&output),
+        },
+        Ok(output) => LinkOutcome::Failed {
+            message: command_message(&output),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => LinkOutcome::Failed {
+            message: "`gh` executable not found".to_string(),
+        },
+        Err(err) => LinkOutcome::Failed {
+            message: err.to_string(),
+        },
+    }
+}
+
+fn parse_native_stack_entries(value: &serde_json::Value) -> Vec<NativeStackEntry> {
+    let Some(entries) = native_stack_array(value) else {
+        return Vec::new();
+    };
+
+    entries
+        .iter()
+        .filter_map(|entry| {
+            let branch = string_field(entry, &["branch", "name", "headRefName", "head_ref", "ref"])
+                .or_else(|| nested_string_field(entry, "head", &["ref", "name", "branch"]))?;
+            let pr_number = number_field(entry, &["pr_number", "prNumber", "number"])
+                .or_else(|| nested_number_field(entry, "pull_request", &["number"]))
+                .or_else(|| nested_number_field(entry, "pullRequest", &["number"]))
+                .or_else(|| nested_number_field(entry, "pr", &["number"]));
+            let base = string_field(entry, &["base", "baseRefName", "target", "parent"])
+                .or_else(|| nested_string_field(entry, "base", &["ref", "name", "branch"]));
+
+            Some(NativeStackEntry {
+                branch,
+                pr_number,
+                base,
+            })
+        })
+        .collect()
+}
+
+fn native_stack_array(value: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    if let Some(array) = value.as_array() {
+        return Some(array);
+    }
+
+    for key in ["branches", "pullRequests", "pull_requests", "prs", "stack"] {
+        if let Some(array) = value.get(key).and_then(|v| v.as_array()) {
+            return Some(array);
+        }
+    }
+
+    None
+}
+
+fn string_field(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(key).and_then(|v| v.as_str()))
+        .map(ToString::to_string)
+}
+
+fn nested_string_field(value: &serde_json::Value, parent: &str, keys: &[&str]) -> Option<String> {
+    value
+        .get(parent)
+        .and_then(|nested| string_field(nested, keys))
+}
+
+fn number_field(value: &serde_json::Value, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|key| value.get(key).and_then(|v| v.as_u64()))
+}
+
+fn nested_number_field(value: &serde_json::Value, parent: &str, keys: &[&str]) -> Option<u64> {
+    value
+        .get(parent)
+        .and_then(|nested| number_field(nested, keys))
+}
+
+pub fn install_extension_with_env(env: &[(&str, &str)]) -> Result<()> {
+    let output = gh_command(env)
+        .args(["extension", "install", "github/gh-stack"])
+        .output()
+        .context("Failed to execute `gh extension install github/gh-stack`")?;
+
+    if !output.status.success() {
+        bail!(
+            "`gh extension install github/gh-stack` failed: {}",
+            output_details(&output)
+        );
+    }
+
+    Ok(())
+}
+
+fn gh_command(env: &[(&str, &str)]) -> Command {
+    let mut command = Command::new("gh");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command
+}
+
+fn feature_disabled_output(output: &Output) -> bool {
+    let message = command_message(output).to_lowercase();
+    message.contains("private preview")
+        || message.contains("not enabled")
+        || message.contains("not been enabled")
+        || message.contains("feature has been enabled")
+}
+
+fn command_message(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn output_details(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => format!("exit status {}", output.status),
+        (false, true) => stdout,
+        (true, false) => stderr,
+        (false, false) => format!("{stdout}\n{stderr}"),
+    }
+}

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -22,6 +22,7 @@ pub enum FeatureState {
 pub enum LinkOutcome {
     Linked,
     FeatureDisabled { message: String },
+    SinglePrValidationRejected { message: String },
     Failed { message: String },
 }
 
@@ -132,6 +133,11 @@ pub fn link_stack_with_env(
         Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
             message: command_message(&output),
         },
+        Ok(output) if single_pr_validation_output(pr_numbers, &output) => {
+            LinkOutcome::SinglePrValidationRejected {
+                message: command_message(&output),
+            }
+        }
         Ok(output) => LinkOutcome::Failed {
             message: command_message(&output),
         },
@@ -282,6 +288,20 @@ fn feature_disabled_output(output: &Output) -> bool {
         || message.contains("not enabled")
         || message.contains("not been enabled")
         || message.contains("feature has been enabled")
+}
+
+fn single_pr_validation_output(pr_numbers: &[u64], output: &Output) -> bool {
+    if pr_numbers.len() != 1 {
+        return false;
+    }
+
+    let message = command_message(output).to_lowercase();
+    (message.contains("require") || message.contains("requires") || message.contains("need"))
+        && (message.contains("at least two")
+            || message.contains("at least 2")
+            || message.contains("multiple pr")
+            || message.contains("more than one")
+            || message.contains("minimum of two"))
 }
 
 fn command_message(output: &Output) -> String {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod gh_stack;
 pub mod pr;
 pub mod pr_template;
 

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -64,6 +64,8 @@ mod fix_tests;
 mod fold_tests;
 #[path = "get_tests.rs"]
 mod get_tests;
+#[path = "gh_stack_tests.rs"]
+mod gh_stack_tests;
 #[path = "github_list_tests.rs"]
 mod github_list_tests;
 #[path = "integration_tests.rs"]

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -1,0 +1,486 @@
+use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn fake_gh_dir(script: &str) -> TempDir {
+    let dir = TempDir::new().expect("temp fake gh dir");
+    let gh = dir.path().join("gh");
+    fs::write(&gh, script).expect("write fake gh");
+    let mut perms = fs::metadata(&gh).expect("fake gh metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&gh, perms).expect("chmod fake gh");
+    dir
+}
+
+fn path_with_fake_gh(fake_dir: &Path) -> String {
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{old_path}", fake_dir.display())
+}
+
+fn write_config(home: &str, api_base_url: &str) {
+    let config_dir = Path::new(home).join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("create stax config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            "[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"body\"\n"
+        ),
+    )
+    .expect("write config");
+}
+
+fn git_stdout(repo: &TestRepo, args: &[&str]) -> String {
+    let output = repo.git(args);
+    output.assert_success();
+    TestRepo::stdout(&output).trim().to_string()
+}
+
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, parent: &str, pr_number: u64) {
+    let parent_revision = git_stdout(repo, &["rev-parse", parent]);
+    let json = serde_json::json!({
+        "parentBranchName": parent,
+        "parentBranchRevision": parent_revision,
+        "prInfo": {
+            "number": pr_number,
+            "state": "OPEN",
+            "isDraft": false
+        }
+    })
+    .to_string();
+
+    let mut hash_child = Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn git hash-object");
+    hash_child
+        .stdin
+        .as_mut()
+        .expect("hash-object stdin")
+        .write_all(json.as_bytes())
+        .expect("write metadata json");
+    let hash_output = hash_child.wait_with_output().expect("wait hash-object");
+    assert!(
+        hash_output.status.success(),
+        "hash-object failed: {}",
+        String::from_utf8_lossy(&hash_output.stderr)
+    );
+    let hash = String::from_utf8_lossy(&hash_output.stdout)
+        .trim()
+        .to_string();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{branch}"),
+        &hash,
+    ])
+    .assert_success();
+}
+
+async fn mock_existing_pr(mock_server: &MockServer, number: u64, branch: &str, base: &str) {
+    let body = serde_json::json!({
+        "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{number}"),
+        "id": number,
+        "number": number,
+        "state": "open",
+        "title": format!("PR {number}"),
+        "body": "",
+        "draft": false,
+        "head": { "ref": branch, "sha": "aaaa", "label": format!("test-owner:{branch}") },
+        "base": { "ref": base, "sha": "bbbb" },
+        "html_url": format!("https://github.com/test-owner/test-repo/pull/{number}")
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/test-owner/test-repo/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/test-owner/test-repo/issues/{number}/comments"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("PATCH"))
+        .and(path(format!("/repos/test-owner/test-repo/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{number}"),
+            "id": number,
+            "number": number,
+            "state": "open",
+            "title": format!("PR {number}"),
+            "body": "<!-- stax-stack-links:start -->\nupdated\n<!-- stax-stack-links:end -->",
+            "draft": false,
+            "head": { "ref": branch, "sha": "aaaa", "label": format!("test-owner:{branch}") },
+            "base": { "ref": base, "sha": "bbbb" },
+            "html_url": format!("https://github.com/test-owner/test-repo/pull/{number}")
+        })))
+        .mount(mock_server)
+        .await;
+}
+
+#[test]
+fn detects_installed_gh_stack_extension_from_gh_extension_list() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let status =
+        stax::github::gh_stack::extension_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(status, stax::github::gh_stack::ExtensionStatus::Installed);
+}
+
+#[test]
+fn link_stack_classifies_private_preview_feature_disabled_failures() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "stack link" ]; then
+  echo "Stacked PRs is currently in private preview and has not been enabled for this repository" >&2
+  exit 4
+fi
+exit 1
+"#,
+    );
+
+    let outcome = stax::github::gh_stack::link_stack_with_path(
+        &[10, 20, 30],
+        "main",
+        "origin",
+        &path_with_fake_gh(fake.path()),
+    );
+
+    assert!(matches!(
+        outcome,
+        stax::github::gh_stack::LinkOutcome::FeatureDisabled { .. }
+    ));
+}
+
+#[test]
+fn link_stack_passes_pr_numbers_bottom_to_top_with_base_and_remote() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+printf '%s\n' "$@" > "$GH_ARGS_FILE"
+exit 0
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let outcome = stax::github::gh_stack::link_stack_with_env(
+        &[10, 20, 30],
+        "main",
+        "upstream",
+        &[
+            ("PATH", path.as_str()),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    let args = fs::read_to_string(args_file).expect("args written");
+    assert_eq!(
+        args,
+        "stack\nlink\n10\n20\n30\n--base\nmain\n--remote\nupstream\n"
+    );
+}
+
+#[test]
+fn view_stack_parses_branches_from_gh_stack_json() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "stack view" ]; then
+  printf '%s\n' "$@" > "$GH_ARGS_FILE"
+  cat <<'JSON'
+{"branches":[
+  {"branch":"feature-a","pr_number":10,"base":"main"},
+  {"branch":"feature-b","pr_number":20,"base":"feature-a"}
+]}
+JSON
+  exit 0
+fi
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let entries = stax::github::gh_stack::view_stack_with_env(
+        "10",
+        &[
+            ("PATH", path.as_str()),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    )
+    .expect("view stack");
+
+    assert_eq!(
+        entries,
+        vec![
+            stax::github::gh_stack::NativeStackEntry {
+                branch: "feature-a".to_string(),
+                pr_number: Some(10),
+                base: Some("main".to_string()),
+            },
+            stax::github::gh_stack::NativeStackEntry {
+                branch: "feature-b".to_string(),
+                pr_number: Some(20),
+                base: Some("feature-a".to_string()),
+            },
+        ]
+    );
+    let args = fs::read_to_string(args_file).expect("args written");
+    assert_eq!(args, "stack\nview\n--json\n10\n");
+}
+
+#[test]
+fn caches_native_stack_feature_state_in_repo_git_config() {
+    let repo = TestRepo::new();
+
+    assert_eq!(
+        stax::github::gh_stack::feature_enabled(repo.path()),
+        stax::github::gh_stack::FeatureState::Unknown
+    );
+
+    stax::github::gh_stack::set_feature_enabled(repo.path(), false).expect("set feature disabled");
+    assert_eq!(
+        stax::github::gh_stack::feature_enabled(repo.path()),
+        stax::github::gh_stack::FeatureState::Disabled
+    );
+
+    stax::github::gh_stack::set_feature_enabled(repo.path(), true).expect("set feature enabled");
+    assert_eq!(
+        stax::github::gh_stack::feature_enabled(repo.path()),
+        stax::github::gh_stack::FeatureState::Enabled
+    );
+}
+
+#[test]
+fn doctor_fix_installs_missing_gh_stack_extension() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.71.0"
+  exit 0
+fi
+if [ "$1 $2" = "extension list" ]; then
+  exit 0
+fi
+if [ "$1 $2 $3" = "extension install github/gh-stack" ]; then
+  echo "installed" >> "$GH_INSTALL_FILE"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let install_file = fake.path().join("installed.txt");
+    let home = repo.clean_home();
+    let git_config = repo.path().join("test-global-gitconfig");
+    let git_config_str = git_config.to_string_lossy().into_owned();
+    let path = path_with_fake_gh(fake.path());
+    let output = crate::common::run_stax_in_script_with_env(
+        &repo.path(),
+        &["doctor", "--fix"],
+        "printf 'y\n'",
+        &[
+            ("HOME", &home),
+            ("GIT_CONFIG_GLOBAL", &git_config_str),
+            ("PATH", &path),
+            ("GH_INSTALL_FILE", install_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Install GitHub gh-stack extension"),
+        "stdout was:\n{stdout}"
+    );
+    assert!(
+        install_file.exists(),
+        "doctor --fix should invoke gh extension install"
+    );
+}
+
+#[test]
+fn submit_help_exposes_native_stack_overrides() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["submit", "--help"]);
+
+    output
+        .assert_success()
+        .assert_stdout_contains("--native-stack")
+        .assert_stdout_contains("--no-native-stack");
+}
+
+#[test]
+fn stack_help_exposes_native_link_commands() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["stack", "--help"]);
+
+    output
+        .assert_success()
+        .assert_stdout_contains("link")
+        .assert_stdout_contains("unlink");
+}
+
+#[tokio::test]
+async fn submit_auto_registers_native_stack_and_keeps_stax_links() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["native-bottom", "native-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack link")
+    printf '%s\n' "$@" >> "$GH_ARGS_FILE"
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    let args = fs::read_to_string(&args_file).expect("gh stack link args written");
+    assert_eq!(
+        args,
+        "stack\nlink\n10\n20\n--base\nmain\n--remote\norigin\n"
+    );
+    assert_eq!(
+        git_stdout(&repo, &["config", "--get", "stax.nativeStack.enabled"]),
+        "true"
+    );
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|request| {
+            request.method.as_str() == "PATCH"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls/10"
+        }),
+        "stax body stack links for #10 should still be synced"
+    );
+    assert!(
+        requests.iter().any(|request| {
+            request.method.as_str() == "PATCH"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls/20"
+        }),
+        "stax body stack links for #20 should still be synced"
+    );
+}
+
+#[tokio::test]
+async fn submit_feature_disabled_caches_false_and_does_not_retry() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["disabled-bottom", "disabled-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack link")
+    echo link >> "$GH_ARGS_FILE"
+    echo "Stacked PRs is currently in private preview and has not been enabled for this repository" >&2
+    exit 4
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+    let env = [
+        ("HOME", home.as_str()),
+        ("STAX_GITHUB_TOKEN", "test-token"),
+        ("PATH", path.as_str()),
+        ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+    ];
+
+    let first = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt", "--quiet"],
+        &env,
+    );
+    first.assert_success();
+    assert!(
+        TestRepo::stderr(&first).trim().is_empty(),
+        "feature-disabled native stack should be silent, stderr was:\n{}",
+        TestRepo::stderr(&first)
+    );
+    assert_eq!(
+        git_stdout(&repo, &["config", "--get", "stax.nativeStack.enabled"]),
+        "false"
+    );
+
+    let second = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt", "--quiet"],
+        &env,
+    );
+    second.assert_success();
+
+    let args = fs::read_to_string(&args_file).expect("first gh stack link attempt recorded");
+    assert_eq!(
+        args, "link\n",
+        "second submit should not retry gh stack link"
+    );
+}

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -418,6 +418,113 @@ exit 1
 }
 
 #[tokio::test]
+async fn submit_auto_registers_single_pr_native_stack_seed() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["native-single"]);
+    repo.git(&["push", "-u", "origin", &branches[0]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack link")
+    printf '%s\n' "$@" >> "$GH_ARGS_FILE"
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    let args = fs::read_to_string(&args_file).expect("gh stack link args written");
+    assert_eq!(args, "stack\nlink\n10\n--base\nmain\n--remote\norigin\n");
+    assert_eq!(
+        git_stdout(&repo, &["config", "--get", "stax.nativeStack.enabled"]),
+        "true"
+    );
+}
+
+#[tokio::test]
+async fn submit_single_pr_native_stack_validation_rejection_is_harmless() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["native-single-rejected"]);
+    repo.git(&["push", "-u", "origin", &branches[0]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack link")
+    printf '%s\n' "$@" >> "$GH_ARGS_FILE"
+    echo "native stacks require at least two PRs" >&2
+    exit 4
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt", "--quiet"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    assert!(
+        TestRepo::stderr(&output).trim().is_empty(),
+        "single-PR native validation rejection should be silent, stderr was:\n{}",
+        TestRepo::stderr(&output)
+    );
+    let args = fs::read_to_string(&args_file).expect("gh stack link attempt recorded");
+    assert_eq!(args, "stack\nlink\n10\n--base\nmain\n--remote\norigin\n");
+    let cached = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
+    assert!(
+        !cached.status.success(),
+        "single-PR validation rejection should not cache native stack as disabled"
+    );
+}
+
+#[tokio::test]
 async fn submit_feature_disabled_caches_false_and_does_not_retry() {
     let mock_server = MockServer::start().await;
 


### PR DESCRIPTION
## Summary

Adds zero-config integration with GitHub native Stacked PRs, using the `gh-stack` extension when it is installed and the repository has access to GitHub's native stack feature.

- Auto-registers submitted GitHub PR stacks with `gh stack link` when capable, while silently falling back to existing stax behavior for users without `gh-stack`, non-enabled repos, or non-GitHub remotes.
- Keeps stax-managed PR body/comment stack links by default, so the native GitHub stack map complements rather than replaces the existing links.
- Adds `stax doctor` readiness/install support, `stax stack link` / `stax stack unlink`, submit overrides, native-stack config, and native-stack discovery for `stax get <PR>`.
- Seeds native GitHub Stack registration even for a single PR, so adding a second PR later can update the same native stack.

## Context

GitHub's native Stacked PRs feature provides a server-side stack object and PR UI stack map that stax cannot create with local branch metadata alone. This PR integrates through the supported external-tool seam, `gh stack link`, instead of depending on private GitHub APIs.

Relevant GitHub feature docs:

- [GitHub native Stacked PRs / gh-stack](https://github.github.com/gh-stack/)

## Behavior

By default, `[submit] native_stack = "auto"` attempts native registration only when the preconditions are met: GitHub remote, `gh` available, `github/gh-stack` extension installed, and at least one PR with metadata. Feature-disabled responses are cached per repo with `stax.nativeStack.enabled=false` so future submits stay quiet.

Single-PR validation failures from `gh-stack` degrade silently without marking the repo feature as disabled. Users can override per run with `stax submit --native-stack` or `stax submit --no-native-stack`, and can manually repair native stack state with `stax stack link` / `stax stack unlink`.

## Test Plan

- [x] `cargo fmt`
- [x] `cargo nextest run gh_stack_tests::`
- [x] `cargo nextest run get_tests::`
- [x] `cargo check --all-targets`
- [x] `git diff --check`
- [x] `make test`


