### PR TITLE
docs: document merge when-ready queue conflict

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -32,7 +32,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 ### `st merge` variants
 
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
-- `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`
+- `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`
 - `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
 - `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, wait briefly for selected downstack PRs to become merged in GitHub, and rebase/retarget remaining descendants; defaults to `--method rebase`
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip


### PR DESCRIPTION
## Summary
- Update the full command reference so `st merge --when-ready` lists `--queue` as an incompatible flag.

## Tests
- Ad-hoc verification: checked `docs/commands/reference.md` contains the updated `--when-ready` incompatibility bullet exactly once and no stale shorter bullet remains.
- `make test` — 1740 passed, 0 skipped.

## Docs
- Updated `docs/commands/reference.md`.
- README.md and skills.md were not changed because they do not list the `--when-ready` incompatibility set.

Closes #539
