### PR TITLE
docs: remove nonexistent task install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Then:
 cargo install --path . --locked
 # or
 make install
-# or
-task install
 ```
 
 No system OpenSSL? Use the vendored feature:


### PR DESCRIPTION
## Summary
- Remove the nonexistent `task install` source-install option from the README.

Closes #568

## Validation
- `git diff --check`
- `rg -n "task install|Taskfile" README.md docs skills.md AGENTS.md learnings.md 2>/dev/null || true`
- `python3 -m mkdocs build --strict` — blocked locally because `mkdocs` is not installed
- `python3 -m venv /tmp/stax-docs-venv && /tmp/stax-docs-venv/bin/pip install -q mkdocs-material && /tmp/stax-docs-venv/bin/mkdocs build --strict` — fails on a pre-existing docs warning: `docs/workflows/releasing.md` links to `../../cliff.toml`, which is outside MkDocs docs files

## Docs note
Docs-only change; no runtime tests needed.
