### PR TITLE
fix: persist TUI pane visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ st redo
   <img alt="stax TUI" src="assets/tui.png" width="760">
 </p>
 
-Bare `st` launches a full-screen TUI for browsing stacks, inspecting branch summaries and cached patches, watching live CI hydrate, and running common ops without leaving the terminal.
+Bare `st` launches a full-screen TUI for browsing stacks, inspecting branch summaries and cached patches, watching live CI hydrate, and running common ops without leaving the terminal. Stack/Summary/Patch pane visibility is remembered per repo.
 
 → [TUI guide](docs/interface/tui.md)
 

--- a/docs/interface/tui.md
+++ b/docs/interface/tui.md
@@ -13,11 +13,11 @@ stax
 - Full-height stack tree with PR status, sync indicators, and ahead/behind counts
 - Selected-branch summary with recommended next actions and live CI progress
 - Patch viewer with a compact diffstat header and scrollable body
-- Runtime pane toggles for small terminals (`1` Stack, `2` Summary, `3` Patch)
+- Runtime pane toggles for small terminals (`1` Stack, `2` Summary, `3` Patch), remembered per repo
 - Keyboard-driven checkout, restack, submit, create, rename, delete
 - Reorder mode for reparenting branches
 
-The dashboard renders immediately from local stack data, then fetches live CI for the selected branch in the background. Diffs are loaded lazily and cached under the repo's common `.git/stax` directory, so reopening the TUI can show unchanged branch patches immediately. While checks are running, the stack row shows a completed/total counter and the summary pane expands with pass/fail/running counts plus elapsed/ETA.
+The dashboard renders immediately from local stack data, then fetches live CI for the selected branch in the background. Diffs are loaded lazily and cached under the repo's common `.git/stax` directory, so reopening the TUI can show unchanged branch patches immediately. Pane visibility is also saved there, so `1`/`2`/`3` layouts stick across launches. While checks are running, the stack row shows a completed/total counter and the summary pane expands with pass/fail/running counts plus elapsed/ETA.
 
 The main `st` TUI is focused on stacks and patches. Worktree management lives in the dedicated [`st wt` dashboard](../worktrees/index.md#dashboard).
 

--- a/skills.md
+++ b/skills.md
@@ -621,7 +621,7 @@ Symbols:
 
 ## Tips
 
-- Run `stax` with no args to launch the interactive TUI; selected-branch CI hydrates in the background, unchanged branch diffs can be reused from the repo-local TUI cache on reopen, and `1`/`2`/`3` toggle the Stack/Summary/Patch panes for small terminals.
+- Run `stax` with no args to launch the interactive TUI; selected-branch CI hydrates in the background, unchanged branch diffs can be reused from the repo-local TUI cache on reopen, and `1`/`2`/`3` toggle the Stack/Summary/Patch panes for small terminals. Pane visibility is remembered per repo.
 - Use `stax --help` or `stax <command> --help` for exact flags.
 - Hidden convenience shortcuts: `stax bc`, `stax bu`, `stax bd`, `stax bs`, `stax w`, `stax wtc`, `stax wtgo`, `stax wtrm`.
 - Use `--yes` for non-interactive scripting.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -189,6 +189,47 @@ impl TuiDiffCache {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct TuiPaneVisibilityState {
+    pub stack: bool,
+    pub summary: bool,
+    pub patch: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct TuiStateCache {
+    #[serde(default)]
+    pub panes: Option<TuiPaneVisibilityState>,
+}
+
+impl TuiStateCache {
+    fn cache_path(git_dir: &std::path::Path) -> PathBuf {
+        git_dir.join("stax").join("tui-state.json")
+    }
+
+    pub fn load(git_dir: &std::path::Path) -> Self {
+        let path = Self::cache_path(git_dir);
+        if !path.exists() {
+            return Self::default();
+        }
+
+        fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, git_dir: &std::path::Path) -> Result<()> {
+        let path = Self::cache_path(git_dir);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self)?;
+        fs::write(&path, json)?;
+        Ok(())
+    }
+}
+
 /// Cache for ahead/behind commit counts, keyed by (base_sha:head_sha).
 ///
 /// The key encodes the current tip OIDs of both refs, so the cache

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,4 +1,7 @@
-use crate::cache::{CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache};
+use crate::cache::{
+    CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiPaneVisibilityState,
+    TuiStateCache,
+};
 use crate::ci::{CheckRunInfo, history};
 use crate::config::Config;
 use crate::engine::{Stack, build_parent_candidates};
@@ -346,6 +349,28 @@ impl PaneVisibility {
             .filter(|visible| *visible)
             .count()
     }
+
+    fn from_persisted(state: TuiPaneVisibilityState) -> Self {
+        let visibility = Self {
+            stack: state.stack,
+            summary: state.summary,
+            patch: state.patch,
+        };
+
+        if visibility.visible_count() == 0 {
+            Self::default()
+        } else {
+            visibility
+        }
+    }
+
+    fn to_persisted(self) -> TuiPaneVisibilityState {
+        TuiPaneVisibilityState {
+            stack: self.stack,
+            summary: self.summary,
+            patch: self.patch,
+        }
+    }
 }
 
 /// Application mode
@@ -481,6 +506,10 @@ impl App {
         let git_dir = repo.git_dir()?;
         let cache = CiCache::load(git_dir);
         let diff_cache_dir = repo.common_git_dir()?;
+        let pane_visibility = TuiStateCache::load(&diff_cache_dir)
+            .panes
+            .map(PaneVisibility::from_persisted)
+            .unwrap_or_default();
         let git_dir = git_dir.to_path_buf();
         let status_set_at = initial_status.as_ref().map(|_| Instant::now());
 
@@ -501,7 +530,7 @@ impl App {
             selected_diff: Vec::new(),
             diff_scroll: 0,
             focused_pane: FocusedPane::Stack,
-            pane_visibility: PaneVisibility::default(),
+            pane_visibility,
             diff_stat: Vec::new(),
             status_message: initial_status,
             status_set_at,
@@ -894,6 +923,7 @@ impl App {
 
         self.pane_visibility.set_visible(pane, !currently_visible);
         self.ensure_focus_visible();
+        self.persist_tui_state();
 
         let pane_name = match pane {
             TuiPane::Stack => "Stack",
@@ -902,6 +932,12 @@ impl App {
         };
         let state = if currently_visible { "hidden" } else { "shown" };
         self.set_status(format!("{} pane {}", pane_name, state));
+    }
+
+    fn persist_tui_state(&self) {
+        let mut state = TuiStateCache::load(&self.diff_cache_dir);
+        state.panes = Some(self.pane_visibility.to_persisted());
+        let _ = state.save(&self.diff_cache_dir);
     }
 
     fn focused_pane_is_visible(&self) -> bool {
@@ -1914,10 +1950,12 @@ fn spawn_ci_loader(repo_path: PathBuf, branch: String) -> Receiver<CiUpdate> {
 mod tests {
     use super::{
         App, BranchCiSummary, BranchDisplay, DiffLineType, DiffRequest, DiffUpdate, FocusedPane,
-        Mode, PaneVisibility, TuiPane, live_ci_summary_text, run_in_tokio_runtime,
-        spawn_diff_loader, substring_filter_indices,
+        Mode, PaneVisibility, TuiPane, TuiPaneVisibilityState, live_ci_summary_text,
+        run_in_tokio_runtime, spawn_diff_loader, substring_filter_indices,
     };
-    use crate::cache::{CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache};
+    use crate::cache::{
+        CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiStateCache,
+    };
     use crate::engine::Stack;
     use crate::git::GitRepo;
     use anyhow::{Result, anyhow};
@@ -2081,6 +2119,32 @@ mod tests {
         assert!(!app.pane_visibility.patch);
         assert_eq!(app.focused_pane, FocusedPane::Stack);
         assert_eq!(app.status_message.as_deref(), Some("Patch pane hidden"));
+    }
+
+    #[test]
+    fn toggling_pane_visibility_persists_for_next_tui_load() {
+        let (_tempdir, repo) = test_repo();
+        let cache_dir = repo.common_git_dir().expect("common git dir");
+        let mut app = minimal_app(repo, vec![skeleton_branch("main", None, true)]);
+
+        app.toggle_pane_visibility(TuiPane::Summary);
+
+        let state = TuiStateCache::load(&cache_dir);
+        let panes = state.panes.expect("pane visibility should be persisted");
+        assert!(panes.stack);
+        assert!(!panes.summary);
+        assert!(panes.patch);
+    }
+
+    #[test]
+    fn invalid_persisted_pane_visibility_falls_back_to_default() {
+        let visibility = PaneVisibility::from_persisted(TuiPaneVisibilityState {
+            stack: false,
+            summary: false,
+            patch: false,
+        });
+
+        assert_eq!(visibility, PaneVisibility::default());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Persist TUI Stack/Summary/Patch pane visibility under the repo-local `.git/stax/tui-state.json`
- Restore the saved pane layout when reopening the TUI, falling back to the default if a stale state hides every pane
- Update README, TUI docs, and agent skills to document sticky pane visibility

## Tests
- `rustfmt --edition 2024 --check src/cache.rs src/tui/app.rs`
- `cargo nextest run tui::app::tests::toggling_pane_visibility_persists_for_next_tui_load tui::app::tests::invalid_persisted_pane_visibility_falls_back_to_default cache::tests::test_cache_save_and_load`
- `make test`

## Docs
Updated `README.md`, `docs/interface/tui.md`, and `skills.md` because pane visibility persistence is user-visible TUI behavior.

Closes #584
