### PR TITLE
test: cover copy pr clipboard fallback

### DIFF
--- a/tests/copy_tests.rs
+++ b/tests/copy_tests.rs
@@ -1,12 +1,13 @@
-use crate::common::{TestRepo, stax_bin};
+use crate::common::{OutputAssertions, TestRepo, stax_bin};
+use std::fs;
 use std::process::{Command, Output};
 
-fn run_copy_without_clipboard(repo: &TestRepo) -> Output {
+fn run_copy_without_clipboard(repo: &TestRepo, args: &[&str]) -> Output {
     let null_path = if cfg!(windows) { "NUL" } else { "/dev/null" };
     let home = repo.clean_home();
 
     let mut cmd = Command::new(stax_bin());
-    cmd.args(["copy"])
+    cmd.args(args)
         .current_dir(repo.path())
         .env("HOME", home)
         .env("GIT_CONFIG_GLOBAL", null_path)
@@ -24,11 +25,47 @@ fn run_copy_without_clipboard(repo: &TestRepo) -> Output {
     cmd.output().expect("Failed to execute stax copy")
 }
 
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, pr_number: u64) {
+    let metadata = serde_json::json!({
+        "parentBranchName": "main",
+        "parentBranchRevision": repo.get_commit_sha("main"),
+        "prInfo": {
+            "number": pr_number,
+            "state": "OPEN"
+        }
+    });
+
+    let metadata_file = tempfile::NamedTempFile::new().expect("metadata temp file");
+    fs::write(metadata_file.path(), metadata.to_string()).expect("write metadata temp file");
+
+    let hash = repo.git(&[
+        "hash-object",
+        "-w",
+        metadata_file.path().to_str().expect("metadata path"),
+    ]);
+    assert!(
+        hash.status.success(),
+        "git hash-object failed: {}",
+        TestRepo::stderr(&hash)
+    );
+
+    let update = repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{}", branch),
+        TestRepo::stdout(&hash).trim(),
+    ]);
+    assert!(
+        update.status.success(),
+        "git update-ref failed: {}",
+        TestRepo::stderr(&update)
+    );
+}
+
 #[test]
 fn copy_prints_branch_and_succeeds_when_clipboard_is_unavailable() {
     let repo = TestRepo::new();
 
-    let output = run_copy_without_clipboard(&repo);
+    let output = run_copy_without_clipboard(&repo, &["copy"]);
 
     assert!(
         output.status.success(),
@@ -48,6 +85,48 @@ fn copy_prints_branch_and_succeeds_when_clipboard_is_unavailable() {
     assert!(
         stderr.contains("Branch name below:"),
         "expected branch fallback label, got:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn copy_pr_prints_url_and_succeeds_when_clipboard_is_unavailable() {
+    let repo = TestRepo::new();
+    let remote = repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/test-owner/test-repo.git",
+    ]);
+    remote.assert_success();
+
+    repo.create_stack(&["copy-pr"]);
+    let branch = repo.current_branch();
+    write_branch_pr_metadata(&repo, &branch, 42);
+
+    let output = run_copy_without_clipboard(&repo, &["copy", "--pr"]);
+
+    assert!(
+        output.status.success(),
+        "expected stax copy --pr to succeed without clipboard\nstderr:\n{}\nstdout:\n{}",
+        TestRepo::stderr(&output),
+        TestRepo::stdout(&output)
+    );
+
+    assert_eq!(
+        TestRepo::stdout(&output),
+        "https://github.com/test-owner/test-repo/pull/42\n"
+    );
+
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("warning:") && stderr.contains("Clipboard unavailable"),
+        "expected clipboard warning, got:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("PR URL below:"),
+        "expected PR URL fallback label, got:\n{}",
         stderr
     );
 }


### PR DESCRIPTION
## Summary
- Add integration coverage for `stax copy --pr` when the desktop clipboard is unavailable.
- Reuse the no-clipboard command runner for both default branch copy and PR URL copy.
- Seed local branch PR metadata and a GitHub-like origin so the test verifies the resolved PR URL fallback output.

## Tests
- `cargo nextest run copy_tests:: --no-fail-fast`
- `rustfmt --edition 2024 --check tests/copy_tests.rs`
- `make test`

## Docs
- Not updated: this is test-only coverage for existing user-visible behavior; no command, flag, default, or documented workflow changed.

Closes #542
