### PR TITLE
fix: let GitHub mark downstack stack PRs merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Merge from the bottom of the stack up to your current branch, with CI and readin
 st merge                  # local cascade merge
 st merge --when-ready     # wait/poll until PRs are mergeable
 st merge --ds             # merge ancestors, rebase current branch
-st merge --stack          # validate current PR once; absorb lower PRs through current
+st merge --stack          # validate current PR once; let GitHub mark lower PRs merged when possible
 st merge --stack --full   # stack-merge the full stack even from the middle
 st merge --remote         # merge remotely on GitHub while you keep working
 st merge --all            # merge the whole stack regardless of position

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -37,7 +37,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
-| `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, merge that PR, and mark lower PRs as absorbed (`--full` includes descendants; GitHub only) |
+| `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, merge that PR, and let GitHub mark lower PRs merged when possible (`--full` includes descendants; GitHub only) |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
 | `st cascade` | Restack, push, and create/update PRs in one shot |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -34,7 +34,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`
 - `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
-- `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, mark selected downstack PRs as absorbed with a back-reference comment, and rebase/retarget remaining descendants; defaults to `--method rebase`
+- `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, wait briefly for selected downstack PRs to become merged in GitHub, and rebase/retarget remaining descendants; defaults to `--method rebase`
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -75,13 +75,13 @@ st merge --stack --full
 st merge --stack --dry-run
 ```
 
-For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, validates CI/mergeability on selected tip PR `B`, retargets `B` to `main`, and merges only `B` through GitHub's merge API. PR `A` is then marked as absorbed with a comment pointing at `B`; PR `C` remains open and is rebased/retargeted onto `main`.
+For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, validates CI/mergeability on selected tip PR `B`, retargets `B` to `main`, and merges only `B` through GitHub's merge API. Stax then waits briefly for GitHub to mark PR `A` merged; if GitHub does not, Stax marks `A` as absorbed with a comment pointing at `B`. PR `C` remains open and is rebased/retargeted onto `main`.
 
 Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `rebase`; pass `--method squash` only when you explicitly want GitHub to squash the selected range into one commit.
 
 This avoids re-running CI for every lower PR because the selected tip already contains that range. The post-merge sync updates trunk and PR metadata without running generic merged-branch deletion; branch cleanup stays scoped to the stack range that was just landed. If trunk moves before the merge, stax aborts and asks you to restack and wait for fresh selected-tip CI.
 
-GitHub still displays absorbed lower PRs as closed rather than merged because only the selected tip PR is merged through GitHub. Stax leaves an explicit absorbed-by comment so the closure is intentional and traceable.
+GitHub may still display an absorbed lower PR as closed rather than merged if its background merge detection does not fire. In that fallback, Stax leaves an explicit absorbed-by comment so the closure is intentional and traceable.
 
 For the no-extra-CI behavior, GitHub branch protection should require status checks but should not require branches to be up to date before merging. If GitHub requires up-to-date branches, it can force another revalidation at merge time.
 

--- a/skills.md
+++ b/skills.md
@@ -227,7 +227,7 @@ stax merge --downstack-only        # Merge ancestors below current, then rebase 
 stax merge --ds                    # Alias for --downstack-only
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
-stax merge --stack                 # GitHub only: validate selected tip once, merge it, and mark lower PRs as absorbed
+stax merge --stack                 # GitHub only: validate selected tip once, merge it, and let lower PRs become merged when GitHub detects it
 stax merge --stack --downstack-only # Stack-merge ancestors below current; keep current open
 stax merge --stack --full          # Stack-merge full stack even from the middle
 stax merge --stack --when-ready    # Wait only for selected tip PR readiness before stack fast-forward merge

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the serverless path from issue #293: validate the selected tip PR
 //! once, retarget that PR to trunk, merge it via GitHub's merge API, then
-//! absorb the selected lower PRs with a back-reference comment.
+//! reconcile selected lower PRs as merged or absorbed.
 
 use crate::commands::merge::{
     PrBaseUpdate, rebase_and_finalize_remaining_branch, update_pr_base_unless_current,
@@ -303,7 +303,7 @@ pub fn run(
     }
     LiveTimer::maybe_finish_ok(merge_timer, "done");
 
-    absorb_downstack_prs(&rt, &client, &resolved, tip, quiet)?;
+    let github_merged_downstack = absorb_downstack_prs(&rt, &client, &resolved, tip, quiet)?;
 
     rebase_remaining_branches(
         &repo,
@@ -336,6 +336,8 @@ pub fn run(
         for pr in &resolved {
             let action = if pr.pr_number == tip.pr_number {
                 "merged"
+            } else if github_merged_downstack.contains(&pr.pr_number) {
+                "merged by GitHub"
             } else {
                 "absorbed"
             };
@@ -716,19 +718,58 @@ fn absorb_downstack_prs(
     prs: &[ResolvedStackPr],
     tip: &ResolvedStackPr,
     quiet: bool,
-) -> Result<()> {
+) -> Result<Vec<u64>> {
+    let mut github_merged = Vec::new();
+
     for pr in prs.iter().filter(|pr| pr.pr_number != tip.pr_number) {
         let timer = LiveTimer::maybe_new(
             !quiet,
-            &format!("Marking downstack PR #{} as absorbed...", pr.pr_number),
+            &format!(
+                "Waiting for downstack PR #{} to be marked merged...",
+                pr.pr_number
+            ),
         );
+        if wait_for_downstack_pr_merged(rt, client, pr.pr_number)? {
+            github_merged.push(pr.pr_number);
+            LiveTimer::maybe_finish_ok(timer, "merged by GitHub");
+            continue;
+        }
+
         let comment = downstack_absorbed_comment(tip.pr_number);
         rt.block_on(async { client.create_issue_comment(pr.pr_number, &comment).await })?;
         rt.block_on(async { client.close_pr(pr.pr_number).await })?;
-        LiveTimer::maybe_finish_ok(timer, "done");
+        LiveTimer::maybe_finish_ok(timer, "closed as absorbed");
     }
 
-    Ok(())
+    Ok(github_merged)
+}
+
+fn wait_for_downstack_pr_merged(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    pr_number: u64,
+) -> Result<bool> {
+    let timeout = downstack_merged_wait();
+    let interval = Duration::from_secs(2);
+    let start = Instant::now();
+
+    loop {
+        if rt.block_on(async { client.is_pr_merged(pr_number).await })? {
+            return Ok(true);
+        }
+        if start.elapsed() >= timeout {
+            return Ok(false);
+        }
+        std::thread::sleep(interval);
+    }
+}
+
+fn downstack_merged_wait() -> Duration {
+    let seconds = std::env::var("STAX_STACK_MERGE_ABSORBED_WAIT_SECS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(20);
+    Duration::from_secs(seconds)
 }
 
 fn rebase_remaining_branches(
@@ -884,7 +925,7 @@ fn print_stack_preview(
         let marker = if idx + 1 == prs.len() {
             "(tip, merged)"
         } else {
-            "(absorbed after tip merge)"
+            "(reconciled after tip merge)"
         };
         println!(
             "  {}. {} (#{}) {}",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7328,7 +7328,8 @@ mod forge_mock_tests {
             .env("GIT_CONFIG_SYSTEM", &gitconfig)
             .env(token_env, "mock-token")
             .env("STAX_DISABLE_UPDATE_CHECK", "1")
-            .env("STAX_TEST_DISABLE_HEAD_SYNC", "1");
+            .env("STAX_TEST_DISABLE_HEAD_SYNC", "1")
+            .env("STAX_STACK_MERGE_ABSORBED_WAIT_SECS", "0");
         command.output().expect("Failed to execute stax")
     }
 
@@ -10434,7 +10435,7 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_stack_retargets_tip_merges_once_and_absorbs_downstack_prs() {
+    async fn test_merge_stack_does_not_close_downstack_pr_when_github_marks_it_merged() {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
@@ -10463,12 +10464,13 @@ mod forge_mock_tests {
         write_branch_pr_metadata(&repo, &branch_a, "main", 601, Some(false));
         write_branch_pr_metadata(&repo, &branch_b, &branch_a, 602, Some(false));
 
+        let mut merged_branch_a = github_pull_fixture(601, &branch_a, "main", "sha-a");
+        merged_branch_a["state"] = serde_json::json!("closed");
+        merged_branch_a["merged_at"] = serde_json::json!("2024-01-01T00:00:00Z");
+
         Mock::given(method("GET"))
             .and(path("/repos/test/repo/pulls/601"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(github_pull_fixture(601, &branch_a, "main", "sha-a")),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(merged_branch_a))
             .mount(&mock_server)
             .await;
 
@@ -10512,24 +10514,6 @@ mod forge_mock_tests {
             .mount(&mock_server)
             .await;
 
-        Mock::given(method("POST"))
-            .and(path("/repos/test/repo/issues/601/comments"))
-            .respond_with(ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
-                9001,
-                "Absorbed into stack merge of #602. This PR's commits landed through the selected tip PR.",
-            )))
-            .mount(&mock_server)
-            .await;
-
-        Mock::given(method("PATCH"))
-            .and(path("/repos/test/repo/pulls/601"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(github_pull_fixture(601, &branch_a, "main", "sha-a")),
-            )
-            .mount(&mock_server)
-            .await;
-
         let merge_output = run_stax_with_env(
             &repo,
             home.path(),
@@ -10557,15 +10541,24 @@ mod forge_mock_tests {
                 .map(|request| format!("{} {}", request.method, request.url.path()))
                 .collect::<Vec<_>>()
         );
+        assert!(
+            requests.iter().all(|request| {
+                request.url.path() != "/repos/test/repo/issues/601/comments"
+                    && !(request.method.as_str() == "PATCH"
+                        && request.url.path() == "/repos/test/repo/pulls/601")
+            }),
+            "Expected no absorbed comment or close call once GitHub reports PR #601 merged, requests were: {:?}",
+            requests
+                .iter()
+                .map(|request| format!("{} {}", request.method, request.url.path()))
+                .collect::<Vec<_>>()
+        );
 
         let tip_patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/602");
         let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/602/merge");
-        let comment_idx =
-            find_request_index(&requests, "POST", "/repos/test/repo/issues/601/comments");
-        let close_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/601");
         assert!(
-            tip_patch_idx < merge_idx && merge_idx < comment_idx && comment_idx < close_idx,
-            "Expected retarget -> tip merge -> comment -> close order, requests were: {:?}",
+            tip_patch_idx < merge_idx,
+            "Expected retarget -> tip merge order, requests were: {:?}",
             requests
                 .iter()
                 .map(|request| format!("{} {}", request.method, request.url.path()))
@@ -10580,17 +10573,6 @@ mod forge_mock_tests {
         let merge_payload: Value = serde_json::from_slice(&merge_request.body).unwrap();
         assert_eq!(merge_payload["merge_method"], "rebase");
         assert_eq!(merge_payload["sha"], branch_b_sha);
-
-        let comment_request = &requests[comment_idx];
-        let comment_payload: Value = serde_json::from_slice(&comment_request.body).unwrap();
-        assert_eq!(
-            comment_payload["body"],
-            "Absorbed into stack merge of #602. This PR's commits landed through the selected tip PR."
-        );
-
-        let close_request = &requests[close_idx];
-        let close_payload: Value = serde_json::from_slice(&close_request.body).unwrap();
-        assert_eq!(close_payload["state"], "closed");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- after `st merge --stack` merges the selected tip PR, wait briefly for GitHub to mark each selected downstack PR as merged
- only fall back to the absorbed comment + manual close when GitHub does not report the lower PR as merged
- update merge-stack docs, README command hints, and skills.md to describe the new behavior

Closes #573.

## Tests

- `cargo nextest run test_merge_stack_does_not_close_downstack_pr_when_github_marks_it_merged test_merge_stack_from_middle_retargets_remaining_child_pr`
- `cargo nextest run merge_stack`
- `make test` (Docker): 1723 passed
