### PR TITLE
Promote linked worktrees to the main checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Each lane is a real Git worktree with normal stax metadata — it appears in `st
 ```bash
 st wt         # open the worktree dashboard
 st wt rs      # restack every lane at once when trunk moves
+st wt promote # move the current lane branch back to the main worktree
 st ss         # submit PRs for the ones that are ready
 ```
 
@@ -317,6 +318,7 @@ st config --set-ai
 | `st split` | Split a branch into stacked branches (by commit or `--hunk`) |
 | `st lane <name> "<task>"` | Spawn an AI agent on a new lane |
 | `st wt` | Open the worktree dashboard |
+| `st wt promote` | Retire the current lane and check its branch out in the main worktree |
 | `st resolve` | AI-resolve an in-progress rebase conflict |
 | `st create --ai` | Generate a branch name from local changes |
 | `st gen` / `st generate` | AI: interactive picker, or `--pr-body` / `--pr-title` / `--commit-msg` |
@@ -416,10 +418,10 @@ Use `--path` to scope either mode to a subdirectory.
 stax runs on Windows (x86_64) with prebuilt binaries on [Releases](https://github.com/cesarferreira/stax/releases). Most commands work identically, with these limitations:
 
 - **Shell integration is not available.** `st setup` supports bash/zsh/fish only. On Windows:
-  - `st wt c` / `st wt go` create and navigate worktrees but cannot auto-`cd` the parent shell. Manually `cd` to the printed path.
+  - `st wt c` / `st wt go` create and navigate worktrees but cannot auto-`cd` the parent shell. `st wt promote` performs the handoff but likewise requires the printed `cd` command.
   - The `sw` quick alias is not available.
   - `st wt rm` (bare) cannot relocate the shell. Specify: `st wt rm <name>`.
-- **Worktree commands still work.** `st wt c/go/ls/ll/cleanup/rm/prune/restack` all function — only the shell-level `cd` is missing.
+- **Worktree commands still work.** `st wt c/go/ls/ll/promote/cleanup/rm/prune/restack` all function — only the shell-level `cd` is missing.
 - **tmux integration requires WSL** or a Unix-like environment. The [stax.tmux](https://github.com/cesarferreira/stax.tmux) plugin is Unix-only.
 
 Everything else — stacked branches, PRs, restack, sync, undo/redo, TUI, AI generation — works on Windows without limitation.

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -195,6 +195,7 @@ Full guide: [Worktrees](../worktrees/index.md) · [AI lanes](../workflows/agent-
 | `st worktree go [name]` | `wt go`, `wtgo` | Navigate to a worktree (shell integration required for `cd`) |
 | `st worktree path <name>` | | Print absolute path (scripting) |
 | `st worktree remove [name]` | `wt rm`, `wtrm` | Remove a worktree (`wt rm` removes the current lane) |
+| `st worktree promote` | `wt promote` | Retire the current lane and check its branch out in the main worktree |
 | `st worktree prune` | `wt prune`, `wtprune` | Clean stale git worktree bookkeeping |
 | `st worktree cleanup` | `wt cleanup`, `wt clean` | Prune + remove safe detached/merged lanes (`--dry-run` previews) |
 | `st worktree restack` | `wt rs`, `wtrs` | Restack all stax-managed worktrees |

--- a/docs/superpowers/plans/2026-07-11-worktree-promote.md
+++ b/docs/superpowers/plans/2026-07-11-worktree-promote.md
@@ -1,0 +1,329 @@
+# Worktree Promote Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `st wt promote`, which safely retires the current linked worktree and checks its branch out in the main worktree.
+
+**Architecture:** A focused `commands::worktree::promote` transaction will preflight both checkouts, run the existing removal hooks, detach the linked checkout, switch the main checkout, and then reuse the existing remove-or-park primitive. Small Git helpers provide detached checkout and HEAD capture for rollback. The existing shell-control protocol will relocate integrated shells only after the transaction succeeds.
+
+**Tech Stack:** Rust, clap, git CLI/libgit2 wrapper, Stax worktree pool/hooks, consolidated nextest integration suite.
+
+## Global Constraints
+
+- The command surface is `st worktree promote` and `st wt promote`; v1 accepts no selector, `--stash`, or `--force`.
+- Both the linked and main worktrees must be clean and free of locks, conflicts, rebases, or merges.
+- Preserve branch commits, upstreams, PR links, and Stax metadata.
+- Roll back both checkout locations after unexpected switch or retirement failures when their paths remain available.
+- Use existing worktree hooks, pooling, removal, and shell-output mechanisms.
+- Update user-facing documentation and `skills.md` in the same change.
+- Use targeted `cargo nextest run worktree_promote_tests::` during development and `make test` for final full-suite validation.
+
+---
+
+### Task 1: Core promotion transaction
+
+**Files:**
+- Create: `src/commands/worktree/promote.rs`
+- Modify: `src/commands/worktree/mod.rs`
+- Modify: `src/commands/worktree/remove.rs`
+- Modify: `src/git/repo.rs`
+- Create: `tests/worktree_promote_tests.rs`
+- Modify: `tests/all_tests.rs`
+
+**Interfaces:**
+- Consumes: `GitRepo::list_worktrees`, `compute_worktree_details`, worktree hook helpers, and `RemovalMode::AllowParking`.
+- Produces: `promote::run(shell_output: bool) -> anyhow::Result<()>`, `GitRepo::switch_detached_in(cwd: &Path, target: Option<&str>) -> anyhow::Result<()>`, `GitRepo::head_oid_in(cwd: &Path) -> anyhow::Result<String>`, and `remove::retire_worktree(...) -> anyhow::Result<String>`.
+
+- [ ] **Step 1: Write failing end-to-end tests**
+
+Create `tests/worktree_promote_tests.rs` with helpers that create a committed feature branch in a linked worktree. Add tests that invoke `repo.run_stax_in(&linked, &["wt", "promote"])` and assert:
+
+```rust
+assert!(output.status.success());
+assert_eq!(git_branch(&repo.path()), feature_branch);
+assert!(!linked.exists());
+assert!(repo.path().join("feature.txt").exists());
+```
+
+Add bad-path tests that dirty the linked checkout, dirty the main checkout, detach the linked checkout, and invoke promote from the main checkout. Each must fail, preserve the original worktree registrations/checkouts, and include the blocking reason in stderr. Register the module in `tests/all_tests.rs`.
+
+- [ ] **Step 2: Run the new tests and confirm the command is absent**
+
+Run: `cargo nextest run worktree_promote_tests::`
+
+Expected: FAIL because clap does not recognize `promote`.
+
+- [ ] **Step 3: Add rollback-capable Git helpers**
+
+Add these focused methods in `src/git/repo.rs`, using the existing `run_git` error style:
+
+```rust
+pub(crate) fn head_oid_in(&self, cwd: &Path) -> Result<String>;
+
+pub(crate) fn switch_detached_in(
+    &self,
+    cwd: &Path,
+    target: Option<&str>,
+) -> Result<()>;
+```
+
+`head_oid_in` runs `git rev-parse HEAD`. `switch_detached_in` runs `git switch --detach` with an optional target and includes the path and Git stderr in failures.
+
+- [ ] **Step 4: Split hook orchestration from removal storage**
+
+Extract the park-or-remove body of `remove_worktree_with_hooks` into:
+
+```rust
+pub(crate) fn retire_worktree(
+    repo: &GitRepo,
+    config: &Config,
+    worktree: &WorktreeInfo,
+    force: bool,
+    mode: RemovalMode,
+) -> Result<String>;
+```
+
+Keep `remove_worktree_with_hooks` behavior unchanged by running `pre_remove`, calling `retire_worktree`, then starting `post_remove`. This lets promotion run the pre-hook before changing checkout state and the post-hook only after the transaction commits.
+
+- [ ] **Step 5: Implement the promotion transaction**
+
+In `src/commands/worktree/promote.rs`, implement:
+
+```rust
+pub fn run(shell_output: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let worktrees = repo.list_worktrees()?;
+    let source = worktrees.iter().find(|wt| wt.is_current).cloned()
+        .context("Could not identify the current worktree")?;
+    let main = worktrees.iter().find(|wt| wt.is_main).cloned()
+        .context("Could not identify the main worktree")?;
+
+    if source.is_main {
+        bail!("Cannot promote the main worktree.");
+    }
+    let branch = source.branch.clone().context(
+        "Cannot promote a detached worktree. Check out a branch first.",
+    )?;
+    ensure_clean_checkout(
+        "current linked worktree",
+        &compute_worktree_details(&repo, source.clone())?,
+    )?;
+    ensure_clean_checkout(
+        "main worktree",
+        &compute_worktree_details(&repo, main.clone())?,
+    )?;
+
+    let main_head = repo.head_oid_in(&main.path)?;
+    run_blocking_hook(
+        config.worktree.hooks.pre_remove.as_deref(),
+        &main.path,
+        "pre_remove",
+    )?;
+    repo.switch_detached_in(&source.path, None)?;
+
+    if let Err(error) = repo.switch_branch_in(&main.path, &branch) {
+        let rollback = repo.switch_branch_in(&source.path, &branch).err();
+        return Err(transaction_error("switch the main worktree", error, rollback));
+    }
+
+    std::env::set_current_dir(&main.path)?;
+    if let Err(error) = retire_worktree(
+        &repo,
+        &config,
+        &source,
+        false,
+        RemovalMode::AllowParking,
+    ) {
+        let main_rollback = restore_checkout(&repo, &main, &main_head).err();
+        let source_rollback = repo.switch_branch_in(&source.path, &branch).err();
+        return Err(transaction_errors(
+            "retire the linked worktree",
+            error,
+            [main_rollback, source_rollback],
+        ));
+    }
+
+    spawn_background_hook(
+        config.worktree.hooks.post_remove.as_deref(),
+        &main.path,
+        "post_remove",
+    )?;
+    finish_success(shell_output, &main.path, &branch);
+    Ok(())
+}
+```
+
+Define `ensure_clean_checkout(label: &str, details: &WorktreeDetails) -> Result<()>` to reject, in order, missing/prunable paths, locks, dirty state, rebases, merges, and conflicts with messages beginning `Cannot promote: the {label}`. Define `restore_checkout` to switch back to `main.branch` when present or detach at `main_head` otherwise. Define `transaction_error`/`transaction_errors` to preserve the original error and append non-empty rollback errors, and `finish_success` to emit either shell-control lines or direct-invocation guidance. Before retirement, call `std::env::set_current_dir(&main.path)` so removal is not executed from inside the retiring directory.
+
+- [ ] **Step 6: Run and fix the focused tests**
+
+Run: `cargo nextest run worktree_promote_tests::`
+
+Expected: PASS for the happy path and all preflight errors.
+
+- [ ] **Step 7: Add injected Git-failure rollback tests**
+
+On Unix, add a temporary `git` shim that delegates to the real Git binary except when environment variables request failure of either `git switch <feature>` in the main worktree or `git worktree remove <linked>`. Assert both failures leave the main worktree on its original checkout and the linked worktree on the feature branch.
+
+- [ ] **Step 8: Run the complete promote module**
+
+Run: `cargo nextest run worktree_promote_tests::`
+
+Expected: PASS, including both rollback tests.
+
+- [ ] **Step 9: Commit the transaction**
+
+```bash
+git add src/commands/worktree/promote.rs src/commands/worktree/mod.rs \
+  src/commands/worktree/remove.rs src/git/repo.rs \
+  tests/worktree_promote_tests.rs tests/all_tests.rs
+git commit -m "feat: add worktree promotion transaction"
+```
+
+### Task 2: CLI and shell integration
+
+**Files:**
+- Modify: `src/cli/args.rs`
+- Modify: `src/cli/mod.rs`
+- Modify: `src/cli/tests.rs`
+- Modify: `src/commands/shell_setup.rs`
+- Modify: `tests/worktree_promote_tests.rs`
+
+**Interfaces:**
+- Consumes: `promote::run(shell_output: bool)` and existing `STAX_SHELL_PATH` / `STAX_SHELL_MESSAGE` output parsing.
+- Produces: clap parsing for `WorktreeCommands::Promote { shell_output: bool }` and POSIX/fish routing through `__stax_run_worktree_shell`.
+
+- [ ] **Step 1: Add failing parser and shell-output tests**
+
+Add a clap test asserting `st wt promote --shell-output` parses as `WorktreeCommands::Promote { shell_output: true }`. Add an integration assertion that successful shell-output mode includes:
+
+```text
+STAX_SHELL_PATH=<absolute main worktree path>
+STAX_SHELL_MESSAGE=Promoted '<branch>' to the main worktree
+```
+
+Add shell-snippet unit assertions that both generated snippets route `promote` through `__stax_run_worktree_shell`.
+
+- [ ] **Step 2: Run tests and confirm parser/routing failures**
+
+Run: `cargo nextest run cli::tests worktree_promote_tests:: commands::shell_setup::tests`
+
+Expected: FAIL because the variant and shell dispatch case are missing.
+
+- [ ] **Step 3: Wire clap and command dispatch**
+
+Add to `WorktreeCommands`:
+
+```rust
+/// Move the current linked-worktree branch to the main worktree
+Promote {
+    #[arg(long, hide = true)]
+    shell_output: bool,
+},
+```
+
+Dispatch it in `src/cli/mod.rs` with:
+
+```rust
+Some(WorktreeCommands::Promote { shell_output }) =>
+    commands::worktree::promote::run(shell_output),
+```
+
+- [ ] **Step 4: Route integrated shells**
+
+In both POSIX and fish snippets, include `promote` in the worktree subcommand case that calls `__stax_run_worktree_shell`. On success, the wrapper consumes the payload and changes directory; on failure, `__stax_run_worktree_shell` returns before changing directory.
+
+- [ ] **Step 5: Implement direct-invocation guidance**
+
+When `shell_output` is false, print the main path and a copyable `cd <path>` line with `Current shell did not move automatically.`. If shell integration is not installed, also print the existing `stax setup` tip. Do not emit shell-control lines on any failure.
+
+- [ ] **Step 6: Run CLI, shell, and promotion tests**
+
+Run: `cargo nextest run cli::tests worktree_promote_tests:: commands::shell_setup::tests`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit CLI integration**
+
+```bash
+git add src/cli/args.rs src/cli/mod.rs src/cli/tests.rs \
+  src/commands/shell_setup.rs tests/worktree_promote_tests.rs
+git commit -m "feat: expose worktree promote command"
+```
+
+### Task 3: User documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/worktrees/index.md`
+- Modify: `docs/commands/reference.md`
+- Modify: `skills.md`
+
+**Interfaces:**
+- Consumes: the completed `st wt promote` behavior.
+- Produces: consistent command maps, workflow guidance, safety rules, and AI-agent guidance.
+
+- [ ] **Step 1: Update every command map**
+
+Add `st wt promote` alongside create/go/remove in each command table. Describe it as retiring the current linked worktree and checking its branch out in the main worktree.
+
+- [ ] **Step 2: Document safety and shell behavior**
+
+In `docs/worktrees/index.md`, add a short promotion section covering clean-checkout requirements, preserved metadata, rollback behavior, shell integration, and the manual `cd` fallback. Explicitly state that the command does not stash or delete the branch.
+
+- [ ] **Step 3: Check documentation consistency**
+
+Run: `rg -n "wt promote|worktree promote" README.md docs skills.md`
+
+Expected: entries in the worktree overview, command reference, canonical worktree guide, and agent skill map.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add README.md docs/worktrees/index.md docs/commands/reference.md skills.md
+git commit -m "docs: document worktree promotion"
+```
+
+### Task 4: Verification and Stax PR
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+**Interfaces:**
+- Consumes: completed implementation, tests, and documentation.
+- Produces: formatted, fully tested branch submitted as a Stax PR.
+
+- [ ] **Step 1: Format and inspect the diff**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS. If it fails, run `cargo fmt --all`, inspect the formatting-only diff, and rerun the check.
+
+Run: `git diff --check main...HEAD && git status --short`
+
+Expected: no whitespace errors and only intentional files.
+
+- [ ] **Step 2: Run targeted verification once more**
+
+Run: `cargo nextest run worktree_promote_tests::`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the repository-prescribed full suite**
+
+Run: `make test`
+
+Expected: PASS through the Docker test path on macOS. If Docker is unavailable, launch Docker Desktop as directed by `AGENTS.md` and retry; do not fall back to a native full suite.
+
+- [ ] **Step 4: Review final branch state**
+
+Run: `git status --short && git log --oneline main..HEAD && stax status`
+
+Expected: a clean tracked `codex/worktree-promote` branch stacked on `main`.
+
+- [ ] **Step 5: Submit the Stax PR**
+
+Run: `stax submit --no-fetch --draft --no-template --edit`
+
+Expected: the branch is pushed and a draft PR is created or updated with `main` as its base. Remove `--edit` if the environment is non-interactive and use `stax submit --ai --yes` to generate the title/body instead.

--- a/docs/superpowers/specs/2026-07-11-worktree-promote-design.md
+++ b/docs/superpowers/specs/2026-07-11-worktree-promote-design.md
@@ -1,0 +1,149 @@
+# Worktree Promote
+
+**Date:** 2026-07-11
+**Status:** Approved
+
+## Problem
+
+A branch checked out in a linked worktree is already a normal Git branch, but
+moving that branch back to the repository's main worktree currently requires a
+manual sequence: leave or remove the linked worktree, check out its branch in
+the main worktree, and relocate the shell. The sequence is easy to get wrong,
+especially because Git prevents one branch from being checked out in two
+worktrees at once.
+
+Stax should provide one safe command for turning the current linked-worktree
+lane into the branch checked out in the main worktree.
+
+## Goals
+
+- Add `st wt promote` / `st worktree promote` for the current linked worktree.
+- Preserve the branch, commits, upstream, PR linkage, and Stax metadata.
+- Retire the linked worktree using the configured remove-or-park behavior.
+- Check out the promoted branch in the main worktree.
+- Move the parent shell to the main worktree when shell integration is active.
+- Fail without changing either worktree when known safety preconditions are not
+  met.
+- Roll back checkout changes when an unexpected Git failure occurs during the
+  handoff.
+
+## Non-goals
+
+- Promoting a named worktree from another checkout.
+- Automatically stashing or moving uncommitted changes.
+- Adding a `--stash` or `--force` mode.
+- Deleting or untracking the promoted branch.
+- Adding the action to the worktree dashboard in the first version.
+- Moving ignored dependency or build artifacts into the main worktree.
+
+## Command Surface
+
+```text
+st worktree promote
+st wt promote
+```
+
+The command accepts no worktree selector in the first version. It always acts
+on the current checkout, which keeps the command's meaning and shell relocation
+unambiguous.
+
+Running it from the main worktree is an error because there is no linked
+worktree to promote. Running it from a detached HEAD is also an error because
+there is no branch to hand off.
+
+## Preconditions
+
+Before running hooks or changing Git state, Stax resolves the main worktree and
+the current linked worktree, then verifies all of the following:
+
+- the current checkout is a linked worktree, not the main worktree;
+- the linked worktree is on a local branch;
+- both the linked worktree and main worktree are clean;
+- neither checkout is locked or has an in-progress merge, rebase, or conflict;
+- the main worktree path exists and is usable; and
+- the branch is not checked out in any worktree other than the current one.
+
+If a check fails, Stax exits with a specific explanation and suggested manual
+recovery command where useful. It does not offer to stash automatically.
+
+## Handoff Flow
+
+Stax records the source branch and the branch currently checked out in the main
+worktree, then performs the handoff:
+
+1. Run the existing blocking `pre_remove` hook for the linked worktree.
+2. Detach HEAD in the linked worktree, releasing the source branch.
+3. Switch the main worktree to the source branch.
+4. Retire the linked worktree through the existing removal infrastructure,
+   allowing configured warm-slot parking when eligible.
+5. Run the existing background `post_remove` hook.
+6. Emit the main worktree path for shell integration and print a concise success
+   message naming the branch and destination.
+
+The command reuses existing worktree discovery, cleanliness checks, hooks,
+parking, removal, and shell-message mechanisms rather than duplicating their
+policies.
+
+## Rollback
+
+All predictable failures are caught during preflight. For unexpected failures:
+
+- If switching the main worktree fails after the linked worktree is detached,
+  Stax switches the linked worktree back to the source branch.
+- If retiring the linked worktree fails after the main worktree has switched,
+  Stax switches the main worktree back to its original branch, then switches
+  the linked worktree back to the source branch.
+- If rollback itself fails, Stax reports the exact resulting checkout state and
+  manual commands needed to recover. It never claims the promotion succeeded.
+
+The linked worktree is not removed before the main checkout succeeds, so the
+most destructive operation occurs last.
+
+## Shell Behavior
+
+With Stax shell integration, a successful `st wt promote` changes the parent
+shell's directory to the main worktree after the command completes. The shell
+wrapper must not move the shell on failure.
+
+Without shell integration, Stax cannot change the parent process's directory.
+It prints the main worktree path and a copyable `cd` command, consistent with
+the existing worktree create/go behavior.
+
+## User-facing Output
+
+Success output should state that the branch was promoted and identify the main
+worktree path. Errors should identify which checkout blocks the operation and
+why, for example:
+
+```text
+Cannot promote: the main worktree has uncommitted changes at <path>.
+Commit or stash those changes, then retry `st wt promote`.
+```
+
+## Documentation
+
+The implementation updates:
+
+- `README.md` if its worktree command overview lists individual actions;
+- `docs/worktrees/index.md`;
+- `docs/commands/reference.md`; and
+- `skills.md`.
+
+## Testing
+
+Integration tests exercise the real `stax` binary in temporary repositories.
+Coverage includes:
+
+- successful promotion of a clean linked worktree;
+- preservation of Stax metadata and the branch's commit;
+- warm-slot parking and real-removal configurations;
+- refusal when the linked worktree is dirty;
+- refusal when the main worktree is dirty;
+- refusal from detached HEAD;
+- refusal from the main worktree;
+- rollback when switching the main worktree fails;
+- rollback when linked-worktree retirement fails; and
+- shell integration relocating only after success.
+
+Targeted worktree tests provide the tight feedback loop. Final full-suite
+verification uses `make test` as required by the repository test policy.

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -28,6 +28,9 @@ st wt c payments-api --from main
 # Jump back into a lane
 st wt go payments-api
 
+# Make this lane the branch checked out in the main worktree
+st wt promote
+
 # Inventory
 st wt ls
 st wt ll
@@ -83,6 +86,7 @@ Selectors accepted by `go`, `path`, `rm`, and reuse paths in `create`:
 | `st wt ll` | `st worktree ll`, `st wtll` | Rich status view with managed/dirty/rebase/conflict/marker/prunable state (`--json`) |
 | `st wt path <name>` | `st worktree path <name>` | Print absolute path |
 | `st wt rm [name]` | `st worktree remove`, `st wtrm` | Remove one worktree (`wt rm` removes current); supports `-f/--force`, `--delete-branch` |
+| `st wt promote` | `st worktree promote` | Retire the current linked worktree and check its branch out in the main worktree |
 | `st wt prune` | `st worktree prune`, `st wtprune` | Remove stale `git worktree` bookkeeping only |
 | `st wt cleanup` | `st worktree cleanup`, `st wt clean` | Prune + bulk-remove safe detached/merged lanes (`--dry-run`, `--yes`, `-f`) |
 | `st wt restack` | `st worktree restack`, `st wtrs`, `st wt rs` | Restack all stax-managed worktrees |
@@ -150,6 +154,7 @@ After installation:
 
 - `st wt c ...` moves the parent shell into the new lane
 - `st wt go ...` moves the parent shell into the selected lane
+- `st wt promote` moves the parent shell to the main worktree after a successful handoff
 - `st lane ...` moves the parent shell into the selected lane
 - `st wt rm` (no arg) can relocate the shell before removing the current worktree
 - `sw <name>` becomes a quick alias for `st wt go <name>`
@@ -157,7 +162,24 @@ After installation:
 Supports `bash`, `zsh`, and `fish`.
 
 !!! note "Windows"
-    On Windows, worktree commands work but the parent shell cannot auto-`cd`, `sw` is unavailable, and tmux integration is not supported. Manually `cd` to the printed path after `st wt c` / `st wt go`. See [Windows notes](../reference/windows.md).
+    On Windows, worktree commands work but the parent shell cannot auto-`cd`, `sw` is unavailable, and tmux integration is not supported. Manually `cd` to the printed path after `st wt c`, `st wt go`, or `st wt promote`. See [Windows notes](../reference/windows.md).
+
+## Promote a lane to the main worktree
+
+Run `st wt promote` inside a linked worktree when you want to continue that
+branch in the repository's main worktree. Stax detaches the linked checkout,
+checks the same branch out in the main worktree, then removes or parks the old
+lane according to the existing warm-slot configuration.
+
+Promotion preserves the branch, commits, upstream, PR linkage, and stax
+metadata. It does not merge, delete, untrack, or automatically stash anything.
+Both the current lane and main worktree must be clean, unlocked, and free of an
+in-progress merge, rebase, or conflicts. If switching or retirement fails,
+Stax restores the original checkouts and reports any rollback problem.
+
+With shell integration, the current shell moves to the main worktree only after
+the handoff succeeds. Without it, Stax prints the main worktree path and a
+copyable `cd` command.
 
 ## Cleanup and safety
 
@@ -165,6 +187,7 @@ Supports `bash`, `zsh`, and `fish`.
 |---|---|
 | `st wt rm [name]` | Remove one live worktree (no name = current) |
 | `st wt rm --delete-branch` | Also delete the branch and its stax metadata |
+| `st wt promote` | Keep the branch and make it the main-worktree checkout |
 | `st wt prune` | Clear stale `git worktree` bookkeeping only — never removes a live directory |
 | `st wt cleanup` | Prune bookkeeping, then bulk-remove safe candidates |
 | `st wt rs` | Restack all stax-managed lanes |

--- a/skills.md
+++ b/skills.md
@@ -111,6 +111,7 @@ stax worktree ll               # Richer worktree status (managed/prunable/confli
 stax worktree go <name>        # Navigate to a worktree (requires shell integration)
 stax worktree path <name>      # Print absolute path of a worktree (for scripting)
 stax worktree remove <name>    # Remove a worktree
+stax worktree promote          # Retire current lane + check its branch out in main worktree
 stax worktree cleanup          # Prune stale bookkeeping + bulk-remove merged/detached worktrees
 stax worktree restack          # Restack all stax-managed worktrees
 stax setup                     # Install shell integration, then optionally offer AI agent skills + auth onboarding
@@ -442,6 +443,7 @@ stax wt ll                                        # Rich status of all lanes
 stax wt rs                                        # Restack ALL stax-managed worktrees after trunk moves
 stax wt rm add-dark-mode --delete-branch          # Remove worktree + delete branch + metadata
 stax wt rm add-dark-mode --force                  # Force remove dirty worktree
+stax wt promote                                    # Continue current lane branch in main worktree
 stax wt cleanup --dry-run                         # Preview bulk prune/remove decisions
 stax wt cleanup                                   # Prune stale entries + remove merged/detached lanes
 
@@ -588,6 +590,9 @@ sw payments-api
 stax restack --all
 stax ss
 
+# Hand this branch back to the main worktree (both checkouts must be clean)
+stax worktree promote
+
 # Clean up
 stax worktree remove payments-api
 ```
@@ -654,7 +659,8 @@ Symbols:
 7. Use `stax lane <name> [prompt]` to give each AI agent its own isolated worktree — prevents agents from conflicting on the same files.
 8. After trunk moves, run `stax wt rs` once instead of rebasing each agent worktree manually.
 9. Use `stax worktree create` when you want a worktree for an existing local branch, fetched remote branch, or human parallel development — `st lane` is the higher-level AI shortcut.
-10. Run `stax setup` once per machine to enable `stax worktree go` and the `sw` alias without executing `stax` on every shell startup.
+10. Use `stax worktree promote` inside a clean lane to retire it and continue its branch in the main worktree without losing stax or PR metadata.
+11. Run `stax setup` once per machine to enable `stax worktree go`, `stax worktree promote`, and the `sw` alias to move the parent shell automatically.
 
 ## Tips
 
@@ -666,4 +672,5 @@ Symbols:
 - Use `--json` on supported commands for machine-readable output.
 - Use `stax lane` with no arguments for an interactive picker over all stax-managed lanes — useful when you forget where a session lives.
 - Use `stax worktree go` (or `sw`) + shell integration to switch between stacks without `cd` gymnastics.
+- Use `stax worktree promote` when a lane should become the main-worktree checkout; it refuses dirty or conflicted checkouts instead of stashing automatically.
 - `stax worktree list` shows ALL worktrees including those created externally via `git worktree add`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1716,6 +1716,12 @@ pub(crate) enum WorktreeCommands {
         delete_branch: bool,
     },
 
+    /// Move the current linked-worktree branch to the main worktree
+    Promote {
+        #[arg(long, hide = true)]
+        shell_output: bool,
+    },
+
     /// Remove stale git worktree bookkeeping
     Prune,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -842,6 +842,9 @@ pub fn run() -> Result<()> {
                 force,
                 delete_branch,
             }) => commands::worktree::remove::run(name, force, delete_branch),
+            Some(WorktreeCommands::Promote { shell_output }) => {
+                commands::worktree::promote::run(shell_output)
+            }
             Some(WorktreeCommands::Prune) => commands::worktree::prune::run(),
             Some(WorktreeCommands::Cleanup {
                 force,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -121,6 +121,17 @@ fn worktree_cleanup_subcommand_parses() {
 }
 
 #[test]
+fn worktree_promote_subcommand_parses_shell_output() {
+    let cli = parse_cli(&["stax", "wt", "promote", "--shell-output"]);
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Worktree {
+            command: Some(WorktreeCommands::Promote { shell_output: true })
+        })
+    ));
+}
+
+#[test]
 fn lane_command_parses_without_name_for_picker() {
     let cli = parse_cli(&["stax", "lane"]);
     assert!(matches!(

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -202,7 +202,7 @@ __stax_dispatch() {
       fi ;;
     worktree|wt)
       case "$2" in
-        go|create|c)
+        go|create|c|promote)
           __stax_run_worktree_shell "$@" ;;
         remove|rm)
           if [[ -z "$3" || "$3" == -* ]]; then
@@ -356,7 +356,7 @@ function __stax_dispatch
             end
         case worktree wt
             switch "$argv[2]"
-                case go create c
+                case go create c promote
                     __stax_run_worktree_shell $argv
                 case remove rm
                     if test (count $argv) -lt 3; or string match -qr '^-' -- "$argv[3]"
@@ -983,6 +983,139 @@ mod tests {
         assert!(snippet.contains("whence -p"));
         assert!(snippet.contains("type -P"));
         assert!(snippet.contains("__stax_exec()"));
+    }
+
+    #[test]
+    fn fish_shell_snippet_routes_worktree_promote_through_shell_output() {
+        let snippet = shell_snippet(ShellKind::Fish);
+
+        assert!(snippet.contains("case go create c promote"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn posix_shell_snippet_wraps_worktree_promote_in_zsh() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+            if err.kind() == ErrorKind::NotFound {
+                return;
+            }
+            panic!("failed to probe zsh: {err}");
+        }
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+
+        let fake_stax = bin_dir.join("stax");
+        fs::write(&fake_stax, "#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\n").expect("write fake stax");
+        let mut perms = fs::metadata(&fake_stax)
+            .expect("fake stax metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_stax, perms).expect("chmod fake stax");
+
+        let snippet_path = dir.path().join("shell-setup.sh");
+        fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
+
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        let path_env = format!("{}:{original_path}", bin_dir.display());
+        let command = format!("source \"{}\"; st wt promote", snippet_path.display());
+        let output = Command::new("zsh")
+            .arg("-lc")
+            .arg(&command)
+            .env("PATH", path_env)
+            .output()
+            .expect("run zsh shell snippet");
+
+        assert!(
+            output.status.success(),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("args:wt promote --shell-output"),
+            "expected promote to inject --shell-output, got:\n{stdout}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn posix_shell_snippet_relocates_after_successful_promote_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+            if err.kind() == ErrorKind::NotFound {
+                return;
+            }
+            panic!("failed to probe zsh: {err}");
+        }
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        let source = dir.path().join("source");
+        let target = dir.path().join("main");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        fs::create_dir_all(&source).expect("create source dir");
+        fs::create_dir_all(&target).expect("create target dir");
+
+        let fake_stax = bin_dir.join("stax");
+        fs::write(
+            &fake_stax,
+            "#!/bin/sh\nprintf 'STAX_SHELL_PATH=%s\\n' \"$PROMOTE_TARGET\"\nprintf 'STAX_SHELL_MESSAGE=promoted\\n'\n",
+        )
+        .expect("write fake stax");
+        let mut perms = fs::metadata(&fake_stax)
+            .expect("fake stax metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_stax, perms).expect("chmod fake stax");
+
+        let snippet_path = dir.path().join("shell-setup.sh");
+        fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        let path_env = format!("{}:{original_path}", bin_dir.display());
+        let command = format!(
+            "source \"{}\"; cd \"{}\"; st wt promote; printf 'cwd:%s\\n' \"$PWD\"",
+            snippet_path.display(),
+            source.display()
+        );
+        let output = Command::new("zsh")
+            .arg("-lc")
+            .arg(&command)
+            .env("PATH", &path_env)
+            .env("PROMOTE_TARGET", &target)
+            .output()
+            .expect("run successful promote wrapper");
+        assert!(output.status.success());
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(&format!("cwd:{}", target.display()))
+        );
+
+        fs::write(
+            &fake_stax,
+            "#!/bin/sh\nprintf 'STAX_SHELL_PATH=%s\\n' \"$PROMOTE_TARGET\"\nexit 1\n",
+        )
+        .expect("write failing fake stax");
+        let command = format!(
+            "source \"{}\"; cd \"{}\"; st wt promote || true; printf 'cwd:%s\\n' \"$PWD\"",
+            snippet_path.display(),
+            source.display()
+        );
+        let output = Command::new("zsh")
+            .arg("-lc")
+            .arg(&command)
+            .env("PATH", path_env)
+            .env("PROMOTE_TARGET", &target)
+            .output()
+            .expect("run failing promote wrapper");
+        assert!(output.status.success());
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(&format!("cwd:{}", source.display()))
+        );
     }
 
     #[cfg(unix)]

--- a/src/commands/worktree/mod.rs
+++ b/src/commands/worktree/mod.rs
@@ -5,6 +5,7 @@ pub mod go;
 pub mod list;
 pub mod ll;
 pub mod pool;
+pub mod promote;
 pub mod prune;
 pub mod remove;
 pub mod restack;

--- a/src/commands/worktree/promote.rs
+++ b/src/commands/worktree/promote.rs
@@ -1,0 +1,164 @@
+use super::remove::{RemovalMode, retire_worktree};
+use super::shared::{
+    WorktreeDetails, compute_worktree_details, emit_shell_message, emit_shell_payload,
+    run_blocking_hook, spawn_background_hook,
+};
+use crate::commands::shell_setup;
+use crate::config::Config;
+use crate::git::GitRepo;
+use crate::git::repo::WorktreeInfo;
+use anyhow::{Context, Result, anyhow, bail};
+use colored::Colorize;
+use std::path::Path;
+
+pub fn run(shell_output: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let worktrees = repo.list_worktrees()?;
+    let source = worktrees
+        .iter()
+        .find(|worktree| worktree.is_current)
+        .cloned()
+        .context("Could not identify the current worktree")?;
+    let main = worktrees
+        .iter()
+        .find(|worktree| worktree.is_main)
+        .cloned()
+        .context("Could not identify the main worktree")?;
+
+    if source.is_main {
+        bail!("Cannot promote the main worktree.");
+    }
+    let branch = source
+        .branch
+        .clone()
+        .context("Cannot promote a detached worktree. Check out a branch first.")?;
+
+    ensure_clean_checkout(
+        "current linked worktree",
+        &compute_worktree_details(&repo, source.clone())?,
+    )?;
+    ensure_clean_checkout(
+        "main worktree",
+        &compute_worktree_details(&repo, main.clone())?,
+    )?;
+
+    let main_head = repo.head_oid_in(&main.path)?;
+    run_blocking_hook(
+        config.worktree.hooks.pre_remove.as_deref(),
+        &main.path,
+        "pre_remove",
+    )?;
+    repo.switch_detached_in(&source.path, None)?;
+
+    if let Err(error) = repo.switch_branch_in(&main.path, &branch) {
+        let rollback = repo.switch_branch_in(&source.path, &branch).err();
+        return Err(transaction_error(
+            "switch the main worktree",
+            error,
+            rollback.into_iter(),
+        ));
+    }
+
+    std::env::set_current_dir(&main.path).with_context(|| {
+        format!(
+            "Failed to enter the main worktree at '{}'",
+            main.path.display()
+        )
+    })?;
+    let retiring_source = WorktreeInfo {
+        is_current: false,
+        ..source.clone()
+    };
+
+    if let Err(error) = retire_worktree(
+        &repo,
+        &config,
+        &retiring_source,
+        false,
+        RemovalMode::AllowParking,
+    ) {
+        let main_rollback = restore_checkout(&repo, &main, &main_head).err();
+        let source_rollback = repo.switch_branch_in(&source.path, &branch).err();
+        return Err(transaction_error(
+            "retire the linked worktree",
+            error,
+            [main_rollback, source_rollback].into_iter().flatten(),
+        ));
+    }
+
+    spawn_background_hook(
+        config.worktree.hooks.post_remove.as_deref(),
+        &main.path,
+        "post_remove",
+    )?;
+    finish_success(shell_output, &main.path, &branch);
+    Ok(())
+}
+
+fn ensure_clean_checkout(label: &str, details: &WorktreeDetails) -> Result<()> {
+    let path = details.info.path.display();
+    if !details.info.path.exists() || details.info.is_prunable {
+        bail!("Cannot promote: the {label} path is unavailable at '{path}'.");
+    }
+    if details.info.is_locked {
+        bail!("Cannot promote: the {label} is locked at '{path}'.");
+    }
+    if details.dirty {
+        bail!(
+            "Cannot promote: the {label} has uncommitted changes at '{path}'.\nCommit or stash those changes, then retry `st wt promote`."
+        );
+    }
+    if details.rebase_in_progress {
+        bail!("Cannot promote: the {label} has a rebase in progress at '{path}'.");
+    }
+    if details.merge_in_progress {
+        bail!("Cannot promote: the {label} has a merge in progress at '{path}'.");
+    }
+    if details.has_conflicts {
+        bail!("Cannot promote: the {label} has unresolved conflicts at '{path}'.");
+    }
+    Ok(())
+}
+
+fn restore_checkout(repo: &GitRepo, worktree: &WorktreeInfo, original_head: &str) -> Result<()> {
+    match worktree.branch.as_deref() {
+        Some(branch) => repo.switch_branch_in(&worktree.path, branch),
+        None => repo.switch_detached_in(&worktree.path, Some(original_head)),
+    }
+}
+
+fn transaction_error(
+    action: &str,
+    error: anyhow::Error,
+    rollback_errors: impl Iterator<Item = anyhow::Error>,
+) -> anyhow::Error {
+    let mut message = format!("Failed to {action}: {error}");
+    for rollback_error in rollback_errors {
+        message.push_str(&format!("\nRollback also failed: {rollback_error}"));
+    }
+    anyhow!(message)
+}
+
+fn finish_success(shell_output: bool, main_path: &Path, branch: &str) {
+    let message = format!("Promoted '{branch}' to the main worktree");
+    if shell_output {
+        emit_shell_payload(main_path, None);
+        emit_shell_message(&message);
+        return;
+    }
+
+    println!("{}  '{}'", "Promoted".green().bold(), branch.cyan());
+    println!("  Main worktree: {}", main_path.display());
+    println!();
+    println!("{}", "Current shell did not move automatically.".yellow());
+    println!("  {}", format!("cd {}", main_path.display()).cyan());
+    if !shell_setup::is_installed() {
+        println!();
+        println!(
+            "{}",
+            "Tip: add shell integration for automatic cd:".dimmed()
+        );
+        println!("  {}", "stax setup".cyan());
+    }
+}

--- a/src/commands/worktree/remove.rs
+++ b/src/commands/worktree/remove.rs
@@ -29,6 +29,31 @@ pub(crate) fn remove_worktree_with_hooks(
     force: bool,
     mode: RemovalMode,
 ) -> Result<String> {
+    let main_workdir = repo.main_repo_workdir()?;
+    run_blocking_hook(
+        config.worktree.hooks.pre_remove.as_deref(),
+        &main_workdir,
+        "pre_remove",
+    )?;
+
+    let display_name = retire_worktree(repo, config, worktree, force, mode)?;
+
+    spawn_background_hook(
+        config.worktree.hooks.post_remove.as_deref(),
+        &main_workdir,
+        "post_remove",
+    )?;
+
+    Ok(display_name)
+}
+
+pub(crate) fn retire_worktree(
+    repo: &GitRepo,
+    config: &Config,
+    worktree: &WorktreeInfo,
+    force: bool,
+    mode: RemovalMode,
+) -> Result<String> {
     if worktree.is_main {
         bail!("Cannot remove the main worktree.");
     }
@@ -39,13 +64,6 @@ pub(crate) fn remove_worktree_with_hooks(
             worktree.path.display()
         );
     }
-
-    let main_workdir = repo.main_repo_workdir()?;
-    run_blocking_hook(
-        config.worktree.hooks.pre_remove.as_deref(),
-        &main_workdir,
-        "pre_remove",
-    )?;
 
     let display_name = worktree
         .branch
@@ -64,11 +82,6 @@ pub(crate) fn remove_worktree_with_hooks(
     if mode == RemovalMode::AllowParking && config.worktree.reuse_slots && !force {
         if let Some(worktrees_dir) = pool_dir.as_deref() {
             if try_park_slot(repo, config, worktree, worktrees_dir)? {
-                spawn_background_hook(
-                    config.worktree.hooks.post_remove.as_deref(),
-                    &main_workdir,
-                    "post_remove",
-                )?;
                 return Ok(display_name);
             }
         }
@@ -86,12 +99,6 @@ pub(crate) fn remove_worktree_with_hooks(
             });
         }
     }
-
-    spawn_background_hook(
-        config.worktree.hooks.post_remove.as_deref(),
-        &main_workdir,
-        "post_remove",
-    )?;
 
     Ok(display_name)
 }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -594,7 +594,7 @@ impl GitRepo {
             .map(
                 |(idx, (path, branch, is_locked, lock_reason, is_prunable, prunable_reason))| {
                     let is_main = idx == 0;
-                    let is_current = path == cwd_normalized;
+                    let is_current = cwd_normalized.starts_with(&path);
                     WorktreeInfo {
                         name: labels[idx].clone(),
                         path,

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -349,6 +349,36 @@ impl GitRepo {
         Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
     }
 
+    pub(crate) fn head_oid_in(&self, cwd: &Path) -> Result<String> {
+        let output = self.run_git(cwd, &["rev-parse", "HEAD"])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!(
+                "git rev-parse HEAD failed in '{}': {}",
+                cwd.display(),
+                stderr
+            );
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    pub(crate) fn switch_detached_in(&self, cwd: &Path, target: Option<&str>) -> Result<()> {
+        let mut args = vec!["switch", "--detach"];
+        if let Some(target) = target {
+            args.push(target);
+        }
+        let output = self.run_git(cwd, &args)?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!(
+                "git switch --detach failed in '{}': {}",
+                cwd.display(),
+                stderr
+            );
+        }
+        Ok(())
+    }
+
     pub(crate) fn stash_push_at(&self, cwd: &Path) -> Result<bool> {
         let output = self.run_git(cwd, &["stash", "push", "-u", "-m", "stax auto-stash"])?;
         if !output.status.success() {

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -126,5 +126,7 @@ mod validate_tests;
 mod worktree_cli_tests;
 #[path = "worktree_pool_tests.rs"]
 mod worktree_pool_tests;
+#[path = "worktree_promote_tests.rs"]
+mod worktree_promote_tests;
 #[path = "worktree_tests.rs"]
 mod worktree_tests;

--- a/tests/worktree_promote_tests.rs
+++ b/tests/worktree_promote_tests.rs
@@ -126,6 +126,19 @@ fn wt_promote_moves_current_branch_to_main_worktree() {
 }
 
 #[test]
+fn wt_promote_works_from_nested_directory() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+    let nested = linked.join("nested").join("directory");
+    fs::create_dir_all(&nested).expect("create nested worktree directory");
+
+    let output = repo.run_stax_in(&nested, &["wt", "promote"]);
+
+    output.assert_success();
+    assert_eq!(current_branch(&repo, &repo.path()), branch);
+    assert!(!linked.exists());
+}
+
+#[test]
 fn wt_promote_refuses_dirty_linked_worktree() {
     let (repo, branch, linked) = setup_promotable_worktree();
     fs::write(linked.join("dirty.txt"), "dirty\n").expect("write dirty source file");

--- a/tests/worktree_promote_tests.rs
+++ b/tests/worktree_promote_tests.rs
@@ -1,0 +1,303 @@
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
+use tempfile::TempDir;
+
+fn setup_promotable_worktree() -> (TestRepo, String, PathBuf) {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["create", "promote-feature"])
+        .assert_success();
+    let branch = repo.current_branch();
+    repo.create_file("feature.txt", "promoted\n");
+    repo.commit("Add promoted feature");
+    repo.run_stax(&["checkout", "main"]).assert_success();
+
+    let linked = PathBuf::from(repo.clean_home()).join("promote-feature-worktree");
+    repo.git(&[
+        "worktree",
+        "add",
+        linked.to_str().expect("UTF-8 worktree path"),
+        &branch,
+    ])
+    .assert_success();
+
+    (repo, branch, linked)
+}
+
+fn current_branch(repo: &TestRepo, path: &Path) -> String {
+    let output = repo.git(&[
+        "-C",
+        path.to_str().expect("UTF-8 repository path"),
+        "branch",
+        "--show-current",
+    ]);
+    output.assert_success();
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn worktree_list(repo: &TestRepo) -> String {
+    let output = repo.git(&["worktree", "list", "--porcelain"]);
+    output.assert_success();
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[cfg(unix)]
+fn real_git_path() -> String {
+    let output = Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("resolve git path");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[cfg(unix)]
+fn failing_git_path() -> (TempDir, String) {
+    let bin_dir = TempDir::new().expect("create git shim directory");
+    let shim = bin_dir.path().join("git");
+    fs::write(
+        &shim,
+        r#"#!/bin/sh
+set -eu
+cwd=$(pwd -P)
+mode=${STAX_PROMOTE_FAIL_MODE:-}
+if [ "$mode" = "main-switch" ] && [ "$cwd" = "$STAX_PROMOTE_MAIN" ] && \
+   [ "${1:-}" = "switch" ] && [ "${2:-}" = "$STAX_PROMOTE_BRANCH" ]; then
+  echo "synthetic main switch failure" >&2
+  exit 41
+fi
+if [ "$mode" = "remove" ] && [ "$cwd" = "$STAX_PROMOTE_MAIN" ] && \
+   [ "${1:-}" = "worktree" ] && [ "${2:-}" = "remove" ]; then
+  echo "synthetic worktree remove failure" >&2
+  exit 42
+fi
+exec "$REAL_GIT" "$@"
+"#,
+    )
+    .expect("write git shim");
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = fs::metadata(&shim)
+        .expect("git shim metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&shim, permissions).expect("make git shim executable");
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    (bin_dir, path)
+}
+
+#[test]
+fn wt_promote_moves_current_branch_to_main_worktree() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+
+    let output = repo.run_stax_in(&linked, &["wt", "promote"]);
+
+    output.assert_success();
+    assert_eq!(current_branch(&repo, &repo.path()), branch);
+    assert!(repo.path().join("feature.txt").exists());
+    assert!(
+        !linked.exists(),
+        "promoted linked worktree should be retired"
+    );
+
+    let status = repo.run_stax(&["status", "--json"]);
+    status.assert_success();
+    let status: Value = serde_json::from_slice(&status.stdout).expect("valid status JSON");
+    let promoted = status["branches"]
+        .as_array()
+        .and_then(|branches| {
+            branches
+                .iter()
+                .find(|candidate| candidate["name"].as_str() == Some(&branch))
+        })
+        .expect("promoted branch should remain tracked");
+    assert_eq!(promoted["parent"].as_str(), Some("main"));
+}
+
+#[test]
+fn wt_promote_refuses_dirty_linked_worktree() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+    fs::write(linked.join("dirty.txt"), "dirty\n").expect("write dirty source file");
+
+    let output = repo.run_stax_in(&linked, &["wt", "promote"]);
+
+    output
+        .assert_failure()
+        .assert_stderr_contains("current linked worktree has uncommitted changes");
+    assert_eq!(current_branch(&repo, &repo.path()), "main");
+    assert_eq!(current_branch(&repo, &linked), branch);
+    assert!(linked.exists());
+}
+
+#[test]
+fn wt_promote_refuses_dirty_main_worktree() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+    repo.create_file("dirty-main.txt", "dirty\n");
+
+    let output = repo.run_stax_in(&linked, &["wt", "promote"]);
+
+    output
+        .assert_failure()
+        .assert_stderr_contains("main worktree has uncommitted changes");
+    assert_eq!(current_branch(&repo, &repo.path()), "main");
+    assert_eq!(current_branch(&repo, &linked), branch);
+    assert!(linked.exists());
+}
+
+#[test]
+fn wt_promote_refuses_detached_linked_worktree() {
+    let (repo, _branch, linked) = setup_promotable_worktree();
+    repo.git(&[
+        "-C",
+        linked.to_str().expect("UTF-8 worktree path"),
+        "switch",
+        "--detach",
+    ])
+    .assert_success();
+
+    let output = repo.run_stax_in(&linked, &["wt", "promote"]);
+
+    output
+        .assert_failure()
+        .assert_stderr_contains("Cannot promote a detached worktree");
+    assert_eq!(current_branch(&repo, &repo.path()), "main");
+    assert!(linked.exists());
+}
+
+#[test]
+fn wt_promote_refuses_main_worktree() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["wt", "promote"]);
+
+    output
+        .assert_failure()
+        .assert_stderr_contains("Cannot promote the main worktree");
+    assert_eq!(current_branch(&repo, &repo.path()), "main");
+}
+
+#[test]
+fn wt_promote_emits_shell_payload_only_after_success() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+
+    let output = repo.run_stax_in(&linked, &["wt", "promote", "--shell-output"]);
+
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    let canonical_main = fs::canonicalize(repo.path()).expect("canonical main path");
+    assert!(
+        stdout.contains(&format!("STAX_SHELL_PATH={}", canonical_main.display())),
+        "expected shell path payload, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "STAX_SHELL_MESSAGE=Promoted '{branch}' to the main worktree"
+        )),
+        "expected shell message payload, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn wt_promote_parks_eligible_managed_worktree() {
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    repo.run_stax_with_env(&["wt", "c", "empty-promote"], &[("HOME", &home)])
+        .assert_success();
+    let path_output = repo.run_stax_with_env(&["wt", "path", "empty-promote"], &[("HOME", &home)]);
+    path_output.assert_success();
+    let linked = PathBuf::from(TestRepo::stdout(&path_output).trim());
+    let branch = current_branch(&repo, &linked);
+
+    let output = repo.run_stax_in_with_env(&linked, &["wt", "promote"], &[("HOME", home.as_str())]);
+
+    output.assert_success();
+    assert_eq!(current_branch(&repo, &repo.path()), branch);
+    assert!(
+        linked.exists(),
+        "eligible worktree should remain as a warm slot"
+    );
+    let listed = worktree_list(&repo);
+    assert!(listed.contains(linked.to_string_lossy().as_ref()));
+    let parked = listed
+        .split("\n\n")
+        .find(|entry| entry.contains(linked.to_string_lossy().as_ref()))
+        .expect("parked worktree entry");
+    assert!(!parked.contains(&format!("branch refs/heads/{branch}")));
+    assert!(
+        parked.contains("detached") || parked.contains("branch refs/heads/main"),
+        "expected slot parked off the promoted branch:\n{parked}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wt_promote_rolls_back_when_main_switch_fails() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+    let (_shim_dir, path) = failing_git_path();
+    let main = fs::canonicalize(repo.path())
+        .expect("canonical main path")
+        .to_string_lossy()
+        .into_owned();
+    let real_git = real_git_path();
+
+    let output = repo.run_stax_in_with_env(
+        &linked,
+        &["wt", "promote"],
+        &[
+            ("PATH", path.as_str()),
+            ("REAL_GIT", real_git.as_str()),
+            ("STAX_PROMOTE_FAIL_MODE", "main-switch"),
+            ("STAX_PROMOTE_MAIN", main.as_str()),
+            ("STAX_PROMOTE_BRANCH", branch.as_str()),
+        ],
+    );
+
+    output
+        .assert_failure()
+        .assert_stderr_contains("synthetic main switch failure");
+    assert_eq!(current_branch(&repo, &repo.path()), "main");
+    assert_eq!(current_branch(&repo, &linked), branch);
+    assert!(linked.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn wt_promote_rolls_back_when_retirement_fails() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+    let (_shim_dir, path) = failing_git_path();
+    let main = fs::canonicalize(repo.path())
+        .expect("canonical main path")
+        .to_string_lossy()
+        .into_owned();
+    let real_git = real_git_path();
+
+    let output = repo.run_stax_in_with_env(
+        &linked,
+        &["wt", "promote"],
+        &[
+            ("PATH", path.as_str()),
+            ("REAL_GIT", real_git.as_str()),
+            ("STAX_PROMOTE_FAIL_MODE", "remove"),
+            ("STAX_PROMOTE_MAIN", main.as_str()),
+            ("STAX_PROMOTE_BRANCH", branch.as_str()),
+        ],
+    );
+
+    output
+        .assert_failure()
+        .assert_stderr_contains("synthetic worktree remove failure");
+    assert_eq!(current_branch(&repo, &repo.path()), "main");
+    assert_eq!(current_branch(&repo, &linked), branch);
+    assert!(linked.exists());
+}


### PR DESCRIPTION
## Summary
- Added `st wt promote` / `st worktree promote` to move the current linked worktree branch back to the main worktree.
- The command now checks both checkouts for clean state, preserves branch metadata, and rolls back if checkout switching or retirement fails.
- Shell integration now hands off to the main worktree on success, with a manual `cd` fallback when shell integration is unavailable.
- Fixed worktree detection for nested directories so promotion works when invoked from subdirectories inside a linked checkout.
- Updated the README, command reference, worktree guide, and `skills.md` to document the new workflow.

## Tests
- Added integration coverage for the happy path, dirty linked/main worktree refusal, detached HEAD refusal, invocation from the main worktree, nested-directory invocation, warm-slot parking, shell payload output, and rollback failures.
- Added CLI parsing and shell snippet tests for the new promote command.