### PR TITLE
Fix full stack temporary submit restacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ st config --set-ai
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
 | `st get [branch|PR]` | Sync the current stack, or fetch a branch/PR stack from remote without overwriting local commits |
-| `st ss` | Submit the full stack, open/update linked PRs |
-| `st branch submit` | Submit only the current branch; can publish a temporary rebased head when its parent is already synced remotely |
+| `st ss` | Submit the full stack, open/update linked PRs; temporary-publishes branches that need restack |
+| `st branch submit` | Submit only the current branch; can publish a temporary rebased head when needed |
 | `st upstack submit` | Submit current branch and descendants, chaining temporary publish heads when needed |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--stack`, `--stack --full`, `--remote`, `--all`) |
 | `st ready` | Interactive PR readiness dashboard for all tracked PRs, newest changed PR first: merge, ping, fix, wait, or draft (`--current`/`--stack` for current stack, `--plain` for table output) |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -269,9 +269,9 @@ Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` in `~/.conf
 - `--stop-here`
 - `--submit-after ask|yes|no`
 
-### Scoped submit temporary restack
+### Temporary publish restack
 
-`st branch submit` and `st upstack submit` can publish a temporary rebased head without moving local branch tips. When a submitted branch needs restack but its excluded parent already matches the remote, Stax creates an internal temporary ref, replays the branch's current commits onto the synced parent for the push, and keeps local metadata unchanged. `st upstack submit` chains descendants onto those temporary publish heads so the remote stack stays linear.
+`st submit`, `st downstack submit`, `st branch submit`, and `st upstack submit` can publish a temporary rebased head without moving local branch tips. When a submitted branch needs restack, Stax creates an internal temporary ref, replays the branch's current commits onto the submitted parent for the push, and keeps local metadata unchanged. Descendants chain onto those temporary publish heads so the remote stack stays linear.
 
 If the excluded parent has local-only commits, scoped submit still refuses and asks you to include ancestors with `st downstack submit` / `st submit` or restack first. `--squash` also requires a local restack first because squashing rewrites local branch history.
 

--- a/skills.md
+++ b/skills.md
@@ -217,10 +217,10 @@ stax bs                            # Hidden shortcut alias for branch submit
 stax upstack submit                # Submit current + descendants
 stax downstack submit              # Submit ancestors + current
 
-# branch/upstack submit can publish temporary rebased heads when the excluded
-# parent is already remote-synced; local branch tips and metadata are not moved.
-# Plain git commits on the branch are included. If the parent has local-only
-# commits, use downstack submit / full submit or restack first.
+# submit can publish temporary rebased heads for branches that need restack;
+# local branch tips and metadata are not moved. Scoped submit still requires an
+# excluded parent to be remote-synced; otherwise use downstack/full submit or
+# restack first.
 
 stax merge --all                   # Merge whole stack
 stax merge --downstack-only        # Merge ancestors below current, then rebase current

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -621,7 +621,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     }
 
     let (publish_sources, _temporary_publish_refs) =
-        prepare_publish_sources_for_submit(&repo, &stack, scope, &branches_to_submit, quiet)?;
+        prepare_publish_sources_for_submit(&repo, &stack, &branches_to_submit, quiet)?;
 
     // Build plan - determine which PRs need create vs update
     let planning_timer = LiveTimer::maybe_new(!quiet, "Planning PR operations...");
@@ -1360,7 +1360,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
             if squash {
                 if plan.uses_temporary_publish_ref {
                     anyhow::bail!(
-                        "--squash cannot be combined with scoped submit of a branch that needs a temporary restack. Run `stax restack` first, then submit with --squash."
+                        "--squash cannot be combined with submitting a branch that needs a temporary restack. Run `stax restack` first, then submit with --squash."
                     );
                 }
                 if let Err(e) = squash_branch_commits(repo.workdir()?, &plan.branch, &plan.parent) {
@@ -2325,15 +2325,10 @@ fn create_pr_failure_context(plan: &PrPlan) -> String {
 fn prepare_publish_sources_for_submit(
     repo: &GitRepo,
     stack: &Stack,
-    scope: SubmitScope,
     branches_to_submit: &[String],
     quiet: bool,
 ) -> Result<(HashMap<String, PublishSource>, TemporaryPublishRefs)> {
     let workdir = repo.workdir()?;
-    if !matches!(scope, SubmitScope::Branch | SubmitScope::Upstack) {
-        return Ok((HashMap::new(), TemporaryPublishRefs::empty(workdir)));
-    }
-
     let mut sources = HashMap::new();
     let temp_root = std::env::temp_dir().join(format!(
         "stax-submit-{}-{}",
@@ -2380,7 +2375,7 @@ fn prepare_publish_sources_for_submit(
         )
         .with_context(|| {
             format!(
-                "Could not prepare temporary restack for scoped submit of '{}'.\n\
+                "Could not prepare temporary restack for submit of '{}'.\n\
                  Run `stax restack` to resolve it locally, then retry submit.",
                 branch
             )
@@ -2401,7 +2396,7 @@ fn prepare_publish_sources_for_submit(
 
     if !sources.is_empty() && !quiet {
         println!(
-            "  {} Prepared {} temporary restack {} for scoped submit",
+            "  {} Prepared {} temporary restack {} for submit",
             "▸".dimmed(),
             sources.len().to_string().cyan(),
             if sources.len() == 1 { "ref" } else { "refs" }

--- a/tests/scoped_submit_tests.rs
+++ b/tests/scoped_submit_tests.rs
@@ -323,6 +323,60 @@ async fn upstack_submit_pr_defaults_exclude_parent_commits_from_temporary_parent
 }
 
 #[tokio::test]
+async fn stack_submit_pr_defaults_exclude_rewritten_parent_commits() {
+    let mock_server = MockServer::start().await;
+    mock_github_pr_create(&mock_server).await;
+
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &mock_server.uri());
+    repo.configure_github_like_submit_remote();
+
+    let branches = repo.create_stack(&["rewrite-parent", "rewrite-child"]);
+    let parent = &branches[0];
+    let child = &branches[1];
+
+    repo.run_stax(&["checkout", parent]).assert_success();
+    repo.create_file("rewrite-parent.txt", "rewritten parent\n");
+    repo.git(&["add", "-A"]).assert_success();
+    repo.git(&["commit", "--amend", "-m", "Rewritten parent"])
+        .assert_success();
+
+    repo.run_stax(&["checkout", child]).assert_success();
+    let output = repo.run_stax_with_env(
+        &[
+            "submit",
+            "--yes",
+            "--no-prompt",
+            "--publish",
+            "--no-template",
+        ],
+        &[("STAX_GITHUB_TOKEN", "test-token")],
+    );
+    assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+    let requests = mock_server.received_requests().await.unwrap();
+    let child_payload = requests
+        .iter()
+        .filter(|request| {
+            request.method.as_str() == "POST"
+                && request.url.path() == "/repos/test-owner/test-repo/pulls"
+        })
+        .map(|request| serde_json::from_slice::<serde_json::Value>(&request.body).unwrap())
+        .find(|payload| payload["head"].as_str() == Some(child.as_str()))
+        .expect("missing child PR create payload");
+
+    assert_eq!(child_payload["title"], "Commit for rewrite-child");
+    assert!(
+        !child_payload["body"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Commit for rewrite-parent"),
+        "child PR body should not include stale parent commits: {child_payload}"
+    );
+}
+
+#[tokio::test]
 async fn branch_submit_pr_defaults_exclude_imported_parent_commits_after_temporary_restack() {
     let mock_server = MockServer::start().await;
     mock_github_pr_create(&mock_server).await;


### PR DESCRIPTION
## Summary

- let full/downstack submit use the existing temporary publish-head restack path when submitted branches need restack
- keep PR default titles/bodies scoped to the rebased child diff after a parent rewrite
- update README/docs/skills wording for temporary publish restacks

Fixes #571.

## Test plan

- `cargo nextest run stack_submit_pr_defaults_exclude_rewritten_parent_commits`
- `cargo nextest run scoped_submit_tests::`
- `make test` (Docker): 1724 passed
