### PR TITLE
feat: native GitHub Stacked PR integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ One giant PR is slow to review and risky to merge. A stack of small PRs is the a
 - **Stack, don't wait.** Keep shipping on top of in-review PRs. `st create`, `st ss`, done.
 - **Native-fast.** A single Rust binary that starts in ~25ms. `st ls` benches ~70× faster than Graphite and ~215× faster than Freephite on this repo.
 - **Agent-native.** Run parallel AI agents on isolated branches (`st lane`), auto-resolve rebase conflicts (`st resolve`), and generate branch names, commit messages, and PR details from real diffs.
+- **GitHub-native stacks, automatically.** When your repo has GitHub's native Stacked PRs enabled and `github/gh-stack` is installed, `st ss` registers the stack with GitHub under the hood — zero config, zero extra commands. See [Native GitHub Stacked PRs](#native-github-stacked-prs).
 - **Undo-first.** Every destructive op snapshots state. `st undo` / `st redo` rescue risky rebases instantly.
 - **Batteries-included TUI.** Run bare `st` to browse the stack, inspect diffs, and watch CI hydrate live.
 
@@ -183,6 +184,23 @@ Lanes start warm: instead of deleting a removed worktree, stax parks it as a reu
 
 → [Agent worktrees](docs/workflows/agent-worktrees.md) · [Multi-worktree workflow](docs/workflows/multi-worktree.md)
 
+<a id="native-github-stacked-prs"></a>
+### Native GitHub Stacked PRs
+
+When a GitHub repo has native Stacked PRs enabled and you have the `github/gh-stack` extension installed, `st ss`/`st bs` automatically register the submitted PRs as a native GitHub Stack — no extra command required. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
+
+```bash
+gh extension install github/gh-stack
+st doctor --fix          # can offer the install, or an upgrade, when needed
+st ss                    # auto-links native stack when available
+st stack link            # manually re-link the current stack
+st stack unlink          # remove the native GitHub Stack object
+```
+
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. stax also strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before talking to `gh stack`, since GitHub's private-preview native-stack API rejects Personal Access Tokens and only accepts an OAuth-authenticated `gh` login. `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics.
+
+→ [Native GitHub Stacks guide](docs/integrations/github-native-stacks.md)
+
 ### Cascade stack merge
 
 Merge from the bottom of the stack up to your current branch, with CI and readiness checks:
@@ -198,20 +216,6 @@ st merge --all            # merge the whole stack regardless of position
 ```
 
 → [Merge and cascade](docs/workflows/merge-and-cascade.md)
-
-### Native GitHub Stacked PRs
-
-When a GitHub repo has native Stacked PRs enabled and you have the `github/gh-stack` extension installed, `st ss` automatically registers the submitted PRs as a native GitHub Stack. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
-
-```bash
-gh extension install github/gh-stack
-st doctor --fix          # can offer the install when missing
-st ss                    # auto-links native stack when available
-st stack link            # manually re-link the current stack
-st stack unlink          # remove the native GitHub Stack object
-```
-
-Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior.
 
 ### AI conflict resolution
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ st merge --all            # merge the whole stack regardless of position
 
 → [Merge and cascade](docs/workflows/merge-and-cascade.md)
 
+### Native GitHub Stacked PRs
+
+When a GitHub repo has native Stacked PRs enabled and you have the `github/gh-stack` extension installed, `st ss` automatically registers the submitted PRs as a native GitHub Stack. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
+
+```bash
+gh extension install github/gh-stack
+st doctor --fix          # can offer the install when missing
+st ss                    # auto-links native stack when available
+st stack link            # manually re-link the current stack
+st stack unlink          # remove the native GitHub Stack object
+```
+
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior.
+
 ### AI conflict resolution
 
 When a rebase stops on a conflict, `st resolve` sends only the conflicted text files to your configured AI agent, applies the result, and resumes the rebase automatically. If the AI returns invalid output, touches a non-conflicted file, or leaves extra conflicts behind, stax bails out and preserves the in-progress rebase so you can inspect or continue manually.

--- a/README.md
+++ b/README.md
@@ -187,17 +187,23 @@ Lanes start warm: instead of deleting a removed worktree, stax parks it as a reu
 <a id="native-github-stacked-prs"></a>
 ### Native GitHub Stacked PRs
 
-When a GitHub repo has native Stacked PRs enabled and you have the `github/gh-stack` extension installed, `st ss`/`st bs` automatically register the submitted PRs as a native GitHub Stack — no extra command required. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
+When a GitHub repo has native Stacked PRs enabled, stax can register your submitted PRs as a native GitHub Stack automatically. This requires GitHub's [`github/gh-stack`](https://github.com/github/gh-stack) CLI extension — install it once:
 
 ```bash
 gh extension install github/gh-stack
-st doctor --fix          # can offer the install, or an upgrade, when needed
+# or let stax install it for you:
+st doctor --fix
+```
+
+That's it — no config needed. From then on, `st ss`/`st bs` auto-link multi-PR stacks under the hood, no extra command required. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
+
+```bash
 st ss                    # auto-links native stack when available
 st stack link            # manually re-link the current stack
 st stack unlink          # remove the native GitHub Stack object
 ```
 
-Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. stax also strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before talking to `gh stack`, since GitHub's private-preview native-stack API rejects Personal Access Tokens and only accepts an OAuth-authenticated `gh` login. `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics.
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. stax also strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before talking to `gh stack`, since GitHub's private-preview native-stack API rejects Personal Access Tokens and only accepts an OAuth-authenticated `gh` login (`gh auth login`). `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics, and reports whether the extension is missing, outdated, or up to date.
 
 → [Native GitHub Stacks guide](docs/integrations/github-native-stacks.md)
 

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -29,6 +29,8 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | Command | What it does |
 |---|---|
 | `st ss` | Submit the whole stack — open or update linked PRs |
+| `st stack link` | Register the current PR stack as a native GitHub Stack when `gh-stack` is available |
+| `st stack unlink` | Remove the native GitHub Stack object for the current stack |
 | `st branch submit` | Submit only the current branch; if its parent is already synced to the remote, Stax may publish a temporary rebased head without moving your local branch |
 | `st upstack submit` | Submit current branch and descendants; descendants are temporarily chained onto any temporary parent publish heads |
 | `st draft [branch]` | Convert the current (or named) branch's PR to draft |
@@ -43,6 +45,8 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st cascade` | Restack, push, and create/update PRs in one shot |
 
 Scoped submit keeps local branch metadata unchanged when it prepares a temporary publish head. Plain `git commit` work on the branch is included; `st restack` remains the command that updates local branch tips and parent revisions.
+
+On GitHub repos with native Stacked PRs enabled, `st ss` auto-registers the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change.
 
 ## Sync, restack, update
 

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -46,7 +46,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 
 Scoped submit keeps local branch metadata unchanged when it prepares a temporary publish head. Plain `git commit` work on the branch is included; `st restack` remains the command that updates local branch tips and parent revisions.
 
-On GitHub repos with native Stacked PRs enabled, `st ss` auto-registers the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change.
+On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change. stax strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before calling `gh stack`, since the private-preview native-stack API only accepts an OAuth-authenticated `gh` login; `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics. See [Native GitHub Stacked PRs](../integrations/github-native-stacks.md).
 
 ## Sync, restack, update
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -10,6 +10,8 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st ll` | | Show stack with PR URLs and full details |
 | `st log` | `l` | Show stack with commits and PR info |
 | `st submit` | `ss` | Submit full current stack |
+| `st stack link` | | Register the current PR stack as a native GitHub Stack via `gh stack link` |
+| `st stack unlink` | | Remove the native GitHub Stack object via `gh stack unstack` |
 | `st merge` | | Cascade-merge from bottom to current (see flags below) |
 | `st merge-when-ready` | `mwr` | Backward-compatible alias for `st merge --when-ready` |
 | `st sync` | `rs` | Pull trunk, delete merged branches (incl. squash merges), reparent children |
@@ -154,7 +156,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st init` | Initialize stax or reconfigure trunk (`--trunk <branch>`) |
 | `st cli upgrade` | Detect install method and run the matching upgrade |
 | `st doctor` | Check repo health |
-| `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config and stale AI skills) |
+| `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config, stale AI skills, and optional `gh-stack` install) |
 | `st skills` | Manage installed AI agent skill files (`list`, `update`, `update --dry-run`) |
 | `st continue` | Continue after conflicts |
 | `st open` | Open repository in browser |
@@ -256,9 +258,10 @@ If the stash cannot apply cleanly while committing below, Stax restores the orig
 - `--ai` generate PR title and body with AI; narrow with `--title` or `--body`
 - `--template <name>` / `--no-template` / `--edit`
 - `--rerequest-review` / `--update-title`
+- `--native-stack` force-attempt native GitHub Stack registration for this submit; `--no-native-stack` skips it
 - `--yes` / `--no-prompt`
 
-Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.config/stax/config.toml`.
+Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` and `native_stack = "auto" | "off" | "link"` in `~/.config/stax/config.toml`.
 
 ### `st merge`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -35,6 +35,8 @@ Config is loaded as follows:
 [submit]
 # stack_links = "comment" # "comment" | "body" | "both" | "off"
 # single_stack = "on"     # "on" | "off" — when "off", skip stack-link sync while the stack has only one PR
+# native_stack = "auto"   # "auto" | "off" | "link" — auto-register native GitHub Stacked PRs when available
+# stack_links_when_native = "keep" # "keep" | "off" — keep stax body/comment links even when native registration succeeds
 
 [ci]
 # alert = false
@@ -202,6 +204,22 @@ When body output is enabled, stax appends a managed block to the bottom of the P
 Stack-link entries use compact PR/MR references and mark the PR being rendered with `👈`. On GitHub, stax keeps native `#123` PR references so GitHub renders its standard linked issue/PR styling; other forges use direct markdown links. The intro text is relative to the PR being rendered, so an imported base PR is described as an imported reference, while a local PR calls out any imported downstack context. Imported branches remain read-only for push and PR metadata updates, but their existing PRs still receive the managed stack links when they are part of the displayed stack.
 
 `single_stack` controls whether stack links are written when the stack contains only one PR. With the default `"on"`, links are always synced per `stack_links`. With `"off"`, stax skips link sync — and removes any stale links left over from a previous `"on"` setting — while the stack has a single PR. As soon as a second PR is submitted on the same stack, links populate on every PR (including the original) automatically.
+
+## Native GitHub Stacked PRs
+
+```toml
+[submit]
+native_stack = "auto"              # "auto" | "off" | "link"
+stack_links_when_native = "keep"   # "keep" | "off"
+```
+
+`native_stack = "auto"` is the default. On GitHub remotes, stax checks for the `github/gh-stack` extension and tries to register submitted multi-PR stacks with GitHub's native Stacked PRs feature. If the extension is missing, the repo does not have private-preview access, or the remote is not GitHub, submit silently keeps the existing stax behavior.
+
+Use `native_stack = "off"` to disable native registration. Use `"link"` to force an attempt even when the repo's feature cache is unknown or disabled. Per run, `st submit --native-stack` forces an attempt and `st submit --no-native-stack` skips it.
+
+`stack_links_when_native = "keep"` preserves stax's body/comment stack links when native registration succeeds. Set it to `"off"` only if you want the GitHub native stack map without stax-managed PR body/comment links.
+
+`st doctor` reports whether `gh-stack` is installed and `st doctor --fix` can install it with `gh extension install github/gh-stack` after confirmation.
 
 ## Forge type override
 

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -1,0 +1,66 @@
+# GitHub native Stacked PRs
+
+GitHub's native Stacked PRs feature adds a stack map, final-target branch protection, and native stack rebase/merge controls to the GitHub PR UI. stax can register its existing stacked PRs with that native feature when the repo has access.
+
+## How it works
+
+stax still owns local stack management: branch creation, parent metadata, restack, submit, PR bodies, and body/comment stack links. After `st submit` creates or updates the PRs, stax can run:
+
+```bash
+gh stack link <pr> [<next-pr> ...] --base <trunk> --remote <remote>
+```
+
+That registers one or more already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order and keeps its own body/comment stack links unless you opt out.
+
+## Requirements
+
+- GitHub remote.
+- Repo has GitHub native Stacked PRs enabled.
+- GitHub CLI `gh` is installed.
+- `github/gh-stack` extension is installed:
+
+```bash
+gh extension install github/gh-stack
+```
+
+The extension must be recent enough to provide the `gh stack link` command (added after `v0.0.1`). Older versions fail with `unknown flag: --base`.
+
+```bash
+gh extension upgrade gh-stack
+```
+
+`st doctor` reports this status — including when the installed extension is too old to expose `gh stack link`. `st doctor --fix` can install the extension when `gh` is available, or upgrade it when it is outdated.
+
+## Default behavior
+
+The default is zero-config:
+
+```toml
+[submit]
+native_stack = "auto"
+stack_links_when_native = "keep"
+```
+
+With `auto`, stax attempts native registration only when the extension is installed, the repo is eligible, and the stack has **at least two PRs** (`gh stack link` requires two or more — a native stack is inherently multi-PR). Single-PR stacks are skipped silently; once a second PR joins the stack, the next submit registers both. If the repo is not enabled for the private preview, stax caches that result locally and stops retrying. Submit still succeeds and behaves like normal stax.
+
+`stack_links_when_native = "keep"` means PR body/comment links continue to sync even when GitHub native registration succeeds.
+
+## Manual commands
+
+```bash
+st stack link
+st stack unlink
+```
+
+Use `st stack link` to register the current stack manually (requires at least two PRs).
+
+`st stack unlink` calls `gh stack unstack`, which only operates on a stack that gh-stack tracks locally. Because stax registers stacks with `gh stack link` (which does **not** create local tracking), `st stack unlink` cannot remove a stax-registered stack directly — it reports that the current branch is not part of a tracked stack. To remove such a stack, run `gh stack checkout <pr>` to adopt it locally first, then `gh stack unstack`, or remove it from the GitHub PR UI.
+
+## Submit overrides
+
+```bash
+st submit --native-stack     # force an attempt for this run
+st submit --no-native-stack  # skip native registration for this run
+```
+
+These only affect native GitHub registration. PR creation, branch pushes, and stax-managed stack links continue to follow the normal submit options.

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -2,6 +2,37 @@
 
 GitHub's native Stacked PRs feature adds a stack map, final-target branch protection, and native stack rebase/merge controls to the GitHub PR UI. stax can register its existing stacked PRs with that native feature when the repo has access.
 
+## Install
+
+This feature needs the [`github/gh-stack`](https://github.com/github/gh-stack) GitHub CLI extension. Install it once:
+
+```bash
+gh extension install github/gh-stack
+# or let stax install it for you:
+st doctor --fix
+```
+
+Upgrade it the same way:
+
+```bash
+gh extension upgrade gh-stack
+# or:
+st doctor --fix
+```
+
+No further setup is required — once the extension is installed, native stack registration is fully automatic (see [Default behavior](#default-behavior) below).
+
+## Requirements
+
+- GitHub remote.
+- Repo has GitHub native Stacked PRs enabled.
+- GitHub CLI `gh` is installed and logged in with an **OAuth-authenticated account** (`gh auth login`). GitHub's native Stacked PRs API is in private preview and rejects Personal Access Tokens outright.
+- `github/gh-stack` extension is installed (see [Install](#install) above), and recent enough to provide the `gh stack link` command (added after `v0.0.1`). Older versions fail with `unknown flag: --base`.
+
+`st doctor` reports this status — including when the installed extension is too old to expose `gh stack link`, or missing entirely. `st doctor --fix` can install the extension when `gh` is available, or upgrade it when it is outdated.
+
+**Recommended: v0.0.6+.** Versions below v0.0.6 report Personal Access Token rejections with the same message used for a genuinely feature-disabled repo ("Stacked PRs are not enabled..."), so stax can't tell the two apart and may incorrectly cache the repo as unsupported. `st doctor` flags this with a soft warning (and `--fix` upgrades it) even though `gh stack link` itself works on any version that exposes the `link` command.
+
 ## How it works
 
 stax still owns local stack management: branch creation, parent metadata, restack, submit, PR bodies, and body/comment stack links. After `st submit` creates or updates the PRs, stax can run:
@@ -12,27 +43,7 @@ gh stack link <pr> [<next-pr> ...] --base <trunk> --remote <remote>
 
 That registers one or more already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order and keeps its own body/comment stack links unless you opt out.
 
-## Requirements
-
-- GitHub remote.
-- Repo has GitHub native Stacked PRs enabled.
-- GitHub CLI `gh` is installed and logged in with an **OAuth-authenticated account** (`gh auth login`). GitHub's native Stacked PRs API is in private preview and rejects Personal Access Tokens outright.
-- `github/gh-stack` extension is installed:
-
-```bash
-gh extension install github/gh-stack
-```
-
-The extension must be recent enough to provide the `gh stack link` command (added after `v0.0.1`). Older versions fail with `unknown flag: --base`.
-
-```bash
-gh extension upgrade gh-stack
-```
-
-`st doctor` reports this status — including when the installed extension is too old to expose `gh stack link`. `st doctor --fix` can install the extension when `gh` is available, or upgrade it when it is outdated.
-
-**Recommended: v0.0.6+.** Versions below v0.0.6 report Personal Access Token rejections with the same message used for a genuinely feature-disabled repo ("Stacked PRs are not enabled..."), so stax can't tell the two apart and may incorrectly cache the repo as unsupported. `st doctor` flags this with a soft warning (and `--fix` upgrades it) even though `gh stack link` itself works on any version that exposes the `link` command.
-
+<a id="default-behavior"></a>
 ## Default behavior
 
 The default is zero-config:

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -64,6 +64,18 @@ If no OAuth-authenticated `gh` account is available at all, native registration 
 
 `stack_links_when_native = "keep"` means PR body/comment links continue to sync even when GitHub native registration succeeds.
 
+## Base branch ownership after linking
+
+Once a stack is registered natively, GitHub owns base-branch transitions for the linked PRs and rejects any `PATCH` that touches `base` — even from stax's own retarget calls — with:
+
+```
+Cannot change the base branch because the pull request is part of a stack.
+```
+
+stax treats this as non-fatal wherever it would otherwise just be re-affirming or cascading a base after a merge (`st submit`, and the retarget-after-merge step in `st merge`, `st merge --queue`, `st merge --remote`, and `st merge --when-ready`): it prints a short `note:` and continues instead of aborting. GitHub either applies the retarget itself shortly after (e.g. once the merged branch is deleted) or leaves it for `st stack link` to reconcile later.
+
+Where a base change to trunk is a hard precondition — merging a single PR out of stack order with `st merge --stack` or `st merge --queue` — stax fails with a clear message instead, since proceeding without the real base would merge into the wrong target. Run `st stack unlink` first if you need to do that.
+
 ## Manual commands
 
 ```bash

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -16,7 +16,7 @@ That registers one or more already-submitted PRs as a native GitHub Stack. stax 
 
 - GitHub remote.
 - Repo has GitHub native Stacked PRs enabled.
-- GitHub CLI `gh` is installed.
+- GitHub CLI `gh` is installed and logged in with an **OAuth-authenticated account** (`gh auth login`). GitHub's native Stacked PRs API is in private preview and rejects Personal Access Tokens outright.
 - `github/gh-stack` extension is installed:
 
 ```bash
@@ -31,6 +31,8 @@ gh extension upgrade gh-stack
 
 `st doctor` reports this status — including when the installed extension is too old to expose `gh stack link`. `st doctor --fix` can install the extension when `gh` is available, or upgrade it when it is outdated.
 
+**Recommended: v0.0.6+.** Versions below v0.0.6 report Personal Access Token rejections with the same message used for a genuinely feature-disabled repo ("Stacked PRs are not enabled..."), so stax can't tell the two apart and may incorrectly cache the repo as unsupported. `st doctor` flags this with a soft warning (and `--fix` upgrades it) even though `gh stack link` itself works on any version that exposes the `link` command.
+
 ## Default behavior
 
 The default is zero-config:
@@ -42,6 +44,12 @@ stack_links_when_native = "keep"
 ```
 
 With `auto`, stax attempts native registration only when the extension is installed, the repo is eligible, and the stack has **at least two PRs** (`gh stack link` requires two or more — a native stack is inherently multi-PR). Single-PR stacks are skipped silently; once a second PR joins the stack, the next submit registers both. If the repo is not enabled for the private preview, stax caches that result locally and stops retrying. Submit still succeeds and behaves like normal stax.
+
+### Personal Access Tokens are shadowed automatically
+
+`gh` treats `GH_TOKEN`/`GITHUB_TOKEN` env vars as overriding whichever account you last logged in with, and native Stacked PRs reject that kind of token during private preview. If you export a PAT for other tooling (CI scripts, other CLIs), it would otherwise silently break native stack registration even though you have a perfectly good OAuth login sitting unused. stax works around this: when it shells out to `gh stack link`/`gh stack unstack`, it always strips `GH_TOKEN`/`GITHUB_TOKEN` first, so `gh` falls back to its stored OAuth-authenticated account. This has no effect on stax's own GitHub API calls (PR creation, comments, etc.), which still use your configured token normally.
+
+If no OAuth-authenticated `gh` account is available at all, native registration is skipped with a note pointing at `gh auth login` — this case is never cached as "feature disabled," since it depends on your local `gh` auth state rather than the repo/org's eligibility.
 
 `stack_links_when_native = "keep"` means PR body/comment links continue to sync even when GitHub native registration succeeds.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - Configuration:
       - Config Reference: configuration/index.md
   - Integrations:
+      - GitHub Native Stacked PRs: integrations/github-native-stacks.md
       - PR Templates and AI: integrations/pr-templates-and-ai.md
       - Claude Code: integrations/claude-code.md
       - Codex: integrations/codex.md

--- a/skills.md
+++ b/skills.md
@@ -224,6 +224,12 @@ stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment l
 # Native Stacked PRs (private preview) reject Personal Access Tokens — stax
 # strips GH_TOKEN/GITHUB_TOKEN before calling `gh stack`, but you still need
 # an OAuth-authenticated `gh` account (`gh auth login`) to exist at all.
+# Once linked, GitHub owns base-branch transitions for those PRs and rejects
+# any PATCH touching `base` ("...part of a stack"). stax treats this as
+# non-fatal in submit/merge cascade retargets (prints a note, continues);
+# `stax merge --stack`/`--queue` fail with an actionable message instead,
+# since merging out of stack order needs a real base change (run
+# `stax stack unlink` first if that's what you want).
 
 stax branch submit                 # Submit current branch only
 stax bs                            # Hidden shortcut alias for branch submit

--- a/skills.md
+++ b/skills.md
@@ -24,6 +24,8 @@ stax ll                        # Stack status with PR URLs/details
 stax log|l                     # Stack status with commits + PR info
 
 stax submit|ss                 # Submit full stack
+stax stack link                # Register current PR stack as native GitHub Stack (GitHub + gh-stack)
+stax stack unlink              # Remove native GitHub Stack object
 stax merge                     # Merge PRs from stack bottom upward
 stax sync|rs                   # Sync trunk + clean merged branches
 stax sweep                     # Classify + optionally delete merged/gone/stale branches
@@ -206,11 +208,19 @@ stax submit --ai --title           # Generate/update PR title only
 stax submit --ai --body            # Generate/update PR body only
 stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
+stax submit --native-stack         # Force-attempt native GitHub Stack registration for this run
+stax submit --no-native-stack      # Skip native GitHub Stack registration for this run
 
 # ~/.config/stax/config.toml; repo-root stax.toml overlays shared values
 [submit]
 stack_links = "body"               # "comment" | "body" | "both" | "off"
 single_stack = "on"                # "on" | "off" — when "off", skip stack-link sync while only one PR exists; populates on all PRs as soon as the stack reaches 2
+native_stack = "auto"              # "auto" | "off" | "link" — auto-register native GitHub Stacked PRs when gh-stack + repo access are available
+stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment links when native registration succeeds
+
+# Native GitHub Stacked PRs are additive. Repos/users without access or without
+# `github/gh-stack` installed behave exactly as normal stax. `stax doctor --fix`
+# can offer `gh extension install github/gh-stack` when `gh` is installed.
 
 stax branch submit                 # Submit current branch only
 stax bs                            # Hidden shortcut alias for branch submit

--- a/skills.md
+++ b/skills.md
@@ -221,6 +221,9 @@ stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment l
 # Native GitHub Stacked PRs are additive. Repos/users without access or without
 # `github/gh-stack` installed behave exactly as normal stax. `stax doctor --fix`
 # can offer `gh extension install github/gh-stack` when `gh` is installed.
+# Native Stacked PRs (private preview) reject Personal Access Tokens — stax
+# strips GH_TOKEN/GITHUB_TOKEN before calling `gh stack`, but you still need
+# an OAuth-authenticated `gh` account (`gh auth login`) to exist at all.
 
 stax branch submit                 # Submit current branch only
 stax bs                            # Hidden shortcut alias for branch submit

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -78,6 +78,12 @@ pub(crate) struct SubmitOptions {
     /// Re-request review from existing reviewers when updating PRs
     #[arg(long)]
     pub(crate) rerequest_review: bool,
+    /// Force-attempt native GitHub Stack registration via `gh stack`
+    #[arg(long, conflicts_with = "no_native_stack")]
+    pub(crate) native_stack: bool,
+    /// Skip native GitHub Stack registration for this submit
+    #[arg(long, conflicts_with = "native_stack")]
+    pub(crate) no_native_stack: bool,
     /// Squash all commits on each branch into one before pushing
     #[arg(long)]
     pub(crate) squash: bool,
@@ -111,6 +117,13 @@ impl From<SubmitOptions> for commands::submit::SubmitOptions {
             title: submit.title,
             body: submit.body,
             rerequest_review: submit.rerequest_review,
+            native_stack_override: if submit.no_native_stack {
+                Some(crate::config::NativeStackMode::Off)
+            } else if submit.native_stack {
+                Some(crate::config::NativeStackMode::Link)
+            } else {
+                None
+            },
             squash: submit.squash,
             update_title: submit.update_title,
         }
@@ -1342,6 +1355,12 @@ pub(crate) enum StackCommands {
         #[arg(long, value_enum, default_value_t = RestackSubmitAfter::No)]
         submit_after: RestackSubmitAfter,
     },
+
+    /// Register the current stack as a native GitHub Stack via `gh stack`
+    Link,
+
+    /// Remove the native GitHub Stack object via `gh stack`
+    Unlink,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -713,6 +713,8 @@ pub fn run() -> Result<()> {
                 auto_stash_pop,
                 submit_after.into(),
             ),
+            StackCommands::Link => commands::stack_cmd::run_link(),
+            StackCommands::Unlink => commands::stack_cmd::run_unlink(),
         },
         // Hidden shortcuts
         Commands::Bc {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge;
 use crate::git::{GitRepo, refs};
+use crate::github::gh_stack::{self, ExtensionStatus, FeatureState};
 use crate::remote::{self, RemoteInfo};
 use anyhow::{Result, bail};
 use colored::Colorize;
@@ -33,6 +34,8 @@ enum RepairAction {
         key: &'static str,
         value: &'static str,
     },
+    InstallGhStackExtension,
+    UpgradeGhStackExtension,
     UpdateSkills,
 }
 
@@ -41,6 +44,12 @@ impl RepairAction {
         match self {
             RepairAction::SetGitConfig { key, value } => {
                 format!("Set git config {key}={value}")
+            }
+            RepairAction::InstallGhStackExtension => {
+                "Install GitHub gh-stack extension".to_string()
+            }
+            RepairAction::UpgradeGhStackExtension => {
+                "Upgrade outdated GitHub gh-stack extension".to_string()
             }
             RepairAction::UpdateSkills => "Update stale AI agent skill files".to_string(),
         }
@@ -123,6 +132,52 @@ pub fn run(fix: bool) -> Result<()> {
             )
             .yellow()
         );
+    }
+
+    if remote_info
+        .as_ref()
+        .map(|info| info.forge == crate::remote::ForgeType::GitHub)
+        .unwrap_or(false)
+    {
+        match gh_stack::extension_status() {
+            ExtensionStatus::Installed => {
+                let feature = gh_stack::feature_enabled(repo.workdir()?);
+                let feature_label = match feature {
+                    FeatureState::Enabled => "repo feature cache: enabled",
+                    FeatureState::Disabled => "repo feature cache: disabled",
+                    FeatureState::Unknown => "repo feature cache: unknown",
+                };
+                println!(
+                    "{} {} {}",
+                    "✓".green(),
+                    "GitHub native stacks: gh-stack extension installed".dimmed(),
+                    format!("({feature_label})").dimmed()
+                );
+            }
+            ExtensionStatus::Outdated => {
+                repair_plan.push(RepairAction::UpgradeGhStackExtension);
+                println!(
+                    "{} {}",
+                    "⚠".yellow(),
+                    "GitHub native stacks: gh-stack extension is outdated and lacks `gh stack link` (run `gh extension upgrade gh-stack`)".yellow()
+                );
+            }
+            ExtensionStatus::NoExtension => {
+                repair_plan.push(RepairAction::InstallGhStackExtension);
+                println!(
+                    "{} {}",
+                    "⚠".yellow(),
+                    "GitHub native stacks: gh-stack extension missing (run `gh extension install github/gh-stack`)".yellow()
+                );
+            }
+            ExtensionStatus::NoGh => {
+                println!(
+                    "{} {}",
+                    "⚠".yellow(),
+                    "GitHub native stacks: GitHub CLI `gh` not found (optional)".yellow()
+                );
+            }
+        }
     }
 
     if repo.is_dirty()? {
@@ -389,6 +444,14 @@ fn apply_repair_action(action: &RepairAction) -> Result<()> {
         }
         RepairAction::UpdateSkills => {
             skills::run_update(false)?;
+        }
+        RepairAction::InstallGhStackExtension => {
+            gh_stack::install_extension()?;
+            println!("{} {}", "✓".green(), action.description().dimmed());
+        }
+        RepairAction::UpgradeGhStackExtension => {
+            gh_stack::upgrade_extension()?;
+            println!("{} {}", "✓".green(), action.description().dimmed());
         }
     }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,7 +3,7 @@ use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge;
 use crate::git::{GitRepo, refs};
-use crate::github::gh_stack::{self, ExtensionStatus, FeatureState};
+use crate::github::gh_stack::{self, ExtensionStatus, FeatureState, VersionStatus};
 use crate::remote::{self, RemoteInfo};
 use anyhow::{Result, bail};
 use colored::Colorize;
@@ -153,6 +153,19 @@ pub fn run(fix: bool) -> Result<()> {
                     "GitHub native stacks: gh-stack extension installed".dimmed(),
                     format!("({feature_label})").dimmed()
                 );
+                if let VersionStatus::BelowRecommended { installed } = gh_stack::version_status() {
+                    repair_plan.push(RepairAction::UpgradeGhStackExtension);
+                    println!(
+                        "{} {}",
+                        "⚠".yellow(),
+                        format!(
+                            "gh-stack v{installed} predates v0.0.6's Personal Access Token \
+                             detection — auth issues may be misreported as \"not enabled for \
+                             this repo\" (run `gh extension upgrade gh-stack`)"
+                        )
+                        .yellow()
+                    );
+                }
             }
             ExtensionStatus::Outdated => {
                 repair_plan.push(RepairAction::UpgradeGhStackExtension);

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -7,7 +7,7 @@ use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::{GitRepo, RebaseResult};
-use crate::github::pr::{MergeMethod, PrMergeStatus};
+use crate::github::pr::{MergeMethod, PrMergeStatus, is_native_stack_base_locked_error};
 use crate::progress::LiveTimer;
 use crate::remote::RemoteInfo;
 use anyhow::{Context, Result};
@@ -49,6 +49,12 @@ struct MergeScope {
 pub(crate) enum PrBaseUpdate {
     Updated,
     AlreadyTargeted,
+    /// GitHub rejected the retarget because the PR is registered in a native
+    /// Stack (private preview) and a follow-up read still shows the old
+    /// base. Callers should treat this as "skipped, not fatal" — GitHub may
+    /// apply the retarget itself once the merged branch is deleted, or the
+    /// stack may need to be re-linked with `st stack link`.
+    NativeStackLocked,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -288,6 +294,10 @@ pub fn run(
                     }
                     Ok(PrBaseUpdate::AlreadyTargeted) => {
                         LiveTimer::maybe_finish_ok(update_base_timer, "already on base");
+                    }
+                    Ok(PrBaseUpdate::NativeStackLocked) => {
+                        LiveTimer::maybe_finish_warn(update_base_timer, "skipped (native Stack)");
+                        print_native_stack_locked_note(quiet, next_pr);
                     }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
@@ -861,14 +871,44 @@ pub(crate) fn update_pr_base_unless_current(
         Ok(()) => Ok(PrBaseUpdate::Updated),
         Err(e) => {
             if is_duplicate_pr_base_error(&e, new_base, expected_head)
-                && pr_base_matches_after_duplicate_error(rt, client, pr_number, new_base)
+                && pr_base_matches_after_recheck(rt, client, pr_number, new_base)
             {
                 return Ok(PrBaseUpdate::AlreadyTargeted);
+            }
+
+            if is_native_stack_base_locked_error(&e) {
+                // GitHub may apply the retarget itself shortly after (e.g. once
+                // the merged branch is deleted) — give it a moment before
+                // treating this as merely skipped rather than done.
+                if pr_base_matches_after_recheck(rt, client, pr_number, new_base) {
+                    return Ok(PrBaseUpdate::AlreadyTargeted);
+                }
+                return Ok(PrBaseUpdate::NativeStackLocked);
             }
 
             Err(e).with_context(|| format!("failed to retarget PR #{} to {}", pr_number, new_base))
         }
     }
+}
+
+/// Print a soft note explaining a skipped retarget on a natively-stacked PR.
+///
+/// Used at cascade sites (retargeting a dependent PR to trunk after its
+/// predecessor merged) where GitHub owning the base transition is fine to
+/// leave for it — or for `st stack link` — to resolve, rather than aborting.
+pub(crate) fn print_native_stack_locked_note(quiet: bool, pr_number: u64) {
+    if quiet {
+        return;
+    }
+    println!(
+        "  {} {}",
+        "note:".dimmed(),
+        format!(
+            "#{pr_number} manages its base via GitHub's native Stack; \
+             retarget it with `st stack link` if it isn't updated automatically"
+        )
+        .dimmed()
+    );
 }
 
 fn ensure_pr_head_matches(pr_number: u64, actual_head: &str, expected_head: &str) -> Result<()> {
@@ -884,12 +924,14 @@ fn ensure_pr_head_matches(pr_number: u64, actual_head: &str, expected_head: &str
     Ok(())
 }
 
-/// Re-read a PR briefly after GitHub reports a duplicate base/head pair.
+/// Re-read a PR briefly after a retarget PATCH was rejected, to check whether
+/// the base ended up correct anyway.
 ///
-/// This covers a stale-response race: the update endpoint can reject a retarget
-/// as a duplicate even though subsequent PR reads show the same PR now targets
-/// the requested base.
-fn pr_base_matches_after_duplicate_error(
+/// Covers two races: (1) GitHub reports a duplicate base/head validation even
+/// though subsequent PR reads show the same PR now targets the requested
+/// base, and (2) a native-Stack base lock where GitHub applies the retarget
+/// itself shortly after (e.g. once the merged branch is deleted).
+fn pr_base_matches_after_recheck(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
     pr_number: u64,

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -232,6 +232,20 @@ pub fn run(
             Ok(PrBaseUpdate::AlreadyTargeted) => {
                 LiveTimer::maybe_finish_ok(retarget_timer, "already on base")
             }
+            Ok(PrBaseUpdate::NativeStackLocked) => {
+                LiveTimer::maybe_finish_err(retarget_timer, "locked");
+                failed = Some((
+                    branch.branch.clone(),
+                    branch.pr_number,
+                    format!(
+                        "PR #{} is registered in a native GitHub Stack, which locks its base \
+                         branch and prevents retargeting it to {} for the queue. Run `st stack \
+                         unlink` first if you need to enqueue it out of stack order.",
+                        branch.pr_number, trunk
+                    ),
+                ));
+                break;
+            }
             Err(e) => {
                 LiveTimer::maybe_finish_err(retarget_timer, "failed");
                 failed = Some((
@@ -283,6 +297,18 @@ pub fn run(
                         }
                         Ok(PrBaseUpdate::AlreadyTargeted) => {
                             LiveTimer::maybe_finish_ok(rollback_timer, "already restored")
+                        }
+                        Ok(PrBaseUpdate::NativeStackLocked) => {
+                            LiveTimer::maybe_finish_warn(rollback_timer, "skipped (native Stack)");
+                            if !quiet {
+                                println!(
+                                    "      {} #{} manages its base via GitHub's native Stack; \
+                                     restore it with `st stack link` if it isn't updated \
+                                     automatically",
+                                    "note:".dimmed(),
+                                    branch.pr_number
+                                );
+                            }
                         }
                         Err(rb_err) => {
                             LiveTimer::maybe_finish_err(rollback_timer, "rollback failed");

--- a/src/commands/merge_remote.rs
+++ b/src/commands/merge_remote.rs
@@ -3,7 +3,9 @@
 //! Dependent PR branches are updated via GitHub's "Update branch" endpoint (`PUT .../update-branch`).
 
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
-use crate::commands::merge::{PrBaseUpdate, update_pr_base_unless_current};
+use crate::commands::merge::{
+    PrBaseUpdate, print_native_stack_locked_note, update_pr_base_unless_current,
+};
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
@@ -238,6 +240,10 @@ pub fn run(
                     Ok(PrBaseUpdate::AlreadyTargeted) => {
                         LiveTimer::maybe_finish_ok(update_base_timer, "already on base")
                     }
+                    Ok(PrBaseUpdate::NativeStackLocked) => {
+                        LiveTimer::maybe_finish_warn(update_base_timer, "skipped (native Stack)");
+                        print_native_stack_locked_note(quiet, next_branch.pr_number);
+                    }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
                         failed_pr = Some((
@@ -304,6 +310,10 @@ pub fn run(
                     }
                     Ok(PrBaseUpdate::AlreadyTargeted) => {
                         LiveTimer::maybe_finish_ok(update_base_timer, "already on base")
+                    }
+                    Ok(PrBaseUpdate::NativeStackLocked) => {
+                        LiveTimer::maybe_finish_warn(update_base_timer, "skipped (native Stack)");
+                        print_native_stack_locked_note(quiet, next_branch.pr_number);
                     }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");
@@ -376,6 +386,10 @@ pub fn run(
                 Ok(PrBaseUpdate::Updated) => LiveTimer::maybe_finish_ok(base_timer, "done"),
                 Ok(PrBaseUpdate::AlreadyTargeted) => {
                     LiveTimer::maybe_finish_ok(base_timer, "already on base")
+                }
+                Ok(PrBaseUpdate::NativeStackLocked) => {
+                    LiveTimer::maybe_finish_warn(base_timer, "skipped (native Stack)");
+                    print_native_stack_locked_note(quiet, pr_num);
                 }
                 Err(e) => {
                     LiveTimer::maybe_finish_err(base_timer, "failed");

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -267,6 +267,15 @@ pub fn run(
                 LiveTimer::maybe_finish_ok(retarget_timer, "already on base");
                 false
             }
+            Ok(PrBaseUpdate::NativeStackLocked) => {
+                LiveTimer::maybe_finish_err(retarget_timer, "locked");
+                anyhow::bail!(
+                    "PR #{} is registered in a native GitHub Stack, which locks its base branch. \
+                     Merge it via the normal stack order (`st merge`) instead of merging out of \
+                     order, or run `st stack unlink` first if you need to retarget it manually.",
+                    tip.pr_number
+                );
+            }
             Err(e) => {
                 LiveTimer::maybe_finish_err(retarget_timer, "failed");
                 return Err(e);

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -1,7 +1,7 @@
 use crate::commands::ci::{fetch_ci_statuses, record_ci_history};
 use crate::commands::merge::{
-    PrBaseUpdate, rebase_and_finalize_remaining_branch, sync_head_after_push,
-    update_pr_base_unless_current,
+    PrBaseUpdate, print_native_stack_locked_note, rebase_and_finalize_remaining_branch,
+    sync_head_after_push, update_pr_base_unless_current,
 };
 use crate::commands::merge_rebase::{
     fetch_remote_for_descendant_rebase, rebase_descendant_onto_remote_trunk_with_provenance,
@@ -344,6 +344,10 @@ pub fn run(
                     }
                     Ok(PrBaseUpdate::AlreadyTargeted) => {
                         LiveTimer::maybe_finish_ok(update_base_timer, "already on base");
+                    }
+                    Ok(PrBaseUpdate::NativeStackLocked) => {
+                        LiveTimer::maybe_finish_warn(update_base_timer, "skipped (native Stack)");
+                        print_native_stack_locked_note(quiet, next_branch.pr_number);
                     }
                     Err(e) => {
                         LiveTimer::maybe_finish_err(update_base_timer, "failed");

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -69,6 +69,16 @@ pub fn run_link() -> Result<()> {
             anyhow::bail!("GitHub rejected the native Stack link: {message}");
         }
         LinkOutcome::Failed { message } => {
+            if gh_stack::is_stack_fork_conflict(&message) {
+                anyhow::bail!(
+                    "Cannot link this stack natively: it shares ancestor PRs with another \
+                     branch that's already registered as a native GitHub Stack. GitHub's native \
+                     Stack feature only supports one linear chain at a time — unlink the other \
+                     branch's stack first (run `stax stack unlink` from that branch, or remove \
+                     the stack from the GitHub PR UI) if you want this one linked instead.\n\n\
+                     gh-stack said: {message}"
+                );
+            }
             anyhow::bail!("Failed to link native GitHub Stack: {message}");
         }
     }

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -1,8 +1,11 @@
 use crate::commands::worktree::shared::platform_shell;
+use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::{GitRepo, refs};
+use crate::github::gh_stack::{self, ExtensionStatus, LinkOutcome};
 use crate::ops::receipt::OpKind;
 use crate::ops::tx::Transaction;
+use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::Result;
 use colored::Colorize;
 use git2::BranchType;
@@ -12,6 +15,140 @@ use std::io::{self, Write};
 // =========================================================================
 // validate
 // =========================================================================
+
+pub fn run_link() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax stack link` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+    ensure_gh_stack_extension()?;
+
+    let stack = Stack::load(&repo)?;
+    let current = repo.current_branch()?;
+    let pr_numbers = current_stack_pr_numbers(&stack, &current)?;
+    // `gh stack link` requires at least two PRs — a native stack is inherently
+    // multi-PR. Fail early with a clear message instead of surfacing gh-stack's
+    // raw "requires at least 2 arg(s)" error.
+    if pr_numbers.len() < 2 {
+        anyhow::bail!(
+            "Native GitHub Stacks require at least 2 PRs in the current stack (found {}). \
+             Submit another branch in this stack, then run `stax stack link` again.",
+            pr_numbers.len()
+        );
+    }
+
+    match gh_stack::link_stack(&pr_numbers, &stack.trunk, &remote_info.name) {
+        LinkOutcome::Linked => {
+            gh_stack::set_feature_enabled(repo.workdir()?, true)?;
+            println!(
+                "{} {}",
+                "✓".green(),
+                format!("Linked {} PRs as a native GitHub Stack", pr_numbers.len()).dimmed()
+            );
+            Ok(())
+        }
+        LinkOutcome::FeatureDisabled { message } => {
+            gh_stack::set_feature_enabled(repo.workdir()?, false)?;
+            anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::SinglePrValidationRejected { message } => {
+            anyhow::bail!("GitHub rejected the native Stack link: {message}");
+        }
+        LinkOutcome::Failed { message } => {
+            anyhow::bail!("Failed to link native GitHub Stack: {message}");
+        }
+    }
+}
+
+pub fn run_unlink() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let remote_info = RemoteInfo::from_repo(&repo, &config)?;
+    if remote_info.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax stack unlink` is only supported for GitHub remotes (found {})",
+            remote_info.forge
+        );
+    }
+    ensure_gh_stack_extension()?;
+
+    match gh_stack::unlink_stack() {
+        LinkOutcome::Linked => {
+            println!("{}", "✓ Native GitHub Stack removed".green());
+            Ok(())
+        }
+        LinkOutcome::FeatureDisabled { message } => {
+            anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::SinglePrValidationRejected { message } => {
+            anyhow::bail!("GitHub rejected the native Stack unlink: {message}");
+        }
+        LinkOutcome::Failed { message } => {
+            // `gh stack unstack` operates on a locally-tracked stack, but stacks
+            // registered via `gh stack link` (the seam stax uses) carry no local
+            // tracking — so unstack reports the current branch is not part of a
+            // stack. Explain the limitation rather than the raw gh-stack error.
+            if message.to_lowercase().contains("not part of a stack") {
+                anyhow::bail!(
+                    "No locally-tracked native stack for the current branch. Native stacks that \
+                     stax registers via `gh stack link` are not tracked locally, so `gh stack \
+                     unstack` cannot remove them. Run `gh stack checkout <pr>` to adopt the stack \
+                     locally first, or remove the stack from the GitHub PR UI."
+                );
+            }
+            anyhow::bail!("Failed to remove native GitHub Stack: {message}");
+        }
+    }
+}
+
+fn ensure_gh_stack_extension() -> Result<()> {
+    match gh_stack::extension_status() {
+        ExtensionStatus::Installed => Ok(()),
+        ExtensionStatus::Outdated => {
+            anyhow::bail!(
+                "`gh-stack` extension is outdated and lacks `gh stack link`. Run `gh extension upgrade gh-stack`."
+            )
+        }
+        ExtensionStatus::NoExtension => {
+            anyhow::bail!(
+                "`gh-stack` extension is not installed. Run `gh extension install github/gh-stack`."
+            )
+        }
+        ExtensionStatus::NoGh => {
+            anyhow::bail!("GitHub CLI `gh` is not installed or not available on PATH.")
+        }
+    }
+}
+
+fn current_stack_pr_numbers(stack: &Stack, current: &str) -> Result<Vec<u64>> {
+    let mut pr_numbers = Vec::new();
+    let mut missing = Vec::new();
+
+    for branch in stack.current_stack(current) {
+        if branch == stack.trunk {
+            continue;
+        }
+        match stack.branches.get(&branch).and_then(|info| info.pr_number) {
+            Some(number) => pr_numbers.push(number),
+            None => missing.push(branch),
+        }
+    }
+
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "These branches have no PR yet, so they cannot be linked into a native stack:\n  {}\n\n\
+             Run `stax submit` to create PRs for the stack, then `stax stack link` again.",
+            missing.join("\n  ")
+        );
+    }
+
+    Ok(pr_numbers)
+}
 
 pub fn run_validate() -> Result<()> {
     let repo = GitRepo::open()?;

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -56,6 +56,15 @@ pub fn run_link() -> Result<()> {
             gh_stack::set_feature_enabled(repo.workdir()?, false)?;
             anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
         }
+        LinkOutcome::AuthTokenUnsupported { message } => {
+            anyhow::bail!(
+                "GitHub rejected the native Stack link: {message}\n\n\
+                 stax already ignores GH_TOKEN/GITHUB_TOKEN when talking to `gh stack`, but no \
+                 OAuth-authenticated `gh` account was found. Run `gh auth login` (or `gh auth \
+                 switch` if you already have one) to add an OAuth-authenticated account, then \
+                 retry."
+            );
+        }
         LinkOutcome::SinglePrValidationRejected { message } => {
             anyhow::bail!("GitHub rejected the native Stack link: {message}");
         }
@@ -84,6 +93,15 @@ pub fn run_unlink() -> Result<()> {
         }
         LinkOutcome::FeatureDisabled { message } => {
             anyhow::bail!("GitHub native Stacked PRs are not enabled for this repo: {message}");
+        }
+        LinkOutcome::AuthTokenUnsupported { message } => {
+            anyhow::bail!(
+                "GitHub rejected the native Stack unlink: {message}\n\n\
+                 stax already ignores GH_TOKEN/GITHUB_TOKEN when talking to `gh stack`, but no \
+                 OAuth-authenticated `gh` account was found. Run `gh auth login` (or `gh auth \
+                 switch` if you already have one) to add an OAuth-authenticated account, then \
+                 retry."
+            );
         }
         LinkOutcome::SinglePrValidationRejected { message } => {
             anyhow::bail!("GitHub rejected the native Stack unlink: {message}");

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -98,6 +98,13 @@ struct PrPlan {
     // Track if this is a no-op (already synced)
     needs_push: bool,
     needs_pr_update: bool,
+    /// True only when the PR's base branch itself differs from the desired
+    /// parent — as opposed to `needs_pr_update`, which is also set by a plain
+    /// push with no base change. GitHub's native Stacked PRs API rejects any
+    /// `PATCH .../pulls/{n}` call that includes `base` once a PR is part of a
+    /// registered stack, even when the value is unchanged, so this must gate
+    /// the `update_pr_base` call separately to avoid firing it on every push.
+    needs_base_update: bool,
     // Empty branches get pushed but no PR created
     is_empty: bool,
     // Branches imported with `stax get` are read-only support branches.
@@ -767,6 +774,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 is_draft: None,
                 needs_push,
                 needs_pr_update: false,
+                needs_base_update: false,
                 is_empty,
                 is_imported,
             });
@@ -934,6 +942,16 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 true // New PR always needs creation
             };
 
+            // Unlike `needs_pr_update` (also true on a plain push with no base
+            // change), this is only true when the base itself is actually
+            // wrong — the one case where calling `update_pr_base` is required.
+            let needs_base_update = !is_empty
+                && !is_imported
+                && existing_pr
+                    .as_ref()
+                    .map(|pr| pr.info.base != base)
+                    .unwrap_or(false);
+
             // Capture tip commit subject for auto-updating PR title on existing PRs.
             // Only computed when the user opts in via `--update-title` so default submits
             // do not silently rewrite PR titles from local commit messages.
@@ -968,6 +986,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 is_draft: None,
                 needs_push,
                 needs_pr_update,
+                needs_base_update,
                 is_empty,
                 is_imported,
             });
@@ -1518,10 +1537,36 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                         &format!("Updating {} #{}...", plan.branch, existing_pr_number),
                     );
 
-                    // Update base if needed
-                    client
-                        .update_pr_base(existing_pr_number, &plan.parent)
-                        .await?;
+                    // Update base only when it actually differs — `needs_pr_update`
+                    // is also true for a plain push with no base change, and GitHub's
+                    // native Stacked PRs API rejects *any* base PATCH (even a no-op)
+                    // once a PR is registered in a stack.
+                    if plan.needs_base_update {
+                        if let Err(e) = client
+                            .update_pr_base(existing_pr_number, &plan.parent)
+                            .await
+                        {
+                            if is_native_stack_base_locked_error(&e) {
+                                if !quiet {
+                                    println!(
+                                        "      {} {}",
+                                        "note:".dimmed(),
+                                        format!(
+                                            "skipped base update for #{existing_pr_number} — \
+                                             GitHub manages the base for PRs registered in a \
+                                             native Stack; run `st stack link` to re-sync"
+                                        )
+                                        .dimmed()
+                                    );
+                                }
+                            } else {
+                                LiveTimer::maybe_finish_warn(update_timer, "failed");
+                                return Err(e).context(format!(
+                                    "Failed to update PR base for #{existing_pr_number}"
+                                ));
+                            }
+                        }
+                    }
 
                     // Auto-update PR title from tip commit subject when it has changed
                     if plan.needs_title_update {
@@ -2576,6 +2621,16 @@ fn update_ref(workdir: &Path, refname: &str, oid: &str) -> Result<()> {
         anyhow::bail!("{}", command_output_details("git update-ref", &output));
     }
     Ok(())
+}
+
+/// True when a PR base-update failure is GitHub rejecting the change because
+/// the PR is registered in a native GitHub Stack (private preview). GitHub
+/// owns base-branch management for stacked PRs once linked, and returns this
+/// validation error for `PATCH .../pulls/{n}` calls that touch `base` — even
+/// when the requested value matches the PR's current base.
+fn is_native_stack_base_locked_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.to_string().to_lowercase().contains("part of a stack"))
 }
 
 fn command_output_details(command: &str, output: &std::process::Output) -> String {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -7,8 +7,8 @@ use crate::forge::ForgeClient;
 use crate::git::GitRepo;
 use crate::github::gh_stack::{self, ExtensionStatus, FeatureState, LinkOutcome};
 use crate::github::pr::{
-    PrInfoWithHead, StackPrInfo, generate_stack_links_markdown, remove_stack_links_from_body,
-    upsert_stack_links_in_body,
+    PrInfoWithHead, StackPrInfo, generate_stack_links_markdown, is_native_stack_base_locked_error,
+    remove_stack_links_from_body, upsert_stack_links_in_body,
 };
 use crate::github::pr_template::{discover_pr_templates, select_template_interactive};
 use crate::ops::receipt::{OpKind, PlanSummary};
@@ -2621,16 +2621,6 @@ fn update_ref(workdir: &Path, refname: &str, oid: &str) -> Result<()> {
         anyhow::bail!("{}", command_output_details("git update-ref", &output));
     }
     Ok(())
-}
-
-/// True when a PR base-update failure is GitHub rejecting the change because
-/// the PR is registered in a native GitHub Stack (private preview). GitHub
-/// owns base-branch management for stacked PRs once linked, and returns this
-/// validation error for `PATCH .../pulls/{n}` calls that touch `base` — even
-/// when the requested value matches the PR's current base.
-fn is_native_stack_base_locked_error(err: &anyhow::Error) -> bool {
-    err.chain()
-        .any(|cause| cause.to_string().to_lowercase().contains("part of a stack"))
 }
 
 fn command_output_details(command: &str, output: &std::process::Output) -> String {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -2184,6 +2184,22 @@ fn maybe_link_native_stack(
             gh_stack::set_feature_enabled(workdir, false)?;
             Ok(false)
         }
+        // Not a durable repo-level fact (unlike `FeatureDisabled`) — the
+        // active `gh` account may change on a later run — so this must
+        // never be cached.
+        LinkOutcome::AuthTokenUnsupported { .. } => {
+            if !quiet {
+                println!(
+                    "  {} {}",
+                    "note:".dimmed(),
+                    "native GitHub Stack link skipped: no OAuth-authenticated `gh` account found \
+                     (Personal Access Tokens are not supported during private preview). Run `gh \
+                     auth login` to add one."
+                        .dimmed()
+                );
+            }
+            Ok(false)
+        }
         LinkOutcome::SinglePrValidationRejected { .. } => Ok(false),
         LinkOutcome::Failed { message } => {
             if !quiet {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -2248,11 +2248,17 @@ fn maybe_link_native_stack(
         LinkOutcome::SinglePrValidationRejected { .. } => Ok(false),
         LinkOutcome::Failed { message } => {
             if !quiet {
-                println!(
-                    "  {} {}",
-                    "note:".dimmed(),
-                    format!("native GitHub Stack link skipped: {message}").dimmed()
-                );
+                let note = if gh_stack::is_stack_fork_conflict(&message) {
+                    "native GitHub Stack link skipped: this stack has forked — another branch \
+                     sharing the same ancestor PRs is already registered as a native Stack, and \
+                     GitHub's native Stack feature only supports one linear chain at a time. \
+                     stax's own PR body/comment stack links still keep this branch's PRs \
+                     connected."
+                        .to_string()
+                } else {
+                    format!("native GitHub Stack link skipped: {message}")
+                };
+                println!("  {} {}", "note:".dimmed(), note.dimmed());
             }
             Ok(false)
         }

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,8 +1,11 @@
 use crate::commands::open::open_url_in_browser;
-use crate::config::{Config, SingleStackMode, StackLinksMode};
+use crate::config::{
+    Config, NativeStackMode, SingleStackMode, StackLinksMode, StackLinksWhenNative,
+};
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
+use crate::github::gh_stack::{self, ExtensionStatus, FeatureState, LinkOutcome};
 use crate::github::pr::{
     PrInfoWithHead, StackPrInfo, generate_stack_links_markdown, remove_stack_links_from_body,
     upsert_stack_links_in_body,
@@ -11,7 +14,7 @@ use crate::github::pr_template::{discover_pr_templates, select_template_interact
 use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
-use crate::remote::{self, RemoteInfo};
+use crate::remote::{self, ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{Editor, Input, Select, theme::ColorfulTheme};
@@ -67,6 +70,7 @@ pub struct SubmitOptions {
     pub title: bool,
     pub body: bool,
     pub rerequest_review: bool,
+    pub native_stack_override: Option<NativeStackMode>,
     pub squash: bool,
     pub update_title: bool,
 }
@@ -359,6 +363,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         title: ai_title,
         body: body_scope,
         rerequest_review,
+        native_stack_override,
         squash,
         update_title,
     } = options;
@@ -378,6 +383,8 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let config = Config::load()?;
     let stack_links_mode = config.submit.stack_links;
     let single_stack_mode = config.submit.single_stack;
+    let stack_links_when_native = config.submit.stack_links_when_native;
+    let native_stack_mode = native_stack_override.unwrap_or(config.submit.native_stack);
 
     // Track if --draft was explicitly passed (we'll ask interactively if not)
     let draft_flag_set = draft;
@@ -1752,13 +1759,25 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             &imported_stack_branches,
         );
 
+        let native_stack_linked = maybe_link_native_stack(
+            repo.workdir()?,
+            &remote_info,
+            &stack.trunk,
+            native_stack_mode,
+            &stack_link_contexts,
+            quiet,
+        )?;
+
         let stack_links_started_at = Instant::now();
-        let effective_stack_links_mode =
-            if single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1 {
-                StackLinksMode::Off
-            } else {
-                stack_links_mode
-            };
+        let native_forces_links_off =
+            native_stack_linked && stack_links_when_native == StackLinksWhenNative::Off;
+        let single_stack_skips_links =
+            single_stack_mode == SingleStackMode::Off && stack_link_contexts.len() <= 1;
+        let effective_stack_links_mode = if native_forces_links_off || single_stack_skips_links {
+            StackLinksMode::Off
+        } else {
+            stack_links_mode
+        };
         for (pr_number, _branch, stack_link_pr_infos) in &stack_link_contexts {
             let sync_timer =
                 LiveTimer::maybe_new(!quiet, &format!("Syncing stack links on #{}...", pr_number));
@@ -2116,6 +2135,67 @@ fn stack_link_contexts_for_sync(
             Some((pr_number, info.branch, context))
         })
         .collect()
+}
+
+fn maybe_link_native_stack(
+    workdir: &Path,
+    remote_info: &RemoteInfo,
+    trunk: &str,
+    mode: NativeStackMode,
+    stack_link_contexts: &[(u64, String, Vec<StackPrInfo>)],
+    quiet: bool,
+) -> Result<bool> {
+    if mode == NativeStackMode::Off || remote_info.forge != ForgeType::GitHub {
+        return Ok(false);
+    }
+
+    let pr_numbers = stack_link_contexts
+        .iter()
+        .map(|(pr_number, _, _)| *pr_number)
+        .collect::<Vec<_>>();
+    // `gh stack link` requires at least two PRs; a single-PR stack cannot form a
+    // native stack. Skip quietly — once a second PR joins the stack, the next
+    // submit registers both.
+    if pr_numbers.len() < 2 {
+        return Ok(false);
+    }
+
+    // Cheap cached check before spawning any `gh` subprocess: if this repo has
+    // already been marked feature-disabled, `auto` mode stays quiet without
+    // probing the extension on every submit.
+    if mode == NativeStackMode::Auto && gh_stack::feature_enabled(workdir) == FeatureState::Disabled
+    {
+        return Ok(false);
+    }
+
+    if gh_stack::extension_status() != ExtensionStatus::Installed {
+        return Ok(false);
+    }
+
+    match gh_stack::link_stack(&pr_numbers, trunk, &remote_info.name) {
+        LinkOutcome::Linked => {
+            gh_stack::set_feature_enabled(workdir, true)?;
+            if !quiet {
+                println!("{} {}", "✓".green(), "Native GitHub Stack linked".dimmed());
+            }
+            Ok(true)
+        }
+        LinkOutcome::FeatureDisabled { .. } => {
+            gh_stack::set_feature_enabled(workdir, false)?;
+            Ok(false)
+        }
+        LinkOutcome::SinglePrValidationRejected { .. } => Ok(false),
+        LinkOutcome::Failed { message } => {
+            if !quiet {
+                println!(
+                    "  {} {}",
+                    "note:".dimmed(),
+                    format!("native GitHub Stack link skipped: {message}").dimmed()
+                );
+            }
+            Ok(false)
+        }
+    }
 }
 
 fn rejected_push_branches(porcelain: &str, specs: &[PushSpec]) -> Vec<String> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,6 +110,13 @@ pub struct SubmitConfig {
     /// Where stax-managed stack links should be synced on submit.
     #[serde(default)]
     pub stack_links: StackLinksMode,
+    /// Whether to register a native GitHub Stack via `gh stack` after submit.
+    #[serde(default)]
+    pub native_stack: NativeStackMode,
+    /// Whether stax-managed stack links should still sync when native stack
+    /// registration succeeds.
+    #[serde(default)]
+    pub stack_links_when_native: StackLinksWhenNative,
     /// Whether to sync stack links when the stack has only one PR.
     /// `On` (default) always syncs per `stack_links`. `Off` skips link sync
     /// (and cleans up stale links) while the stack has <= 1 PRs; once a 2nd
@@ -138,6 +145,23 @@ pub enum StackLinksMode {
     Comment,
     Body,
     Both,
+    Off,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NativeStackMode {
+    Off,
+    Link,
+    #[default]
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum StackLinksWhenNative {
+    #[default]
+    Keep,
     Off,
 }
 

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -371,12 +371,19 @@ fn auth_token_unsupported_output(output: &Output) -> bool {
 /// linear — a PR can only anchor one native-stack "tip" at a time — so this
 /// fires whenever a *local* stack forks (two branches created off the same
 /// ancestor branch each try to register their own native Stack). gh-stack
-/// reports this as e.g. `"Cannot update stack: this would remove #123 from
-/// the stack"`, which stax surfaces as a plain-language note instead of the
-/// raw multi-line CLI dump.
+/// surfaces this in a couple of different shapes depending on whether it
+/// detects the conflict up front or only after attempting a reorder:
+///   - `"Cannot update stack: this would remove #123 from the stack"`
+///   - `"Failed to update stack (HTTP 409): Stack contents have changed"`
+///     (seen alongside a `422 PullRequest.base is invalid` on the branch
+///     gh-stack tried to reparent to fit its assumed linear order)
+///
+/// Both are surfaced as the same plain-language note instead of the raw
+/// multi-line CLI dump.
 pub(crate) fn is_stack_fork_conflict(message: &str) -> bool {
     let lower = message.to_lowercase();
-    lower.contains("would remove") && lower.contains("from the stack")
+    (lower.contains("would remove") && lower.contains("from the stack"))
+        || lower.contains("stack contents have changed")
 }
 
 fn single_pr_validation_output(pr_numbers: &[u64], output: &Output) -> bool {

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -4,6 +4,17 @@ use std::process::{Command, Output};
 
 const FEATURE_ENABLED_KEY: &str = "stax.nativeStack.enabled";
 
+/// Below this version, `gh-stack` reports Personal Access Token rejections
+/// with the same ambiguous "Stacked PRs are not enabled" message it uses for
+/// a genuinely feature-disabled repo (fixed in v0.0.6's "PAT auth warning"
+/// change, which introduced the distinct "Personal access tokens are not
+/// supported" message `auth_token_unsupported_output` matches on). Below
+/// this version, an auth-token issue can still be misclassified as
+/// `FeatureDisabled` and incorrectly cached. This is purely a `doctor`
+/// diagnostic — `gh stack link` itself still works on any version that
+/// passes `link_command_supported` (added after v0.0.1).
+const RECOMMENDED_GH_STACK_VERSION: (u32, u32, u32) = (0, 0, 6);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExtensionStatus {
     NoGh,
@@ -12,6 +23,20 @@ pub enum ExtensionStatus {
     /// (added after v0.0.1), so stax cannot register native stacks with it.
     Outdated,
     Installed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionStatus {
+    /// Version string on the `gh extension list` line couldn't be parsed
+    /// (unreleased/dev build, unexpected format, etc.) — not treated as an
+    /// error since `link_command_supported` already gates real capability.
+    Unknown,
+    BelowRecommended {
+        installed: String,
+    },
+    MeetsRecommended {
+        installed: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,9 +49,24 @@ pub enum FeatureState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LinkOutcome {
     Linked,
-    FeatureDisabled { message: String },
-    SinglePrValidationRejected { message: String },
-    Failed { message: String },
+    FeatureDisabled {
+        message: String,
+    },
+    /// GitHub's native Stacked PRs API is in private preview and rejects
+    /// Personal Access Tokens outright — only OAuth app tokens (the ones
+    /// stored via `gh auth login`) are accepted. This is distinct from
+    /// `FeatureDisabled` (the repo/org not having the feature at all) and
+    /// must never be cached as such, since it depends on which `gh` account
+    /// is active rather than any durable repo-level fact.
+    AuthTokenUnsupported {
+        message: String,
+    },
+    SinglePrValidationRejected {
+        message: String,
+    },
+    Failed {
+        message: String,
+    },
 }
 
 pub fn extension_status() -> ExtensionStatus {
@@ -80,6 +120,60 @@ fn link_command_supported(env: &[(&str, &str)]) -> bool {
         }
         Err(_) => false,
     }
+}
+
+pub fn version_status() -> VersionStatus {
+    version_status_with_env(&[])
+}
+
+pub fn version_status_with_path(path: &str) -> VersionStatus {
+    version_status_with_env(&[("PATH", path)])
+}
+
+/// Checks the installed `github/gh-stack` version against
+/// `RECOMMENDED_GH_STACK_VERSION`. Informational only — never blocks `gh
+/// stack link` from being attempted; surfaced by `stax doctor` so users on
+/// an old version know to upgrade for reliable auth-error diagnostics.
+pub fn version_status_with_env(env: &[(&str, &str)]) -> VersionStatus {
+    let Some(installed) = installed_gh_stack_version(env) else {
+        return VersionStatus::Unknown;
+    };
+
+    if parse_semver(&installed).is_some_and(|v| v >= RECOMMENDED_GH_STACK_VERSION) {
+        VersionStatus::MeetsRecommended { installed }
+    } else {
+        VersionStatus::BelowRecommended { installed }
+    }
+}
+
+/// Extracts the raw version string (e.g. `"0.0.7"`) from the `gh extension
+/// list` line for `github/gh-stack`, if present and parseable.
+fn installed_gh_stack_version(env: &[(&str, &str)]) -> Option<String> {
+    let output = gh_command(env).args(["extension", "list"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .find(|line| line.contains("github/gh-stack"))
+        .and_then(|line| {
+            line.split_whitespace()
+                .find_map(|token| {
+                    token
+                        .strip_prefix('v')
+                        .filter(|v| parse_semver(v).is_some())
+                })
+                .map(str::to_string)
+        })
+}
+
+fn parse_semver(version: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
 }
 
 pub fn feature_enabled(repo_path: impl AsRef<Path>) -> FeatureState {
@@ -148,6 +242,12 @@ pub fn link_stack_with_env(
 
     match command.output() {
         Ok(output) if output.status.success() => LinkOutcome::Linked,
+        // Must be checked before `feature_disabled_output`: gh-stack's PAT
+        // rejection message also contains "private preview", which would
+        // otherwise be misclassified as the repo/org lacking the feature.
+        Ok(output) if auth_token_unsupported_output(&output) => LinkOutcome::AuthTokenUnsupported {
+            message: command_message(&output),
+        },
         Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
             message: command_message(&output),
         },
@@ -179,6 +279,9 @@ pub fn unlink_stack() -> LinkOutcome {
 pub fn unlink_stack_with_env(env: &[(&str, &str)]) -> LinkOutcome {
     match gh_command(env).args(["stack", "unstack"]).output() {
         Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if auth_token_unsupported_output(&output) => LinkOutcome::AuthTokenUnsupported {
+            message: command_message(&output),
+        },
         Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
             message: command_message(&output),
         },
@@ -230,8 +333,18 @@ pub fn upgrade_extension_with_env(env: &[(&str, &str)]) -> Result<()> {
     Ok(())
 }
 
+/// `gh` env vars that override the CLI's stored (OAuth) credentials.
+/// GitHub's native Stacked PRs API is in private preview and rejects
+/// Personal Access Tokens, so stax strips these before shelling out to
+/// `gh stack`, letting `gh` fall back to a keyring-stored OAuth account
+/// even when a PAT is exported for other tooling (CI scripts, other CLIs).
+const AUTH_OVERRIDE_ENV_VARS: &[&str] = &["GH_TOKEN", "GITHUB_TOKEN"];
+
 fn gh_command(env: &[(&str, &str)]) -> Command {
     let mut command = Command::new("gh");
+    for var in AUTH_OVERRIDE_ENV_VARS {
+        command.env_remove(var);
+    }
     for (key, value) in env {
         command.env(key, value);
     }
@@ -244,6 +357,12 @@ fn feature_disabled_output(output: &Output) -> bool {
         || message.contains("not enabled")
         || message.contains("not been enabled")
         || message.contains("feature has been enabled")
+}
+
+fn auth_token_unsupported_output(output: &Output) -> bool {
+    command_message(output)
+        .to_lowercase()
+        .contains("personal access token")
 }
 
 fn single_pr_validation_output(pr_numbers: &[u64], output: &Output) -> bool {

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -365,6 +365,20 @@ fn auth_token_unsupported_output(output: &Output) -> bool {
         .contains("personal access token")
 }
 
+/// True when `gh stack link` rejected the request because the requested PR
+/// chain shares ancestor PRs with another branch that's already registered
+/// as a native GitHub Stack. GitHub's native Stack feature is inherently
+/// linear — a PR can only anchor one native-stack "tip" at a time — so this
+/// fires whenever a *local* stack forks (two branches created off the same
+/// ancestor branch each try to register their own native Stack). gh-stack
+/// reports this as e.g. `"Cannot update stack: this would remove #123 from
+/// the stack"`, which stax surfaces as a plain-language note instead of the
+/// raw multi-line CLI dump.
+pub(crate) fn is_stack_fork_conflict(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("would remove") && lower.contains("from the stack")
+}
+
 fn single_pr_validation_output(pr_numbers: &[u64], output: &Output) -> bool {
     if pr_numbers.len() != 1 {
         return false;

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -1,0 +1,280 @@
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::{Command, Output};
+
+const FEATURE_ENABLED_KEY: &str = "stax.nativeStack.enabled";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionStatus {
+    NoGh,
+    NoExtension,
+    /// `github/gh-stack` is installed but predates the `gh stack link` command
+    /// (added after v0.0.1), so stax cannot register native stacks with it.
+    Outdated,
+    Installed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureState {
+    Unknown,
+    Disabled,
+    Enabled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkOutcome {
+    Linked,
+    FeatureDisabled { message: String },
+    SinglePrValidationRejected { message: String },
+    Failed { message: String },
+}
+
+pub fn extension_status() -> ExtensionStatus {
+    extension_status_with_env(&[])
+}
+
+pub fn extension_status_with_path(path: &str) -> ExtensionStatus {
+    extension_status_with_env(&[("PATH", path)])
+}
+
+fn extension_status_with_env(env: &[(&str, &str)]) -> ExtensionStatus {
+    let version = gh_command(env).arg("--version").output();
+    match version {
+        Ok(output) if output.status.success() => {}
+        Ok(_) => return ExtensionStatus::NoGh,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return ExtensionStatus::NoGh,
+        Err(_) => return ExtensionStatus::NoGh,
+    }
+
+    let extensions = gh_command(env).args(["extension", "list"]).output();
+    match extensions {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.lines().any(|line| line.contains("github/gh-stack")) {
+                if link_command_supported(env) {
+                    ExtensionStatus::Installed
+                } else {
+                    ExtensionStatus::Outdated
+                }
+            } else {
+                ExtensionStatus::NoExtension
+            }
+        }
+        _ => ExtensionStatus::NoExtension,
+    }
+}
+
+/// Probe whether the installed `gh-stack` exposes the `link` subcommand that
+/// stax relies on. Parses `gh stack --help` output rather than exit codes so it
+/// stays robust across the extension's cobra help behavior.
+fn link_command_supported(env: &[(&str, &str)]) -> bool {
+    match gh_command(env).args(["stack", "--help"]).output() {
+        Ok(output) => {
+            let text = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            text.lines()
+                .any(|line| line.trim_start().starts_with("link"))
+        }
+        Err(_) => false,
+    }
+}
+
+pub fn feature_enabled(repo_path: impl AsRef<Path>) -> FeatureState {
+    let output = Command::new("git")
+        .args(["config", "--get", FEATURE_ENABLED_KEY])
+        .current_dir(repo_path.as_ref())
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => match String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .to_lowercase()
+            .as_str()
+        {
+            "true" => FeatureState::Enabled,
+            "false" => FeatureState::Disabled,
+            _ => FeatureState::Unknown,
+        },
+        _ => FeatureState::Unknown,
+    }
+}
+
+pub fn set_feature_enabled(repo_path: impl AsRef<Path>, enabled: bool) -> Result<()> {
+    let value = if enabled { "true" } else { "false" };
+    let output = Command::new("git")
+        .args(["config", FEATURE_ENABLED_KEY, value])
+        .current_dir(repo_path.as_ref())
+        .output()
+        .context("Failed to run git config for native stack feature cache")?;
+
+    if !output.status.success() {
+        bail!(
+            "failed to set native stack feature cache: {}",
+            output_details(&output)
+        );
+    }
+
+    Ok(())
+}
+
+pub fn link_stack(pr_numbers: &[u64], base: &str, remote: &str) -> LinkOutcome {
+    link_stack_with_env(pr_numbers, base, remote, &[])
+}
+
+pub fn link_stack_with_path(
+    pr_numbers: &[u64],
+    base: &str,
+    remote: &str,
+    path: &str,
+) -> LinkOutcome {
+    link_stack_with_env(pr_numbers, base, remote, &[("PATH", path)])
+}
+
+pub fn link_stack_with_env(
+    pr_numbers: &[u64],
+    base: &str,
+    remote: &str,
+    env: &[(&str, &str)],
+) -> LinkOutcome {
+    let mut command = gh_command(env);
+    command.args(["stack", "link"]);
+    for number in pr_numbers {
+        command.arg(number.to_string());
+    }
+    command.args(["--base", base, "--remote", remote]);
+
+    match command.output() {
+        Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
+            message: command_message(&output),
+        },
+        Ok(output) if single_pr_validation_output(pr_numbers, &output) => {
+            LinkOutcome::SinglePrValidationRejected {
+                message: command_message(&output),
+            }
+        }
+        Ok(output) => LinkOutcome::Failed {
+            message: command_message(&output),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => LinkOutcome::Failed {
+            message: "`gh` executable not found".to_string(),
+        },
+        Err(err) => LinkOutcome::Failed {
+            message: err.to_string(),
+        },
+    }
+}
+
+pub fn install_extension() -> Result<()> {
+    install_extension_with_env(&[])
+}
+
+pub fn unlink_stack() -> LinkOutcome {
+    unlink_stack_with_env(&[])
+}
+
+pub fn unlink_stack_with_env(env: &[(&str, &str)]) -> LinkOutcome {
+    match gh_command(env).args(["stack", "unstack"]).output() {
+        Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if feature_disabled_output(&output) => LinkOutcome::FeatureDisabled {
+            message: command_message(&output),
+        },
+        Ok(output) => LinkOutcome::Failed {
+            message: command_message(&output),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => LinkOutcome::Failed {
+            message: "`gh` executable not found".to_string(),
+        },
+        Err(err) => LinkOutcome::Failed {
+            message: err.to_string(),
+        },
+    }
+}
+
+pub fn install_extension_with_env(env: &[(&str, &str)]) -> Result<()> {
+    let output = gh_command(env)
+        .args(["extension", "install", "github/gh-stack"])
+        .output()
+        .context("Failed to execute `gh extension install github/gh-stack`")?;
+
+    if !output.status.success() {
+        bail!(
+            "`gh extension install github/gh-stack` failed: {}",
+            output_details(&output)
+        );
+    }
+
+    Ok(())
+}
+
+pub fn upgrade_extension() -> Result<()> {
+    upgrade_extension_with_env(&[])
+}
+
+pub fn upgrade_extension_with_env(env: &[(&str, &str)]) -> Result<()> {
+    let output = gh_command(env)
+        .args(["extension", "upgrade", "gh-stack"])
+        .output()
+        .context("Failed to execute `gh extension upgrade gh-stack`")?;
+
+    if !output.status.success() {
+        bail!(
+            "`gh extension upgrade gh-stack` failed: {}",
+            output_details(&output)
+        );
+    }
+
+    Ok(())
+}
+
+fn gh_command(env: &[(&str, &str)]) -> Command {
+    let mut command = Command::new("gh");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command
+}
+
+fn feature_disabled_output(output: &Output) -> bool {
+    let message = command_message(output).to_lowercase();
+    message.contains("private preview")
+        || message.contains("not enabled")
+        || message.contains("not been enabled")
+        || message.contains("feature has been enabled")
+}
+
+fn single_pr_validation_output(pr_numbers: &[u64], output: &Output) -> bool {
+    if pr_numbers.len() != 1 {
+        return false;
+    }
+
+    let message = command_message(output).to_lowercase();
+    (message.contains("require") || message.contains("requires") || message.contains("need"))
+        && (message.contains("at least two")
+            || message.contains("at least 2")
+            || message.contains("multiple pr")
+            || message.contains("more than one")
+            || message.contains("minimum of two"))
+}
+
+fn command_message(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn output_details(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => format!("exit status {}", output.status),
+        (false, true) => stdout,
+        (true, false) => stderr,
+        (false, false) => format!("{stdout}\n{stderr}"),
+    }
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod gh_stack;
 pub mod pr;
 pub mod pr_template;
 

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -13,6 +13,28 @@ const STACK_COMMENT_MARKER: &str = "<!-- stax-stack-comment -->";
 const STACK_LINKS_BODY_START_MARKER: &str = "<!-- stax-stack-links:start -->";
 const STACK_LINKS_BODY_END_MARKER: &str = "<!-- stax-stack-links:end -->";
 
+/// True when a PR base-update failure is GitHub rejecting the change because
+/// the PR is registered in a native GitHub Stack (private preview). GitHub
+/// owns base-branch management for stacked PRs once linked, and returns this
+/// validation error for `PATCH .../pulls/{n}` calls that touch `base` — even
+/// when the requested value matches the PR's current base, or when the
+/// caller is trying to perform a legitimate retarget (e.g. a merge cascade
+/// moving the next PR onto trunk).
+///
+/// Matches on GitHub's exact wording ("...pull request is part of a
+/// stack.") rather than the shorter "part of a stack" fragment, so a
+/// hypothetical negated message like "...is not part of a stack" can never
+/// be misclassified as a lock (the two phrases aren't substrings of one
+/// another, since "not " breaks the contiguous match).
+pub(crate) fn is_native_stack_base_locked_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .to_string()
+            .to_lowercase()
+            .contains("pull request is part of a stack")
+    })
+}
+
 /// A comment on a PR issue thread (conversation comment)
 #[derive(Debug, Clone)]
 pub struct IssueComment {
@@ -1591,6 +1613,43 @@ mod tests {
     use octocrab::Octocrab;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn is_native_stack_base_locked_error_matches_githubs_exact_wording() {
+        let err = anyhow::anyhow!(
+            "Cannot change the base branch because the pull request is part of a stack."
+        )
+        .context("Failed to update PR base");
+
+        assert!(is_native_stack_base_locked_error(&err));
+    }
+
+    #[test]
+    fn is_native_stack_base_locked_error_ignores_unrelated_validation_errors() {
+        let err = anyhow::anyhow!(
+            "A pull request already exists for base branch 'main' and head branch 'feature'"
+        )
+        .context("Failed to update PR base");
+
+        assert!(!is_native_stack_base_locked_error(&err));
+    }
+
+    #[test]
+    fn is_native_stack_base_locked_error_ignores_generic_errors() {
+        let err = anyhow::anyhow!("connection reset by peer").context("Failed to update PR base");
+
+        assert!(!is_native_stack_base_locked_error(&err));
+    }
+
+    #[test]
+    fn is_native_stack_base_locked_error_does_not_misfire_on_negated_wording() {
+        // Guards against a hypothetical future GitHub message that negates
+        // stack membership — must not collide with the lock detector.
+        let err = anyhow::anyhow!("The pull request is not part of a stack, so this is a no-op")
+            .context("Failed to update PR base");
+
+        assert!(!is_native_stack_base_locked_error(&err));
+    }
 
     #[test]
     fn test_merge_method_from_str_squash() {

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -100,6 +100,8 @@ mod status_tests;
 mod submit_fetch_failure_tests;
 #[path = "submit_no_verify_tests.rs"]
 mod submit_no_verify_tests;
+#[path = "submit_pr_base_tests.rs"]
+mod submit_pr_base_tests;
 #[path = "sweep_tests.rs"]
 mod sweep_tests;
 #[path = "track_all_prs_tests.rs"]

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -64,6 +64,8 @@ mod fix_tests;
 mod fold_tests;
 #[path = "get_tests.rs"]
 mod get_tests;
+#[path = "gh_stack_tests.rs"]
+mod gh_stack_tests;
 #[path = "github_list_tests.rs"]
 mod github_list_tests;
 #[path = "integration_tests.rs"]

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -194,6 +194,183 @@ exit 1
 }
 
 #[test]
+fn version_status_flags_versions_below_recommended() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "extension list" ]; then
+  echo "gh-stack github/gh-stack v0.0.4"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let status = stax::github::gh_stack::version_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(
+        status,
+        stax::github::gh_stack::VersionStatus::BelowRecommended {
+            installed: "0.0.4".to_string()
+        }
+    );
+}
+
+#[test]
+fn version_status_accepts_recommended_or_newer_versions() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "extension list" ]; then
+  echo "gh-stack github/gh-stack v0.0.7"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let status = stax::github::gh_stack::version_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(
+        status,
+        stax::github::gh_stack::VersionStatus::MeetsRecommended {
+            installed: "0.0.7".to_string()
+        }
+    );
+}
+
+#[test]
+fn version_status_is_unknown_when_version_cannot_be_parsed() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "extension list" ]; then
+  echo "gh-stack github/gh-stack (unknown)"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let status = stax::github::gh_stack::version_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(status, stax::github::gh_stack::VersionStatus::Unknown);
+}
+
+#[test]
+fn doctor_recommends_upgrade_for_gh_stack_below_recommended_version() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.4"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+    let home = repo.clean_home();
+    let git_config = repo.path().join("test-global-gitconfig");
+    let git_config_str = git_config.to_string_lossy().into_owned();
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["doctor"],
+        &[
+            ("HOME", &home),
+            ("GIT_CONFIG_GLOBAL", &git_config_str),
+            ("PATH", &path),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("v0.0.4") && stdout.contains("gh extension upgrade gh-stack"),
+        "expected a version-upgrade recommendation, stdout was:\n{stdout}"
+    );
+}
+
+#[test]
+fn link_stack_classifies_pat_rejection_distinctly_from_feature_disabled() {
+    // gh-stack's PAT-rejection message also contains "private preview", so
+    // this must not be misclassified as the repo/org lacking the feature
+    // (which would get permanently cached as `FeatureDisabled`).
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "stack link" ]; then
+  echo "Personal access tokens are not supported by gh stack during private preview" >&2
+  echo "  Run gh auth login to authenticate with OAuth instead." >&2
+  exit 1
+fi
+exit 1
+"#,
+    );
+
+    let outcome = stax::github::gh_stack::link_stack_with_path(
+        &[10, 20],
+        "main",
+        "origin",
+        &path_with_fake_gh(fake.path()),
+    );
+
+    assert!(
+        matches!(
+            outcome,
+            stax::github::gh_stack::LinkOutcome::AuthTokenUnsupported { .. }
+        ),
+        "expected AuthTokenUnsupported, got {outcome:?}"
+    );
+}
+
+#[test]
+fn link_stack_strips_ambient_token_env_vars_before_calling_gh() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "stack link" ]; then
+  {
+    echo "GH_TOKEN=${GH_TOKEN:-unset}"
+    echo "GITHUB_TOKEN=${GITHUB_TOKEN:-unset}"
+  } > "$ENV_DUMP_FILE"
+  exit 0
+fi
+exit 1
+"#,
+    );
+    let env_dump_file = fake.path().join("env.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    // Simulate PAT env vars exported ambiently in the user's shell (e.g. for
+    // other tooling/CI scripts) that would otherwise shadow an existing
+    // OAuth-authenticated `gh` login. `Command` inherits these by default
+    // unless explicitly removed, so this reproduces the real-world bug.
+    unsafe {
+        std::env::set_var("GH_TOKEN", "ghp_should_be_stripped");
+        std::env::set_var("GITHUB_TOKEN", "ghp_should_also_be_stripped");
+    }
+
+    let outcome = stax::github::gh_stack::link_stack_with_env(
+        &[10, 20],
+        "main",
+        "origin",
+        &[
+            ("PATH", path.as_str()),
+            ("ENV_DUMP_FILE", env_dump_file.to_str().unwrap()),
+        ],
+    );
+
+    unsafe {
+        std::env::remove_var("GH_TOKEN");
+        std::env::remove_var("GITHUB_TOKEN");
+    }
+
+    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    let dump = fs::read_to_string(env_dump_file).expect("env dump written");
+    assert_eq!(dump, "GH_TOKEN=unset\nGITHUB_TOKEN=unset\n");
+}
+
+#[test]
 fn link_stack_passes_pr_numbers_bottom_to_top_with_base_and_remote() {
     let fake = fake_gh_dir(
         r#"#!/bin/sh
@@ -397,10 +574,7 @@ exit 1
     );
     let path = path_with_fake_gh(fake.path());
 
-    let output = repo.run_stax_with_env(
-        &["stack", "link"],
-        &[("HOME", &home), ("PATH", &path)],
-    );
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
 
     assert!(!output.status.success(), "single-PR link should fail");
     let stderr = TestRepo::stderr(&output);
@@ -438,10 +612,12 @@ exit 1
     );
     let path = path_with_fake_gh(fake.path());
 
-    let output =
-        repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
 
-    assert!(!output.status.success(), "link should fail when a branch lacks a PR");
+    assert!(
+        !output.status.success(),
+        "link should fail when a branch lacks a PR"
+    );
     let stderr = TestRepo::stderr(&output);
     assert!(
         stderr.contains(&branches[1]) && stderr.contains("stax submit"),
@@ -646,5 +822,63 @@ exit 1
     assert_eq!(
         args, "link\n",
         "second submit should not retry gh stack link"
+    );
+}
+
+#[tokio::test]
+async fn submit_auth_token_unsupported_does_not_cache_feature_disabled() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["pat-bottom", "pat-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link")
+    echo "Personal access tokens are not supported by gh stack during private preview" >&2
+    exit 1
+    ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no OAuth-authenticated") || stdout.contains("gh auth login"),
+        "expected an actionable auth note, stdout was:\n{stdout}"
+    );
+    // Unlike a genuine feature-disabled response, an auth-token rejection is
+    // not a durable repo-level fact — it must not be cached, so a later
+    // submit retries once the user's `gh` auth situation changes.
+    let cached = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
+    assert!(
+        !cached.status.success(),
+        "auth-token-unsupported outcome must not cache the native stack feature as disabled"
     );
 }

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -939,6 +939,112 @@ fn stack_link_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump
     );
 }
 
+/// The fake `gh stack link` response gh-stack gives when it doesn't detect a
+/// forked stack up front and instead attempts to reorder PRs to fit its
+/// assumed linear chain, which fails once it hits a branch it can't
+/// reparent — a real-world variant of the same forked-stack limitation as
+/// `FORK_CONFLICT_GH_STACK_SCRIPT` above, but with different wording.
+const FORK_CONFLICT_REORDER_GH_STACK_SCRIPT: &str = r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link")
+    {
+      echo "Looking up PRs for 2 branches..."
+      echo "Checking existing stacks..."
+      echo "failed to update base branch for PR #999 to fork-conflict-reorder-top: HTTP 422: Validation Failed"
+      echo "PullRequest.base is invalid"
+      echo "Failed to update stack (HTTP 409): Stack contents have changed"
+    } >&2
+    exit 1
+    ;;
+esac
+exit 1
+"#;
+
+#[tokio::test]
+async fn submit_explains_forked_native_stack_reorder_conflict_instead_of_raw_gh_stack_dump() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches =
+        repo.create_stack(&["fork-conflict-reorder-bottom", "fork-conflict-reorder-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(FORK_CONFLICT_REORDER_GH_STACK_SCRIPT);
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("this stack has forked"),
+        "expected a plain-language fork-conflict note, stdout was:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("PullRequest.base is invalid"),
+        "the raw multi-line gh-stack dump should not leak to the user, stdout was:\n{stdout}"
+    );
+
+    let feature_cache = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
+    assert!(
+        !feature_cache.status.success(),
+        "a forked-stack reorder conflict must not be cached as feature-disabled, but got: {}",
+        TestRepo::stdout(&feature_cache)
+    );
+}
+
+#[test]
+fn stack_link_explains_forked_native_stack_reorder_conflict_instead_of_raw_gh_stack_dump() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&[
+        "fork-conflict-reorder-link-a",
+        "fork-conflict-reorder-link-b",
+    ]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    let fake = fake_gh_dir(FORK_CONFLICT_REORDER_GH_STACK_SCRIPT);
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+
+    assert!(
+        !output.status.success(),
+        "linking a forked stack should fail"
+    );
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("shares ancestor PRs") && stderr.contains("stax stack unlink"),
+        "expected a plain-language fork-conflict explanation with unlink guidance, stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Stack contents have changed"),
+        "the underlying gh-stack detail should still be included for debugging, stderr was:\n{stderr}"
+    );
+}
+
 #[tokio::test]
 async fn submit_auto_registers_native_stack_and_keeps_stax_links() {
     let mock_server = MockServer::start().await;

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -1,0 +1,650 @@
+use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn fake_gh_dir(script: &str) -> TempDir {
+    let dir = TempDir::new().expect("temp fake gh dir");
+    let gh = dir.path().join("gh");
+    fs::write(&gh, script).expect("write fake gh");
+    let mut perms = fs::metadata(&gh).expect("fake gh metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&gh, perms).expect("chmod fake gh");
+    dir
+}
+
+fn path_with_fake_gh(fake_dir: &Path) -> String {
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{old_path}", fake_dir.display())
+}
+
+fn write_config(home: &str, api_base_url: &str) {
+    let config_dir = Path::new(home).join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("create stax config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            "[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"body\"\n"
+        ),
+    )
+    .expect("write config");
+}
+
+fn git_stdout(repo: &TestRepo, args: &[&str]) -> String {
+    let output = repo.git(args);
+    output.assert_success();
+    TestRepo::stdout(&output).trim().to_string()
+}
+
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, parent: &str, pr_number: u64) {
+    let parent_revision = git_stdout(repo, &["rev-parse", parent]);
+    let json = serde_json::json!({
+        "parentBranchName": parent,
+        "parentBranchRevision": parent_revision,
+        "prInfo": {
+            "number": pr_number,
+            "state": "OPEN",
+            "isDraft": false
+        }
+    })
+    .to_string();
+
+    let mut hash_child = Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn git hash-object");
+    hash_child
+        .stdin
+        .as_mut()
+        .expect("hash-object stdin")
+        .write_all(json.as_bytes())
+        .expect("write metadata json");
+    let hash_output = hash_child.wait_with_output().expect("wait hash-object");
+    assert!(
+        hash_output.status.success(),
+        "hash-object failed: {}",
+        String::from_utf8_lossy(&hash_output.stderr)
+    );
+    let hash = String::from_utf8_lossy(&hash_output.stdout)
+        .trim()
+        .to_string();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{branch}"),
+        &hash,
+    ])
+    .assert_success();
+}
+
+async fn mock_existing_pr(mock_server: &MockServer, number: u64, branch: &str, base: &str) {
+    let body = serde_json::json!({
+        "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{number}"),
+        "id": number,
+        "number": number,
+        "state": "open",
+        "title": format!("PR {number}"),
+        "body": "",
+        "draft": false,
+        "head": { "ref": branch, "sha": "aaaa", "label": format!("test-owner:{branch}") },
+        "base": { "ref": base, "sha": "bbbb" },
+        "html_url": format!("https://github.com/test-owner/test-repo/pull/{number}")
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/test-owner/test-repo/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/test-owner/test-repo/issues/{number}/comments"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("PATCH"))
+        .and(path(format!("/repos/test-owner/test-repo/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{number}"),
+            "id": number,
+            "number": number,
+            "state": "open",
+            "title": format!("PR {number}"),
+            "body": "<!-- stax-stack-links:start -->\nupdated\n<!-- stax-stack-links:end -->",
+            "draft": false,
+            "head": { "ref": branch, "sha": "aaaa", "label": format!("test-owner:{branch}") },
+            "base": { "ref": base, "sha": "bbbb" },
+            "html_url": format!("https://github.com/test-owner/test-repo/pull/{number}")
+        })))
+        .mount(mock_server)
+        .await;
+}
+
+#[test]
+fn detects_installed_gh_stack_extension_from_gh_extension_list() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let status =
+        stax::github::gh_stack::extension_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(status, stax::github::gh_stack::ExtensionStatus::Installed);
+}
+
+#[test]
+fn detects_outdated_gh_stack_extension_without_link_command() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.1"; exit 0 ;;
+  "stack --help") printf 'Available Commands:\n  add   Add a new branch\n  view  View the current stack\n'; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let status =
+        stax::github::gh_stack::extension_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(status, stax::github::gh_stack::ExtensionStatus::Outdated);
+}
+
+#[test]
+fn link_stack_classifies_private_preview_feature_disabled_failures() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1 $2" = "stack link" ]; then
+  echo "Stacked PRs is currently in private preview and has not been enabled for this repository" >&2
+  exit 4
+fi
+exit 1
+"#,
+    );
+
+    let outcome = stax::github::gh_stack::link_stack_with_path(
+        &[10, 20, 30],
+        "main",
+        "origin",
+        &path_with_fake_gh(fake.path()),
+    );
+
+    assert!(matches!(
+        outcome,
+        stax::github::gh_stack::LinkOutcome::FeatureDisabled { .. }
+    ));
+}
+
+#[test]
+fn link_stack_passes_pr_numbers_bottom_to_top_with_base_and_remote() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+printf '%s\n' "$@" > "$GH_ARGS_FILE"
+exit 0
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let outcome = stax::github::gh_stack::link_stack_with_env(
+        &[10, 20, 30],
+        "main",
+        "upstream",
+        &[
+            ("PATH", path.as_str()),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    let args = fs::read_to_string(args_file).expect("args written");
+    assert_eq!(
+        args,
+        "stack\nlink\n10\n20\n30\n--base\nmain\n--remote\nupstream\n"
+    );
+}
+
+#[test]
+fn caches_native_stack_feature_state_in_repo_git_config() {
+    let repo = TestRepo::new();
+
+    assert_eq!(
+        stax::github::gh_stack::feature_enabled(repo.path()),
+        stax::github::gh_stack::FeatureState::Unknown
+    );
+
+    stax::github::gh_stack::set_feature_enabled(repo.path(), false).expect("set feature disabled");
+    assert_eq!(
+        stax::github::gh_stack::feature_enabled(repo.path()),
+        stax::github::gh_stack::FeatureState::Disabled
+    );
+
+    stax::github::gh_stack::set_feature_enabled(repo.path(), true).expect("set feature enabled");
+    assert_eq!(
+        stax::github::gh_stack::feature_enabled(repo.path()),
+        stax::github::gh_stack::FeatureState::Enabled
+    );
+}
+
+#[test]
+fn doctor_fix_installs_missing_gh_stack_extension() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.71.0"
+  exit 0
+fi
+if [ "$1 $2" = "extension list" ]; then
+  exit 0
+fi
+if [ "$1 $2 $3" = "extension install github/gh-stack" ]; then
+  echo "installed" >> "$GH_INSTALL_FILE"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let install_file = fake.path().join("installed.txt");
+    let home = repo.clean_home();
+    let git_config = repo.path().join("test-global-gitconfig");
+    let git_config_str = git_config.to_string_lossy().into_owned();
+    let path = path_with_fake_gh(fake.path());
+    let output = crate::common::run_stax_in_script_with_env(
+        &repo.path(),
+        &["doctor", "--fix"],
+        "printf 'y\n'",
+        &[
+            ("HOME", &home),
+            ("GIT_CONFIG_GLOBAL", &git_config_str),
+            ("PATH", &path),
+            ("GH_INSTALL_FILE", install_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Install GitHub gh-stack extension"),
+        "stdout was:\n{stdout}"
+    );
+    assert!(
+        install_file.exists(),
+        "doctor --fix should invoke gh extension install"
+    );
+}
+
+#[test]
+fn doctor_fix_upgrades_outdated_gh_stack_extension() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.71.0"
+  exit 0
+fi
+if [ "$1 $2" = "extension list" ]; then
+  echo "gh-stack github/gh-stack v0.0.1"
+  exit 0
+fi
+if [ "$1 $2" = "stack --help" ]; then
+  printf 'Available Commands:\n  view  View the current stack\n'
+  exit 0
+fi
+if [ "$1 $2 $3" = "extension upgrade gh-stack" ]; then
+  echo "upgraded" >> "$GH_UPGRADE_FILE"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let upgrade_file = fake.path().join("upgraded.txt");
+    let home = repo.clean_home();
+    let git_config = repo.path().join("test-global-gitconfig");
+    let git_config_str = git_config.to_string_lossy().into_owned();
+    let path = path_with_fake_gh(fake.path());
+    let output = crate::common::run_stax_in_script_with_env(
+        &repo.path(),
+        &["doctor", "--fix"],
+        "printf 'y\n'",
+        &[
+            ("HOME", &home),
+            ("GIT_CONFIG_GLOBAL", &git_config_str),
+            ("PATH", &path),
+            ("GH_UPGRADE_FILE", upgrade_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("outdated") && stdout.contains("gh extension upgrade gh-stack"),
+        "doctor should report the outdated extension, stdout was:\n{stdout}"
+    );
+    assert!(
+        upgrade_file.exists(),
+        "doctor --fix should invoke gh extension upgrade"
+    );
+}
+
+#[test]
+fn submit_help_exposes_native_stack_overrides() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["submit", "--help"]);
+
+    output
+        .assert_success()
+        .assert_stdout_contains("--native-stack")
+        .assert_stdout_contains("--no-native-stack");
+}
+
+#[test]
+fn stack_help_exposes_native_link_commands() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["stack", "--help"]);
+
+    output
+        .assert_success()
+        .assert_stdout_contains("link")
+        .assert_stdout_contains("unlink");
+}
+
+#[test]
+fn stack_link_rejects_single_pr_stack_with_clear_message() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["only-branch"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link") echo "requires at least 2 arg(s), only received 1" >&2; exit 1 ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["stack", "link"],
+        &[("HOME", &home), ("PATH", &path)],
+    );
+
+    assert!(!output.status.success(), "single-PR link should fail");
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("at least 2 PRs"),
+        "expected a clear multi-PR requirement message, stderr was:\n{stderr}"
+    );
+    // The friendly guard must fire before shelling out to `gh stack link`.
+    assert!(
+        !stderr.contains("arg(s)"),
+        "raw gh-stack arity error should not leak, stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn stack_link_tells_user_to_submit_when_a_branch_has_no_pr() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["linked-bottom", "unsubmitted-top"]);
+    // Only the bottom branch has a PR; the current (top) branch does not.
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link") echo "should not be called" >&2; exit 1 ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output =
+        repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+
+    assert!(!output.status.success(), "link should fail when a branch lacks a PR");
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains(&branches[1]) && stderr.contains("stax submit"),
+        "expected an actionable submit-first message naming the branch, stderr was:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("should not be called"),
+        "must not shell out to `gh stack link` when PRs are missing, stderr was:\n{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn submit_auto_registers_native_stack_and_keeps_stax_links() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["native-bottom", "native-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link")
+    printf '%s\n' "$@" >> "$GH_ARGS_FILE"
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    let args = fs::read_to_string(&args_file).expect("gh stack link args written");
+    assert_eq!(
+        args,
+        "stack\nlink\n10\n20\n--base\nmain\n--remote\norigin\n"
+    );
+    assert_eq!(
+        git_stdout(&repo, &["config", "--get", "stax.nativeStack.enabled"]),
+        "true"
+    );
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|request| {
+            request.method.as_str() == "PATCH"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls/10"
+        }),
+        "stax body stack links for #10 should still be synced"
+    );
+    assert!(
+        requests.iter().any(|request| {
+            request.method.as_str() == "PATCH"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls/20"
+        }),
+        "stax body stack links for #20 should still be synced"
+    );
+}
+
+#[tokio::test]
+async fn submit_does_not_native_link_single_pr_stack() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["native-single"]);
+    repo.git(&["push", "-u", "origin", &branches[0]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link")
+    printf '%s\n' "$@" >> "$GH_ARGS_FILE"
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    // `gh stack link` requires >=2 PRs, so a single-PR stack must never attempt it.
+    assert!(
+        !args_file.exists(),
+        "single-PR submit should not invoke `gh stack link`"
+    );
+    let cached = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
+    assert!(
+        !cached.status.success(),
+        "single-PR submit should not touch the native stack feature cache"
+    );
+}
+
+#[tokio::test]
+async fn submit_feature_disabled_caches_false_and_does_not_retry() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["disabled-bottom", "disabled-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link")
+    echo link >> "$GH_ARGS_FILE"
+    echo "Stacked PRs is currently in private preview and has not been enabled for this repository" >&2
+    exit 4
+    ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+    let env = [
+        ("HOME", home.as_str()),
+        ("STAX_GITHUB_TOKEN", "test-token"),
+        ("PATH", path.as_str()),
+        ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+    ];
+
+    let first = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt", "--quiet"],
+        &env,
+    );
+    first.assert_success();
+    assert!(
+        TestRepo::stderr(&first).trim().is_empty(),
+        "feature-disabled native stack should be silent, stderr was:\n{}",
+        TestRepo::stderr(&first)
+    );
+    assert_eq!(
+        git_stdout(&repo, &["config", "--get", "stax.nativeStack.enabled"]),
+        "false"
+    );
+
+    let second = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt", "--quiet"],
+        &env,
+    );
+    second.assert_success();
+
+    let args = fs::read_to_string(&args_file).expect("first gh stack link attempt recorded");
+    assert_eq!(
+        args, "link\n",
+        "second submit should not retry gh stack link"
+    );
+}

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -150,6 +150,58 @@ exit 1
 }
 
 #[test]
+fn extension_status_reports_no_gh_when_gh_binary_is_missing() {
+    // An empty PATH (no `gh` anywhere) must be classified as `NoGh`, not
+    // silently treated as `NoExtension` or crash/hang the caller.
+    let empty_dir = TempDir::new().expect("empty temp dir");
+
+    let status = stax::github::gh_stack::extension_status_with_path(
+        empty_dir.path().to_str().expect("utf8 path"),
+    );
+
+    assert_eq!(status, stax::github::gh_stack::ExtensionStatus::NoGh);
+}
+
+#[test]
+fn extension_status_reports_no_extension_when_gh_stack_not_in_extension_list() {
+    // `gh` is present and working, but the user never installed the
+    // `github/gh-stack` extension — the single most common "no gh-stack"
+    // scenario for real users.
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-eco github/gh-eco v1.0.0"; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let status =
+        stax::github::gh_stack::extension_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(status, stax::github::gh_stack::ExtensionStatus::NoExtension);
+}
+
+#[test]
+fn extension_status_reports_no_extension_when_extension_list_is_empty() {
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let status =
+        stax::github::gh_stack::extension_status_with_path(&path_with_fake_gh(fake.path()));
+
+    assert_eq!(status, stax::github::gh_stack::ExtensionStatus::NoExtension);
+}
+
+#[test]
 fn detects_outdated_gh_stack_extension_without_link_command() {
     let fake = fake_gh_dir(
         r#"#!/bin/sh
@@ -626,6 +678,160 @@ exit 1
     assert!(
         !stderr.contains("should not be called"),
         "must not shell out to `gh stack link` when PRs are missing, stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn stack_link_fails_with_actionable_message_when_extension_not_installed() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["stacklink-a", "stacklink-b"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-eco github/gh-eco v1.0.0"; exit 0 ;;
+  "stack link") echo "should not be called" >&2; exit 1 ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+
+    assert!(
+        !output.status.success(),
+        "link should fail cleanly without the gh-stack extension"
+    );
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("gh-stack") && stderr.contains("gh extension install github/gh-stack"),
+        "expected an actionable install hint, stderr was:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("should not be called"),
+        "must not shell out to `gh stack link` when the extension isn't installed, stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn stack_unlink_fails_with_actionable_message_when_extension_not_installed() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["stackunlink-a", "stackunlink-b"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-eco github/gh-eco v1.0.0"; exit 0 ;;
+  "stack unstack") echo "should not be called" >&2; exit 1 ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(&["stack", "unlink"], &[("HOME", &home), ("PATH", &path)]);
+
+    assert!(
+        !output.status.success(),
+        "unlink should fail cleanly without the gh-stack extension"
+    );
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("gh-stack") && stderr.contains("gh extension install github/gh-stack"),
+        "expected an actionable install hint, stderr was:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("should not be called"),
+        "must not shell out to gh-stack when the extension isn't installed, stderr was:\n{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn submit_multi_pr_stack_succeeds_without_gh_stack_extension_installed() {
+    // The most common real-world case: a user who has never installed
+    // `github/gh-stack` at all. `st submit` with the default config
+    // (`native_stack = "auto"`) must behave exactly as if native-stack
+    // support didn't exist — no hang, no error, no `gh stack link` call,
+    // and stax's own PR/body-link management proceeds normally.
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["no-extension-bottom", "no-extension-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") exit 0 ;;
+  "stack link") echo "should not be called" >&2; exit 1 ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    assert!(
+        !args_file.exists(),
+        "submit must never invoke `gh stack link` when the extension isn't installed"
+    );
+    let feature_cache = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
+    assert!(
+        !feature_cache.status.success(),
+        "the native-stack feature cache must stay unset when gh-stack was never called, but got: {}",
+        TestRepo::stdout(&feature_cache)
+    );
+
+    // stax's own PR management (body/comment stack links) must be entirely
+    // unaffected by the absence of gh-stack.
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|request| {
+            request.method.as_str() == "PATCH"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls/10"
+        }),
+        "stax body stack links for #10 should still sync without gh-stack installed"
+    );
+    assert!(
+        requests.iter().any(|request| {
+            request.method.as_str() == "PATCH"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls/20"
+        }),
+        "stax body stack links for #20 should still sync without gh-stack installed"
     );
 }
 

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -835,6 +835,110 @@ exit 1
     );
 }
 
+/// The fake `gh stack link` response gh-stack gives when a local stack has
+/// forked: another branch sharing the same ancestor PRs already anchors a
+/// native GitHub Stack, and GitHub's native Stack feature only supports one
+/// linear chain at a time.
+const FORK_CONFLICT_GH_STACK_SCRIPT: &str = r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.71.0"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link")
+    {
+      echo "Looking up PRs for 2 branches..."
+      echo "Checking existing stacks..."
+      echo "Cannot update stack: this would remove #999 from the stack"
+      echo "Current stack: #10, #20, #999"
+      echo "Include all existing PRs in the command to update the stack"
+    } >&2
+    exit 1
+    ;;
+esac
+exit 1
+"#;
+
+#[tokio::test]
+async fn submit_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump() {
+    let mock_server = MockServer::start().await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_config(&home, &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+    let branches = repo.create_stack(&["fork-conflict-bottom", "fork-conflict-top"]);
+    repo.git(&["push", "-u", "origin", &branches[0], &branches[1]])
+        .assert_success();
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
+    mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
+
+    let fake = fake_gh_dir(FORK_CONFLICT_GH_STACK_SCRIPT);
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--no-fetch", "--yes", "--no-prompt"],
+        &[
+            ("HOME", &home),
+            ("STAX_GITHUB_TOKEN", "test-token"),
+            ("PATH", &path),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("this stack has forked"),
+        "expected a plain-language fork-conflict note, stdout was:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Include all existing PRs"),
+        "the raw multi-line gh-stack dump should not leak to the user, stdout was:\n{stdout}"
+    );
+
+    // Non-fatal: the fork conflict must not have blocked native-stack
+    // caching from being left alone (it's not a durable repo-level fact),
+    // nor stax's own PR management.
+    let feature_cache = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
+    assert!(
+        !feature_cache.status.success(),
+        "a forked-stack conflict must not be cached as feature-disabled, but got: {}",
+        TestRepo::stdout(&feature_cache)
+    );
+}
+
+#[test]
+fn stack_link_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["fork-conflict-link-a", "fork-conflict-link-b"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    let fake = fake_gh_dir(FORK_CONFLICT_GH_STACK_SCRIPT);
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+
+    assert!(
+        !output.status.success(),
+        "linking a forked stack should fail"
+    );
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("shares ancestor PRs") && stderr.contains("stax stack unlink"),
+        "expected a plain-language fork-conflict explanation with unlink guidance, stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("would remove #999"),
+        "the underlying gh-stack detail should still be included for debugging, stderr was:\n{stderr}"
+    );
+}
+
 #[tokio::test]
 async fn submit_auto_registers_native_stack_and_keeps_stax_links() {
     let mock_server = MockServer::start().await;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10333,6 +10333,275 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
+    async fn test_merge_treats_native_stack_base_lock_as_non_fatal() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-lock-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-lock-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(101, &branch_a, "main", "sha-a"),
+                github_pull_fixture(102, &branch_b, &branch_a, "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(101, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // GitHub never actually applies the retarget: the PR remains
+        // registered in a native Stack, so every re-check still shows the
+        // original base.
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, &branch_a, "sha-b")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Validation Failed",
+                "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+                "errors": [{
+                    "resource": "PullRequest",
+                    "field": "base",
+                    "code": "invalid",
+                    "message": "Cannot change the base branch because the pull request is part of a stack."
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/101/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/102/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        mount_github_review_status(&mock_server, 101, "APPROVED").await;
+        mount_github_review_status(&mock_server, 102, "APPROVED").await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge should not abort when GitHub locks the base of a natively-stacked PR: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let stdout = TestRepo::stdout(&merge_output);
+        assert!(
+            stdout.contains("native Stack"),
+            "Expected a soft note about the native Stack base lock. Output:\n{}",
+            stdout
+        );
+
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/102");
+        let merge_a_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/101/merge");
+        let merge_b_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/102/merge");
+        assert!(
+            patch_idx > merge_a_idx,
+            "Expected the locked retarget attempt after the parent PR merged, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            merge_b_idx > patch_idx,
+            "Expected the dependent PR to still be merged despite the locked retarget, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_treats_native_stack_base_lock_as_done_when_github_applies_it() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-lock-auto-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-lock-auto-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(101, &branch_a, "main", "sha-a"),
+                github_pull_fixture(102, &branch_b, &branch_a, "sha-b")
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/101"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(101, &branch_a, "main", "sha-a")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // GitHub rejects the explicit PATCH, but applies the retarget itself
+        // shortly after (e.g. once the merged branch is deleted).
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, &branch_a, "sha-b")),
+            )
+            .with_priority(1)
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(102, &branch_b, "main", "sha-b")),
+            )
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/102"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Validation Failed",
+                "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+                "errors": [{
+                    "resource": "PullRequest",
+                    "field": "base",
+                    "code": "invalid",
+                    "message": "Cannot change the base branch because the pull request is part of a stack."
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/101/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-a-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/102/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-b-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        mount_github_review_status(&mock_server, 101, "APPROVED").await;
+        mount_github_review_status(&mock_server, 102, "APPROVED").await;
+
+        let merge_output = run_stax_with_env(
+            &repo,
+            home.path(),
+            &["merge", "--yes", "--no-wait", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            merge_output.status.success(),
+            "Merge failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
+        );
+
+        let stdout = TestRepo::stdout(&merge_output);
+        assert!(
+            stdout.contains("already on base"),
+            "Expected the native Stack lock to be treated as already applied once GitHub \
+             caught up. Output:\n{}",
+            stdout
+        );
+        assert!(
+            !stdout.contains("native Stack"),
+            "Did not expect the soft-skip note once GitHub applied the retarget. Output:\n{}",
+            stdout
+        );
+    }
+
+    #[tokio::test]
     async fn test_merge_surfaces_duplicate_retarget_error_when_base_does_not_change() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;

--- a/tests/submit_pr_base_tests.rs
+++ b/tests/submit_pr_base_tests.rs
@@ -1,0 +1,189 @@
+//! Regression tests for `stax submit`'s PR base handling once a PR is
+//! registered with GitHub's native Stacked PRs feature.
+//!
+//! Once a PR is linked into a native GitHub Stack (via `gh stack link`,
+//! triggered automatically by submit — see `gh_stack_tests.rs`), GitHub's
+//! REST API rejects *any* `PATCH .../pulls/{n}` call that includes `base`,
+//! even a no-op re-send of the PR's current base. Submit used to call
+//! `update_pr_base` whenever a branch merely needed a push, regardless of
+//! whether the base had actually changed, which broke every subsequent
+//! submit for a native-linked stack. See `is_native_stack_base_locked_error`
+//! and `needs_base_update` in `src/commands/submit.rs`.
+
+use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::Path;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn write_test_config(home: &Path, api_base_url: &str) {
+    let config_dir = home.join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("failed to create test config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            "[remote]\napi_base_url = \"{api_base_url}\"\n\n\
+             [submit]\nstack_links = \"off\"\nnative_stack = \"off\"\n"
+        ),
+    )
+    .expect("failed to write test config");
+}
+
+fn pr_fixture(number: u64, branch: &str, base: &str) -> serde_json::Value {
+    serde_json::json!({
+        "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{number}"),
+        "id": number,
+        "number": number,
+        "state": "open",
+        "draft": false,
+        "title": format!("PR {number}"),
+        "body": "",
+        "head": { "ref": branch, "sha": "aaaa", "label": format!("test-owner:{branch}") },
+        "base": { "ref": base, "sha": "bbbb" },
+        "html_url": format!("https://github.com/test-owner/test-repo/pull/{number}")
+    })
+}
+
+/// Mounts the GET endpoints submit always hits for an existing PR: the PR
+/// itself and its issue comments (checked even with `stack_links = "off"`).
+async fn mock_existing_pr_reads(mock_server: &MockServer, number: u64, branch: &str, base: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/test-owner/test-repo/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(pr_fixture(number, branch, base)))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/test-owner/test-repo/issues/{number}/comments"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+}
+
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, parent: &str, pr_number: u64) {
+    let parent_revision = {
+        let output = repo.git(&["rev-parse", parent]);
+        output.assert_success();
+        TestRepo::stdout(&output).trim().to_string()
+    };
+    let metadata = serde_json::json!({
+        "parentBranchName": parent,
+        "parentBranchRevision": parent_revision,
+        "prInfo": {
+            "number": pr_number,
+            "state": "OPEN",
+            "isDraft": false
+        }
+    });
+
+    let metadata_file = tempfile::NamedTempFile::new().expect("metadata temp file");
+    fs::write(metadata_file.path(), metadata.to_string()).expect("write metadata temp file");
+    let hash = repo.git(&[
+        "hash-object",
+        "-w",
+        metadata_file.path().to_str().expect("metadata path"),
+    ]);
+    hash.assert_success();
+    let blob = TestRepo::stdout(&hash);
+    repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{branch}"),
+        blob.trim(),
+    ])
+    .assert_success();
+}
+
+/// Pushing new commits to an already-open PR whose base hasn't changed must
+/// not re-send `base` in the update PATCH — GitHub rejects that once the PR
+/// is part of a native Stack, and even off a native stack it is a pointless
+/// no-op call.
+#[tokio::test]
+async fn submit_does_not_repatch_base_when_only_pushing_new_commits() {
+    let mock_server = MockServer::start().await;
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+
+    repo.create_stack(&["base-stable"]);
+    let branch = repo.current_branch();
+    repo.git(&["push", "-u", "origin", &branch])
+        .assert_success();
+
+    write_branch_pr_metadata(&repo, &branch, "main", 501);
+    mock_existing_pr_reads(&mock_server, 501, &branch, "main").await;
+
+    // New local commit, not yet pushed: `needs_push` becomes true while the
+    // base ("main") stays exactly what GitHub already reports.
+    repo.create_file("base-stable-extra.txt", "more work\n");
+    repo.commit("More work on base-stable");
+
+    // Deliberately no PATCH mock: if stax still called `update_pr_base` here,
+    // wiremock would answer 404 and the unfixed code would abort the whole
+    // submit with "Failed to update PR base".
+    let output = repo.run_stax_with_env(
+        &["submit", "--yes", "--no-prompt", "--no-template"],
+        &[("STAX_GITHUB_TOKEN", "test-token")],
+    );
+    assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(
+        !requests.iter().any(|r| r.method.as_str() == "PATCH"
+            && r.url.path() == "/repos/test-owner/test-repo/pulls/501"),
+        "submit should not PATCH an unchanged PR base: {requests:#?}"
+    );
+}
+
+/// When the base genuinely does need to change but GitHub rejects it because
+/// the PR is registered in a native Stack, submit must report a soft note
+/// and keep going rather than aborting the whole run.
+#[tokio::test]
+async fn submit_treats_native_stack_base_lock_as_non_fatal() {
+    let mock_server = MockServer::start().await;
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+
+    repo.create_stack(&["base-locked"]);
+    let branch = repo.current_branch();
+
+    // Local metadata says the parent is "main", but GitHub still reports a
+    // stale base for the PR — a genuine mismatch, not a push-only no-op.
+    write_branch_pr_metadata(&repo, &branch, "main", 502);
+    mock_existing_pr_reads(&mock_server, 502, &branch, "stale-base").await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/test-owner/test-repo/pulls/502"))
+        .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+            "message": "Validation Failed",
+            "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+            "errors": [{
+                "code": "invalid",
+                "field": "base",
+                "message": "Cannot change the base branch because the pull request is part of a stack.",
+                "resource": "PullRequest"
+            }]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(
+        &["submit", "--yes", "--no-prompt", "--no-template"],
+        &[("STAX_GITHUB_TOKEN", "test-token")],
+    );
+    assert!(
+        output.status.success(),
+        "submit should not abort on a native-stack base lock: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("skipped base update") && stdout.contains("native Stack"),
+        "expected a soft note about the locked base, got: {stdout}"
+    );
+}

--- a/tests/submit_pr_base_tests.rs
+++ b/tests/submit_pr_base_tests.rs
@@ -187,3 +187,59 @@ async fn submit_treats_native_stack_base_lock_as_non_fatal() {
         "expected a soft note about the locked base, got: {stdout}"
     );
 }
+
+/// `stax update` (sync + restack + submit) reuses the exact same submit
+/// planning/PR-update logic as `stax submit`. Regression coverage for a real
+/// user report: `st update` was surfacing the raw GitHub "part of a stack"
+/// error as a fatal failure instead of the soft note above, even though
+/// `stax submit` alone handled it gracefully — see
+/// `submit_treats_native_stack_base_lock_as_non_fatal`.
+#[tokio::test]
+async fn update_treats_native_stack_base_lock_as_non_fatal() {
+    let mock_server = MockServer::start().await;
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+
+    repo.create_stack(&["base-locked-update"]);
+    let branch = repo.current_branch();
+    repo.git(&["push", "-u", "origin", &branch])
+        .assert_success();
+
+    // Local metadata says the parent is "main", but GitHub still reports a
+    // stale base for the PR — a genuine mismatch, not a push-only no-op.
+    write_branch_pr_metadata(&repo, &branch, "main", 503);
+    mock_existing_pr_reads(&mock_server, 503, &branch, "stale-base").await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/test-owner/test-repo/pulls/503"))
+        .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+            "message": "Validation Failed",
+            "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
+            "errors": [{
+                "code": "invalid",
+                "field": "base",
+                "message": "Cannot change the base branch because the pull request is part of a stack.",
+                "resource": "PullRequest"
+            }]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(
+        &["update", "--force", "--yes", "--no-prompt"],
+        &[("STAX_GITHUB_TOKEN", "test-token")],
+    );
+    assert!(
+        output.status.success(),
+        "update should not abort on a native-stack base lock: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("skipped base update") && stdout.contains("native Stack"),
+        "expected a soft note about the locked base, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Clean reimplementation of native GitHub Stacked PR support, replacing #564 (reverted in #566).

Registers stax-managed stacks with GitHub's native Stacked PRs feature via the `github/gh-stack` extension (`gh stack link`). Verified against `github/gh-stack v0.0.7`; built only on commands/behavior that the real extension actually provides.

## What it does

- **`stax submit`** auto-links multi-PR stacks when the extension is present and the repo is eligible (`[submit] native_stack = "auto"`). Feature-disabled repos are cached so future submits stay quiet. `--native-stack` / `--no-native-stack` override per run.
- **`stax stack link` / `stax stack unlink`** for manual control.
- **`stax doctor`** reports extension readiness (installed / missing / outdated); `stax doctor --fix` installs or upgrades it.
- Keeps stax body/comment stack links alongside the native map by default (`stack_links_when_native`).

## Correctness details (the gaps that sank #564)

- **≥2 PRs required.** `gh stack link` needs two or more PRs. Single-PR stacks are skipped on submit and rejected by `stax stack link` with a clear message (no raw `requires at least 2 arg(s)` leak).
- **Outdated extension.** `gh stack link` postdates `gh-stack v0.0.1`; older versions are detected (probing `gh stack --help`) and reported as outdated, with `doctor --fix` running `gh extension upgrade`.
- **No fictional read API.** `gh stack view --json` has no per-PR lookup, so there is no `st get`/`st merge` "native discovery" — those paths from #564 were dropped rather than shipped broken.
- **Honest unlink.** `gh stack unstack` needs a locally-tracked stack, which `gh stack link` doesn't create; `stax stack unlink` explains this instead of erroring cryptically or risking a destructive delete.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo nextest run gh_stack_tests::` — 13 pass (fake `gh` shim + wiremock): extension detection (installed/outdated), link arg ordering, feature caching, doctor install/upgrade, single-PR handling, submit auto-link keeping stax links, feature-disabled caching.

## Related

- Reverts/replaces #564
- Revert PR: #566