### PR TITLE
docs: cover visible commands in reference

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -28,6 +28,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st cascade` | | Restack from bottom and submit updates |
 | `st diff` | | Show per-branch diffs vs parent |
 | `st range-diff` | | Show range-diff for branches needing restack |
+| `st stack` | `s` | Stack command namespace for `submit` and `restack` (`st stack submit`, `st stack restack`) |
 
 ### `st merge` variants
 
@@ -63,6 +64,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st get [branch|PR]` | | Sync current stack, or fetch, sync/create, checkout, and track a remote branch/PR |
 | `st modify` | `m` | Amend staged changes into current commit (`-a` stages all, `-r` restacks after) |
 | `st rename` | | Rename current branch |
+| `st move [target]` | `mv` | Move the current branch and descendants onto a new parent (`st upstack onto` parity alias; picker when omitted) |
 | `st branch track` | | Track an existing branch |
 | `st branch track --all-prs` | | Track all open PRs (GitHub, GitLab, Gitea) |
 | `st branch untrack` | `ut` | Remove stax metadata |
@@ -128,6 +130,8 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st pr list` | List open PRs (GitHub, GitLab, Gitea) |
 | `st pr list --ready` | Open live PR readiness for all tracked branch PRs, newest changed PR first (`--current`/`--stack` limits to the current stack, `--plain` prints a table) |
 | `st ready` | Short alias for `st pr list --ready` (`--current`, `--stack`, `--all`, `--plain`, `--json`) |
+| `st draft [branch]` | Mark the current or named branch's PR as a draft |
+| `st undraft [branch]` | Mark the current or named branch's PR as ready for review |
 | `st issue list` | List open issues |
 | `st comments` | Show PR comments |
 | `st copy` · `st copy --pr` | Copy branch name · PR URL |
@@ -137,6 +141,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st changelog --find [query]` | Flag form of commit fuzzy-find |
 | `st generate` · `st gen` | AI generation: interactive picker, or `--pr-body` / `--pr-title` / `--commit-msg` |
 | `st ss --ai` | Submit with AI-generated PR title/body suggestions |
+| `st watch` | Live auto-refreshing stack status with CI and PR state (`--current`, `--interval <seconds>`) |
 
 ## Utilities
 
@@ -150,9 +155,17 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st cli upgrade` | Detect install method and run the matching upgrade |
 | `st doctor` | Check repo health |
 | `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config and stale AI skills) |
+| `st skills` | Manage installed AI agent skill files (`list`, `update`, `update --dry-run`) |
 | `st continue` | Continue after conflicts |
 | `st open` | Open repository in browser |
 | `st demo` | Interactive tutorial — no auth or repo required |
+
+### `st tmux`
+
+| Command | Description |
+|---|---|
+| `st tmux status` | Print a compact tmux-formatted status string for `status-right` |
+| `st tmux popup` | Open `stax watch --current` in a tmux display-popup |
 
 ## Worktrees
 

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -116,6 +116,51 @@ fn test_get_help() {
         .assert_stdout_contains("--force");
 }
 
+#[test]
+fn test_full_command_reference_mentions_visible_top_level_commands() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["--help"]);
+    output.assert_success();
+
+    let stdout = TestRepo::stdout(&output);
+    let docs = include_str!("../docs/commands/reference.md");
+    let mut in_commands = false;
+    let mut missing = Vec::new();
+
+    for line in stdout.lines() {
+        if line.starts_with("Commands:") {
+            in_commands = true;
+            continue;
+        }
+        if line.starts_with("Options:") {
+            in_commands = false;
+        }
+        if !in_commands || line.trim().is_empty() {
+            continue;
+        }
+
+        let Some(command) = line.split_whitespace().next() else {
+            continue;
+        };
+        if command == "help" {
+            continue;
+        }
+
+        let documented = docs.contains(&format!("`st {command}"))
+            || docs.contains(&format!("`stax {command}"))
+            || docs.contains(&format!("### `{command}`"));
+        if !documented {
+            missing.push(command.to_string());
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "docs/commands/reference.md is missing visible top-level commands: {}",
+        missing.join(", ")
+    );
+}
+
 // =============================================================================
 // Sync Command Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add missing visible top-level commands to `docs/commands/reference.md`: `skills`, `stack`, `draft`, `undraft`, `watch`, `tmux`, and `move`.
- Add a regression test that compares visible top-level `stax --help` commands against the full command reference.

## Tests
- `python3 - <<'PY' ...` docs parity check: passed, `missing: []`
- `rustfmt --edition 2021 --check tests/command_coverage_tests.rs`: passed
- `cargo nextest run command_coverage_tests::test_full_command_reference_mentions_visible_top_level_commands`: passed
- `make test`: passed, 1741 tests

## Docs note
- User-visible documentation behavior is the scope of this change; updated the relevant full command reference directly.
- No README or `skills.md` updates needed because both already mention the affected commands/workflows at the appropriate level.

Closes #579
