### PR TITLE
perf(test): reduce native macOS test overhead

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install quality-gate dependencies
+        run: sudo apt-get update && sudo apt-get install -y mold ripgrep
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - For full-suite validation, always use `make test`.
 - On macOS, `make test` intentionally routes to the Docker fast path.
 - Use native paths only when explicitly needed:
-  - `make test-native`
+  - `make test-native` (guarded nextest path; validates the file-descriptor limit)
   - `make test-local-ramdisk`
   - `make test-local-fast`
 - Targeted single-test runs via `cargo nextest run <pattern>` are fine and encouraged for tight feedback loops; switch to `make test` once changes are ready for verification.
@@ -18,6 +18,7 @@
 ## Why
 
 - This suite is process/filesystem heavy (`git` + `stax` subprocesses), and Linux Docker is dramatically faster and more stable than native macOS for full runs.
+- Native macOS performance remains sensitive to endpoint-security tooling; do not assume a warm native timing will match Docker.
 
 ## Documentation Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,19 @@ cargo run -- <command>
 
 ## Running Tests
 
-The test suite is process/filesystem heavy (spawns `git` and `stax` subprocesses). `make test` uses Docker on macOS when available; otherwise it runs native nextest with the optimized test profile, sanitized token env, disabled update checks, and a repo-local temp directory.
+The test suite is process/filesystem heavy (spawns `git` and `stax`
+subprocesses). `make test` uses Docker on macOS when available; otherwise it
+runs native nextest with the optimized test profile, sanitized token env,
+disabled update checks, and a repo-local temp directory. On macOS,
+`make test-native` additionally checks and raises the file-descriptor limit
+before starting. Endpoint-security tooling can make native macOS runs much
+slower and more variable than Docker.
 
 ```bash
 # Full test suite (preferred — uses Docker on macOS when available)
 make test
 
-# Full suite natively through the same optimized local path
+# Guarded native fallback (timings vary on macOS)
 make test-native
 
 # Explicit optimized local nextest path used by native full-suite runs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-release release ensure-git-cliff install clean test test-native test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint benchmark-status all
+.PHONY: build build-release release ensure-git-cliff install clean test test-native test-native-script test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint benchmark-status all
 
 RAMDISK_NAME ?= STAXRAM
 RAMDISK_SIZE_MB ?= 2048
@@ -55,20 +55,26 @@ test:
 	fi
 
 # Run all tests natively on host
-test-native:
+test-native: test-native-script
 	$(MAKE) test-local-fast
+
+# Verify the native test runner's guards and phase selection.
+test-native-script:
+	./scripts/native-tests-tests.sh
 
 # Run tests with automation-friendly native defaults (custom temp root, token-free env, optimized profile)
 test-local-fast:
 	mkdir -p .test-tmp
-	@threads="$${NEXTEST_TEST_THREADS:-}"; \
-	if [ -z "$$threads" ] && [ "$$(uname)" = "Darwin" ]; then \
-		threads="$(MAC_LOCAL_TEST_THREADS)"; \
-	fi; \
-	if [ -z "$$threads" ]; then \
-		threads="num-cpus"; \
-	fi; \
-	env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" TMPDIR="$$(pwd)/.test-tmp" NEXTEST_TEST_THREADS="$$threads" RUST_MIN_STACK=4194304 cargo nextest run --cargo-profile "$(NATIVE_CARGO_PROFILE)"
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		NEXTEST_TEST_THREADS="$${NEXTEST_TEST_THREADS:-$(MAC_LOCAL_TEST_THREADS)}" \
+		NATIVE_CARGO_PROFILE="$(NATIVE_CARGO_PROFILE)" \
+		STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" \
+		TMPDIR="$$(pwd)/.test-tmp" \
+		./scripts/native-tests.sh; \
+	else \
+		threads="$${NEXTEST_TEST_THREADS:-num-cpus}"; \
+		env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" TMPDIR="$$(pwd)/.test-tmp" NEXTEST_TEST_THREADS="$$threads" RUST_MIN_STACK=4194304 cargo nextest run --cargo-profile "$(NATIVE_CARGO_PROFILE)"; \
+	fi
 
 # Create a RAM disk for fast local test temp dirs (macOS only)
 ramdisk-up:

--- a/README.md
+++ b/README.md
@@ -436,7 +436,11 @@ Before opening a PR, run:
 make test
 ```
 
-On macOS this uses Docker when available. On Linux and other native paths it runs nextest with the optimized test profile and sanitized test environment.
+On macOS this uses Docker when available. `make test-native` is the guarded
+fallback: it checks the file-descriptor limit, sanitizes the environment, and
+runs nextest with the optimized test profile. Native macOS timings can still
+vary substantially with endpoint-security tooling, so Docker remains the
+recommended full-suite path.
 
 To cut a release, run:
 

--- a/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
+++ b/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
@@ -1,0 +1,899 @@
+# Native macOS Test Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the guarded native macOS full-suite path run every discovered test with a median warm runtime of at most 75 seconds while preserving Docker/CI nextest behavior.
+
+**Architecture:** Keep nextest for the 790 fast unit/bin tests, but run the consolidated integration binary once with eight libtest threads to avoid per-test macOS security inspection. Make the integration binary safe for shared-process concurrency, then remove high-volume Git fixture subprocesses with a focused `git2` bootstrap module while continuing to execute the real `stax` binary in scenarios.
+
+**Tech Stack:** Rust 1.96, cargo-nextest 0.9.114, libtest, git2 0.21, Bash, GNU Make, stax 0.94.
+
+## Global Constraints
+
+- Every discovered test must pass; the suite must never drop below the 1,838-test baseline.
+- Three warm `make test-native` runs must have a median of at most 75 seconds and no run above 90 seconds.
+- Native integration concurrency is exactly eight threads unless `NEXTEST_TEST_THREADS` explicitly overrides it.
+- Do not disable or bypass Gatekeeper, Endpoint Security, provenance checks, or journaling.
+- Docker, Apple Container, Linux native fallback, and CI keep nextest process isolation.
+- Integration scenarios continue to execute the real `stax` binary and scenario-defining Git operations.
+- Raw full-suite `cargo test` remains unsupported; only the guarded `make test-native` orchestration may batch integration tests.
+- Keep changes focused on test correctness, fixture setup, native orchestration, and required contributor documentation.
+
+---
+
+### Task 1: Make clipboard fallback deterministic and harmless
+
+**Files:**
+- Modify: `tests/copy_tests.rs:5-28`
+- Modify: `src/commands/copy.rs:68-83`
+
+**Interfaces:**
+- Consumes: existing `STAX_TEST_*` convention and `write_to_clipboard(&str) -> anyhow::Result<()>`.
+- Produces: child-process override `STAX_TEST_FORCE_CLIPBOARD_UNAVAILABLE=1`.
+
+- [ ] **Step 1: Add the failing native integration expectation**
+
+Update `run_copy_without_clipboard` so the child process explicitly requests the unavailable path:
+
+```rust
+cmd.args(args)
+    .current_dir(repo.path())
+    .env("HOME", home)
+    .env("GIT_CONFIG_GLOBAL", null_path)
+    .env("GIT_CONFIG_SYSTEM", null_path)
+    .env("STAX_DISABLE_UPDATE_CHECK", "1")
+    .env("STAX_TEST_DISABLE_HEAD_SYNC", "1")
+    .env("STAX_TEST_FORCE_CLIPBOARD_UNAVAILABLE", "1")
+    .env_remove("DISPLAY")
+    .env_remove("WAYLAND_DISPLAY")
+    .env_remove("XDG_SESSION_TYPE")
+    .env_remove("GITHUB_TOKEN")
+    .env_remove("STAX_GITHUB_TOKEN")
+    .env_remove("GH_TOKEN")
+    .env_remove("STAX_SHELL_INTEGRATION");
+```
+
+- [ ] **Step 2: Run the clipboard tests and verify the new expectation fails on macOS**
+
+Run:
+
+```bash
+cargo nextest run copy_tests::
+```
+
+Expected: the two fallback tests fail because `stax copy` still reaches the native pasteboard and prints `copied to clipboard`.
+
+- [ ] **Step 3: Implement the minimal clipboard test hook**
+
+Add the guard at the start of `write_to_clipboard`:
+
+```rust
+fn write_to_clipboard(text: &str) -> Result<()> {
+    if std::env::var_os("STAX_TEST_FORCE_CLIPBOARD_UNAVAILABLE").is_some() {
+        anyhow::bail!("clipboard unavailable by test request");
+    }
+
+    let mut clipboard =
+        Clipboard::new().map_err(|e| anyhow::anyhow!("Failed to access clipboard: {}", e))?;
+    clipboard
+        .set_text(text)
+        .map_err(|e| anyhow::anyhow!("Failed to copy to clipboard: {}", e))?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Verify clipboard happy and fallback paths**
+
+Run:
+
+```bash
+cargo nextest run copy_tests:: commands::copy::tests::
+```
+
+Expected: all copy integration and unit tests pass, and the integration tests no longer touch the user's clipboard.
+
+- [ ] **Step 5: Commit the clipboard isolation change**
+
+```bash
+git add src/commands/copy.rs tests/copy_tests.rs
+git commit -m "test: isolate native clipboard fallback"
+```
+
+---
+
+### Task 2: Remove process-global environment mutation from integration tests
+
+**Files:**
+- Modify: `src/github/gh_stack.rs:340-351`
+- Modify: `tests/gh_stack_tests.rs:420-460`
+- Modify: `tests/track_all_prs_tests.rs:40-52`
+- Modify: `tests/integration_tests.rs:7456-7465`
+- Modify: `scripts/lint.sh:1-5`
+
+**Interfaces:**
+- Consumes: `link_stack_with_env(..., env: &[(&str, &str)])` and per-command environment APIs.
+- Produces: lint invariant that `tests/**/*.rs` never calls process-global `env::set_var` or `env::remove_var`.
+
+- [ ] **Step 1: Add the failing lint invariant**
+
+Insert this guard before the Clippy invocation in `scripts/lint.sh`:
+
+```bash
+global_env_mutations="$(rg -n '(std::)?env::(set_var|remove_var)' tests --glob '*.rs' || true)"
+if [[ -n "${global_env_mutations}" ]]; then
+  echo "integration tests must configure child commands instead of mutating process-global environment" >&2
+  echo "${global_env_mutations}" >&2
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Run the invariant and verify it reports every current mutation**
+
+Run:
+
+```bash
+./scripts/lint.sh
+```
+
+Expected: FAIL before Clippy, listing `gh_stack_tests.rs`, `track_all_prs_tests.rs`, and `integration_tests.rs`.
+
+- [ ] **Step 3: Make injected gh-stack auth variables removable per command**
+
+Change `gh_command` so explicit test environment is applied before auth overrides are removed:
+
+```rust
+fn gh_command(env: &[(&str, &str)]) -> Command {
+    let mut command = Command::new("gh");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    for var in AUTH_OVERRIDE_ENV_VARS {
+        command.env_remove(var);
+    }
+    command
+}
+```
+
+Rename the test to `link_stack_strips_injected_token_env_vars_before_calling_gh`
+and replace the global mutation with explicit entries:
+
+```rust
+let outcome = stax::github::gh_stack::link_stack_with_env(
+    &[10, 20],
+    "main",
+    "origin",
+    &[
+        ("PATH", path.as_str()),
+        ("ENV_DUMP_FILE", env_dump_file.to_str().unwrap()),
+        ("GH_TOKEN", "ghp_should_be_stripped"),
+        ("GITHUB_TOKEN", "ghp_should_also_be_stripped"),
+    ],
+);
+```
+
+Delete the surrounding `std::env::set_var` and `std::env::remove_var` blocks.
+
+- [ ] **Step 4: Remove redundant global token mutation from binary integration tests**
+
+In `test_track_all_prs_no_token`, remove both `std::env::remove_var` calls because `TestRepo::run_stax` already removes both tokens from the exact child command.
+
+In `setup_mock_github`, remove the unused process-global assignment:
+
+```rust
+async fn setup_mock_github() -> (TestRepo, MockServer) {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let repo = TestRepo::new_with_remote();
+    (repo, mock_server)
+}
+```
+
+- [ ] **Step 5: Verify the affected behavior and the lint invariant**
+
+Run:
+
+```bash
+cargo nextest run gh_stack_tests:: track_all_prs_tests:: integration_tests::forge_mock_tests::test_submit_with_mock_pr_creation
+./scripts/lint.sh
+```
+
+Expected: targeted tests pass; lint reaches and passes Clippy with no process-global environment matches under `tests/`.
+
+- [ ] **Step 6: Commit shared-process environment safety**
+
+```bash
+git add src/github/gh_stack.rs tests/gh_stack_tests.rs tests/track_all_prs_tests.rs tests/integration_tests.rs scripts/lint.sh
+git commit -m "test: make integration environments process-local"
+```
+
+---
+
+### Task 3: Add the guarded hybrid native runner
+
+**Files:**
+- Create: `scripts/native-tests.sh`
+- Create: `scripts/native-tests-tests.sh`
+- Modify: `Makefile:1-72`
+
+**Interfaces:**
+- Consumes: `NEXTEST_TEST_THREADS`, `NATIVE_CARGO_PROFILE`, `STAX_TEST_TMPDIR`, and `TMPDIR`.
+- Produces: `scripts/native-tests.sh`; Make targets `test-native-script`, `test-native`, and the macOS branch of `test-local-fast`.
+
+- [ ] **Step 1: Write shell-level tests for command order, environment sanitation, failure propagation, and file limits**
+
+Create `scripts/native-tests-tests.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runner="${root}/scripts/native-tests.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fake_cargo="${tmp}/fake-cargo"
+cat >"${fake_cargo}" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if env | grep -Eq '^(GITHUB_TOKEN|STAX_GITHUB_TOKEN|GH_TOKEN)='; then
+  echo "GitHub token environment leaked into cargo" >&2
+  exit 90
+fi
+printf '%s\n' "$*" >>"${STAX_NATIVE_TEST_LOG}"
+if [[ "${STAX_NATIVE_TEST_FAIL_PHASE:-}" == "${1:-}" ]]; then
+  exit 23
+fi
+exit 0
+FAKE
+chmod +x "${fake_cargo}"
+
+log="${tmp}/cargo.log"
+GITHUB_TOKEN=secret STAX_GITHUB_TOKEN=secret GH_TOKEN=secret \
+  STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+  STAX_NATIVE_TEST_LOG="${log}" \
+  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+  TMPDIR="${tmp}/test-tmp" \
+  NEXTEST_TEST_THREADS=8 \
+  NATIVE_CARGO_PROFILE=test-container \
+  "${runner}"
+
+expected="${tmp}/expected.log"
+printf '%s\n' \
+  'nextest run --lib --bins --cargo-profile test-container' \
+  'test --profile test-container --test all_tests -- --test-threads=8' \
+  >"${expected}"
+diff -u "${expected}" "${log}"
+
+: >"${log}"
+set +e
+STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+  STAX_NATIVE_TEST_LOG="${log}" \
+  STAX_NATIVE_TEST_FAIL_PHASE=nextest \
+  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+  "${runner}"
+status=$?
+set -e
+[[ "${status}" -eq 23 ]]
+[[ "$(wc -l <"${log}" | tr -d ' ')" -eq 1 ]]
+
+: >"${log}"
+set +e
+STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+  STAX_NATIVE_TEST_LOG="${log}" \
+  STAX_NATIVE_TEST_FAIL_PHASE=test \
+  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+  "${runner}"
+status=$?
+set -e
+[[ "${status}" -eq 23 ]]
+[[ "$(wc -l <"${log}" | tr -d ' ')" -eq 2 ]]
+
+set +e
+(
+  ulimit -Sn 64
+  ulimit -Hn 64
+  STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+    STAX_NATIVE_TEST_LOG="${tmp}/limit.log" \
+    STAX_NATIVE_TEST_REQUIRED_NOFILE=4096 \
+    STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+    "${runner}"
+) >"${tmp}/limit.stdout" 2>"${tmp}/limit.stderr"
+status=$?
+set -e
+[[ "${status}" -eq 2 ]]
+grep -q 'requires a file-descriptor limit of at least 4096' "${tmp}/limit.stderr"
+[[ ! -e "${tmp}/limit.log" ]]
+
+echo "native test runner checks passed"
+```
+
+- [ ] **Step 2: Make the shell test executable and verify it fails because the runner is absent**
+
+Run:
+
+```bash
+chmod +x scripts/native-tests-tests.sh
+./scripts/native-tests-tests.sh
+```
+
+Expected: FAIL because `scripts/native-tests.sh` does not exist.
+
+- [ ] **Step 3: Implement the guarded native runner**
+
+Create `scripts/native-tests.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${root}"
+
+required_nofile="${STAX_NATIVE_TEST_REQUIRED_NOFILE:-4096}"
+threads="${NEXTEST_TEST_THREADS:-8}"
+profile="${NATIVE_CARGO_PROFILE:-test-container}"
+test_tmpdir="${STAX_TEST_TMPDIR:-${root}/.test-tmp}"
+cargo_cmd="${STAX_NATIVE_TEST_CARGO:-cargo}"
+
+soft_nofile="$(ulimit -Sn)"
+hard_nofile="$(ulimit -Hn)"
+
+if [[ "${soft_nofile}" != "unlimited" && "${soft_nofile}" -lt "${required_nofile}" ]]; then
+  if [[ "${hard_nofile}" != "unlimited" && "${hard_nofile}" -lt "${required_nofile}" ]]; then
+    echo "native tests require a file-descriptor limit of at least ${required_nofile}; hard limit is ${hard_nofile}" >&2
+    exit 2
+  fi
+  if ! ulimit -Sn "${required_nofile}"; then
+    echo "failed to raise the native test file-descriptor limit to ${required_nofile}" >&2
+    exit 2
+  fi
+fi
+
+mkdir -p "${test_tmpdir}"
+unset GITHUB_TOKEN STAX_GITHUB_TOKEN GH_TOKEN
+export STAX_DISABLE_UPDATE_CHECK=1
+export STAX_TEST_TMPDIR="${test_tmpdir}"
+export TMPDIR="${TMPDIR:-${test_tmpdir}}"
+export NEXTEST_TEST_THREADS="${threads}"
+export RUST_MIN_STACK="${RUST_MIN_STACK:-4194304}"
+
+echo "native tests: profile=${profile} threads=${threads} nofile=$(ulimit -Sn)"
+"${cargo_cmd}" nextest run --lib --bins --cargo-profile "${profile}"
+"${cargo_cmd}" test --profile "${profile}" --test all_tests -- --test-threads="${threads}"
+```
+
+- [ ] **Step 4: Make the runner executable and verify all shell-level tests pass**
+
+Run:
+
+```bash
+chmod +x scripts/native-tests.sh
+./scripts/native-tests-tests.sh
+bash -n scripts/native-tests.sh scripts/native-tests-tests.sh
+```
+
+Expected: `native test runner checks passed`; Bash syntax check exits zero.
+
+- [ ] **Step 5: Wire the runner into the Makefile without changing Docker or non-macOS behavior**
+
+Add `test-native-script` to `.PHONY`, then use:
+
+```make
+test-native-script:
+	./scripts/native-tests-tests.sh
+
+test-native: test-native-script
+	$(MAKE) test-local-fast
+
+test-local-fast:
+	mkdir -p .test-tmp
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		NEXTEST_TEST_THREADS="$${NEXTEST_TEST_THREADS:-$(MAC_LOCAL_TEST_THREADS)}" \
+		NATIVE_CARGO_PROFILE="$(NATIVE_CARGO_PROFILE)" \
+		STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" \
+		TMPDIR="$$(pwd)/.test-tmp" \
+		./scripts/native-tests.sh; \
+	else \
+		threads="$${NEXTEST_TEST_THREADS:-num-cpus}"; \
+		env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN \
+			STAX_DISABLE_UPDATE_CHECK=1 \
+			STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" \
+			TMPDIR="$$(pwd)/.test-tmp" \
+			NEXTEST_TEST_THREADS="$$threads" \
+			RUST_MIN_STACK=4194304 \
+			cargo nextest run --cargo-profile "$(NATIVE_CARGO_PROFILE)"; \
+	fi
+```
+
+Do not change `test`, `test-docker`, `test-container`, or the container runner macro.
+
+- [ ] **Step 6: Run the new native path once for correctness and record the warm runtime**
+
+Run:
+
+```bash
+/usr/bin/time -p make test-native
+```
+
+Expected: shell runner checks pass, all unit/bin and integration tests pass, and the output reports the effective profile, thread count, and file limit. Record the wall-clock result for comparison; do not claim the 75-second gate until three warm runs complete.
+
+- [ ] **Step 7: Commit the guarded native runner**
+
+```bash
+git add Makefile scripts/native-tests.sh scripts/native-tests-tests.sh
+git commit -m "test: batch native macOS integration runs"
+```
+
+---
+
+### Task 4: Replace repository bootstrap subprocesses with git2
+
+**Files:**
+- Create: `tests/common/git_fixture.rs`
+- Modify: `tests/common/mod.rs:1-14,143-191,800-835`
+- Modify: `tests/integration_tests.rs:1-110`
+
+**Interfaces:**
+- Consumes: `git2::RepositoryInitOptions`, `git2::Signature`, existing `git2` dependency.
+- Produces: `pub(crate) fn init_test_repo(path: &Path) -> anyhow::Result<()>`.
+
+- [ ] **Step 1: Write fixture equivalence and error-path tests before the initializer exists**
+
+Create `tests/common/git_fixture.rs` with only the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::init_test_repo;
+    use tempfile::{NamedTempFile, tempdir};
+
+    #[test]
+    fn initializes_clean_main_repo_with_deterministic_identity() {
+        let dir = tempdir().expect("temp dir");
+        init_test_repo(dir.path()).expect("initialize fixture");
+
+        let repo = git2::Repository::open(dir.path()).expect("open fixture");
+        assert_eq!(repo.head().unwrap().shorthand(), Some("main"));
+        assert_eq!(repo.head().unwrap().peel_to_commit().unwrap().message(), Some("Initial commit"));
+        assert!(repo.statuses(None).unwrap().is_empty());
+
+        let config = repo.config().unwrap();
+        assert_eq!(config.get_string("user.name").unwrap(), "Test User");
+        assert_eq!(config.get_string("user.email").unwrap(), "test@test.com");
+    }
+
+    #[test]
+    fn reports_repository_path_when_initialization_fails() {
+        let file = NamedTempFile::new().expect("temp file");
+        let error = init_test_repo(file.path()).unwrap_err().to_string();
+        assert!(error.contains("initialize test repository"));
+        assert!(error.contains(&file.path().display().to_string()));
+    }
+}
+```
+
+Declare `mod git_fixture;` in `tests/common/mod.rs`.
+
+- [ ] **Step 2: Run the fixture tests and verify compilation fails**
+
+Run:
+
+```bash
+cargo nextest run common::git_fixture::tests::
+```
+
+Expected: FAIL to compile because `init_test_repo` is not defined.
+
+- [ ] **Step 3: Implement the git2 initializer above the tests**
+
+Add:
+
+```rust
+use anyhow::{Context, Result};
+use git2::{Repository, RepositoryInitOptions, Signature};
+use std::fs;
+use std::path::Path;
+
+pub(crate) fn init_test_repo(path: &Path) -> Result<()> {
+    let mut options = RepositoryInitOptions::new();
+    options.initial_head("main");
+    let repo = Repository::init_opts(path, &options).with_context(|| {
+        format!("initialize test repository at {}", path.display())
+    })?;
+
+    let mut config = repo.config().context("open test repository config")?;
+    config.set_str("user.name", "Test User")?;
+    config.set_str("user.email", "test@test.com")?;
+    config.set_bool("commit.gpgSign", false)?;
+
+    fs::write(path.join("README.md"), "# Test Repo\n")
+        .context("write test repository README")?;
+    let mut index = repo.index().context("open test repository index")?;
+    index.add_path(Path::new("README.md"))?;
+    index.write()?;
+    let tree_id = index.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+    let signature = Signature::now("Test User", "test@test.com")?;
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        "Initial commit",
+        &tree,
+        &[],
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Verify fixture unit tests pass**
+
+Run:
+
+```bash
+cargo nextest run common::git_fixture::tests::
+```
+
+Expected: both happy-path and invalid-path tests pass.
+
+- [ ] **Step 5: Use the initializer in both TestRepo constructors**
+
+Re-export the helper in `tests/common/mod.rs`:
+
+```rust
+mod git_fixture;
+pub(crate) use git_fixture::init_test_repo;
+```
+
+Replace the five-process bootstrap in `tests/common/mod.rs::TestRepo::new` with:
+
+```rust
+pub fn new() -> Self {
+    let dir = test_tempdir();
+    init_test_repo(dir.path()).expect("Failed to initialize test repository");
+    Self {
+        dir,
+        home_dir: test_tempdir(),
+        remote_dir: None,
+    }
+}
+```
+
+Import and use the same helper in `tests/integration_tests.rs`:
+
+```rust
+use crate::common::init_test_repo;
+
+fn new() -> Self {
+    let dir = test_tempdir();
+    init_test_repo(dir.path()).expect("Failed to initialize test repository");
+    Self {
+        dir,
+        remote_dir: None,
+    }
+}
+```
+
+- [ ] **Step 6: Verify representative fixture consumers and the full native runner**
+
+Run:
+
+```bash
+cargo nextest run common::tests:: integration_tests:: create_below_tests:: worktree_tests::
+/usr/bin/time -p make test-native
+```
+
+Expected: targeted fixture, remote, branch, and worktree scenarios pass; the full native runner passes every discovered test and is faster than the Task 3 measurement.
+
+- [ ] **Step 7: Commit the shared bootstrap optimization**
+
+```bash
+git add tests/common/git_fixture.rs tests/common/mod.rs tests/integration_tests.rs
+git commit -m "perf(test): initialize fixtures with git2"
+```
+
+---
+
+### Task 5: Optimize repeated fixture commits only if the 75-second median is not met
+
+**Files:**
+- Modify: `tests/common/git_fixture.rs`
+- Modify: `tests/common/mod.rs:480-520`
+- Modify: `tests/integration_tests.rs:320-365`
+
+**Interfaces:**
+- Consumes: repositories created by `init_test_repo` and deterministic local identity config.
+- Produces: `pub(crate) fn commit_all(path: &Path, message: &str) -> anyhow::Result<git2::Oid>`.
+
+- [ ] **Step 1: Measure three warm native runs after Task 4**
+
+Run three separate times and record each `real` value:
+
+```bash
+/usr/bin/time -p make test-native
+```
+
+If the median is at most 75 seconds and no run exceeds 90 seconds, mark the remaining steps in this task skipped with the three measured values. Otherwise continue.
+
+- [ ] **Step 2: Add failing commit helper tests**
+
+Add to `tests/common/git_fixture.rs`:
+
+```rust
+#[test]
+fn commits_added_modified_and_deleted_files() {
+    let dir = tempdir().expect("temp dir");
+    init_test_repo(dir.path()).expect("initialize fixture");
+    std::fs::write(dir.path().join("added.txt"), "added\n").unwrap();
+    std::fs::write(dir.path().join("README.md"), "changed\n").unwrap();
+    std::fs::remove_file(dir.path().join("README.md")).unwrap();
+
+    let oid = super::commit_all(dir.path(), "fixture update").expect("commit fixture");
+    let repo = git2::Repository::open(dir.path()).unwrap();
+    assert_eq!(repo.find_commit(oid).unwrap().message(), Some("fixture update"));
+    assert!(repo.statuses(None).unwrap().is_empty());
+}
+
+#[test]
+fn commit_all_rejects_an_empty_change() {
+    let dir = tempdir().expect("temp dir");
+    init_test_repo(dir.path()).expect("initialize fixture");
+    let error = super::commit_all(dir.path(), "empty").unwrap_err().to_string();
+    assert!(error.contains("no fixture changes to commit"));
+}
+```
+
+- [ ] **Step 3: Run the commit helper tests and verify they fail to compile**
+
+Run:
+
+```bash
+cargo nextest run common::git_fixture::tests::
+```
+
+Expected: FAIL because `commit_all` is undefined.
+
+- [ ] **Step 4: Implement in-process add-all and commit**
+
+Add:
+
+```rust
+pub(crate) fn commit_all(path: &Path, message: &str) -> Result<git2::Oid> {
+    let repo = Repository::open(path)
+        .with_context(|| format!("open test repository at {}", path.display()))?;
+    let parent = repo.head()?.peel_to_commit()?;
+    let mut index = repo.index()?;
+    index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
+    index.update_all(["*"], None)?;
+    index.write()?;
+    let tree_id = index.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+    if tree.id() == parent.tree_id() {
+        anyhow::bail!("no fixture changes to commit");
+    }
+    let signature = Signature::now("Test User", "test@test.com")?;
+    Ok(repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        message,
+        &tree,
+        &[&parent],
+    )?)
+}
+```
+
+Re-export `commit_all` from `tests/common/mod.rs`, import it in the legacy
+module with `use crate::common::{commit_all, init_test_repo};`, and replace
+only the plain fixture `TestRepo::commit` implementations in
+`tests/common/mod.rs` and `tests/integration_tests.rs`. Do not replace helpers
+used to exercise hooks, signing failures, merge behavior, or explicit Git
+error paths.
+
+- [ ] **Step 5: Verify commit semantics and full native performance**
+
+Run:
+
+```bash
+cargo nextest run common::git_fixture::tests:: create_rollback_tests:: modify_tests:: integration_tests::
+/usr/bin/time -p make test-native
+```
+
+Expected: commit helper tests and representative behavior tests pass; full native run improves without losing coverage.
+
+If three subsequent warm runs still have a median above 75 seconds or any run
+above 90 seconds, stop before documentation and PR submission, return to
+systematic profiling with the new runner, and revise this plan from the fresh
+profile. Do not weaken the gate or add unmeasured optimizations.
+
+- [ ] **Step 6: Commit the conditional fixture commit optimization**
+
+```bash
+git add tests/common/git_fixture.rs tests/common/mod.rs tests/integration_tests.rs
+git commit -m "perf(test): commit fixture changes in process"
+```
+
+---
+
+### Task 6: Document the supported native path
+
+**Files:**
+- Modify: `README.md:430-440`
+- Modify: `CONTRIBUTING.md:7-60`
+- Modify: `AGENTS.md:3-20`
+- Review only: `skills.md`
+
+**Interfaces:**
+- Consumes: final measured native behavior and guarded Make targets.
+- Produces: contributor guidance that distinguishes `make test`, `make test-native`, and unsupported raw `cargo test`.
+
+- [ ] **Step 1: Update README contributor guidance**
+
+Replace the sentence after the `make test` block with:
+
+```markdown
+On macOS, `make test` uses Docker when available. Use `make test-native` for the
+guarded native path: unit/bin tests run under nextest, while the consolidated
+integration binary runs once with bounded concurrency to avoid macOS
+per-process security overhead. Linux and container paths continue to use
+nextest for the full suite. Do not run the raw full suite with `cargo test`.
+```
+
+- [ ] **Step 2: Update CONTRIBUTING commands and expectations**
+
+Describe `make test-native` as the supported guarded native runner, state that
+it requires Bash and a soft file-descriptor limit of 4,096 (raised by the
+runner when the hard limit permits), and document the measured warm median from
+Task 5. Keep Docker recommended for the default `make test` path until all
+three native measurements meet the performance gate.
+
+Use this command block:
+
+````markdown
+```bash
+# Full suite; preferred and Docker-backed on macOS when available
+make test
+
+# Guarded native macOS suite
+make test-native
+
+# Targeted iteration remains process-isolated
+cargo nextest run module_name::test_name
+```
+````
+
+- [ ] **Step 3: Update AGENTS.md policy without blessing raw cargo test**
+
+State explicitly:
+
+```markdown
+- `make test-native` is the only sanctioned batched native macOS full-suite
+  path. It runs unit/bin tests with nextest and the consolidated integration
+  binary with eight libtest threads, after sanitizing environment and checking
+  the file-descriptor limit.
+- Do not run the raw full suite via `cargo test`; the Make target owns the
+  concurrency and environment safeguards.
+```
+
+Keep `make test` as the required final validation command and Docker as its
+default macOS route.
+
+- [ ] **Step 4: Confirm skills.md needs no change**
+
+Run:
+
+```bash
+rg -n 'make test|test-native|test-local-fast|full suite|cargo test' skills.md
+```
+
+Expected: no contributor/native test workflow entry exists. Record in the PR
+body: `skills.md unchanged because it documents the stax CLI command map, not
+repository contributor test orchestration.`
+
+- [ ] **Step 5: Verify documentation consistency and commit**
+
+Run:
+
+```bash
+rg -n 'make test-native|raw full suite|eight libtest threads|4,096' README.md CONTRIBUTING.md AGENTS.md
+git diff --check
+```
+
+Expected: each document describes the same guarded path and raw `cargo test`
+restriction; no whitespace errors.
+
+```bash
+git add README.md CONTRIBUTING.md AGENTS.md
+git commit -m "docs: document fast native macOS tests"
+```
+
+---
+
+### Task 7: Run final quality, correctness, and performance gates
+
+**Files:**
+- Modify only if verification exposes a defect in files already listed above.
+- Update: `docs/superpowers/plans/2026-07-11-native-macos-test-performance.md` checkbox state.
+
+**Interfaces:**
+- Consumes: completed implementation and repository test policy.
+- Produces: fresh evidence for the stax PR body.
+
+- [ ] **Step 1: Run formatting and lint verification**
+
+Run:
+
+```bash
+cargo fmt -- --check
+make lint
+git diff --check
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 2: Run the required Docker full suite**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: the full Docker suite passes with every discovered test. If Docker is unavailable, start Docker Desktop and retry; do not substitute another full-suite command.
+
+- [ ] **Step 3: Warm the native artifacts once**
+
+Run:
+
+```bash
+make test-native
+```
+
+Expected: every discovered test passes. This warm-up is not one of the three measured runs.
+
+- [ ] **Step 4: Run and record three native performance measurements**
+
+Run three separate times:
+
+```bash
+/usr/bin/time -p make test-native
+```
+
+Expected: every run passes all discovered tests; median `real` time is at most 75 seconds; no run exceeds 90 seconds. Record the three values and median in the PR body.
+
+- [ ] **Step 5: Review the complete branch before publishing**
+
+Invoke `superpowers:requesting-code-review`, inspect every finding, and resolve all correctness, regression, or test-policy issues. Re-run the affected targeted checks after any change.
+
+- [ ] **Step 6: Commit the completed plan checklist**
+
+Mark completed plan checkboxes, then commit the execution record:
+
+```bash
+git add docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
+git commit -m "docs: complete native test performance plan"
+```
+
+- [ ] **Step 7: Check stack and branch state**
+
+Run:
+
+```bash
+git status --short
+stax validate
+stax status
+git log --oneline main..HEAD
+```
+
+Expected: clean worktree, valid metadata for `codex/native-macos-test-performance`, and only the focused design/implementation/documentation commits above `main`.
+
+- [ ] **Step 8: Submit the completed branch as a stax PR**
+
+Run:
+
+```bash
+stax submit --yes --no-prompt
+```
+
+Expected: branch is pushed and a PR targeting `main` is created or updated. The PR body must include the Docker result, three native timings and median, the two rejected filesystem/concurrency experiments, and the `skills.md` no-change note. Do not add agent attribution.

--- a/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
+++ b/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
@@ -2,9 +2,19 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the guarded native macOS full-suite path run every discovered test with a median warm runtime of at most 75 seconds while preserving Docker/CI nextest behavior.
+**Status:** Experiment concluded; the original performance gate was not met. The user authorized a draft PR containing only the safe partial improvements.
 
-**Architecture:** Keep nextest for the 790 fast unit/bin tests, but run the consolidated integration binary once with eight libtest threads to avoid per-test macOS security inspection. Make the integration binary safe for shared-process concurrency, then remove high-volume Git fixture subprocesses with a focused `git2` bootstrap module while continuing to execute the real `stax` binary in scenarios.
+**Outcome:** The hybrid and sharded libtest runners were rejected after unstable
+measurements ranging from 73.29 to 136.17 seconds. The retained runner uses
+nextest for the complete suite. The final retained native path passed all 1,843
+tests in 115.58 seconds; after adding the final timeout regression test, Docker
+passed all 1,844 tests in 35.861 seconds of test execution and remains
+recommended. The unchecked steps below are the historical
+execution plan, not claims that the original acceptance gate passed.
+
+**Original goal (not met):** Make the guarded native macOS full-suite path run every discovered test with a median warm runtime of at most 75 seconds while preserving Docker/CI nextest behavior.
+
+**Original architecture hypothesis (rejected):** Keep nextest for the 790 fast unit/bin tests, but run the consolidated integration binary once with eight libtest threads to avoid per-test macOS security inspection. The retained implementation instead uses guarded nextest for the full suite plus the safe fixture and isolation improvements.
 
 **Tech Stack:** Rust 1.96, cargo-nextest 0.9.114, libtest, git2 0.21, Bash, GNU Make, stax 0.94.
 
@@ -208,7 +218,11 @@ git commit -m "test: make integration environments process-local"
 
 ---
 
-### Task 3: Add the guarded hybrid native runner
+### Task 3: Experiment with a guarded hybrid native runner (rejected)
+
+The steps in this task record the tested hypothesis. The final draft reverts
+to one guarded full-suite nextest invocation because the hybrid path was slower
+and less stable under sustained endpoint inspection.
 
 **Files:**
 - Create: `scripts/native-tests.sh`
@@ -718,6 +732,10 @@ git commit -m "perf(test): commit fixture changes in process"
 
 ### Task 6: Document the supported native path
 
+**Final deviation:** Documentation describes a guarded nextest fallback and
+explicitly keeps Docker recommended; it does not claim the rejected hybrid
+runner or a passing 75-second gate.
+
 **Files:**
 - Modify: `README.md:430-440`
 - Modify: `CONTRIBUTING.md:7-60`
@@ -811,6 +829,11 @@ git commit -m "docs: document fast native macOS tests"
 ---
 
 ### Task 7: Run final quality, correctness, and performance gates
+
+**Recorded result:** Formatting/lint passed, Docker passed the final 1,844-test
+suite, and the guarded native nextest path passed the then-current 1,843 tests
+in 115.58 seconds. The performance gate failed, so submission is an explicitly
+authorized draft PR, not completion of the original goal.
 
 **Files:**
 - Modify only if verification exposes a defect in files already listed above.

--- a/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
+++ b/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
@@ -8,7 +8,7 @@
 measurements ranging from 73.29 to 136.17 seconds. The retained runner uses
 nextest for the complete suite. The final retained native path passed all 1,843
 tests in 115.58 seconds; after adding the final timeout regression test, Docker
-passed all 1,844 tests in 35.861 seconds of test execution and remains
+passed all 1,858 tests in 36.093 seconds of test execution and remains
 recommended. The unchecked steps below are the historical
 execution plan, not claims that the original acceptance gate passed.
 
@@ -830,7 +830,7 @@ git commit -m "docs: document fast native macOS tests"
 
 ### Task 7: Run final quality, correctness, and performance gates
 
-**Recorded result:** Formatting/lint passed, Docker passed the final 1,844-test
+**Recorded result:** Formatting/lint passed, Docker passed the final 1,858-test
 suite, and the guarded native nextest path passed the then-current 1,843 tests
 in 115.58 seconds. The performance gate failed, so submission is an explicitly
 authorized draft PR, not completion of the original goal.

--- a/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
+++ b/docs/superpowers/plans/2026-07-11-native-macos-test-performance.md
@@ -9,8 +9,12 @@ measurements ranging from 73.29 to 136.17 seconds. The retained runner uses
 nextest for the complete suite. The final retained native path passed all 1,843
 tests in 115.58 seconds; after adding the final timeout regression test, Docker
 passed all 1,858 tests in 36.093 seconds of test execution and remains
-recommended. The unchecked steps below are the historical
-execution plan, not claims that the original acceptance gate passed.
+recommended. A subsequent native run exposed five leaking zsh
+process-substitution tests that remained alive past 376 seconds. After making
+the POSIX shell wrapper build its argument array synchronously,
+`make test-native` passed all 1,862 tests in 157.945 seconds. The unchecked
+steps below are the historical execution plan, not claims that the original
+acceptance gate passed.
 
 **Original goal (not met):** Make the guarded native macOS full-suite path run every discovered test with a median warm runtime of at most 75 seconds while preserving Docker/CI nextest behavior.
 
@@ -833,7 +837,9 @@ git commit -m "docs: document fast native macOS tests"
 **Recorded result:** Formatting/lint passed, Docker passed the final 1,858-test
 suite, and the guarded native nextest path passed the then-current 1,843 tests
 in 115.58 seconds. The performance gate failed, so submission is an explicitly
-authorized draft PR, not completion of the original goal.
+authorized draft PR, not completion of the original goal. After fixing an
+intermittent zsh process-substitution leak, the latest native verification
+passed all 1,862 tests in 157.945 seconds.
 
 **Files:**
 - Modify only if verification exposes a defect in files already listed above.

--- a/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
+++ b/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
@@ -14,8 +14,8 @@ clipboard fallback, process-local integration environments, in-process `git2`
 fixture setup/commits, and more deterministic PTY input.
 
 The finalized native run passed the then-current 1,843 tests in 115.58 seconds.
-A final PTY timeout regression test brought the suite to 1,844 tests, all of
-which pass in Docker. A sharded
+A final PTY timeout regression test plus the latest `main` brought the suite to
+1,858 tests, all of which pass in Docker. A sharded
 experiment reached 73.29 seconds once but later warm runs varied up to 136.17
 seconds, so the 75-second median / 90-second maximum goal was not achieved.
 Docker remains the supported fast and stable macOS full-suite path. Sections

--- a/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
+++ b/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
@@ -15,7 +15,11 @@ fixture setup/commits, and more deterministic PTY input.
 
 The finalized native run passed the then-current 1,843 tests in 115.58 seconds.
 A final PTY timeout regression test plus the latest `main` brought the suite to
-1,858 tests, all of which pass in Docker. A sharded
+1,858 tests, all of which pass in Docker. A later 1,861-test native run exposed
+an intermittent zsh process-substitution leak: five shell-integration tests
+were still running after 376 seconds. Building the shell-output argument array
+synchronously removed those child processes; the following `make test-native`
+run passed all 1,862 tests in 157.945 seconds. A sharded
 experiment reached 73.29 seconds once but later warm runs varied up to 136.17
 seconds, so the 75-second median / 90-second maximum goal was not achieved.
 Docker remains the supported fast and stable macOS full-suite path. Sections

--- a/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
+++ b/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
@@ -1,0 +1,225 @@
+# Native macOS test performance
+
+**Date:** 2026-07-11
+**Status:** Design approved, self-reviewed, pending user review
+
+## Problem
+
+The full stax test suite is fast and stable in the Linux Docker path but has
+historically taken much longer when run natively on macOS. The suite is
+process- and filesystem-heavy: nextest launches each test in its own process,
+integration tests launch the real `stax` binary, and fixture setup repeatedly
+launches Git.
+
+Direct measurements on the target Apple Silicon Mac showed:
+
+| Configuration | Result |
+|---|---:|
+| Warm native full suite, APFS, nextest, 8 workers | 138.49s |
+| 237-test Git-heavy module, APFS, 8 workers | 54.74s |
+| Same module, HFS+ RAM disk, 8 workers | 64.41s |
+| Same module, APFS, 10 workers | 60.41s |
+| Same module, APFS, 6 workers | 69.00s |
+| 790 unit/bin tests under nextest | 6.55s |
+| 237-test module batched in one libtest process | 52.81s |
+
+The RAM disk was non-journaled and still regressed performance, so APFS
+journaling is not the dominant cause. During a sustained integration run,
+`syspolicyd`, `trustd`, and the installed Endpoint Security extension consumed
+substantial CPU. The locally built test and `stax` binaries are linker-signed
+ad hoc but are not accepted by Gatekeeper. This makes repeated process launch
+and inspection the primary native-specific cost.
+
+Two clipboard fallback tests also fail natively because removing Linux display
+variables does not disable the macOS pasteboard. They can overwrite the user's
+real clipboard while claiming to test an unavailable clipboard.
+
+## Goal
+
+Provide a supported native macOS test path that:
+
+- runs every discovered test successfully (1,838 tests at the measured
+  baseline);
+- has a median warm runtime of at most 75 seconds across three runs;
+- has no individual warm run longer than 90 seconds;
+- does not disable or bypass Gatekeeper, Endpoint Security, or other host
+  security controls;
+- preserves the existing Docker and CI nextest paths;
+- continues to exercise the real `stax` executable in integration tests.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Native runner | Hybrid: nextest for unit/bin tests, one controlled libtest process for the consolidated integration binary. |
+| Native concurrency | Eight integration test threads, matching the measured optimum. |
+| Docker and CI | Keep nextest process isolation and existing container behavior unchanged. |
+| Fixture bootstrap | Use `git2` in-process for repository initialization and the initial commit. |
+| Behavior under test | Continue launching the real `stax` binary and Git where the scenario explicitly exercises Git behavior. |
+| Environment isolation | Configure child processes directly; do not mutate process-global environment variables in integration tests. |
+| Clipboard isolation | Add a test-only `STAX_TEST_*` override that deterministically makes clipboard access unavailable. |
+| Security controls | Do not remove provenance attributes, alter Gatekeeper policy, or request Endpoint Security exclusions. |
+| Raw `cargo test` | Remains unsupported as a contributor workflow; only the guarded `make test-native` orchestration is sanctioned. |
+
+## Architecture
+
+### Native runner
+
+Add a focused native test script invoked by `make test-native` and
+`make test-local-fast` on macOS. It performs two phases:
+
+1. Run unit and bin tests with nextest and the `test-container` Cargo profile.
+2. Run the single `all_tests` integration binary through libtest with exactly
+   eight test threads.
+
+The script owns the sanitized environment currently assembled in the Makefile:
+GitHub token variables are removed, update checks are disabled,
+`STAX_TEST_TMPDIR` and `TMPDIR` point at the repository-local temporary root,
+`RUST_MIN_STACK` is set, and the `test-container` profile is used. It raises
+the process file-descriptor limit when the current soft limit is lower than
+4,096, then reports the effective limit and fails before running tests if the
+hard limit prevents a 4,096 soft limit. The current development machine already
+has a higher limit; the guard protects contributors with the older macOS
+default of 256 descriptors.
+
+Linux native fallback, Docker, Apple Container, and CI retain nextest for all
+tests. `make test` continues to select Docker on macOS when Docker is present;
+`make test-native` is the explicit fast native path.
+
+### Hermetic integration environment
+
+The consolidated integration binary can only run tests concurrently if they do
+not modify process-global state. Tests that currently call
+`std::env::set_var` or `std::env::remove_var` will instead set or remove values
+on the exact `Command` they spawn. Helpers will expose explicit methods for
+token-bearing and token-free child environments so the intended state is
+visible at each call site.
+
+Clipboard fallback tests will set a narrowly named `STAX_TEST_*` environment
+variable on their child `stax` command. The copy command will check this hook
+before constructing `arboard::Clipboard` and return the same clipboard
+unavailable error used for real backend failures. The hook is undocumented,
+test-only infrastructure consistent with existing `STAX_TEST_*` controls and
+does not change normal CLI behavior.
+
+### In-process repository bootstrap
+
+Extract repository bootstrap into a shared test fixture module used by both
+`tests/common/mod.rs` and the legacy fixture inside
+`tests/integration_tests.rs`. The initializer uses the existing `git2`
+dependency to:
+
+1. initialize a repository with `main` as the initial branch;
+2. create the baseline worktree file;
+3. add it to the index;
+4. create the initial commit with a deterministic test signature;
+5. leave `HEAD` attached to `main`.
+
+This removes repeated `git init`, `git config`, `git add`, `git commit`, and
+branch-renaming processes from every fixture while preserving the observable
+repository state. Scenario helpers continue to use the Git CLI when a test is
+specifically validating CLI-facing Git behavior, remotes, hooks, rebases, or
+failure modes.
+
+Fixture equivalence is tested explicitly: initial branch, clean status, initial
+commit message, configured identity behavior, and compatibility with the
+existing `TestRepo` methods.
+
+## Data flow
+
+```text
+make test-native
+  -> native test script
+     -> sanitize environment and validate file limit
+     -> cargo nextest run --lib --bins (8 workers)
+     -> cargo test --test all_tests (one process, 8 libtest threads)
+        -> shared git2 fixture bootstrap
+        -> per-test temporary repository
+        -> real stax child process
+        -> Git/libgit2 behavior exercised by the scenario
+```
+
+No repository state is shared between tests. Batching changes process lifetime,
+not fixture isolation.
+
+## Error handling
+
+- If unit/bin tests fail, the native runner stops before integration tests.
+- If the file-descriptor limit cannot be raised to the required value, the
+  runner exits with an actionable message rather than attempting a flaky run.
+- If an integration test mutates process-global environment, a dedicated
+  source check/test fails and identifies the call site.
+- Clipboard test forcing is scoped to child commands and cannot affect the
+  parent test runner or the user's clipboard.
+- Fixture initialization errors include the failed bootstrap operation and
+  temporary repository path.
+- The native runner does not silently fall back to Docker or a slower profile.
+
+## Performance implementation stages
+
+Changes are applied and measured in this order:
+
+1. Make clipboard and environment-sensitive integration tests hermetic.
+2. Add the guarded hybrid native runner and benchmark it.
+3. Replace fixture bootstrap subprocesses with the shared `git2` initializer
+   and benchmark again.
+4. If the median remains above 75 seconds, profile the hybrid runner and
+   convert only additional high-volume fixture setup operations to `git2`.
+   Production command execution and scenario-defining Git subprocesses remain
+   out of scope.
+
+Each stage must preserve correctness before its performance result is used.
+Optimizations that regress the representative module or introduce flakes are
+removed rather than accumulated.
+
+## Tests and verification
+
+### Correctness
+
+- Clipboard fallback tests pass on macOS without changing the real clipboard.
+- Token/environment isolation tests pass when integration tests share one
+  process.
+- Shared fixture bootstrap produces `main`, one initial commit, and a clean
+  worktree.
+- Fixture bootstrap failures return contextual errors.
+- The native runner rejects an intentionally insufficient file limit with the
+  expected guidance.
+- The native runner propagates failures from both unit and integration phases.
+
+### Targeted commands
+
+Use nextest module filters during development. Use the guarded native runner
+only after the environment and fixture changes are in place. Do not use raw
+full-suite `cargo test` as a contributor command.
+
+### Full verification
+
+1. Run `make test` for the existing Docker full-suite path.
+2. Run `make test-native` three times after a warm build.
+3. Require every discovered test to pass on every run, with no reduction from
+   the 1,838-test baseline.
+4. Require a median runtime no greater than 75 seconds and no run greater than
+   90 seconds.
+5. Run formatting and lint checks required by the repository.
+
+## Documentation
+
+Update contributor-facing documentation in the same change:
+
+- `README.md`: explain the fast native path and keep Docker as the default
+  macOS full-suite path until the native performance gate is met.
+- `CONTRIBUTING.md`: document `make test-native`, its requirements, and expected
+  warm runtime.
+- `AGENTS.md`: permit the guarded native runner while continuing to prohibit
+  raw full-suite `cargo test`.
+- `skills.md`: update test workflow guidance if it references the old native
+  behavior.
+
+## Out of scope
+
+- Disabling journaling or moving tests to a RAM disk.
+- Removing macOS provenance metadata or changing Gatekeeper policy.
+- Requesting exclusions from Kandji or another Endpoint Security product.
+- Replacing scenario-defining Git operations with mocks.
+- Changing Docker, Apple Container, or CI test isolation.
+- Reducing test coverage to meet the runtime target.

--- a/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
+++ b/docs/superpowers/specs/2026-07-11-native-macos-test-performance-design.md
@@ -1,7 +1,26 @@
 # Native macOS test performance
 
 **Date:** 2026-07-11
-**Status:** Design approved, self-reviewed, pending user review
+**Status:** Experiment concluded; original performance target not met; partial improvements retained in a draft PR
+
+## Outcome
+
+The hybrid libtest runner described in the original design was implemented and
+measured, but it was slower and less stable under sustained macOS endpoint
+inspection. It was rejected and reverted. The retained native runner uses
+nextest for the complete suite, with environment sanitation and a guarded
+file-descriptor limit. The retained partial improvements are deterministic
+clipboard fallback, process-local integration environments, in-process `git2`
+fixture setup/commits, and more deterministic PTY input.
+
+The finalized native run passed the then-current 1,843 tests in 115.58 seconds.
+A final PTY timeout regression test brought the suite to 1,844 tests, all of
+which pass in Docker. A sharded
+experiment reached 73.29 seconds once but later warm runs varied up to 136.17
+seconds, so the 75-second median / 90-second maximum goal was not achieved.
+Docker remains the supported fast and stable macOS full-suite path. Sections
+describing the 75-second target below record the original experiment criteria,
+not a claim about the retained implementation.
 
 ## Problem
 
@@ -51,8 +70,8 @@ Provide a supported native macOS test path that:
 
 | Decision | Choice |
 |---|---|
-| Native runner | Hybrid: nextest for unit/bin tests, one controlled libtest process for the consolidated integration binary. |
-| Native concurrency | Eight integration test threads, matching the measured optimum. |
+| Native runner | Guarded nextest for the complete suite; the hybrid libtest experiment was rejected. |
+| Native concurrency | Eight nextest workers by default, still overridable through `NEXTEST_TEST_THREADS`. |
 | Docker and CI | Keep nextest process isolation and existing container behavior unchanged. |
 | Fixture bootstrap | Use `git2` in-process for repository initialization and the initial commit. |
 | Behavior under test | Continue launching the real `stax` binary and Git where the scenario explicitly exercises Git behavior. |
@@ -66,11 +85,9 @@ Provide a supported native macOS test path that:
 ### Native runner
 
 Add a focused native test script invoked by `make test-native` and
-`make test-local-fast` on macOS. It performs two phases:
-
-1. Run unit and bin tests with nextest and the `test-container` Cargo profile.
-2. Run the single `all_tests` integration binary through libtest with exactly
-   eight test threads.
+`make test-local-fast` on macOS. It runs the complete suite with nextest and
+the `test-container` Cargo profile. The attempted two-phase nextest/libtest
+runner did not deliver stable performance and is not retained.
 
 The script owns the sanitized environment currently assembled in the Makefile:
 GitHub token variables are removed, update checks are disabled,
@@ -131,20 +148,18 @@ existing `TestRepo` methods.
 make test-native
   -> native test script
      -> sanitize environment and validate file limit
-     -> cargo nextest run --lib --bins (8 workers)
-     -> cargo test --test all_tests (one process, 8 libtest threads)
+     -> cargo nextest run (8 workers by default)
         -> shared git2 fixture bootstrap
         -> per-test temporary repository
         -> real stax child process
         -> Git/libgit2 behavior exercised by the scenario
 ```
 
-No repository state is shared between tests. Batching changes process lifetime,
-not fixture isolation.
+No repository state is shared between tests.
 
 ## Error handling
 
-- If unit/bin tests fail, the native runner stops before integration tests.
+- If any test fails, nextest propagates the failure from the native runner.
 - If the file-descriptor limit cannot be raised to the required value, the
   runner exits with an actionable message rather than attempting a flaky run.
 - If an integration test mutates process-global environment, a dedicated
@@ -160,13 +175,13 @@ not fixture isolation.
 Changes are applied and measured in this order:
 
 1. Make clipboard and environment-sensitive integration tests hermetic.
-2. Add the guarded hybrid native runner and benchmark it.
+2. Add the guarded hybrid native runner and benchmark it (rejected after the
+   performance and stability gate failed).
 3. Replace fixture bootstrap subprocesses with the shared `git2` initializer
    and benchmark again.
-4. If the median remains above 75 seconds, profile the hybrid runner and
-   convert only additional high-volume fixture setup operations to `git2`.
-   Production command execution and scenario-defining Git subprocesses remain
-   out of scope.
+4. Profile the hybrid and sharded runners, then retain only safe fixture and
+   test-determinism improvements. Production command execution and
+   scenario-defining Git subprocesses remained out of scope.
 
 Each stage must preserve correctness before its performance result is used.
 Optimizations that regress the representative module or introduce flakes are
@@ -184,7 +199,7 @@ removed rather than accumulated.
 - Fixture bootstrap failures return contextual errors.
 - The native runner rejects an intentionally insufficient file limit with the
   expected guidance.
-- The native runner propagates failures from both unit and integration phases.
+- The native runner propagates nextest failures.
 
 ### Targeted commands
 
@@ -206,8 +221,8 @@ full-suite `cargo test` as a contributor command.
 
 Update contributor-facing documentation in the same change:
 
-- `README.md`: explain the fast native path and keep Docker as the default
-  macOS full-suite path until the native performance gate is met.
+- `README.md`: explain the guarded native fallback and keep Docker as the
+  default macOS full-suite path because the native performance gate was not met.
 - `CONTRIBUTING.md`: document `make test-native`, its requirements, and expected
   warm runtime.
 - `AGENTS.md`: permit the guarded native runner while continuing to prohibit

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v rg >/dev/null 2>&1; then
+  echo "lint requires ripgrep (rg) to check test environment mutations" >&2
+  exit 1
+fi
+
 global_env_mutations="$(rg -n '(std::)?env::(set_var|remove_var)' tests --glob '*.rs' || true)"
 if [[ -n "${global_env_mutations}" ]]; then
   echo "integration tests must configure child commands instead of mutating process-global environment" >&2

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+global_env_mutations="$(rg -n '(std::)?env::(set_var|remove_var)' tests --glob '*.rs' || true)"
+if [[ -n "${global_env_mutations}" ]]; then
+  echo "integration tests must configure child commands instead of mutating process-global environment" >&2
+  echo "${global_env_mutations}" >&2
+  exit 1
+fi
+
 # Keep new Clippy warnings fatal while the explicitly listed legacy lint debt is
 # paid down. Removing an allowance is always safe; adding one requires review.
 cargo clippy --all-targets --all-features --no-deps -- \

--- a/scripts/native-tests-tests.sh
+++ b/scripts/native-tests-tests.sh
@@ -15,7 +15,8 @@ if env | grep -Eq '^(GITHUB_TOKEN|STAX_GITHUB_TOKEN|GH_TOKEN)='; then
   exit 90
 fi
 printf '%s\n' "$*" >>"${STAX_NATIVE_TEST_LOG}"
-if [[ "${STAX_NATIVE_TEST_FAIL_PHASE:-}" == "${1:-}" ]]; then
+if [[ -n "${STAX_NATIVE_TEST_FAIL_MATCH:-}" ]] && \
+  [[ "$*" == *"${STAX_NATIVE_TEST_FAIL_MATCH}"* ]]; then
   exit 23
 fi
 exit 0
@@ -32,36 +33,20 @@ GITHUB_TOKEN=secret STAX_GITHUB_TOKEN=secret GH_TOKEN=secret \
   NATIVE_CARGO_PROFILE=test-container \
   "${runner}"
 
-expected="${tmp}/expected.log"
-printf '%s\n' \
-  'nextest run --lib --bins --cargo-profile test-container' \
-  'test --profile test-container --test all_tests -- --test-threads=8' \
-  >"${expected}"
-diff -u "${expected}" "${log}"
-
-: >"${log}"
-set +e
-STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
-  STAX_NATIVE_TEST_LOG="${log}" \
-  STAX_NATIVE_TEST_FAIL_PHASE=nextest \
-  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
-  "${runner}"
-status=$?
-set -e
-[[ "${status}" -eq 23 ]]
+grep -Fxq 'nextest run --cargo-profile test-container' "${log}"
 [[ "$(wc -l <"${log}" | tr -d ' ')" -eq 1 ]]
 
 : >"${log}"
 set +e
 STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
   STAX_NATIVE_TEST_LOG="${log}" \
-  STAX_NATIVE_TEST_FAIL_PHASE=test \
+  STAX_NATIVE_TEST_FAIL_MATCH='nextest run' \
   STAX_TEST_TMPDIR="${tmp}/test-tmp" \
   "${runner}"
 status=$?
 set -e
 [[ "${status}" -eq 23 ]]
-[[ "$(wc -l <"${log}" | tr -d ' ')" -eq 2 ]]
+[[ "$(wc -l <"${log}" | tr -d ' ')" -eq 1 ]]
 
 set +e
 (

--- a/scripts/native-tests-tests.sh
+++ b/scripts/native-tests-tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runner="${root}/scripts/native-tests.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fake_cargo="${tmp}/fake-cargo"
+cat >"${fake_cargo}" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if env | grep -Eq '^(GITHUB_TOKEN|STAX_GITHUB_TOKEN|GH_TOKEN)='; then
+  echo "GitHub token environment leaked into cargo" >&2
+  exit 90
+fi
+printf '%s\n' "$*" >>"${STAX_NATIVE_TEST_LOG}"
+if [[ "${STAX_NATIVE_TEST_FAIL_PHASE:-}" == "${1:-}" ]]; then
+  exit 23
+fi
+exit 0
+FAKE
+chmod +x "${fake_cargo}"
+
+log="${tmp}/cargo.log"
+GITHUB_TOKEN=secret STAX_GITHUB_TOKEN=secret GH_TOKEN=secret \
+  STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+  STAX_NATIVE_TEST_LOG="${log}" \
+  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+  TMPDIR="${tmp}/test-tmp" \
+  NEXTEST_TEST_THREADS=8 \
+  NATIVE_CARGO_PROFILE=test-container \
+  "${runner}"
+
+expected="${tmp}/expected.log"
+printf '%s\n' \
+  'nextest run --lib --bins --cargo-profile test-container' \
+  'test --profile test-container --test all_tests -- --test-threads=8' \
+  >"${expected}"
+diff -u "${expected}" "${log}"
+
+: >"${log}"
+set +e
+STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+  STAX_NATIVE_TEST_LOG="${log}" \
+  STAX_NATIVE_TEST_FAIL_PHASE=nextest \
+  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+  "${runner}"
+status=$?
+set -e
+[[ "${status}" -eq 23 ]]
+[[ "$(wc -l <"${log}" | tr -d ' ')" -eq 1 ]]
+
+: >"${log}"
+set +e
+STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+  STAX_NATIVE_TEST_LOG="${log}" \
+  STAX_NATIVE_TEST_FAIL_PHASE=test \
+  STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+  "${runner}"
+status=$?
+set -e
+[[ "${status}" -eq 23 ]]
+[[ "$(wc -l <"${log}" | tr -d ' ')" -eq 2 ]]
+
+set +e
+(
+  ulimit -Sn 64
+  ulimit -Hn 64
+  STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
+    STAX_NATIVE_TEST_LOG="${tmp}/limit.log" \
+    STAX_NATIVE_TEST_REQUIRED_NOFILE=4096 \
+    STAX_TEST_TMPDIR="${tmp}/test-tmp" \
+    "${runner}"
+) >"${tmp}/limit.stdout" 2>"${tmp}/limit.stderr"
+status=$?
+set -e
+[[ "${status}" -eq 2 ]]
+if ! grep -q 'require a file-descriptor limit of at least 4096' "${tmp}/limit.stderr"; then
+  echo "expected native file-limit error, got:" >&2
+  cat "${tmp}/limit.stderr" >&2
+  exit 1
+fi
+[[ ! -e "${tmp}/limit.log" ]]
+
+echo "native test runner checks passed"

--- a/scripts/native-tests.sh
+++ b/scripts/native-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${root}"
+
+required_nofile="${STAX_NATIVE_TEST_REQUIRED_NOFILE:-4096}"
+threads="${NEXTEST_TEST_THREADS:-8}"
+profile="${NATIVE_CARGO_PROFILE:-test-container}"
+test_tmpdir="${STAX_TEST_TMPDIR:-${root}/.test-tmp}"
+cargo_cmd="${STAX_NATIVE_TEST_CARGO:-cargo}"
+
+soft_nofile="$(ulimit -Sn)"
+hard_nofile="$(ulimit -Hn)"
+
+if [[ "${soft_nofile}" != "unlimited" ]] && (( soft_nofile < required_nofile )); then
+  if [[ "${hard_nofile}" != "unlimited" ]] && (( hard_nofile < required_nofile )); then
+    echo "native tests require a file-descriptor limit of at least ${required_nofile}; hard limit is ${hard_nofile}" >&2
+    exit 2
+  fi
+
+  if ! ulimit -Sn "${required_nofile}"; then
+    echo "failed to raise the native test file-descriptor limit to ${required_nofile}" >&2
+    exit 2
+  fi
+fi
+
+mkdir -p "${test_tmpdir}"
+
+unset GITHUB_TOKEN STAX_GITHUB_TOKEN GH_TOKEN
+export STAX_DISABLE_UPDATE_CHECK=1
+export STAX_TEST_TMPDIR="${test_tmpdir}"
+export TMPDIR="${TMPDIR:-${test_tmpdir}}"
+export NEXTEST_TEST_THREADS="${threads}"
+export RUST_MIN_STACK="${RUST_MIN_STACK:-4194304}"
+
+echo "native tests: profile=${profile} threads=${threads} nofile=$(ulimit -Sn)"
+
+"${cargo_cmd}" nextest run --lib --bins --cargo-profile "${profile}"
+"${cargo_cmd}" test --profile "${profile}" --test all_tests -- --test-threads="${threads}"

--- a/scripts/native-tests.sh
+++ b/scripts/native-tests.sh
@@ -35,6 +35,4 @@ export NEXTEST_TEST_THREADS="${threads}"
 export RUST_MIN_STACK="${RUST_MIN_STACK:-4194304}"
 
 echo "native tests: profile=${profile} threads=${threads} nofile=$(ulimit -Sn)"
-
-"${cargo_cmd}" nextest run --lib --bins --cargo-profile "${profile}"
-"${cargo_cmd}" test --profile "${profile}" --test all_tests -- --test-threads="${threads}"
+"${cargo_cmd}" nextest run --cargo-profile "${profile}"

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -73,6 +73,10 @@ fn resolve_value(target: CopyTarget) -> Result<String> {
 /// Returns an error describing why the clipboard could not be used (e.g. no
 /// desktop clipboard in a headless/SSH/CI session).
 fn write_to_clipboard(text: &str) -> Result<()> {
+    if std::env::var_os("STAX_TEST_FORCE_CLIPBOARD_UNAVAILABLE").is_some() {
+        anyhow::bail!("clipboard unavailable by test request");
+    }
+
     let mut clipboard =
         Clipboard::new().map_err(|e| anyhow::anyhow!("Failed to access clipboard: {}", e))?;
     clipboard

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -1123,7 +1123,7 @@ mod tests {
     fn posix_shell_snippet_resolves_real_binary_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
             if err.kind() == ErrorKind::NotFound {
                 return;
             }
@@ -1153,7 +1153,7 @@ mod tests {
         let path_env = format!("{}:{original_path}", bin_dir.display());
         let command = format!("source \"{}\"; st config", snippet_path.display());
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
             .env("PATH", path_env)
             .output()
@@ -1184,7 +1184,7 @@ mod tests {
     fn posix_shell_snippet_keeps_path_for_worktree_shell_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
             if err.kind() == ErrorKind::NotFound {
                 return;
             }
@@ -1214,7 +1214,7 @@ mod tests {
         let path_env = format!("{}:{original_path}", bin_dir.display());
         let command = format!("source \"{}\"; st wtgo demo-lane", snippet_path.display());
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
             .env("PATH", path_env)
             .output()
@@ -1245,7 +1245,7 @@ mod tests {
     fn posix_shell_snippet_wraps_lane_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
             if err.kind() == ErrorKind::NotFound {
                 return;
             }
@@ -1275,7 +1275,7 @@ mod tests {
         let path_env = format!("{}:{original_path}", bin_dir.display());
         let command = format!("source \"{}\"; st lane review-pass", snippet_path.display());
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
             .env("PATH", path_env)
             .output()
@@ -1306,7 +1306,7 @@ mod tests {
     fn posix_shell_snippet_wraps_checkout_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
+        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
             if err.kind() == ErrorKind::NotFound {
                 return;
             }
@@ -1336,7 +1336,7 @@ mod tests {
         let path_env = format!("{}:{original_path}", bin_dir.display());
         let command = format!("source \"{}\"; st bco feature", snippet_path.display());
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
             .env("PATH", path_env)
             .output()

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -101,26 +101,6 @@ __stax_exec() {
   "$bin" "$@"
 }
 
-__stax_insert_shell_output() {
-  local out=()
-  local inserted=0
-  local arg
-
-  for arg in "$@"; do
-    if [[ $inserted -eq 0 && "$arg" == "--" ]]; then
-      out+=("--shell-output")
-      inserted=1
-    fi
-    out+=("$arg")
-  done
-
-  if [[ $inserted -eq 0 ]]; then
-    out+=("--shell-output")
-  fi
-
-  printf '%s\0' "${out[@]}"
-}
-
 __stax_run_worktree_shell() {
   local raw
   local target_path=""
@@ -128,11 +108,20 @@ __stax_run_worktree_shell() {
   local message=""
   local passthrough=()
   local cmd=()
+  local inserted=0
   local item
 
-  while IFS= read -r -d '' item; do
+  for item in "$@"; do
+    if [[ $inserted -eq 0 && "$item" == "--" ]]; then
+      cmd+=("--shell-output")
+      inserted=1
+    fi
     cmd+=("$item")
-  done < <(__stax_insert_shell_output "$@")
+  done
+
+  if [[ $inserted -eq 0 ]]; then
+    cmd+=("--shell-output")
+  fi
 
   raw=$(__stax_exec "${cmd[@]}") || return $?
 
@@ -983,6 +972,16 @@ mod tests {
         assert!(snippet.contains("whence -p"));
         assert!(snippet.contains("type -P"));
         assert!(snippet.contains("__stax_exec()"));
+    }
+
+    #[test]
+    fn posix_shell_snippet_builds_shell_output_args_without_process_substitution() {
+        let snippet = shell_snippet(ShellKind::Posix);
+
+        assert!(
+            !snippet.contains("< <(__stax_insert_shell_output"),
+            "shell-output argument handling must not leave asynchronous process-substitution children"
+        );
     }
 
     #[test]

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -342,11 +342,11 @@ const AUTH_OVERRIDE_ENV_VARS: &[&str] = &["GH_TOKEN", "GITHUB_TOKEN"];
 
 fn gh_command(env: &[(&str, &str)]) -> Command {
     let mut command = Command::new("gh");
-    for var in AUTH_OVERRIDE_ENV_VARS {
-        command.env_remove(var);
-    }
     for (key, value) in env {
         command.env(key, value);
+    }
+    for var in AUTH_OVERRIDE_ENV_VARS {
+        command.env_remove(var);
     }
     command
 }

--- a/tests/common/git_fixture.rs
+++ b/tests/common/git_fixture.rs
@@ -1,0 +1,70 @@
+use anyhow::{Context, Result};
+use git2::{Repository, RepositoryInitOptions, Signature};
+use std::fs;
+use std::path::Path;
+
+pub(crate) fn init_test_repo(path: &Path) -> Result<()> {
+    let mut options = RepositoryInitOptions::new();
+    options.initial_head("main");
+    let repo = Repository::init_opts(path, &options)
+        .with_context(|| format!("initialize test repository at {}", path.display()))?;
+
+    let mut config = repo.config().context("open test repository config")?;
+    config.set_str("user.name", "Test User")?;
+    config.set_str("user.email", "test@test.com")?;
+    config.set_bool("commit.gpgSign", false)?;
+
+    fs::write(path.join("README.md"), "# Test Repo\n").context("write test repository README")?;
+    let mut index = repo.index().context("open test repository index")?;
+    index.add_path(Path::new("README.md"))?;
+    index.write()?;
+    let tree_id = index.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+    let signature = Signature::now("Test User", "test@test.com")?;
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        "Initial commit",
+        &tree,
+        &[],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::init_test_repo;
+    use tempfile::{NamedTempFile, tempdir};
+
+    #[test]
+    fn initializes_clean_main_repo_with_deterministic_identity() {
+        let dir = tempdir().expect("temp dir");
+        init_test_repo(dir.path()).expect("initialize fixture");
+
+        let repo = git2::Repository::open(dir.path()).expect("open fixture");
+        assert_eq!(repo.head().unwrap().shorthand().unwrap(), "main");
+        assert_eq!(
+            repo.head()
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .message()
+                .unwrap(),
+            "Initial commit"
+        );
+        assert!(repo.statuses(None).unwrap().is_empty());
+
+        let config = repo.config().unwrap();
+        assert_eq!(config.get_string("user.name").unwrap(), "Test User");
+        assert_eq!(config.get_string("user.email").unwrap(), "test@test.com");
+    }
+
+    #[test]
+    fn reports_repository_path_when_initialization_fails() {
+        let file = NamedTempFile::new().expect("temp file");
+        let error = init_test_repo(file.path()).unwrap_err().to_string();
+        assert!(error.contains("initialize test repository"));
+        assert!(error.contains(&file.path().display().to_string()));
+    }
+}

--- a/tests/common/git_fixture.rs
+++ b/tests/common/git_fixture.rs
@@ -32,6 +32,62 @@ pub(crate) fn init_test_repo(path: &Path) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn commit_all(path: &Path, message: &str) -> Result<git2::Oid> {
+    let repo = Repository::open(path)
+        .with_context(|| format!("open test repository at {}", path.display()))?;
+    let parent = repo.head()?.peel_to_commit()?;
+    let mut index = repo.index()?;
+    let mut nested_worktrees = Vec::new();
+    let worktrees = repo.worktrees()?;
+    for name in worktrees.iter() {
+        let Some(name) = name? else {
+            continue;
+        };
+        let worktree = repo.find_worktree(name)?;
+        if let Ok(relative_path) = worktree.path().strip_prefix(path) {
+            nested_worktrees.push(relative_path.to_path_buf());
+        }
+    }
+    index.update_all(["*"], None)?;
+    let mut status_options = git2::StatusOptions::new();
+    status_options
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .exclude_submodules(true);
+    let statuses = repo.statuses(Some(&mut status_options))?;
+    for entry in statuses.iter() {
+        if !entry.status().contains(git2::Status::WT_NEW) {
+            continue;
+        }
+        let relative_path = Path::new(entry.path()?);
+        if nested_worktrees
+            .iter()
+            .any(|worktree| relative_path.starts_with(worktree))
+        {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(path.join(relative_path))?;
+        if metadata.is_file() || metadata.file_type().is_symlink() {
+            index.add_path(relative_path)?;
+        }
+    }
+    index.write()?;
+    let tree_id = index.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+    if tree.id() == parent.tree_id() {
+        anyhow::bail!("no fixture changes to commit");
+    }
+    let signature = Signature::now("Test User", "test@test.com")?;
+    Ok(repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        message,
+        &tree,
+        &[&parent],
+    )?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::init_test_repo;
@@ -66,5 +122,63 @@ mod tests {
         let error = init_test_repo(file.path()).unwrap_err().to_string();
         assert!(error.contains("initialize test repository"));
         assert!(error.contains(&file.path().display().to_string()));
+    }
+
+    #[test]
+    fn commits_added_modified_and_deleted_files() {
+        let dir = tempdir().expect("temp dir");
+        init_test_repo(dir.path()).expect("initialize fixture");
+        std::fs::write(dir.path().join("deleted.txt"), "delete me\n").unwrap();
+        super::commit_all(dir.path(), "add deletion candidate").unwrap();
+
+        std::fs::write(dir.path().join("added.txt"), "added\n").unwrap();
+        std::fs::write(dir.path().join("README.md"), "changed\n").unwrap();
+        std::fs::remove_file(dir.path().join("deleted.txt")).unwrap();
+
+        let oid = super::commit_all(dir.path(), "fixture update").expect("commit fixture");
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let commit = repo.find_commit(oid).unwrap();
+        assert_eq!(commit.message().unwrap(), "fixture update");
+        let tree = commit.tree().unwrap();
+        assert!(tree.get_name("added.txt").is_some());
+        assert!(tree.get_name("deleted.txt").is_none());
+        let readme = tree.get_name("README.md").unwrap();
+        assert_eq!(repo.find_blob(readme.id()).unwrap().content(), b"changed\n");
+        assert!(repo.statuses(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn commit_all_rejects_an_empty_change() {
+        let dir = tempdir().expect("temp dir");
+        init_test_repo(dir.path()).expect("initialize fixture");
+        let error = super::commit_all(dir.path(), "empty")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("no fixture changes to commit"));
+    }
+
+    #[test]
+    fn commit_all_ignores_nested_linked_worktrees() {
+        let dir = tempdir().expect("temp dir");
+        init_test_repo(dir.path()).expect("initialize fixture");
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let nested_worktree = dir.path().join("nested-worktree");
+        repo.worktree("nested-worktree", &nested_worktree, None)
+            .expect("create nested linked worktree");
+        std::fs::write(dir.path().join("main.txt"), "main change\n").unwrap();
+
+        super::commit_all(dir.path(), "main update").expect("commit main worktree change");
+        assert_eq!(
+            repo.status_file(std::path::Path::new("main.txt")).unwrap(),
+            git2::Status::CURRENT
+        );
+        assert!(
+            repo.head()
+                .unwrap()
+                .peel_to_tree()
+                .unwrap()
+                .get_name("main.txt")
+                .is_some()
+        );
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@
 //! - Assertion utilities for test output
 
 mod git_fixture;
-pub(crate) use git_fixture::init_test_repo;
+pub(crate) use git_fixture::{commit_all, init_test_repo};
 
 use serde_json::Value;
 use std::fs;
@@ -80,13 +80,10 @@ fn sh_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
-/// Delay before the first TUI keystrokes in `script`-based integration tests.
-///
-/// Keep this conservative: the `script` PTY helper does not provide a readiness
-/// signal, so sending input too early races the TUI startup/re-render path and
-/// can make multi-round flows silently accept the wrong branch name.
+/// Conservative fallback before the first TUI keystrokes when no stable text
+/// prompt is available for readiness detection.
 pub const TUI_SCRIPT_LEAD_DELAY: &str = "sleep 1";
-/// Pause between TUI interaction rounds.
+/// Conservative fallback between TUI rounds without a stable text prompt.
 pub const TUI_SCRIPT_STEP_DELAY: &str = "sleep 2";
 
 #[allow(dead_code)]
@@ -101,18 +98,47 @@ pub fn run_stax_in_script_with_env(
     env: &[(&str, &str)],
 ) -> Output {
     let stax_bin = stax_bin();
+    let transcript_dir = test_tempdir();
+    let transcript_path = transcript_dir.path().join("tui-transcript");
+    let input_status_path = transcript_dir.path().join("input-status");
+    fs::write(&transcript_path, "").expect("create TUI transcript");
+    let quoted_transcript = sh_quote(&transcript_path.to_string_lossy());
+    let quoted_input_status = sh_quote(&input_status_path.to_string_lossy());
     let command = std::iter::once(stax_bin.to_string_lossy().into_owned())
         .chain(args.iter().map(|arg| (*arg).to_string()))
         .map(|part| sh_quote(&part))
         .collect::<Vec<_>>()
         .join(" ");
 
+    let input_with_readiness = format!(
+        r#"set -e
+STAX_TUI_TRANSCRIPT={quoted_transcript}
+wait_for_tui_text() {{
+  expected=$1
+  wait_attempts=${{STAX_TUI_WAIT_ATTEMPTS:-200}}
+  attempts=0
+  while [ "$attempts" -lt "$wait_attempts" ]; do
+    if grep -Fq "$expected" "$STAX_TUI_TRANSCRIPT" 2>/dev/null; then return 0; fi
+    attempts=$((attempts + 1))
+    sleep 0.05
+  done
+  echo "timed out waiting for TUI text: $expected" >&2
+  return 1
+}}
+{input_script}"#
+    );
+
+    let input_pipeline = format!(
+        "(set +e; ({input_with_readiness}); input_status=$?; printf '%s\\n' \"$input_status\" > {quoted_input_status}; exit \"$input_status\")"
+    );
     let shell_script = if cfg!(target_os = "macos") {
-        format!("({input_script}) | script -q /dev/null {command}")
+        format!(
+            "{input_pipeline} | script -qF /dev/null {command} > {quoted_transcript}; script_status=$?; input_status=$(cat {quoted_input_status} 2>/dev/null || printf 1); cat {quoted_transcript}; if [ \"$input_status\" -ne 0 ]; then exit \"$input_status\"; fi; exit \"$script_status\""
+        )
     } else {
         format!(
-            "({input_script}) | script -qefc {} /dev/null",
-            sh_quote(&command)
+            "{input_pipeline} | script -qefc {} /dev/null > {quoted_transcript}; script_status=$?; input_status=$(cat {quoted_input_status} 2>/dev/null || printf 1); cat {quoted_transcript}; if [ \"$input_status\" -ne 0 ]; then exit \"$input_status\"; fi; exit \"$script_status\"",
+            sh_quote(&command),
         )
     };
 
@@ -462,17 +488,7 @@ impl TestRepo {
 
     /// Create a commit with all staged changes
     pub fn commit(&self, message: &str) {
-        hermetic_git_command()
-            .args(["add", "-A"])
-            .current_dir(self.path())
-            .output()
-            .expect("Failed to stage files");
-
-        hermetic_git_command()
-            .args(["commit", "-m", message])
-            .current_dir(self.path())
-            .output()
-            .expect("Failed to commit");
+        commit_all(&self.path(), message).expect("Failed to commit fixture changes");
     }
 
     /// Get the current branch name
@@ -798,5 +814,20 @@ mod tests {
 
         let output = repo.run_stax(&["checkout", "nonexistent"]);
         output.assert_failure();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tui_readiness_timeout_fails_the_scripted_command() {
+        let repo = TestRepo::new();
+        let output = run_stax_in_script_with_env(
+            &repo.path(),
+            &["--version"],
+            "wait_for_tui_text 'prompt that will never appear'",
+            &[("STAX_TUI_WAIT_ATTEMPTS", "1")],
+        );
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("timed out waiting for TUI text"));
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,6 +5,9 @@
 //! - Helper methods for common test scenarios
 //! - Assertion utilities for test output
 
+mod git_fixture;
+pub(crate) use git_fixture::init_test_repo;
+
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -144,43 +147,7 @@ impl TestRepo {
     /// Create a new test repository with git init and an initial commit on main
     pub fn new() -> Self {
         let dir = test_tempdir();
-        let path = dir.path();
-
-        // Initialize git repo
-        hermetic_git_command()
-            .args(["init", "-b", "main"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to init git repo");
-
-        // Configure git user for commits
-        hermetic_git_command()
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to set git email");
-
-        hermetic_git_command()
-            .args(["config", "user.name", "Test User"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to set git name");
-
-        // Create initial commit
-        let readme = path.join("README.md");
-        fs::write(&readme, "# Test Repo\n").expect("Failed to write README");
-
-        hermetic_git_command()
-            .args(["add", "-A"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to stage files");
-
-        hermetic_git_command()
-            .args(["commit", "-m", "Initial commit"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to create initial commit");
+        init_test_repo(dir.path()).expect("Failed to initialize test repository");
 
         Self {
             dir,

--- a/tests/copy_tests.rs
+++ b/tests/copy_tests.rs
@@ -14,6 +14,7 @@ fn run_copy_without_clipboard(repo: &TestRepo, args: &[&str]) -> Output {
         .env("GIT_CONFIG_SYSTEM", null_path)
         .env("STAX_DISABLE_UPDATE_CHECK", "1")
         .env("STAX_TEST_DISABLE_HEAD_SYNC", "1")
+        .env("STAX_TEST_FORCE_CLIPBOARD_UNAVAILABLE", "1")
         .env_remove("DISPLAY")
         .env_remove("WAYLAND_DISPLAY")
         .env_remove("XDG_SESSION_TYPE")

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -414,7 +414,7 @@ exit 1
 }
 
 #[test]
-fn link_stack_strips_ambient_token_env_vars_before_calling_gh() {
+fn link_stack_strips_injected_token_env_vars_before_calling_gh() {
     let fake = fake_gh_dir(
         r#"#!/bin/sh
 if [ "$1 $2" = "stack link" ]; then
@@ -430,15 +430,6 @@ exit 1
     let env_dump_file = fake.path().join("env.txt");
     let path = path_with_fake_gh(fake.path());
 
-    // Simulate PAT env vars exported ambiently in the user's shell (e.g. for
-    // other tooling/CI scripts) that would otherwise shadow an existing
-    // OAuth-authenticated `gh` login. `Command` inherits these by default
-    // unless explicitly removed, so this reproduces the real-world bug.
-    unsafe {
-        std::env::set_var("GH_TOKEN", "ghp_should_be_stripped");
-        std::env::set_var("GITHUB_TOKEN", "ghp_should_also_be_stripped");
-    }
-
     let outcome = stax::github::gh_stack::link_stack_with_env(
         &[10, 20],
         "main",
@@ -446,13 +437,10 @@ exit 1
         &[
             ("PATH", path.as_str()),
             ("ENV_DUMP_FILE", env_dump_file.to_str().unwrap()),
+            ("GH_TOKEN", "ghp_should_be_stripped"),
+            ("GITHUB_TOKEN", "ghp_should_also_be_stripped"),
         ],
     );
-
-    unsafe {
-        std::env::remove_var("GH_TOKEN");
-        std::env::remove_var("GITHUB_TOKEN");
-    }
 
     assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
     let dump = fs::read_to_string(env_dump_file).expect("env dump written");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 //! These tests create real temporary git repositories and run actual stax commands
 //! to verify end-to-end functionality.
 
-use crate::common::init_test_repo;
+use crate::common::{commit_all, init_test_repo};
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -292,17 +292,7 @@ impl TestRepo {
 
     /// Create a commit with all staged changes
     fn commit(&self, message: &str) {
-        hermetic_git_command()
-            .args(["add", "-A"])
-            .current_dir(self.path())
-            .output()
-            .expect("Failed to stage files");
-
-        hermetic_git_command()
-            .args(["commit", "-m", message])
-            .current_dir(self.path())
-            .output()
-            .expect("Failed to commit");
+        commit_all(&self.path(), message).expect("Failed to commit fixture changes");
     }
 
     /// Get the current branch name

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7482,9 +7482,6 @@ mod forge_mock_tests {
         let mock_server = MockServer::start().await;
         let repo = TestRepo::new_with_remote();
 
-        // Set environment variables for the mock
-        unsafe { std::env::set_var("STAX_GITHUB_TOKEN", "mock-token") };
-
         (repo, mock_server)
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,6 +3,7 @@
 //! These tests create real temporary git repositories and run actual stax commands
 //! to verify end-to-end functionality.
 
+use crate::common::init_test_repo;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -62,43 +63,7 @@ impl TestRepo {
     /// Create a new test repository with git init and an initial commit on main
     fn new() -> Self {
         let dir = test_tempdir();
-        let path = dir.path();
-
-        // Initialize git repo
-        hermetic_git_command()
-            .args(["init", "-b", "main"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to init git repo");
-
-        // Configure git user for commits
-        hermetic_git_command()
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to set git email");
-
-        hermetic_git_command()
-            .args(["config", "user.name", "Test User"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to set git name");
-
-        // Create initial commit
-        let readme = path.join("README.md");
-        fs::write(&readme, "# Test Repo\n").expect("Failed to write README");
-
-        hermetic_git_command()
-            .args(["add", "-A"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to stage files");
-
-        hermetic_git_command()
-            .args(["commit", "-m", "Initial commit"])
-            .current_dir(path)
-            .output()
-            .expect("Failed to create initial commit");
+        init_test_repo(dir.path()).expect("Failed to initialize test repository");
 
         Self {
             dir,

--- a/tests/split_hunk_tests.rs
+++ b/tests/split_hunk_tests.rs
@@ -94,9 +94,11 @@ fn test_split_hunk_requires_terminal() {
 /// Each round: j(down to hunk), Space(select), Enter(finish round), Enter(accept name).
 fn split_hunk_script(rounds: usize) -> String {
     let mut parts = vec![common::TUI_SCRIPT_LEAD_DELAY.to_string()];
-    for _ in 0..rounds {
+    for round in 0..rounds {
         parts.push("printf 'j \\r\\r'".to_string());
-        parts.push(common::TUI_SCRIPT_STEP_DELAY.to_string());
+        if round + 1 < rounds {
+            parts.push("sleep 1".to_string());
+        }
     }
     parts.join("; ")
 }

--- a/tests/staging_menu_tests.rs
+++ b/tests/staging_menu_tests.rs
@@ -15,15 +15,16 @@ use common::{OutputAssertions, TestRepo};
 
 fn select_menu_option(index: usize) -> String {
     let downs = "\\033[B".repeat(index);
-    format!("{}; printf '{}\\r'", common::TUI_SCRIPT_LEAD_DELAY, downs)
+    format!(
+        "wait_for_tui_text 'No files staged'; printf '{}\\r'; sleep 0.2",
+        downs
+    )
 }
 
 fn select_patch_and_stage_first_hunk() -> String {
     let downs = "\\033[B";
     format!(
-        "{lead}; printf '{downs}\\r'; {step}; printf 'y\\n'",
-        lead = common::TUI_SCRIPT_LEAD_DELAY,
-        step = common::TUI_SCRIPT_STEP_DELAY,
+        "wait_for_tui_text 'No files staged'; printf '{downs}\\r'; wait_for_tui_text 'Stage this hunk'; printf 'y\\n'; sleep 0.2",
         downs = downs
     )
 }

--- a/tests/track_all_prs_tests.rs
+++ b/tests/track_all_prs_tests.rs
@@ -43,10 +43,6 @@ fn test_track_all_prs_conflicts_with_parent() {
 fn test_track_all_prs_no_token() {
     let repo = TestRepo::new_with_remote();
 
-    // Ensure no token is set
-    unsafe { std::env::remove_var("GITHUB_TOKEN") };
-    unsafe { std::env::remove_var("STAX_GITHUB_TOKEN") };
-
     let output = repo.run_stax(&["branch", "track", "--all-prs"]);
 
     // Should fail - the command requires GitHub integration


### PR DESCRIPTION
## Summary

- make clipboard fallback and GitHub-token integration tests deterministic and process-local
- initialize and commit common Git fixtures in-process with `git2`, including linked-worktree handling
- add a guarded native nextest runner with token sanitation and file-descriptor checks
- make PTY staging tests wait for real prompts and propagate readiness timeouts
- prevent POSIX shell-integration tests from leaking zsh process-substitution children
- document the native experiment outcome while keeping Docker as the recommended macOS full-suite path

## Outcome

The original native performance gate was not met, but the supported native path is substantially faster than the historical 20-minute run and now completes reliably.

- baseline warm native nextest run: 138.49s
- earlier guarded native run: 115.58s for the then-current 1,843-test suite
- reported regression: five zsh shell-integration tests remained alive past 376 seconds
- corrected native verification: 1,862 tests passed in 157.945s
- final Docker verification: 1,862 tests passed in 42.812s of test execution
- one sharded experiment reached 73.29s, but sustained warm runs varied up to 136.17s, so the 75s median / 90s maximum target was rejected

The evidence points to macOS endpoint-security process inspection, rather than APFS journaling, as the remaining dominant cost. A non-journaled HFS+ RAM disk regressed a representative module from 54.74s to 64.41s; higher concurrency also increased runtime and introduced PTY flakes.

## Verification

- `make lint`
- `make test` — 1,862 passed, 0 failed, 42.812s test execution
- `make test-native` — 1,862 passed, 0 failed, 157.945s
- 20 consecutive eight-way zsh shell-wrapper stress runs
- native runner shell contract and targeted fixture/PTY regression tests

## Documentation

`skills.md` is unchanged because it documents the stax CLI command map, not repository contributor test orchestration.