### PR TITLE
docs: clarify native stack unlink limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@ That's it — no config needed. From then on, `st ss`/`st bs` auto-link multi-PR
 ```bash
 st ss                    # auto-links native stack when available
 st stack link            # manually re-link the current stack
-st stack unlink          # remove the native GitHub Stack object
+st stack unlink          # unstack a locally tracked native GitHub Stack
 ```
 
-Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. stax also strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before talking to `gh stack`, since GitHub's private-preview native-stack API rejects Personal Access Tokens and only accepts an OAuth-authenticated `gh` login (`gh auth login`). `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics, and reports whether the extension is missing, outdated, or up to date.
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. stax also strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before talking to `gh stack`, since GitHub's private-preview native-stack API rejects Personal Access Tokens and only accepts an OAuth-authenticated `gh` login (`gh auth login`). `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics, and reports whether the extension is missing, outdated, or up to date. `st stack unlink` delegates to `gh stack unstack`, so stacks that stax registered with `gh stack link` may need `gh stack checkout <pr>` first to create gh-stack's local tracking; otherwise remove the native stack in the GitHub UI.
 
 → [Native GitHub Stacks guide](docs/integrations/github-native-stacks.md)
 

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -30,7 +30,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 |---|---|
 | `st ss` | Submit the whole stack — open or update linked PRs |
 | `st stack link` | Register the current PR stack as a native GitHub Stack when `gh-stack` is available |
-| `st stack unlink` | Remove the native GitHub Stack object for the current stack |
+| `st stack unlink` | Unstack a locally tracked native GitHub Stack; stax-linked stacks may require `gh stack checkout <pr>` first |
 | `st branch submit` | Submit only the current branch; if its parent is already synced to the remote, Stax may publish a temporary rebased head without moving your local branch |
 | `st upstack submit` | Submit current branch and descendants; descendants are temporarily chained onto any temporary parent publish heads |
 | `st draft [branch]` | Convert the current (or named) branch's PR to draft |
@@ -46,7 +46,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 
 Scoped submit keeps local branch metadata unchanged when it prepares a temporary publish head. Plain `git commit` work on the branch is included; `st restack` remains the command that updates local branch tips and parent revisions.
 
-On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change. stax strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before calling `gh stack`, since the private-preview native-stack API only accepts an OAuth-authenticated `gh` login; `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics. See [Native GitHub Stacked PRs](../integrations/github-native-stacks.md).
+On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change. stax strips ambient `GH_TOKEN`/`GITHUB_TOKEN` before calling `gh stack`, since the private-preview native-stack API only accepts an OAuth-authenticated `gh` login; `st doctor` recommends `gh-stack` v0.0.6+ for reliable auth-error diagnostics. `st stack unlink` delegates to `gh stack unstack`, which only works for stacks gh-stack tracks locally; if stax registered the stack, run `gh stack checkout <pr>` first or remove the native stack in the GitHub UI. See [Native GitHub Stacked PRs](../integrations/github-native-stacks.md).
 
 ## Sync, restack, update
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -11,7 +11,7 @@ The complete command surface. For day-to-day commands only, see [Core commands](
 | `st log` | `l` | Show stack with commits and PR info |
 | `st submit` | `ss` | Submit full current stack |
 | `st stack link` | | Register the current PR stack as a native GitHub Stack via `gh stack link` |
-| `st stack unlink` | | Remove the native GitHub Stack object via `gh stack unstack` |
+| `st stack unlink` | | Unstack a locally tracked native GitHub Stack via `gh stack unstack`; stax-linked stacks may require `gh stack checkout <pr>` first |
 | `st merge` | | Cascade-merge from bottom to current (see flags below) |
 | `st merge-when-ready` | `mwr` | Backward-compatible alias for `st merge --when-ready` |
 | `st sync` | `rs` | Pull trunk, delete merged branches (incl. squash merges), reparent children |

--- a/skills.md
+++ b/skills.md
@@ -25,7 +25,7 @@ stax log|l                     # Stack status with commits + PR info
 
 stax submit|ss                 # Submit full stack
 stax stack link                # Register current PR stack as native GitHub Stack (GitHub + gh-stack)
-stax stack unlink              # Remove native GitHub Stack object
+stax stack unlink              # Unstack locally tracked native stack; stax-linked stacks may need gh stack checkout <pr>
 stax merge                     # Merge PRs from stack bottom upward
 stax sync|rs                   # Sync trunk + clean merged branches
 stax sweep                     # Classify + optionally delete merged/gone/stale branches

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1359,7 +1359,7 @@ pub(crate) enum StackCommands {
     /// Register the current stack as a native GitHub Stack via `gh stack`
     Link,
 
-    /// Remove the native GitHub Stack object via `gh stack`
+    /// Unstack a locally tracked native GitHub Stack via `gh stack`
     Unlink,
 }
 

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -161,6 +161,35 @@ fn test_full_command_reference_mentions_visible_top_level_commands() {
     );
 }
 
+#[test]
+fn docs_clarify_stack_unlink_requires_gh_stack_local_tracking() {
+    let docs = [
+        ("README.md", include_str!("../README.md")),
+        (
+            "docs/commands/core.md",
+            include_str!("../docs/commands/core.md"),
+        ),
+        (
+            "docs/commands/reference.md",
+            include_str!("../docs/commands/reference.md"),
+        ),
+        ("skills.md", include_str!("../skills.md")),
+    ];
+
+    for (path, content) in docs {
+        assert!(
+            !content.contains("Remove native GitHub Stack object")
+                && !content.contains("remove the native GitHub Stack object")
+                && !content.contains("Remove the native GitHub Stack object"),
+            "{path} should not imply `st stack unlink` directly removes every native GitHub Stack object"
+        );
+        assert!(
+            content.contains("gh stack checkout <pr>") || content.contains("locally tracked"),
+            "{path} should mention gh-stack local tracking or `gh stack checkout <pr>` for `st stack unlink`"
+        );
+    }
+}
+
 // =============================================================================
 // Sync Command Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Clarify that `st stack unlink` delegates to `gh stack unstack` and only works for native stacks that gh-stack tracks locally.
- Update README, command docs, `skills.md`, and CLI help to point stax-linked stacks toward `gh stack checkout <pr>` or GitHub UI removal.
- Add a docs consistency regression test so high-traffic docs do not revert to claiming direct native stack removal.

## Tests
- `cargo nextest run command_coverage_tests::docs_clarify_stack_unlink_requires_gh_stack_local_tracking`
- `rustfmt --edition 2024 --check src/cli/args.rs tests/command_coverage_tests.rs`
- `cargo nextest run command_coverage_tests::test_full_command_reference_mentions_visible_top_level_commands`
- `make test` (1788 passed)

## Docs note
- Updated `README.md`, `docs/commands/core.md`, `docs/commands/reference.md`, and `skills.md` because this changes user-visible command guidance.

Closes #592
