### PR TITLE
feat: make sync summaries actionable

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -309,6 +309,8 @@ st completions elvish
 - `--delete-upstream-gone`
 - `--force` / `--safe` / `--continue` / `--quiet` / `--verbose`
 - Imported branches from `st get` are remote-delete exempt: once they are detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch.
+- The completion footer summarizes the trunk commit, file, and line delta together with non-zero merged-cleanup, imported-update, and restack counts. It reuses sync's existing results and does not perform extra network or Git work.
+- When sync itself leaves exceptional work behind, it reports skipped cleanup with its reason, trunk update failures, and cleanup-driven checkout changes. It prints one prioritized next command: recover trunk first, then inspect blocked cleanup with `st sweep`. Routine restack health remains visible in `st ls` and the TUI instead of appearing after every sync.
 
 ### `st restack`
 

--- a/docs/superpowers/plans/2026-07-11-action-first-sync-summary.md
+++ b/docs/superpowers/plans/2026-07-11-action-first-sync-summary.md
@@ -1,0 +1,150 @@
+# Action-First Sync Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich `st sync` with a zero-extra-I/O change summary and conditional next-action guidance.
+
+**Architecture:** Extend the existing `SyncStats` accumulator with structured outcomes gathered during the current sync phases. Keep formatting in pure helpers so output behavior and next-command priority are unit-testable, then populate the accumulator without adding Git or network operations.
+
+**Tech Stack:** Rust, git2, existing Stax integration harness, colored terminal output.
+
+## Global Constraints
+
+- Add no network calls or Git subprocesses to the default reporting path.
+- Preserve `--quiet` behavior and existing detailed warnings.
+- Omit zero-value footer segments and print at most one contextual `Next:` command.
+- Update `docs/commands/reference.md` and `skills.md`; leave the README command table unchanged because command semantics and flags do not change.
+
+---
+
+### Task 1: Preserve and render existing sync facts
+
+**Files:**
+- Modify: `src/commands/sync.rs`
+
+**Interfaces:**
+- Produces: `parse_diff_shortstat(&str) -> Option<(usize, usize, usize)>` returning files, additions, and deletions.
+- Produces: extended `SyncStats` footer fields for imported updates and checkout changes.
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add assertions that shortstat parsing preserves `752`, that the footer contains
+`752 files`, and that updated imported branches appear only when non-zero.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `cargo nextest run --lib commands::sync::tests::parses_diff_shortstat_line_counts commands::sync::tests::render_sync_footer_is_colored_and_compact`
+
+Expected: FAIL because the parser still returns only additions/deletions and the
+footer has no file/imported fields.
+
+- [ ] **Step 3: Implement the minimal data changes**
+
+Extend `TrunkSummary::Pulled` with `files: usize`, preserve the first shortstat
+number, add `imported_branches_updated: usize` to `SyncStats`, and render both
+segments with correct singular/plural copy.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `cargo nextest run --lib commands::sync::tests::`
+
+Expected: all sync unit tests pass.
+
+### Task 2: Render conditional attention and one next command
+
+**Files:**
+- Modify: `src/commands/sync.rs`
+
+**Interfaces:**
+- Produces: `CleanupSkip { branch: String, reason: String }`.
+- Produces: `render_sync_follow_up(&SyncStats) -> Vec<String>`.
+- Consumes: final trunk reachability, current/final checkout, and cleanup outcomes.
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover skipped-cleanup reasons, checkout changes, an out-of-sync trunk, clean
+output with no follow-up, and next-command priority: trunk recovery before
+`st sweep`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `cargo nextest run --lib commands::sync::tests::render_sync_follow_up`
+
+Expected: FAIL because the follow-up renderer does not exist.
+
+- [ ] **Step 3: Implement structured collection and rendering**
+
+Accumulate cleanup skip reasons at existing `continue`/blocked paths, compare
+the initial and final checkout, mark trunk reachability using the already
+resolved fetched revision, and print the pure renderer's lines after the footer
+when not quiet.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `cargo nextest run --lib commands::sync::tests::`
+
+Expected: all sync unit tests pass.
+
+### Task 3: Verify the CLI behavior end to end
+
+**Files:**
+- Modify: `tests/integration_tests.rs`
+
+**Interfaces:**
+- Consumes: the public `st sync` command output.
+- Produces: regression coverage for file-count output and the absence of ambient restack guidance.
+
+- [ ] **Step 1: Add failing integration assertions**
+
+Extend the existing trunk-update sync test to assert a `file` count in the
+completion footer. Add or extend a stacked-branch sync test to assert that
+routine restack state does not produce a warning or `Next:` command when
+`--restack` is absent.
+
+- [ ] **Step 2: Run targeted integration tests and verify RED/GREEN behavior**
+
+Run each exact module path with `cargo nextest run integration_tests::<test_name>`.
+
+Expected: each assertion fails before its corresponding implementation and
+passes afterward.
+
+- [ ] **Step 3: Run the sync-focused integration module filters**
+
+Run: `cargo nextest run 'integration_tests::test_sync'`
+
+Expected: all selected sync integration tests pass.
+
+### Task 4: Document and verify the user-visible output
+
+**Files:**
+- Modify: `docs/commands/reference.md`
+- Modify: `skills.md`
+
+**Interfaces:**
+- Produces: user and agent guidance matching the implemented default output.
+
+- [ ] **Step 1: Update documentation**
+
+Describe the enriched completion footer, conditional attention lines, and
+single next-command priority without documenting internal implementation.
+
+- [ ] **Step 2: Run formatting and targeted validation**
+
+Run: `cargo fmt --check`
+
+Run: `cargo nextest run --lib commands::sync::tests::`
+
+Expected: formatting is clean and all sync unit tests pass.
+
+- [ ] **Step 3: Run full-suite validation**
+
+Run: `make test`
+
+Expected: the Docker-backed full suite passes with zero failures.
+
+- [ ] **Step 4: Review the final diff and publish with Stax**
+
+Run: `git diff --check && git status --short && st ss --draft --no-template`
+
+Expected: no whitespace errors, only scoped files are changed, and Stax creates
+or updates the draft PR for `cesar/improve-sync-summary`.

--- a/docs/superpowers/specs/2026-07-11-action-first-sync-summary-design.md
+++ b/docs/superpowers/specs/2026-07-11-action-first-sync-summary-design.md
@@ -1,0 +1,70 @@
+# Action-First Sync Summary Design
+
+## Goal
+
+Make the final `st sync` / `st rs` output answer two questions without adding
+meaningful runtime: what changed, and what still needs attention?
+
+## Default output
+
+Keep the existing one-line completion footer and enrich it only with information
+already produced by the sync flow:
+
+```text
+Sync complete! main +108 commits | 752 files +30,954 -5,422 | cleaned 2 merged | updated 1 imported | 14.022s
+```
+
+The footer omits zero-value optional segments. An up-to-date trunk retains the
+existing `main up to date` wording.
+
+## Conditional follow-up
+
+After the footer, print a compact attention section only when sync leaves work
+behind:
+
+```text
+⚠ Cleanup skipped for old-auth (dirty worktree)
+→ Checked out main after cleanup
+Next: st sweep
+```
+
+The possible messages are:
+
+- cleanup attempts that were declined or could not safely delete a branch,
+  including the branch and concise reason;
+- trunk not reaching the fetched remote revision;
+- a checkout change caused by cleaning the current branch;
+- imported branches updated during sync.
+
+Print at most one `Next:` command. Priority is trunk recovery, then inspecting
+skipped cleanup with `st sweep`. Routine restack health is intentionally absent:
+it is ambient repository state already available in `st ls` and the TUI, and
+would otherwise turn the completion summary into a persistent nag.
+
+## Data and performance
+
+- Preserve the file count already emitted by `git diff --shortstat`; do not add a
+  second diff.
+- Accumulate cleanup, imported-update, and checkout results while their existing
+  operations run.
+- Do not add network calls or Git subprocesses to the default reporting path.
+
+## Error handling
+
+Reporting must never hide an existing detailed warning. The final summary may
+repeat exceptional actionable state caused by sync in shorter form.
+
+## Tests
+
+- Unit tests cover shortstat parsing, footer rendering, attention rendering, and
+  next-command priority.
+- Integration tests exercise the binary for a trunk update and verify that a
+  branch needing routine restacking does not add follow-up noise.
+- Existing sync tests remain unchanged unless the richer output intentionally
+  extends their assertions.
+
+## Documentation
+
+Document the compact footer and conditional attention lines in
+`docs/commands/reference.md` and `skills.md`. The README command table does not
+need a change because command semantics and flags are unchanged.

--- a/skills.md
+++ b/skills.md
@@ -285,6 +285,8 @@ stax sync --full                   # Fetch all remote branches with --prune (slo
 stax sync --no-delete              # Keep merged branches
 stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 # sync cleanup may delete merged/gone imported support branches locally, but never push-deletes their remotes.
+# The sync footer reports trunk commits/files/line changes plus non-zero cleanup/imported/restack counts.
+# Conditional attention lines name blocked cleanup, trunk failures, and checkout changes, followed by one prioritized next command. Routine restack health stays in stax ls and the TUI.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
 stax sweep --delete                # Delete merged/tracked-merged PRs + upstream-gone branches with no unique work after confirmation

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -33,6 +33,40 @@ struct SyncStats {
     trunk: Option<TrunkSummary>,
     merged_branches_cleaned: usize,
     restacked_branches: usize,
+    imported_branches_updated: usize,
+    trunk_not_updated: Option<TrunkNotUpdated>,
+    cleanup_skips: Vec<CleanupSkip>,
+    checkout_change: Option<CheckoutChange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrunkNotUpdated {
+    branch: String,
+    remote_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CleanupSkip {
+    branch: String,
+    reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CheckoutChange {
+    from: String,
+    to: String,
+}
+
+impl SyncStats {
+    fn record_cleanup_skip(&mut self, branch: &str, reason: impl Into<String>) {
+        if self.cleanup_skips.iter().any(|skip| skip.branch == branch) {
+            return;
+        }
+        self.cleanup_skips.push(CleanupSkip {
+            branch: branch.to_string(),
+            reason: reason.into(),
+        });
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +90,7 @@ enum TrunkSummary {
     Pulled {
         branch: String,
         commits: usize,
+        files: usize,
         additions: usize,
         deletions: usize,
     },
@@ -544,6 +579,7 @@ pub fn run(
         quiet,
         verbose,
     )?;
+    stats.imported_branches_updated = updated_imported_branches.len();
     if !imported_branches.is_empty() {
         step_timings.push((
             "update imported branches".to_string(),
@@ -675,8 +711,11 @@ pub fn run(
                         blocking_worktree_cleanup,
                         confirmed_dirty_worktree_removal,
                     ));
-                } else if !quiet {
-                    println!("    {} {}", branch.bright_black(), "skipped".dimmed());
+                } else {
+                    stats.record_cleanup_skip(branch, "not confirmed");
+                    if !quiet {
+                        println!("    {} {}", branch.bright_black(), "skipped".dimmed());
+                    }
                 }
             }
 
@@ -716,6 +755,10 @@ pub fn run(
                 }
 
                 if !parent_exists_locally {
+                    stats.record_cleanup_skip(
+                        branch,
+                        format!("missing local parent {}", parent_branch),
+                    );
                     if !quiet {
                         println!(
                             "    {} {}",
@@ -833,6 +876,7 @@ pub fn run(
                             }
                         }
                         Err(checkout_error) => {
+                            stats.record_cleanup_skip(branch, "checkout failed");
                             if !quiet {
                                 println!(
                                     "    {} {}",
@@ -897,6 +941,7 @@ pub fn run(
                     match crate::git::refs::delete_metadata(repo.inner(), branch) {
                         Ok(()) => true,
                         Err(e) => {
+                            stats.record_cleanup_skip(branch, "metadata cleanup failed");
                             println!(
                                 "{}",
                                 format!(
@@ -914,6 +959,14 @@ pub fn run(
 
                 if metadata_deleted {
                     stats.merged_branches_cleaned += 1;
+                }
+
+                if !local_deleted && local_still_exists {
+                    let reason = blocking_worktree_cleanup
+                        .as_ref()
+                        .and_then(BlockingWorktreeCleanup::blocker_summary)
+                        .unwrap_or_else(|| "local branch kept".to_string());
+                    stats.record_cleanup_skip(branch, reason);
                 }
 
                 if !quiet {
@@ -1137,6 +1190,7 @@ pub fn run(
                     );
 
                 if !confirm {
+                    stats.record_cleanup_skip(branch, "not confirmed");
                     if !quiet {
                         println!("    {} {}", branch.bright_black(), "skipped".dimmed());
                     }
@@ -1156,6 +1210,7 @@ pub fn run(
                             }
                         }
                         Err(checkout_error) => {
+                            stats.record_cleanup_skip(branch, "checkout failed");
                             if !quiet {
                                 println!(
                                     "    {} {}",
@@ -1213,6 +1268,7 @@ pub fn run(
                     match crate::git::refs::delete_metadata(repo.inner(), branch) {
                         Ok(()) => true,
                         Err(e) => {
+                            stats.record_cleanup_skip(branch, "metadata cleanup failed");
                             println!(
                                 "{}",
                                 format!(
@@ -1227,6 +1283,14 @@ pub fn run(
                 } else {
                     false
                 };
+
+                if !local_deleted && local_still_exists {
+                    let reason = blocking_worktree_cleanup
+                        .as_ref()
+                        .and_then(BlockingWorktreeCleanup::blocker_summary)
+                        .unwrap_or_else(|| "local branch kept".to_string());
+                    stats.record_cleanup_skip(branch, reason);
+                }
 
                 if !quiet {
                     if local_deleted {
@@ -1625,6 +1689,22 @@ pub fn run(
         .is_some_and(|remote| resolve_ref_oid(&workdir, &stack.trunk).as_deref() == Some(remote));
     stats.trunk = trunk_reached_remote.then_some(trunk_summary).flatten();
 
+    if !trunk_reached_remote {
+        stats.trunk_not_updated = Some(TrunkNotUpdated {
+            branch: stack.trunk.clone(),
+            remote_ref: remote_trunk_ref.clone(),
+        });
+    }
+
+    if current_after_deletions != current {
+        stats.checkout_change = Some(CheckoutChange {
+            from: current.clone(),
+            to: current_after_deletions.clone(),
+        });
+    }
+
+    stats.cleanup_skips.sort_by(|a, b| a.branch.cmp(&b.branch));
+
     if let Some(pr_refresh_elapsed) = refresh_pr_draft_states(&repo, &config, quiet) {
         step_timings.push(("refresh PR metadata".to_string(), pr_refresh_elapsed));
     }
@@ -1651,11 +1731,14 @@ pub fn run(
             render_sync_footer(&stats, sync_started_at.elapsed())
         );
 
-        if !restack && stats.merged_branches_cleaned > 0 && config.ui.tips {
-            println!(
-                "{}",
-                "Hint: Run `st restack --all` to rebase branches onto the updated trunk.".dimmed()
-            );
+        let follow_up = render_sync_follow_up(&stats);
+        if !follow_up.is_empty() {
+            println!();
+            for line in follow_up {
+                if config.ui.tips || !line.starts_with("Next:") {
+                    println!("{}", line);
+                }
+            }
         }
     }
 
@@ -2826,6 +2909,7 @@ fn render_sync_footer(stats: &SyncStats, total_duration: Duration) -> String {
             TrunkSummary::Pulled {
                 branch,
                 commits,
+                files,
                 additions,
                 deletions,
             } => {
@@ -2840,7 +2924,8 @@ fn render_sync_footer(stats: &SyncStats, total_duration: Duration) -> String {
                     .green()
                 ));
                 parts.push(format!(
-                    "{} {}",
+                    "{} {} {}",
+                    format!("{} file{}", files, if *files == 1 { "" } else { "s" }).dimmed(),
                     format!("+{}", additions).green(),
                     format!("-{}", deletions).red()
                 ));
@@ -2868,8 +2953,51 @@ fn render_sync_footer(stats: &SyncStats, total_duration: Duration) -> String {
         ));
     }
 
+    if stats.imported_branches_updated > 0 {
+        parts.push(format!(
+            "{} {}",
+            "updated".dimmed(),
+            format!("{} imported", stats.imported_branches_updated)
+                .cyan()
+                .bold()
+        ));
+    }
+
     parts.push(format!("{}", format_duration(total_duration).cyan()));
     parts.join(&format!("{}", " | ".dimmed()))
+}
+
+fn render_sync_follow_up(stats: &SyncStats) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    if let Some(trunk) = &stats.trunk_not_updated {
+        lines.push(format!(
+            "⚠ {} did not reach {}; review the warnings above",
+            trunk.branch, trunk.remote_ref
+        ));
+    }
+
+    for skip in &stats.cleanup_skips {
+        lines.push(format!(
+            "⚠ Cleanup skipped for {} ({})",
+            skip.branch, skip.reason
+        ));
+    }
+
+    if let Some(checkout) = &stats.checkout_change {
+        lines.push(format!(
+            "→ Checked out {} after cleanup (was {})",
+            checkout.to, checkout.from
+        ));
+    }
+
+    if stats.trunk_not_updated.is_some() {
+        lines.push("Next: st trunk".to_string());
+    } else if !stats.cleanup_skips.is_empty() {
+        lines.push("Next: st sweep".to_string());
+    }
+
+    lines
 }
 
 fn wait_for_trunk_summary(
@@ -2896,11 +3024,12 @@ fn summarize_trunk_transition(
 
             if is_ancestor(workdir, local_before, remote_after_fetch) {
                 let commits = count_commits_between(workdir, local_before, remote_after_fetch)?;
-                let (additions, deletions) =
+                let (files, additions, deletions) =
                     diff_line_stats_between(workdir, local_before, remote_after_fetch)?;
                 return Ok(Some(TrunkSummary::Pulled {
                     branch: branch.to_string(),
                     commits,
+                    files,
                     additions,
                     deletions,
                 }));
@@ -2959,7 +3088,11 @@ fn count_commits_between(workdir: &Path, base: &str, head: &str) -> Result<usize
         .context("Failed to parse fetched trunk commit count")
 }
 
-fn diff_line_stats_between(workdir: &Path, base: &str, head: &str) -> Result<(usize, usize)> {
+fn diff_line_stats_between(
+    workdir: &Path,
+    base: &str,
+    head: &str,
+) -> Result<(usize, usize, usize)> {
     let range = format!("{}..{}", base, head);
     let output = Command::new("git")
         .args([
@@ -2987,11 +3120,12 @@ fn diff_line_stats_between(workdir: &Path, base: &str, head: &str) -> Result<(us
         .ok_or_else(|| anyhow::anyhow!("Failed to parse git diff --shortstat output: {stdout:?}"))
 }
 
-fn parse_diff_shortstat(output: &str) -> Option<(usize, usize)> {
+fn parse_diff_shortstat(output: &str) -> Option<(usize, usize, usize)> {
     if output.trim().is_empty() {
-        return Some((0, 0));
+        return Some((0, 0, 0));
     }
 
+    let mut files = 0;
     let mut additions = 0;
     let mut deletions = 0;
     let mut recognized = false;
@@ -2999,6 +3133,7 @@ fn parse_diff_shortstat(output: &str) -> Option<(usize, usize)> {
     for part in output.trim().split(',').map(str::trim) {
         let value = part.split_whitespace().next()?.parse::<usize>().ok()?;
         if part.contains("file changed") || part.contains("files changed") {
+            files = value;
             recognized = true;
         } else if part.contains("insertion") {
             additions = value;
@@ -3009,7 +3144,7 @@ fn parse_diff_shortstat(output: &str) -> Option<(usize, usize)> {
         }
     }
 
-    recognized.then_some((additions, deletions))
+    recognized.then_some((files, additions, deletions))
 }
 
 #[cfg(test)]
@@ -3048,11 +3183,14 @@ mod tests {
                 trunk: Some(TrunkSummary::Pulled {
                     branch: "main".to_string(),
                     commits: 1,
+                    files: 12,
                     additions: 434,
                     deletions: 22,
                 }),
                 merged_branches_cleaned: 2,
                 restacked_branches: 1,
+                imported_branches_updated: 1,
+                ..SyncStats::default()
             },
             Duration::from_millis(14_022),
         );
@@ -3061,10 +3199,13 @@ mod tests {
 
         assert!(footer.contains("main"));
         assert!(footer.contains("+1 commit"));
+        assert!(footer.contains("12 files"));
         assert!(footer.contains("+434"));
         assert!(footer.contains("-22"));
         assert!(footer.contains("cleaned"));
         assert!(footer.contains("restacked"));
+        assert!(footer.contains("updated"));
+        assert!(footer.contains("1 imported"));
         assert!(footer.contains("14.022s"));
         assert!(footer.contains('\u{1b}'));
     }
@@ -3080,6 +3221,8 @@ mod tests {
                 }),
                 merged_branches_cleaned: 0,
                 restacked_branches: 0,
+                imported_branches_updated: 0,
+                ..SyncStats::default()
             },
             Duration::from_secs(2),
         );
@@ -3093,12 +3236,66 @@ mod tests {
     }
 
     #[test]
+    fn render_sync_follow_up_is_empty_when_sync_needs_no_attention() {
+        assert!(render_sync_follow_up(&SyncStats::default()).is_empty());
+    }
+
+    #[test]
+    fn render_sync_follow_up_prioritizes_trunk_recovery() {
+        let lines = render_sync_follow_up(&SyncStats {
+            trunk_not_updated: Some(TrunkNotUpdated {
+                branch: "main".to_string(),
+                remote_ref: "origin/main".to_string(),
+            }),
+            cleanup_skips: vec![CleanupSkip {
+                branch: "old-auth".to_string(),
+                reason: "dirty worktree".to_string(),
+            }],
+            checkout_change: Some(CheckoutChange {
+                from: "old-auth".to_string(),
+                to: "main".to_string(),
+            }),
+            ..SyncStats::default()
+        });
+        let output = lines.join("\n");
+
+        assert!(output.contains("main did not reach origin/main"));
+        assert!(output.contains("Cleanup skipped for old-auth (dirty worktree)"));
+        assert!(output.contains("Checked out main after cleanup (was old-auth)"));
+        assert!(output.contains("Next: st trunk"));
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|line| line.starts_with("Next:"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn render_sync_follow_up_suggests_sweep_for_skipped_cleanup() {
+        let lines = render_sync_follow_up(&SyncStats {
+            cleanup_skips: vec![CleanupSkip {
+                branch: "old-auth".to_string(),
+                reason: "dirty worktree".to_string(),
+            }],
+            ..SyncStats::default()
+        });
+
+        let output = lines.join("\n");
+
+        assert!(output.contains("Next: st sweep"));
+        assert!(!output.contains("Next: st restack --all"));
+    }
+
+    #[test]
     fn waits_for_slow_trunk_summary_instead_of_dropping_it() {
         let worker = std::thread::spawn(|| {
             std::thread::sleep(Duration::from_millis(1_100));
             Ok(Some(TrunkSummary::Pulled {
                 branch: "main".to_string(),
                 commits: 108,
+                files: 752,
                 additions: 30_954,
                 deletions: 5_422,
             }))
@@ -3112,6 +3309,7 @@ mod tests {
             summary,
             TrunkSummary::Pulled {
                 commits: 108,
+                files: 752,
                 additions: 30_954,
                 deletions: 5_422,
                 ..
@@ -3134,7 +3332,7 @@ mod tests {
     fn parses_diff_shortstat_line_counts() {
         assert_eq!(
             parse_diff_shortstat(" 752 files changed, 30954 insertions(+), 5422 deletions(-)\n"),
-            Some((30_954, 5_422))
+            Some((752, 30_954, 5_422))
         );
     }
 
@@ -3142,13 +3340,13 @@ mod tests {
     fn parses_diff_shortstat_with_only_insertions() {
         assert_eq!(
             parse_diff_shortstat(" 1 file changed, 7 insertions(+)\n"),
-            Some((7, 0))
+            Some((1, 7, 0))
         );
     }
 
     #[test]
     fn parses_empty_diff_shortstat_as_zero_changes() {
-        assert_eq!(parse_diff_shortstat(""), Some((0, 0)));
+        assert_eq!(parse_diff_shortstat(""), Some((0, 0, 0)));
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3106,7 +3106,7 @@ fn test_sync_pulls_trunk_updates() {
         stdout
     );
     assert!(
-        stdout.contains("+1 -0"),
+        stdout.contains("1 file +1 -0"),
         "Expected trunk diff stats in sync footer, got: {}",
         stdout
     );
@@ -3140,8 +3140,13 @@ fn test_sync_with_feature_branch() {
 
     let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("Sync") || stdout.contains("complete") || stdout.contains("Updating"),
-        "Expected sync output, got: {}",
+        !stdout.contains("need restacking"),
+        "Ambient restack state should not appear in sync output, got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("Next: st restack"),
+        "Sync should not nag about routine restacking, got: {}",
         stdout
     );
 }
@@ -5565,6 +5570,25 @@ fn test_sync_detects_merged_branch_when_local_trunk_diverged() {
         output.status.success(),
         "Sync failed: {}",
         TestRepo::stderr(&output)
+    );
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("main did not reach origin/main"),
+        "Expected diverged trunk attention, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Next: st trunk"),
+        "Expected trunk recovery command, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&format!(
+            "Checked out main after cleanup (was {})",
+            branch_name
+        )),
+        "Expected checkout-change summary, got: {}",
+        stdout
     );
 
     // Branch should be deleted as merged even though local main diverged

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -476,8 +476,12 @@ fn sync_keeps_metadata_when_branch_delete_blocked_by_worktree() {
     repo.git(&["push", "origin", "--delete", &a])
         .assert_success();
 
-    let output = repo.run_stax_in(&wt_a, &["sync", "--force", "--safe", "--quiet"]);
-    output.assert_success();
+    let output = repo.run_stax_in(&wt_a, &["sync", "--force", "--safe"]);
+    output
+        .assert_success()
+        .assert_stdout_contains(&format!("Cleanup skipped for {}", a))
+        .assert_stdout_contains("checkout failed")
+        .assert_stdout_contains("Next: st sweep");
 
     let branch_ref = format!("refs/heads/{}", a);
     repo.git(&["show-ref", "--verify", "--quiet", &branch_ref])


### PR DESCRIPTION
## Summary

- enrich the `st rs` footer with file counts and imported-branch updates
- surface exceptional sync outcomes such as trunk failures, blocked cleanup, and cleanup-driven checkout changes
- keep routine restack health in `st ls` and the TUI instead of nagging after every sync
- avoid the extra final stack scan previously needed for restack guidance

## Testing

- `make check`
- `make test` — 1,855 tests passed
- `cargo nextest run integration_tests::test_sync_with_feature_branch`

## Documentation

- updated `docs/commands/reference.md`, `skills.md`, and the implementation design/plan
- `README.md` does not need an update because command semantics, flags, defaults, and quick-start workflows are unchanged