### PR TITLE
feat: add GPUI desktop read-only cockpit

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -37,6 +37,52 @@ jobs:
       - name: Run quality gates
         run: make lint
 
+  gui-quality:
+    name: GPUI Compile and Clippy
+    runs-on: macos-latest
+    env:
+      RUSTFLAGS: ""
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.1
+          components: clippy
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: macos-latest-gui
+      - name: Check GPUI package
+        run: cargo check -p stax-gui --locked
+      - name: Lint GPUI package
+        # Clippy also lints the local stax path dependency. Mirror the reviewed
+        # legacy allowances from scripts/lint.sh while keeping other warnings fatal.
+        run: |
+          cargo clippy -p stax-gui --all-targets --locked -- \
+            -D warnings \
+            -A clippy::assertions_on_constants \
+            -A clippy::bool_assert_comparison \
+            -A clippy::clone_on_copy \
+            -A clippy::collapsible_if \
+            -A clippy::collapsible_match \
+            -A clippy::double_comparisons \
+            -A clippy::if_same_then_else \
+            -A clippy::items_after_test_module \
+            -A clippy::len_zero \
+            -A clippy::let_and_return \
+            -A clippy::manual_checked_ops \
+            -A clippy::needless_borrow \
+            -A clippy::needless_lifetimes \
+            -A clippy::too_many_arguments \
+            -A clippy::to_string_in_format_args \
+            -A clippy::type_complexity \
+            -A clippy::unnecessary_map_or \
+            -A clippy::unnecessary_sort_by \
+            -A clippy::useless_format \
+            -A clippy::useless_vec
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -50,12 +50,18 @@ jobs:
         with:
           toolchain: 1.96.1
           components: clippy
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.114
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
           key: macos-latest-gui
       - name: Check GPUI package
         run: cargo check -p stax-gui --locked
+      - name: Test GPUI package
+        run: cargo nextest run -p stax-gui --locked
       - name: Lint GPUI package
         # Clippy also lints the local stax path dependency. Mirror the reviewed
         # legacy allowances from scripts/lint.sh while keeping other warnings fatal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -98,6 +128,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +169,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a3c86f3fd70c0ffa500ed189abfa90b5a52398a45d5dc372fcc38ebeb7a645"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +227,213 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-io",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.4.1",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite 2.6.1",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite 2.6.1",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite 2.6.1",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -143,6 +445,25 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+dependencies = [
+ "async-compression",
+ "crc32fast",
+ "futures-lite 2.6.1",
+ "pin-project",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic"
@@ -166,6 +487,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,12 +548,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -197,6 +590,18 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -211,6 +616,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +638,53 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -238,10 +705,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "camino"
@@ -286,6 +779,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
+dependencies = [
+ "heck 0.4.1",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "tempfile",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,7 +814,16 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -310,6 +839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,7 +858,29 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -360,7 +920,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -380,6 +940,53 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "cocoa"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.10.0",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "core-foundation 0.10.0",
+ "core-graphics-types 0.2.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -407,6 +1014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-fds"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b60b5124979fccd9addd89d8b97a1d6eebb4950694520c75ddd722535ea443f"
+dependencies = [
+ "nix 0.31.3",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +1035,33 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "deflate64",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -437,6 +1081,18 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -487,9 +1143,19 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -502,10 +1168,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.0",
+ "core-graphics-types 0.2.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4583956b9806b69f73fcb23aee05eb3620efc282972f08f6a6db7504f8334d"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "cfg-if",
+ "core-foundation 0.10.0",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-video"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45e71d5be22206bed53c3c3cb99315fc4c3d31b8963808c6bc4538168c4f8ef"
+dependencies = [
+ "block",
+ "core-foundation 0.10.0",
+ "core-graphics2",
+ "io-surface",
+ "libc",
+ "metal",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -615,11 +1373,11 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.13.0",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
@@ -633,6 +1391,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -653,7 +1417,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -667,15 +1441,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -728,6 +1518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +1542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +1559,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -769,6 +1571,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -786,7 +1601,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -812,10 +1627,39 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -824,7 +1668,30 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -835,7 +1702,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -861,6 +1728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,13 +1746,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dwrote"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -902,7 +1817,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -921,7 +1836,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -935,16 +1850,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "embed-resource"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
+dependencies = [
+ "cc",
+ "memchr",
+ "rustc_version",
+ "toml 1.1.2+spec-1.1.0",
+ "vswhom",
+ "winreg",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -961,6 +1957,16 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etagere"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc89bf99e5dc15954a60f707c1e09d7540e5cd9af85fa75caa0b510bc08c5342"
+dependencies = [
+ "euclid",
+ "svg_fmt",
+]
 
 [[package]]
 name = "etcetera"
@@ -983,12 +1989,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -1000,9 +2050,33 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ff"
@@ -1029,6 +2103,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1060,6 +2144,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +2192,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,13 +2251,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "fs4"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -1143,6 +2328,34 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand 2.4.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1210,8 +2423,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
- "windows-link",
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1255,6 +2468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "git2"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +2491,282 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gpui"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979b45cfa6ec723b6f42330915a1b3769b930d02b2d505f9697f8ca602bee707"
+dependencies = [
+ "anyhow",
+ "async-task",
+ "bindgen",
+ "block",
+ "calloop",
+ "cbindgen",
+ "cocoa",
+ "cocoa-foundation",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "core-graphics",
+ "core-text",
+ "core-video",
+ "ctor",
+ "derive_more 0.99.20",
+ "embed-resource",
+ "etagere",
+ "flume",
+ "foreign-types",
+ "futures",
+ "gpui-macros",
+ "gpui_collections",
+ "gpui_http_client",
+ "gpui_media",
+ "gpui_refineable",
+ "gpui_semantic_version",
+ "gpui_sum_tree",
+ "gpui_util",
+ "gpui_util_macros",
+ "image",
+ "inventory",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "lyon",
+ "metal",
+ "naga",
+ "num_cpus",
+ "objc",
+ "oo7",
+ "parking",
+ "parking_lot",
+ "pathfinder_geometry",
+ "pin-project",
+ "postage",
+ "profiling",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "resvg",
+ "schemars",
+ "seahash",
+ "serde",
+ "serde_json",
+ "slotmap",
+ "smallvec",
+ "smol",
+ "stacksafe",
+ "strum 0.27.2",
+ "taffy",
+ "thiserror 2.0.18",
+ "usvg",
+ "uuid",
+ "waker-fn",
+ "windows",
+ "windows-core 0.61.2",
+ "windows-numerics",
+ "windows-registry 0.5.3",
+ "zed-font-kit",
+]
+
+[[package]]
+name = "gpui-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb02dd63a2859714ac7b6b476937617c3c744157af1b49f7c904023a79039be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "gpui_collections"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae39dc6d3d201be97e4bc08d96dbef2bc5b5c3d5734e05786e8cc3043342351c"
+dependencies = [
+ "indexmap",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "gpui_derive_refineable"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644de174341a87b3478bd65b66bca38af868bcf2b2e865700523734f83cfc664"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "gpui_http_client"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23822b0a6d2c5e6a42507980a0ab3848610ea908942c8ef98187f646f690335e"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "async-fs",
+ "bytes",
+ "derive_more 0.99.20",
+ "futures",
+ "gpui_util",
+ "http",
+ "http-body",
+ "log",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "url",
+ "zed-async-tar",
+ "zed-reqwest",
+]
+
+[[package]]
+name = "gpui_media"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cb8912ae17371725132d2b7eec6797a255accc95d58ee5c1134b529810f14b"
+dependencies = [
+ "anyhow",
+ "bindgen",
+ "core-foundation 0.10.0",
+ "core-video",
+ "ctor",
+ "foreign-types",
+ "metal",
+ "objc",
+]
+
+[[package]]
+name = "gpui_perf"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40a0961dcf598955130e867f4b731150a20546427b41b1a63767c1037a86d77"
+dependencies = [
+ "gpui_collections",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "gpui_refineable"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258cb099254e9468181aee5614410fba61db4ae115fc1d51b4a0b985f60d6641"
+dependencies = [
+ "gpui_derive_refineable",
+]
+
+[[package]]
+name = "gpui_semantic_version"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201e45eff7b695528fb3af6560a534943fbc2db5323d755b9d198bd743948e35"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
+name = "gpui_sum_tree"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f3bedd573fafafa13d1200b356c588cf094fb2786e3684bb3f5ea59b549fa9"
+dependencies = [
+ "arrayvec",
+ "log",
+ "rayon",
+]
+
+[[package]]
+name = "gpui_util"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68faea25903ae524de9af83990b9aa51bcbc8dd085929ac0aea7fd41905e05c3"
+dependencies = [
+ "anyhow",
+ "async-fs",
+ "async_zip",
+ "command-fds",
+ "dirs 4.0.0",
+ "dunce",
+ "futures",
+ "futures-lite 1.13.0",
+ "globset",
+ "gpui_collections",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "regex",
+ "rust-embed",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_json_lenient",
+ "shlex 1.3.0",
+ "smol",
+ "take-until",
+ "tempfile",
+ "tendril",
+ "unicase",
+ "walkdir",
+ "which",
+]
+
+[[package]]
+name = "gpui_util_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c28f65ef47fb97e21e82fd4dd75ccc2506eda010c846dc8054015ea234f1a22"
+dependencies = [
+ "gpui_perf",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "grid"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12101ecc8225ea6d675bc70263074eab6169079621c2186fe0c66590b2df9681"
 
 [[package]]
 name = "group"
@@ -1297,6 +2796,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1332,6 +2843,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1349,6 +2866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,7 +2886,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1429,6 +2952,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1518,7 +3050,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1646,6 +3178,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +3258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +3281,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "io-surface"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "554b8c5d64ec09a3a520fe58e4d48a73e00ff32899cdcbe32a4877afd4968b8e"
+dependencies = [
+ "cgl",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "leaky-cow",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +3332,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1733,7 +3371,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1807,7 +3445,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -1822,6 +3460,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1863,16 +3521,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "leak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd100e01f1154f2908dfa7d02219aeab25d0b9c7fa955164192e3245255a0c73"
+
+[[package]]
+name = "leaky-cow"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a8225d44241fd324a8af2806ba635fc7c8a7e9a7de4d5cf3ef54e71f5926fc"
+dependencies = [
+ "leak",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -1885,6 +3574,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1925,6 +3624,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1955,6 +3660,19 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+dependencies = [
+ "serde_core",
+ "value-bag",
+]
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "lru"
@@ -1972,13 +3690,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lyon"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0578bdecb7d6d88987b8b2b1e3a4e2f81df9d0ece1078623324a567904e7b7"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e43b7e44161571868f5c931d12583592c223c5583eef86b08aa02b7048a3552"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1986,6 +3791,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -2000,6 +3814,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2040,6 +3885,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.8.0",
+ "bitflags 2.13.0",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.15.5",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "strum 0.26.3",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +3947,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +3975,35 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2084,8 +4028,19 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.6",
+ "serde",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
 ]
 
 [[package]]
@@ -2126,6 +4081,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +4118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2228,6 +4203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "octocrab"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,6 +4265,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oo7"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3299dd401feaf1d45afd8fd1c0586f10fcfb22f244bb9afa942cec73503b89d"
+dependencies = [
+ "aes",
+ "ashpd",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "cbc",
+ "cipher",
+ "digest 0.10.7",
+ "endi",
+ "futures-lite 2.6.1",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hkdf",
+ "hmac",
+ "md-5",
+ "num",
+ "num-bigint-dig",
+ "pbkdf2",
+ "rand 0.9.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zbus",
+ "zbus_macros",
+ "zeroize",
+ "zvariant",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +4349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,7 +4367,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2350,7 +4379,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2378,6 +4407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,9 +4430,50 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -2465,7 +4541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2521,6 +4597,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +4627,23 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.4.1",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs1"
@@ -2574,10 +4673,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postage"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3fb618632874fb76937c2361a7f22afd393c982a2165595407edc75b06d3c1"
+dependencies = [
+ "atomic 0.5.3",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "parking_lot",
+ "pin-project",
+ "pollster",
+ "static_assertions",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2623,6 +4785,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +4823,79 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -2642,7 +4908,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2662,7 +4928,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2792,12 +5058,12 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
  "serde",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -2857,14 +5123,114 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2878,6 +5244,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -2885,6 +5262,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2993,6 +5390,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,6 +5411,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3017,13 +5437,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3035,6 +5461,48 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "globset",
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3053,6 +5521,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3060,7 +5541,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3092,6 +5573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,7 +5597,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3146,6 +5636,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,10 +5678,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "indexmap",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -3205,7 +5745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3262,16 +5802,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_fmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e497af288b3b95d067a23a4f749f2861121ffcb2f6d8379310dcda040c345ed"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_lenient"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3283,6 +5857,26 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3307,14 +5901,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3322,6 +5933,12 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -3376,7 +5993,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3394,6 +6011,15 @@ checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
  "rustc_version",
  "simdutf8",
+]
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
 ]
 
 [[package]]
@@ -3415,6 +6041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,10 +6062,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite 2.6.1",
+]
 
 [[package]]
 name = "snafu"
@@ -3447,7 +6108,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3468,6 +6129,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -3484,6 +6148,40 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stacksafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9c1172965d317e87ddb6d364a040d958b40a1db82b6ef97da26253a8b3d090"
+dependencies = [
+ "stacker",
+ "stacksafe-macro",
+]
+
+[[package]]
+name = "stacksafe-macro"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172175341049678163e979d9107ca3508046d4d2a7c6682bee46ac541b17db69"
+dependencies = [
+ "proc-macro-error2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3504,7 +6202,7 @@ dependencies = [
  "console",
  "crossterm",
  "dialoguer",
- "dirs",
+ "dirs 6.0.0",
  "fs4",
  "futures-util",
  "fuzzy-matcher",
@@ -3521,9 +6219,22 @@ dependencies = [
  "tempfile",
  "termimad",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "update-informer",
  "wiremock",
+]
+
+[[package]]
+name = "stax-gui"
+version = "0.94.0"
+dependencies = [
+ "anyhow",
+ "dirs 6.0.0",
+ "gpui",
+ "serde",
+ "serde_json",
+ "stax",
+ "tempfile",
 ]
 
 [[package]]
@@ -3533,6 +6244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,11 +6260,54 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3553,7 +6316,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3564,6 +6327,100 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb9efbae90f97301f4d25f3be63dfd99d6b7af9d088228a52ec960d649b2e7d"
+
+[[package]]
+name = "sval_buffer"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5c0280ea0af40b3a1fd0b532680b5067482ffb81412ee66ec04b1d9952b49a"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b9067f2e68f58e110cf8019a268057e3791cf74b0fdb1b3c7c6e49104f44e6"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ebdbf0e4b175884aa587fcf551c16dabe245ea04235abdd8cbbd160b27ed5a"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e448d9fa216a6c16670b28d624fbbcf5c04e41eb187bd7c52e01222ffa72a12"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021de5b5c26efd544c694cef9b8a9abe8633481bf3be1ea145a18a740818b291"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ef5ffec8bc52ded04ee424ab8d959e25e64fd40a48a16d21f8991ce824c1bb"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b983833a8a2390f89ebcf9b9acd06883017014b4ffd72ee28e0c9de6852039f5"
+dependencies = [
+ "serde_core",
+ "sval",
+ "sval_nested",
+]
+
+[[package]]
+name = "svg_fmt"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -3608,16 +6465,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "taffy"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13e5d13f79d558b5d353a98072ca8ca0e99da429467804de959aa8c83c9a004"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
+]
+
+[[package]]
+name = "take-until"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bdb6fa0dfa67b38c1e66b7041ba9dcf23b99d8121907cd31c807a332f7a0bbb"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
+ "fastrand 2.4.1",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3644,7 +6560,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook 0.3.18",
  "windows-sys 0.61.2",
 ]
@@ -3656,7 +6572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -3688,14 +6604,14 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
@@ -3762,6 +6678,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +6722,32 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -3856,6 +6812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,17 +6838,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3893,13 +6882,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3994,6 +7015,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,10 +7042,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4023,10 +7106,16 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -4118,6 +7207,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4141,10 +7263,59 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "atomic",
+ "atomic 0.6.1",
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16530907bfe2999a1773ca5900a65101e092c70f642f25cc23ca0c43573262c5"
+dependencies = [
+ "erased-serde",
+ "serde_core",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ae130edd690eaa877e4f40605d534790d1cf1d651e7685bd6a144521b251f"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
 ]
 
 [[package]]
@@ -4160,6 +7331,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,6 +7358,12 @@ checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -4289,6 +7486,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,6 +7550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,7 +7573,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -4412,6 +7628,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,6 +7671,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,9 +7713,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4479,9 +7753,56 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -4489,7 +7810,25 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4498,7 +7837,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4534,7 +7882,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4559,7 +7922,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4569,6 +7932,21 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4584,6 +7962,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4593,6 +7977,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4620,6 +8010,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4629,6 +8025,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4644,6 +8046,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4653,6 +8061,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4668,9 +8082,46 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wiremock"
@@ -4717,7 +8168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4728,7 +8179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -4802,7 +8253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -4811,6 +8262,38 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"
@@ -4833,6 +8316,156 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-lite 2.6.1",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
+name = "zed-async-tar"
+version = "0.5.0-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf4b5f655e29700e473cb1acd914ab112b37b62f96f7e642d5fc6a0c02eb881"
+dependencies = [
+ "async-std",
+ "filetime",
+ "libc",
+ "pin-project",
+ "redox_syscall 0.2.16",
+ "xattr",
+]
+
+[[package]]
+name = "zed-font-kit"
+version = "0.14.1-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3898e450f36f852edda72e3f985c34426042c4951790b23b107f93394f9bff5"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "core-foundation 0.10.0",
+ "core-graphics",
+ "core-text",
+ "dirs 5.0.1",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "zed-reqwest"
+version = "0.12.15-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2d05756ff48539950c3282ad7acf3817ad3f08797c205ad1c34a2ce03b9970"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-socks",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "windows-registry 0.4.0",
 ]
 
 [[package]]
@@ -4934,3 +8567,68 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,12 +2263,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.13.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6230,6 +6230,7 @@ version = "0.94.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
+ "fs4",
  "gpui",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +27,19 @@ dependencies = [
  "cipher",
  "cpufeatures 0.2.17",
  "zeroize",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -192,12 +214,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "ash-window"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bca67b61cb81e5553babde81b8211f713cb6db79766f80168f3e5f40ea6c82"
+dependencies = [
+ "ash",
+ "raw-window-handle",
+ "raw-window-metal",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.13",
+ "zbus",
 ]
 
 [[package]]
@@ -530,6 +599,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +709,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "blade-graphics"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71cfb73b98eb9f58ee84048aa1bdf4e7497fd20c141b57523499fa066b48fed"
+dependencies = [
+ "ash",
+ "ash-window",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "codespan-reporting",
+ "glow",
+ "gpu-alloc",
+ "gpu-alloc-ash",
+ "hidden-trait",
+ "js-sys",
+ "khronos-egl",
+ "libloading",
+ "log",
+ "mint",
+ "naga",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "objc2-ui-kit",
+ "once_cell",
+ "raw-window-handle",
+ "slab",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "blade-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27142319e2f4c264581067eaccb9f80acccdde60d8b4bf57cc50cd3152f109ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "blade-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6be3a82c001ba7a17b6f8e413ede5d1004e6047213f8efaf0ffc15b5c4904c"
+dependencies = [
+ "blade-graphics",
+ "bytemuck",
+ "log",
+ "profiling",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -703,6 +854,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -734,6 +899,18 @@ dependencies = [
  "rustix 0.38.44",
  "slab",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -943,16 +1120,46 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation 0.1.2",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
 dependencies = [
  "bitflags 2.13.0",
  "block",
- "cocoa-foundation",
+ "cocoa-foundation 0.2.0",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
  "libc",
  "objc",
 ]
@@ -1089,6 +1296,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1396,19 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
@@ -1176,6 +1416,19 @@ dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-helmer-fork"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32eb7c354ae9f6d437a6039099ce7ecd049337a8109b23d73e48e8ffba8e9cd5"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
  "foreign-types",
  "libc",
 ]
@@ -1222,7 +1475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
 dependencies = [
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types",
  "libc",
 ]
@@ -1248,6 +1501,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
+dependencies = [
+ "bitflags 2.13.0",
+ "fontdb 0.16.2",
+ "log",
+ "rangemap",
+ "rustc-hash 1.1.0",
+ "rustybuzz 0.14.1",
+ "self_cell",
+ "smol_str",
+ "swash",
+ "sys-locale",
+ "ttf-parser 0.21.1",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1707,6 +1983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +2026,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtor"
@@ -2192,12 +2480,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
  "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -2211,7 +2522,7 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -2478,6 +2789,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "git2"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,28 +2854,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
+dependencies = [
+ "bitflags 2.13.0",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-ash"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643756f08ef6def813c776199e4766596395a4c6530373c9a4374a64de2f53a1"
+dependencies = [
+ "ash",
+ "gpu-alloc-types",
+ "tinyvec",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "gpui"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "979b45cfa6ec723b6f42330915a1b3769b930d02b2d505f9697f8ca602bee707"
 dependencies = [
  "anyhow",
+ "as-raw-xcb-connection",
+ "ashpd 0.11.1",
  "async-task",
+ "backtrace",
  "bindgen",
+ "blade-graphics",
+ "blade-macros",
+ "blade-util",
  "block",
+ "bytemuck",
  "calloop",
+ "calloop-wayland-source",
  "cbindgen",
- "cocoa",
- "cocoa-foundation",
+ "cocoa 0.26.0",
+ "cocoa-foundation 0.2.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
- "core-graphics",
+ "core-graphics 0.24.0",
  "core-text",
  "core-video",
+ "cosmic-text",
  "ctor",
  "derive_more 0.99.20",
  "embed-resource",
  "etagere",
+ "filedescriptor",
  "flume",
  "foreign-types",
  "futures",
@@ -2569,6 +2951,7 @@ dependencies = [
  "num_cpus",
  "objc",
  "oo7",
+ "open",
  "parking",
  "parking_lot",
  "pathfinder_geometry",
@@ -2592,11 +2975,21 @@ dependencies = [
  "usvg",
  "uuid",
  "waker-fn",
- "windows",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-plasma",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-numerics",
  "windows-registry 0.5.3",
+ "x11-clipboard",
+ "x11rb",
+ "xkbcommon",
  "zed-font-kit",
+ "zed-scap",
+ "zed-xim",
 ]
 
 [[package]]
@@ -2729,12 +3122,15 @@ dependencies = [
  "dunce",
  "futures",
  "futures-lite 1.13.0",
+ "git2 0.20.4",
  "globset",
  "gpui_collections",
+ "gpui_util_macros",
  "itertools 0.14.0",
  "libc",
  "log",
  "nix 0.29.0",
+ "rand 0.9.4",
  "regex",
  "rust-embed",
  "schemars",
@@ -2812,6 +3208,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2870,6 +3272,17 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hidden-trait"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ed9e850438ac849bec07e7d09fbe9309cbd396a5988c30b010580ce08860df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "hkdf"
@@ -3328,6 +3741,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3892,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3873,6 +4315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,6 +4361,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
+ "spirv",
  "strum 0.26.3",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -3991,6 +4440,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -4127,6 +4585,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
 ]
 
 [[package]]
@@ -4146,8 +4616,10 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "objc2",
+ "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -4200,6 +4672,62 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -4271,7 +4799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3299dd401feaf1d45afd8fd1c0586f10fcfb22f244bb9afa942cec73503b89d"
 dependencies = [
  "aes",
- "ashpd",
+ "ashpd 0.12.3",
  "async-fs",
  "async-io",
  "async-lock",
@@ -4297,6 +4825,16 @@ dependencies = [
  "zbus_macros",
  "zeroize",
  "zvariant",
+]
+
+[[package]]
+name = "open"
+version = "5.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+dependencies = [
+ "is-wsl",
+ "libc",
 ]
 
 [[package]]
@@ -4898,6 +5436,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,6 +5587,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
@@ -5199,6 +5761,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8caa82e31bb98fee12fa8f051c94a6aa36b07cddb03f0d4fc558988360ff1"
+dependencies = [
+ "cocoa 0.25.0",
+ "core-graphics 0.23.2",
+ "objc",
+ "raw-window-handle",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5790,16 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -5499,6 +6083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5637,6 +6227,23 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.21.1",
+ "unicode-bidi-mirroring 0.2.0",
+ "unicode-ccc 0.2.0",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "rustybuzz"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
@@ -5646,9 +6253,9 @@ dependencies = [
  "core_maths",
  "log",
  "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring 0.4.0",
+ "unicode-ccc 0.4.0",
  "unicode-properties",
  "unicode-script",
 ]
@@ -5704,10 +6311,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "screencapturekit"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5eeeb57ac94960cfe5ff4c402be6585ae4c8d29a2cf41b276048c2e849d64e"
+dependencies = [
+ "screencapturekit-sys",
+]
+
+[[package]]
+name = "screencapturekit-sys"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22411b57f7d49e7fe08025198813ee6fd65e1ee5eff4ebc7880c12c82bde4c60"
+dependencies = [
+ "block",
+ "dispatch",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "once_cell",
+]
 
 [[package]]
 name = "seahash"
@@ -5760,6 +6396,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -6056,6 +6698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6092,6 +6744,12 @@ dependencies = [
  "blocking",
  "futures-lite 2.6.1",
 ]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 
 [[package]]
 name = "snafu"
@@ -6131,6 +6789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6206,7 +6873,7 @@ dependencies = [
  "fs4",
  "futures-util",
  "fuzzy-matcher",
- "git2",
+ "git2 0.21.0",
  "indicatif",
  "octocrab",
  "ratatui",
@@ -6424,6 +7091,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "swash"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6466,6 +7144,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6503,6 +7204,18 @@ name = "take-until"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdb6fa0dfa67b38c1e66b7041ba9dcf23b99d8121907cd31c807a332f7a0bbb"
+
+[[package]]
+name = "tao-core-video-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271450eb289cb4d8d0720c6ce70c72c8c858c93dd61fc625881616752e6b98f6"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "objc",
+]
 
 [[package]]
 name = "tempfile"
@@ -6723,6 +7436,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -7017,6 +7739,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
@@ -7067,9 +7801,21 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-bidi-mirroring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ccc"
@@ -7082,6 +7828,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-properties"
@@ -7216,13 +7968,13 @@ dependencies = [
  "base64",
  "data-url",
  "flate2",
- "fontdb",
+ "fontdb 0.23.0",
  "imagesize",
  "kurbo",
  "log",
  "pico-args",
  "roxmltree",
- "rustybuzz",
+ "rustybuzz 0.20.1",
  "simplecss",
  "siphasher",
  "strict-num",
@@ -7512,6 +8264,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7673,6 +8522,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7682,6 +8541,19 @@ dependencies = [
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
+]
+
+[[package]]
+name = "windows-capture"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4df73e95feddb9ec1a7e9c2ca6323b8c97d5eeeff78d28f1eccdf19c882b24"
+dependencies = [
+ "parking_lot",
+ "rayon",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-future",
 ]
 
 [[package]]
@@ -7695,12 +8567,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -7712,8 +8596,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -7732,9 +8616,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7794,6 +8700,15 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8248,14 +9163,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11-clipboard"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+dependencies = [
+ "libc",
+ "x11rb",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
+ "libc",
  "rustix 1.1.4",
  "x11rb-protocol",
+ "xcursor",
 ]
 
 [[package]]
@@ -8274,6 +9212,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+ "x11",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xim-ctext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac61a7062c40f3c37b6e82eeeef835d5cc7824b632a72784a89b3963c33284c"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "xim-parser"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcee45f89572d5a65180af3a84e7ddb24f5ea690a6d3aa9de231281544dd7b7"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "xkbcommon"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
+dependencies = [
+ "as-raw-xcb-connection",
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
 name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8284,6 +9276,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
@@ -8403,7 +9401,7 @@ dependencies = [
  "bitflags 2.13.0",
  "byteorder",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "core-text",
  "dirs 5.0.1",
  "dwrote",
@@ -8468,6 +9466,48 @@ dependencies = [
  "web-sys",
  "windows-registry 0.4.0",
 ]
+
+[[package]]
+name = "zed-scap"
+version = "0.0.8-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b338d705ae33a43ca00287c11129303a7a0aa57b101b72a1c08c863f698ac8"
+dependencies = [
+ "anyhow",
+ "cocoa 0.25.0",
+ "core-graphics-helmer-fork",
+ "log",
+ "objc",
+ "rand 0.8.6",
+ "screencapturekit",
+ "screencapturekit-sys",
+ "sysinfo",
+ "tao-core-video-sys",
+ "windows 0.61.3",
+ "windows-capture",
+ "x11",
+ "xcb",
+]
+
+[[package]]
+name = "zed-xim"
+version = "0.4.0-zed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0b46ed118eba34d9ba53d94ddc0b665e0e06a2cf874cfa2dd5dec278148642"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.5",
+ "log",
+ "x11rb",
+ "xim-ctext",
+ "xim-parser",
+]
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,26 @@
-[package]
-name = "stax"
+[workspace]
+members = [".", "crates/stax-gui"]
+default-members = ["."]
+resolver = "2"
+
+[workspace.package]
 version = "0.94.0"
 edition = "2024"
 rust-version = "1.96"
-default-run = "stax"
-description = "Fast stacked Git branches and PRs"
 license = "MIT"
 authors = ["Cesar Ferreira"]
 repository = "https://github.com/cesarferreira/stax"
+
+[package]
+name = "stax"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+default-run = "stax"
+description = "Fast stacked Git branches and PRs"
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
 # Integration tests are consolidated into a single binary (tests/all_tests.rs)
 # instead of one binary per file. Linking ~50 separate test binaries (each
 # statically linking the whole stax lib + octocrab/git2/ratatui) dominated build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ chrono = "0.4"
 update-informer = "1"
 
 # Advisory file locking for the warm-worktree pool manifest
-fs4 = "0.13"
+fs4 = "1.1.0"
 
 # Temp files
 tempfile = "3"

--- a/crates/stax-gui/Cargo.toml
+++ b/crates/stax-gui/Cargo.toml
@@ -22,3 +22,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 stax = { path = "../.." }
 tempfile = "3"
+
+[dev-dependencies]
+gpui = { version = "=0.2.2", default-features = false, features = ["font-kit", "test-support"] }

--- a/crates/stax-gui/Cargo.toml
+++ b/crates/stax-gui/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "stax-gui"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Native macOS desktop app for stax"
+publish = false
+
+[[bin]]
+name = "stax-gui"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+dirs = "6"
+gpui = { version = "=0.2.2", default-features = false, features = ["font-kit"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+stax = { path = "../.." }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/stax-gui/Cargo.toml
+++ b/crates/stax-gui/Cargo.toml
@@ -16,10 +16,9 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 dirs = "6"
+fs4 = "1.1.0"
 gpui = { version = "=0.2.2", default-features = false, features = ["font-kit"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 stax = { path = "../.." }
-
-[dev-dependencies]
 tempfile = "3"

--- a/crates/stax-gui/src/hydration.rs
+++ b/crates/stax-gui/src/hydration.rs
@@ -1,0 +1,295 @@
+use stax::application::{
+    BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, RepositorySession,
+};
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+
+pub(crate) type HydrationFuture<T> =
+    Pin<Box<dyn Future<Output = Result<T, String>> + Send + 'static>>;
+
+pub(crate) trait BranchHydrationService: Send + Sync {
+    fn load_details(
+        &self,
+        repository: PathBuf,
+        branch: BranchSummary,
+    ) -> HydrationFuture<BranchDetails>;
+
+    fn load_cached_diff(
+        &self,
+        repository: PathBuf,
+        branch: String,
+        parent: String,
+    ) -> HydrationFuture<Option<BranchDiff>>;
+
+    fn load_diff(
+        &self,
+        repository: PathBuf,
+        branch: String,
+        parent: String,
+    ) -> HydrationFuture<BranchDiff>;
+
+    fn load_ci(&self, repository: PathBuf, branch: String) -> HydrationFuture<CiSummary>;
+}
+
+pub(crate) struct NativeBranchHydrationService;
+
+impl BranchHydrationService for NativeBranchHydrationService {
+    fn load_details(
+        &self,
+        repository: PathBuf,
+        branch: BranchSummary,
+    ) -> HydrationFuture<BranchDetails> {
+        Box::pin(async move {
+            RepositorySession::open(repository)
+                .and_then(|session| session.branch_details(&branch))
+                .map_err(|error| format!("{error:#}"))
+        })
+    }
+
+    fn load_cached_diff(
+        &self,
+        repository: PathBuf,
+        branch: String,
+        parent: String,
+    ) -> HydrationFuture<Option<BranchDiff>> {
+        Box::pin(async move {
+            RepositorySession::open(repository)
+                .and_then(|session| session.cached_diff(&branch, &parent))
+                .map_err(|error| format!("{error:#}"))
+        })
+    }
+
+    fn load_diff(
+        &self,
+        repository: PathBuf,
+        branch: String,
+        parent: String,
+    ) -> HydrationFuture<BranchDiff> {
+        Box::pin(async move {
+            RepositorySession::open(repository)
+                .and_then(|session| session.refresh_diff(&branch, &parent))
+                .map_err(|error| format!("{error:#}"))
+        })
+    }
+
+    fn load_ci(&self, repository: PathBuf, branch: String) -> HydrationFuture<CiSummary> {
+        Box::pin(async move {
+            RepositorySession::open(repository)
+                .and_then(|session| session.load_ci(&branch))
+                .map_err(|error| format!("{error:#}"))
+        })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DetailsHydrationRequest {
+    pub(crate) token: DetailRequestToken,
+    pub(crate) branch: BranchSummary,
+}
+
+#[derive(Clone)]
+pub(crate) struct DiffHydrationRequest {
+    pub(crate) token: DetailRequestToken,
+    pub(crate) parent: Option<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct CiHydrationRequest {
+    pub(crate) token: DetailRequestToken,
+}
+
+struct BoundedStream<T> {
+    active: bool,
+    queued: Option<T>,
+}
+
+impl<T> Default for BoundedStream<T> {
+    fn default() -> Self {
+        Self {
+            active: false,
+            queued: None,
+        }
+    }
+}
+
+impl<T> BoundedStream<T> {
+    fn enqueue(&mut self, request: T) -> Option<T> {
+        if self.active {
+            self.queued = Some(request);
+            None
+        } else {
+            self.active = true;
+            Some(request)
+        }
+    }
+
+    fn finish(&mut self) -> Option<T> {
+        match self.queued.take() {
+            Some(request) => Some(request),
+            None => {
+                self.active = false;
+                None
+            }
+        }
+    }
+
+    fn has_queued(&self) -> bool {
+        self.queued.is_some()
+    }
+
+    fn clear_queued(&mut self) {
+        self.queued = None;
+    }
+}
+
+/// Owns at most one active request and one latest queued request per stream.
+#[derive(Default)]
+pub(crate) struct HydrationCoordinator {
+    details: BoundedStream<DetailsHydrationRequest>,
+    diff: BoundedStream<DiffHydrationRequest>,
+    ci: BoundedStream<CiHydrationRequest>,
+}
+
+impl HydrationCoordinator {
+    pub(crate) fn enqueue_details(
+        &mut self,
+        token: DetailRequestToken,
+        branch: BranchSummary,
+    ) -> Option<DetailsHydrationRequest> {
+        self.details
+            .enqueue(DetailsHydrationRequest { token, branch })
+    }
+
+    pub(crate) fn finish_details(&mut self) -> Option<DetailsHydrationRequest> {
+        self.details.finish()
+    }
+
+    pub(crate) fn enqueue_diff(
+        &mut self,
+        token: DetailRequestToken,
+        parent: Option<String>,
+    ) -> Option<DiffHydrationRequest> {
+        self.diff.enqueue(DiffHydrationRequest { token, parent })
+    }
+
+    pub(crate) fn diff_has_queued(&self) -> bool {
+        self.diff.has_queued()
+    }
+
+    pub(crate) fn finish_diff(&mut self) -> Option<DiffHydrationRequest> {
+        self.diff.finish()
+    }
+
+    pub(crate) fn enqueue_ci(&mut self, token: DetailRequestToken) -> Option<CiHydrationRequest> {
+        self.ci.enqueue(CiHydrationRequest { token })
+    }
+
+    pub(crate) fn finish_ci(&mut self) -> Option<CiHydrationRequest> {
+        self.ci.finish()
+    }
+
+    pub(crate) fn clear_queued_ci(&mut self) {
+        self.ci.clear_queued();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BoundedStream, BranchHydrationService, HydrationFuture, NativeBranchHydrationService,
+    };
+    use stax::application::RepositorySession;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use std::task::{Context, Poll, Waker};
+    use tempfile::TempDir;
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(["-C", path.to_str().unwrap()])
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn resolve<T>(mut future: HydrationFuture<T>) -> Result<T, String> {
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(result) => result,
+            Poll::Pending => panic!("native repository hydration unexpectedly yielded"),
+        }
+    }
+
+    #[test]
+    fn bounded_stream_keeps_only_the_latest_queued_request() {
+        let mut stream = BoundedStream::default();
+
+        assert_eq!(stream.enqueue(1), Some(1));
+        assert_eq!(stream.enqueue(2), None);
+        assert_eq!(stream.enqueue(3), None);
+        assert_eq!(stream.finish(), Some(3));
+        assert_eq!(stream.finish(), None);
+        assert_eq!(stream.enqueue(4), Some(4));
+    }
+
+    #[test]
+    fn native_hydration_returns_seeded_cache_then_recomputes_fresh_diff() {
+        let temp = TempDir::new().unwrap();
+        git(temp.path(), &["init", "-b", "main"]);
+        git(temp.path(), &["config", "user.email", "test@example.com"]);
+        git(temp.path(), &["config", "user.name", "Test User"]);
+        fs::write(temp.path().join("file.txt"), "main\n").unwrap();
+        git(temp.path(), &["add", "file.txt"]);
+        git(temp.path(), &["commit", "-m", "main"]);
+        git(temp.path(), &["switch", "-c", "feature"]);
+        fs::write(temp.path().join("file.txt"), "main\nfeature\n").unwrap();
+        git(temp.path(), &["add", "file.txt"]);
+        git(temp.path(), &["commit", "-m", "feature"]);
+
+        let session = RepositorySession::open(temp.path()).unwrap();
+        let actual = session.diff("feature", "main").unwrap();
+        let cache_path = temp.path().join(".git/stax/tui-diff-cache.json");
+        let mut stored: serde_json::Value =
+            serde_json::from_slice(&fs::read(&cache_path).unwrap()).unwrap();
+        let entry = stored["entries"]
+            .as_object_mut()
+            .unwrap()
+            .values_mut()
+            .next()
+            .unwrap();
+        entry["diff"]["stat"] = serde_json::json!([]);
+        entry["diff"]["lines"] = serde_json::json!([
+            {"content": "incorrect cached patch", "line_type": "context"}
+        ]);
+        fs::write(&cache_path, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
+
+        let service = NativeBranchHydrationService;
+        let cached = resolve(service.load_cached_diff(
+            temp.path().to_path_buf(),
+            "feature".into(),
+            "main".into(),
+        ))
+        .unwrap()
+        .unwrap();
+        assert_eq!(cached.lines[0].content, "incorrect cached patch");
+
+        let fresh =
+            resolve(service.load_diff(temp.path().to_path_buf(), "feature".into(), "main".into()))
+                .unwrap();
+
+        assert_eq!(fresh, actual);
+        assert_eq!(
+            session.cached_diff("feature", "main").unwrap(),
+            Some(actual)
+        );
+    }
+}

--- a/crates/stax-gui/src/lib.rs
+++ b/crates/stax-gui/src/lib.rs
@@ -1,13 +1,28 @@
 pub mod preferences;
 pub mod state;
+pub mod theme;
 mod views;
 
 use gpui::{App, Application};
 use std::path::PathBuf;
 
 pub fn run(repository: Option<PathBuf>) {
-    Application::new().run(move |cx: &mut App| {
-        crate::views::open_initial_window(repository.clone(), cx);
+    let application = Application::new();
+    application.on_reopen(|cx| {
+        if cx.windows().is_empty() {
+            open_window_or_quit(None, cx);
+        }
+    });
+    application.run(move |cx: &mut App| {
+        crate::views::init(cx);
+        open_window_or_quit(repository.clone(), cx);
         cx.activate(true);
     });
+}
+
+fn open_window_or_quit(repository: Option<PathBuf>, cx: &mut App) {
+    if let Err(error) = crate::views::open_initial_window(repository, cx) {
+        eprintln!("stax-gui startup error: {error:#}");
+        cx.quit();
+    }
 }

--- a/crates/stax-gui/src/lib.rs
+++ b/crates/stax-gui/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod preferences;
+pub mod state;
 mod views;
 
 use gpui::{App, Application};

--- a/crates/stax-gui/src/lib.rs
+++ b/crates/stax-gui/src/lib.rs
@@ -1,3 +1,4 @@
+mod hydration;
 pub mod preferences;
 pub mod state;
 pub mod theme;

--- a/crates/stax-gui/src/lib.rs
+++ b/crates/stax-gui/src/lib.rs
@@ -1,0 +1,11 @@
+mod views;
+
+use gpui::{App, Application};
+use std::path::PathBuf;
+
+pub fn run(repository: Option<PathBuf>) {
+    Application::new().run(move |cx: &mut App| {
+        crate::views::open_initial_window(repository.clone(), cx);
+        cx.activate(true);
+    });
+}

--- a/crates/stax-gui/src/main.rs
+++ b/crates/stax-gui/src/main.rs
@@ -1,0 +1,6 @@
+use std::path::PathBuf;
+
+fn main() {
+    let repository = std::env::args_os().nth(1).map(PathBuf::from);
+    stax_gui::run(repository);
+}

--- a/crates/stax-gui/src/preferences.rs
+++ b/crates/stax-gui/src/preferences.rs
@@ -1,0 +1,606 @@
+use anyhow::{Context, Result, ensure};
+use fs4::FileExt;
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+const MAX_RECENT_REPOSITORIES: usize = 10;
+
+#[derive(Debug, Clone)]
+pub struct RecentRepositories {
+    path: PathBuf,
+}
+
+struct ExclusiveLock {
+    file: File,
+}
+
+impl Drop for ExclusiveLock {
+    fn drop(&mut self) {
+        let _ = <File as FileExt>::unlock(&self.file);
+    }
+}
+
+impl RecentRepositories {
+    pub fn at(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn default_path() -> PathBuf {
+        dirs::data_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("stax/gui/recent-repositories.json")
+    }
+
+    pub fn load(&self) -> Result<Vec<PathBuf>> {
+        self.load_unlocked()
+    }
+
+    fn load_unlocked(&self) -> Result<Vec<PathBuf>> {
+        let contents = match fs::read(&self.path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to read recent repositories from {}",
+                        self.path.display()
+                    )
+                });
+            }
+        };
+        let stored: Vec<PathBuf> = serde_json::from_slice(&contents).with_context(|| {
+            format!(
+                "failed to parse recent repositories from {}",
+                self.path.display()
+            )
+        })?;
+
+        let mut seen = HashSet::new();
+        let mut repositories = Vec::new();
+        for stored_path in stored {
+            let canonical = match stored_path.canonicalize() {
+                Ok(canonical) => canonical,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to canonicalize recent repository {} listed in {}",
+                            stored_path.display(),
+                            self.path.display()
+                        )
+                    });
+                }
+            };
+            let metadata = match fs::metadata(&canonical) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to inspect recent repository {} listed in {}",
+                            canonical.display(),
+                            self.path.display()
+                        )
+                    });
+                }
+            };
+            if metadata.is_dir() && seen.insert(canonical.clone()) {
+                repositories.push(canonical);
+                if repositories.len() == MAX_RECENT_REPOSITORIES {
+                    break;
+                }
+            }
+        }
+        Ok(repositories)
+    }
+
+    pub fn record(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        let metadata = fs::metadata(path)
+            .with_context(|| format!("repository path {} is not accessible", path.display()))?;
+        ensure!(
+            metadata.is_dir(),
+            "repository path {} is not a directory",
+            path.display()
+        );
+        let canonical = path.canonicalize().with_context(|| {
+            format!("failed to canonicalize repository path {}", path.display())
+        })?;
+
+        let _lock = self.acquire_lock()?;
+        let mut repositories = self.load_unlocked()?;
+        repositories.retain(|existing| existing != &canonical);
+        repositories.insert(0, canonical);
+        repositories.truncate(MAX_RECENT_REPOSITORIES);
+        self.save(&repositories)
+    }
+
+    fn preferences_directory(&self) -> &Path {
+        self.path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."))
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        self.preferences_directory()
+            .join(".recent-repositories.lock")
+    }
+
+    fn ensure_private_directory(&self) -> Result<&Path> {
+        let parent = self.preferences_directory();
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create recent repositories directory {}",
+                parent.display()
+            )
+        })?;
+        restrict_directory_permissions(parent)?;
+        Ok(parent)
+    }
+
+    fn acquire_lock(&self) -> Result<ExclusiveLock> {
+        self.ensure_private_directory()?;
+        let lock_path = self.lock_path();
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&lock_path)
+            .with_context(|| format!("failed to open preferences lock {}", lock_path.display()))?;
+        restrict_file_permissions(&file, &lock_path)?;
+        <File as FileExt>::lock(&file)
+            .with_context(|| format!("failed to lock preferences {}", lock_path.display()))?;
+        Ok(ExclusiveLock { file })
+    }
+
+    fn save(&self, repositories: &[PathBuf]) -> Result<()> {
+        let parent = self.ensure_private_directory()?;
+
+        let mut temporary = NamedTempFile::new_in(parent).with_context(|| {
+            format!(
+                "failed to create temporary recent repositories file in {}",
+                parent.display()
+            )
+        })?;
+        restrict_file_permissions(temporary.as_file(), temporary.path())?;
+        serde_json::to_writer_pretty(temporary.as_file_mut(), repositories).with_context(|| {
+            format!(
+                "failed to serialize recent repositories for {}",
+                self.path.display()
+            )
+        })?;
+        temporary
+            .as_file_mut()
+            .write_all(b"\n")
+            .with_context(|| format!("failed to write {}", self.path.display()))?;
+        temporary
+            .as_file_mut()
+            .flush()
+            .with_context(|| format!("failed to flush {}", self.path.display()))?;
+        temporary
+            .as_file()
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", self.path.display()))?;
+        let persisted = temporary
+            .persist(&self.path)
+            .map_err(|error| error.error)
+            .with_context(|| {
+                format!(
+                    "failed to atomically replace recent repositories file {}",
+                    self.path.display()
+                )
+            })?;
+        drop(persisted);
+        sync_parent_directory(parent)?;
+        Ok(())
+    }
+}
+
+impl Default for RecentRepositories {
+    fn default() -> Self {
+        Self::at(Self::default_path())
+    }
+}
+
+fn restrict_directory_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).with_context(|| {
+            format!(
+                "failed to restrict recent repositories directory {}",
+                path.display()
+            )
+        })?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn restrict_file_permissions(file: &File, path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to restrict preferences file {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = file;
+        let _ = path;
+    }
+    Ok(())
+}
+
+fn sync_parent_directory(parent: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let directory = File::open(parent).with_context(|| {
+            format!(
+                "failed to open recent repositories directory {} for sync",
+                parent.display()
+            )
+        })?;
+        match directory.sync_all() {
+            Ok(()) => {}
+            #[cfg(target_os = "macos")]
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to sync recent repositories directory {}",
+                        parent.display()
+                    )
+                });
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = parent;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecentRepositories;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command};
+    use std::thread;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    const WRITER_STORE_ENV: &str = "STAX_TEST_RECENT_WRITER_STORE";
+    const WRITER_REPOSITORY_ENV: &str = "STAX_TEST_RECENT_WRITER_REPOSITORY";
+    const WRITER_READY_ENV: &str = "STAX_TEST_RECENT_WRITER_READY";
+
+    fn store(temp: &TempDir) -> RecentRepositories {
+        RecentRepositories::at(temp.path().join("preferences/recent-repositories.json"))
+    }
+
+    fn create_repository(parent: &Path, name: &str) -> PathBuf {
+        let path = parent.join(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_stored_paths(path: &Path, repositories: &[PathBuf]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, serde_json::to_vec(repositories).unwrap()).unwrap();
+    }
+
+    fn spawn_writer(store: &Path, repository: &Path, ready: &Path) -> Child {
+        Command::new(std::env::current_exe().unwrap())
+            .arg("preferences::tests::concurrent_record_worker")
+            .arg("--exact")
+            .arg("--nocapture")
+            .env(WRITER_STORE_ENV, store)
+            .env(WRITER_REPOSITORY_ENV, repository)
+            .env(WRITER_READY_ENV, ready)
+            .spawn()
+            .unwrap()
+    }
+
+    fn wait_for_path(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn missing_preferences_file_loads_an_empty_list() {
+        let temp = TempDir::new().unwrap();
+
+        assert_eq!(store(&temp).load().unwrap(), Vec::<PathBuf>::new());
+    }
+
+    #[test]
+    fn default_store_uses_the_platform_data_directory() {
+        let expected = dirs::data_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("stax/gui/recent-repositories.json");
+
+        assert_eq!(RecentRepositories::default_path(), expected);
+        assert_eq!(RecentRepositories::default().path, expected);
+    }
+
+    #[test]
+    fn record_round_trips_a_canonical_repository_path() {
+        let temp = TempDir::new().unwrap();
+        let repository = create_repository(temp.path(), "repository");
+        let recent = store(&temp);
+
+        recent.record(&repository).unwrap();
+
+        assert_eq!(
+            recent.load().unwrap(),
+            vec![repository.canonicalize().unwrap()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_paths_deduplicate_symlinked_repositories() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let repository = create_repository(temp.path(), "repository");
+        let alias = temp.path().join("repository-alias");
+        symlink(&repository, &alias).unwrap();
+        let recent = store(&temp);
+
+        recent.record(&repository).unwrap();
+        recent.record(&alias).unwrap();
+
+        assert_eq!(
+            recent.load().unwrap(),
+            vec![repository.canonicalize().unwrap()]
+        );
+    }
+
+    #[test]
+    fn record_keeps_the_ten_newest_repositories() {
+        let temp = TempDir::new().unwrap();
+        let recent = store(&temp);
+        let repositories: Vec<_> = (0..12)
+            .map(|index| create_repository(temp.path(), &format!("repository-{index}")))
+            .collect();
+
+        for repository in &repositories {
+            recent.record(repository).unwrap();
+        }
+
+        let expected: Vec<_> = repositories[2..]
+            .iter()
+            .rev()
+            .map(|path| path.canonicalize().unwrap())
+            .collect();
+        assert_eq!(recent.load().unwrap(), expected);
+    }
+
+    #[test]
+    fn load_filters_missing_entries_without_rewriting_the_file() {
+        let temp = TempDir::new().unwrap();
+        let existing = create_repository(temp.path(), "existing");
+        let missing = temp.path().join("missing");
+        let preferences_path = temp.path().join("preferences/recent-repositories.json");
+        let stored_paths = vec![missing, existing.clone()];
+        let stored = serde_json::to_vec(&stored_paths).unwrap();
+        write_stored_paths(&preferences_path, &stored_paths);
+        let recent = RecentRepositories::at(&preferences_path);
+
+        assert_eq!(
+            recent.load().unwrap(),
+            vec![existing.canonicalize().unwrap()]
+        );
+        assert_eq!(fs::read(&preferences_path).unwrap(), stored);
+    }
+
+    #[test]
+    fn load_filters_persisted_regular_files() {
+        let temp = TempDir::new().unwrap();
+        let repository = create_repository(temp.path(), "repository");
+        let regular_file = temp.path().join("not-a-repository");
+        fs::write(&regular_file, b"file").unwrap();
+        let preferences_path = temp.path().join("preferences/recent-repositories.json");
+        write_stored_paths(&preferences_path, &[regular_file, repository.clone()]);
+
+        assert_eq!(
+            RecentRepositories::at(preferences_path).load().unwrap(),
+            vec![repository.canonicalize().unwrap()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_deduplicates_raw_symlink_aliases_without_rewriting() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let repository = create_repository(temp.path(), "repository");
+        let alias = temp.path().join("alias");
+        symlink(&repository, &alias).unwrap();
+        let preferences_path = temp.path().join("preferences/recent-repositories.json");
+        let stored_paths = vec![alias.clone(), repository.clone(), alias];
+        write_stored_paths(&preferences_path, &stored_paths);
+        let original = fs::read(&preferences_path).unwrap();
+
+        assert_eq!(
+            RecentRepositories::at(&preferences_path).load().unwrap(),
+            vec![repository.canonicalize().unwrap()]
+        );
+        assert_eq!(fs::read(&preferences_path).unwrap(), original);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_reports_non_not_found_canonicalization_failures() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let first = temp.path().join("loop-a");
+        let second = temp.path().join("loop-b");
+        symlink(&second, &first).unwrap();
+        symlink(&first, &second).unwrap();
+        let preferences_path = temp.path().join("preferences/recent-repositories.json");
+        write_stored_paths(&preferences_path, std::slice::from_ref(&first));
+
+        let error = RecentRepositories::at(preferences_path)
+            .load()
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("canonicalize recent repository"));
+        assert!(error.contains(&first.display().to_string()));
+    }
+
+    #[test]
+    fn malformed_json_returns_an_actionable_error() {
+        let temp = TempDir::new().unwrap();
+        let preferences_path = temp.path().join("preferences/recent-repositories.json");
+        fs::create_dir_all(preferences_path.parent().unwrap()).unwrap();
+        fs::write(&preferences_path, b"{not valid json").unwrap();
+
+        let error = RecentRepositories::at(&preferences_path)
+            .load()
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("parse recent repositories"));
+        assert!(error.contains(&preferences_path.display().to_string()));
+    }
+
+    #[test]
+    fn record_rejects_missing_and_non_directory_paths_with_context() {
+        let temp = TempDir::new().unwrap();
+        let recent = store(&temp);
+        let missing = temp.path().join("missing");
+        let file = temp.path().join("file");
+        fs::write(&file, b"not a directory").unwrap();
+
+        for invalid in [&missing, &file] {
+            let error = recent.record(invalid).unwrap_err().to_string();
+            assert!(error.contains(&invalid.display().to_string()));
+            assert!(error.contains("repository"));
+        }
+    }
+
+    #[test]
+    fn successful_save_leaves_no_temporary_file() {
+        let temp = TempDir::new().unwrap();
+        let repository = create_repository(temp.path(), "repository");
+        let preferences_dir = temp.path().join("preferences");
+        let preferences_path = preferences_dir.join("recent-repositories.json");
+        let recent = RecentRepositories::at(&preferences_path);
+
+        recent.record(&repository).unwrap();
+
+        let entries: Vec<_> = fs::read_dir(&preferences_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        let names: HashSet<_> = entries.into_iter().collect();
+        assert_eq!(
+            names,
+            HashSet::from([
+                preferences_path.file_name().unwrap().to_owned(),
+                recent.lock_path().file_name().unwrap().to_owned(),
+            ])
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preferences_directory_and_files_are_user_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let repository = create_repository(temp.path(), "repository");
+        let preferences_dir = temp.path().join("preferences");
+        fs::create_dir_all(&preferences_dir).unwrap();
+        fs::set_permissions(&preferences_dir, fs::Permissions::from_mode(0o777)).unwrap();
+        let recent = RecentRepositories::at(preferences_dir.join("recent-repositories.json"));
+
+        recent.record(&repository).unwrap();
+
+        assert_eq!(
+            fs::metadata(&preferences_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&recent.path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            fs::metadata(recent.lock_path())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn concurrent_record_worker() {
+        let Some(store) = std::env::var_os(WRITER_STORE_ENV) else {
+            return;
+        };
+        let repository = std::env::var_os(WRITER_REPOSITORY_ENV).unwrap();
+        let ready = std::env::var_os(WRITER_READY_ENV).unwrap();
+
+        fs::write(ready, b"ready").unwrap();
+        RecentRepositories::at(store).record(repository).unwrap();
+    }
+
+    #[test]
+    fn concurrent_process_writers_preserve_both_repositories() {
+        let temp = TempDir::new().unwrap();
+        let first_repository = create_repository(temp.path(), "repository-a");
+        let second_repository = create_repository(temp.path(), "repository-b");
+        let recent = store(&temp);
+        let lock = recent.acquire_lock().unwrap();
+        let first_ready = temp.path().join("first-ready");
+        let second_ready = temp.path().join("second-ready");
+        let mut first = spawn_writer(&recent.path, &first_repository, &first_ready);
+        let mut second = spawn_writer(&recent.path, &second_repository, &second_ready);
+
+        wait_for_path(&first_ready);
+        wait_for_path(&second_ready);
+        thread::sleep(Duration::from_millis(250));
+        let first_was_blocked = first.try_wait().unwrap().is_none();
+        let second_was_blocked = second.try_wait().unwrap().is_none();
+        drop(lock);
+        let first_status = first.wait().unwrap();
+        let second_status = second.wait().unwrap();
+
+        assert!(first_was_blocked);
+        assert!(second_was_blocked);
+        assert!(first_status.success());
+        assert!(second_status.success());
+        let loaded: HashSet<_> = recent.load().unwrap().into_iter().collect();
+        assert_eq!(
+            loaded,
+            HashSet::from([
+                first_repository.canonicalize().unwrap(),
+                second_repository.canonicalize().unwrap(),
+            ])
+        );
+    }
+}

--- a/crates/stax-gui/src/state.rs
+++ b/crates/stax-gui/src/state.rs
@@ -1,0 +1,444 @@
+use stax::application::{
+    BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, RepositorySnapshot,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoadState<T> {
+    Idle,
+    Loading,
+    Ready(T),
+    Failed(String),
+}
+
+impl<T> LoadState<T> {
+    pub fn ready(&self) -> Option<&T> {
+        match self {
+            Self::Ready(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        match self {
+            Self::Failed(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceState {
+    snapshot: RepositorySnapshot,
+    selected_branch: Option<String>,
+    details: LoadState<BranchDetails>,
+    diff: LoadState<BranchDiff>,
+    ci: LoadState<CiSummary>,
+    generation: u64,
+}
+
+impl WorkspaceState {
+    pub fn new(snapshot: RepositorySnapshot) -> Self {
+        let selected_branch = snapshot
+            .branches
+            .iter()
+            .find(|branch| branch.name == snapshot.current_branch)
+            .or_else(|| snapshot.branches.first())
+            .map(|branch| branch.name.clone());
+
+        Self {
+            snapshot,
+            selected_branch,
+            details: LoadState::Idle,
+            diff: LoadState::Idle,
+            ci: LoadState::Idle,
+            generation: 0,
+        }
+    }
+
+    pub fn snapshot(&self) -> &RepositorySnapshot {
+        &self.snapshot
+    }
+
+    pub fn selected_branch(&self) -> Option<&str> {
+        self.selected_branch.as_deref()
+    }
+
+    pub fn details(&self) -> &LoadState<BranchDetails> {
+        &self.details
+    }
+
+    pub fn diff(&self) -> &LoadState<BranchDiff> {
+        &self.diff
+    }
+
+    pub fn ci(&self) -> &LoadState<CiSummary> {
+        &self.ci
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn select_branch(&mut self, name: &str) -> Option<DetailRequestToken> {
+        if !self
+            .snapshot
+            .branches
+            .iter()
+            .any(|branch| branch.name == name)
+        {
+            return None;
+        }
+
+        self.selected_branch = Some(name.to_owned());
+        self.advance_generation();
+        self.details = LoadState::Idle;
+        self.diff = LoadState::Idle;
+        self.ci = LoadState::Idle;
+        Some(self.current_token(name))
+    }
+
+    pub fn begin_hydration(&mut self) -> Option<(DetailRequestToken, BranchSummary)> {
+        let summary = self
+            .selected_branch
+            .as_deref()
+            .and_then(|selected| {
+                self.snapshot
+                    .branches
+                    .iter()
+                    .find(|branch| branch.name == selected)
+            })?
+            .clone();
+        self.advance_generation();
+        let token = self.current_token(&summary.name);
+
+        self.details = LoadState::Loading;
+        self.diff = LoadState::Loading;
+        self.ci = LoadState::Loading;
+        Some((token, summary))
+    }
+
+    pub fn apply_details(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<BranchDetails, String>,
+    ) -> bool {
+        if !self.matches(&token) {
+            return false;
+        }
+        self.details = result.map_or_else(LoadState::Failed, LoadState::Ready);
+        true
+    }
+
+    pub fn apply_diff(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<BranchDiff, String>,
+    ) -> bool {
+        if !self.matches(&token) {
+            return false;
+        }
+        self.diff = result.map_or_else(LoadState::Failed, LoadState::Ready);
+        true
+    }
+
+    pub fn apply_ci(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<CiSummary, String>,
+    ) -> bool {
+        if !self.matches(&token) {
+            return false;
+        }
+        self.ci = result.map_or_else(LoadState::Failed, LoadState::Ready);
+        true
+    }
+
+    fn advance_generation(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    fn current_token(&self, branch: &str) -> DetailRequestToken {
+        DetailRequestToken::new(
+            self.snapshot.repository_root.clone(),
+            branch,
+            self.generation,
+        )
+    }
+
+    fn matches(&self, token: &DetailRequestToken) -> bool {
+        self.selected_branch.as_deref().is_some_and(|branch| {
+            token.matches(&self.snapshot.repository_root, branch, self.generation)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LoadState, WorkspaceState};
+    use stax::application::{
+        BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, RepositorySnapshot,
+    };
+    use std::path::PathBuf;
+
+    fn branch(name: &str, is_current: bool) -> BranchSummary {
+        BranchSummary {
+            name: name.into(),
+            parent: None,
+            column: 0,
+            is_current,
+            is_trunk: false,
+            needs_restack: false,
+            pr_number: None,
+            pr_state: None,
+            ci_state: None,
+        }
+    }
+
+    fn snapshot(repository: &str, current: &str, branches: &[(&str, bool)]) -> RepositorySnapshot {
+        RepositorySnapshot {
+            repository_root: PathBuf::from(repository),
+            current_branch: current.into(),
+            trunk: "main".into(),
+            branches: branches
+                .iter()
+                .map(|(name, is_current)| branch(name, *is_current))
+                .collect(),
+        }
+    }
+
+    fn details(ahead: usize) -> BranchDetails {
+        BranchDetails {
+            ahead,
+            behind: 0,
+            has_remote: false,
+            unpushed: 0,
+            unpulled: 0,
+            commits: Vec::new(),
+        }
+    }
+
+    fn diff(line: &str) -> BranchDiff {
+        BranchDiff {
+            stat: Vec::new(),
+            lines: vec![stax::application::DiffLine {
+                content: line.into(),
+                kind: stax::application::DiffLineKind::Context,
+            }],
+        }
+    }
+
+    fn ci(status: &str) -> CiSummary {
+        CiSummary {
+            overall_status: Some(status.into()),
+            total: 0,
+            passed: 0,
+            failed: 0,
+            running: 0,
+            queued: 0,
+            skipped: 0,
+            started_at: None,
+            completed_at: None,
+            average_secs: None,
+        }
+    }
+
+    #[test]
+    fn new_selects_the_current_branch_and_starts_idle() {
+        let state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-b",
+            &[("feature-a", false), ("feature-b", true)],
+        ));
+
+        assert_eq!(state.snapshot().repository_root, PathBuf::from("/repo"));
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+        assert_eq!(state.generation(), 0);
+        assert_eq!(state.details(), &LoadState::Idle);
+        assert_eq!(state.diff(), &LoadState::Idle);
+        assert_eq!(state.ci(), &LoadState::Idle);
+    }
+
+    #[test]
+    fn new_falls_back_to_the_first_branch_when_current_is_absent() {
+        let state = WorkspaceState::new(snapshot(
+            "/repo",
+            "detached",
+            &[("feature-a", false), ("feature-b", false)],
+        ));
+
+        assert_eq!(state.selected_branch(), Some("feature-a"));
+    }
+
+    #[test]
+    fn empty_snapshot_has_no_selection_or_hydration_request() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "main", &[]));
+
+        assert_eq!(state.selected_branch(), None);
+        assert_eq!(state.generation(), 0);
+        assert_eq!(state.begin_hydration(), None);
+        assert_eq!(state.generation(), 0);
+        assert_eq!(state.details(), &LoadState::Idle);
+        assert_eq!(state.diff(), &LoadState::Idle);
+        assert_eq!(state.ci(), &LoadState::Idle);
+    }
+
+    #[test]
+    fn invalid_selection_does_not_mutate_state() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "feature-a", &[("feature-a", true)]));
+        let (token, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_details(token.clone(), Err("keep details".into())));
+        assert!(state.apply_diff(token.clone(), Err("keep diff".into())));
+        assert!(state.apply_ci(token, Err("keep ci".into())));
+        let generation = state.generation();
+
+        assert_eq!(state.select_branch("missing"), None);
+        assert_eq!(state.selected_branch(), Some("feature-a"));
+        assert_eq!(state.generation(), generation);
+        assert_eq!(state.details().error(), Some("keep details"));
+        assert_eq!(state.diff().error(), Some("keep diff"));
+        assert_eq!(state.ci().error(), Some("keep ci"));
+    }
+
+    #[test]
+    fn valid_selection_increments_generation_and_resets_hydration() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        let (initial, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_details(initial.clone(), Ok(details(1))));
+        assert!(state.apply_diff(initial.clone(), Ok(diff("old"))));
+        assert!(state.apply_ci(initial, Ok(ci("success"))));
+
+        let first = state.select_branch("feature-a").unwrap();
+        assert_eq!(first, DetailRequestToken::new("/repo", "feature-a", 2));
+        assert_eq!(state.generation(), 2);
+        assert_eq!(state.details(), &LoadState::Idle);
+        assert_eq!(state.diff(), &LoadState::Idle);
+        assert_eq!(state.ci(), &LoadState::Idle);
+
+        let second = state.select_branch("feature-b").unwrap();
+        assert_eq!(second, DetailRequestToken::new("/repo", "feature-b", 3));
+        assert_eq!(state.generation(), 3);
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+    }
+
+    #[test]
+    fn begin_hydration_marks_all_results_loading_and_returns_current_request() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-b",
+            &[("feature-a", false), ("feature-b", true)],
+        ));
+
+        let (token, summary) = state.begin_hydration().unwrap();
+
+        assert_eq!(token, DetailRequestToken::new("/repo", "feature-b", 1));
+        assert_eq!(summary, branch("feature-b", true));
+        assert_eq!(state.generation(), 1);
+        assert_eq!(state.details(), &LoadState::Loading);
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert_eq!(state.ci(), &LoadState::Loading);
+    }
+
+    #[test]
+    fn matching_results_become_ready_and_failures_preserve_their_messages() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "feature-a", &[("feature-a", true)]));
+        let (token, _) = state.begin_hydration().unwrap();
+
+        assert!(state.apply_details(token.clone(), Ok(details(2))));
+        assert!(state.apply_diff(token.clone(), Ok(diff("ready"))));
+        assert!(state.apply_ci(token, Ok(ci("success"))));
+        assert_eq!(state.details().ready(), Some(&details(2)));
+        assert_eq!(state.diff().ready(), Some(&diff("ready")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+        assert_eq!(state.details().error(), None);
+
+        state.select_branch("feature-a").unwrap();
+        let (retry, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_details(retry.clone(), Err("details failed".into())));
+        assert!(state.apply_diff(retry.clone(), Err("diff failed".into())));
+        assert!(state.apply_ci(retry, Err("ci failed".into())));
+        assert_eq!(state.details().error(), Some("details failed"));
+        assert_eq!(state.diff().error(), Some("diff failed"));
+        assert_eq!(state.ci().error(), Some("ci failed"));
+        assert_eq!(state.details().ready(), None);
+    }
+
+    #[test]
+    fn every_result_type_rejects_repository_branch_and_generation_mismatches() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        state.select_branch("feature-a").unwrap();
+        let (current, _) = state.begin_hydration().unwrap();
+
+        let mismatches = [
+            DetailRequestToken::new("/other-repo", "feature-a", current.generation),
+            DetailRequestToken::new("/repo", "feature-b", current.generation),
+            DetailRequestToken::new("/repo", "feature-a", current.generation - 1),
+        ];
+
+        for token in mismatches {
+            assert!(!state.apply_details(token.clone(), Ok(details(9))));
+            assert!(!state.apply_diff(token.clone(), Ok(diff("stale"))));
+            assert!(!state.apply_ci(token, Ok(ci("failure"))));
+        }
+
+        assert_eq!(state.details(), &LoadState::Loading);
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert_eq!(state.ci(), &LoadState::Loading);
+    }
+
+    #[test]
+    fn rapid_branch_selection_prevents_old_results_from_overwriting_new_state() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        let (old, _) = state.begin_hydration().unwrap();
+        state.select_branch("feature-b").unwrap();
+        let (current, _) = state.begin_hydration().unwrap();
+
+        assert!(!state.apply_details(old.clone(), Ok(details(99))));
+        assert!(!state.apply_diff(old.clone(), Ok(diff("old"))));
+        assert!(!state.apply_ci(old, Ok(ci("failure"))));
+        assert_eq!(state.details(), &LoadState::Loading);
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert_eq!(state.ci(), &LoadState::Loading);
+        assert!(state.apply_details(current.clone(), Ok(details(3))));
+        assert!(state.apply_diff(current.clone(), Ok(diff("new"))));
+        assert!(state.apply_ci(current, Ok(ci("success"))));
+        assert_eq!(state.details().ready(), Some(&details(3)));
+        assert_eq!(state.diff().ready(), Some(&diff("new")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+    }
+
+    #[test]
+    fn retrying_same_branch_hydration_rejects_the_older_request() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "feature-a", &[("feature-a", true)]));
+        let (old, _) = state.begin_hydration().unwrap();
+        let (retry, _) = state.begin_hydration().unwrap();
+
+        assert_eq!(old.generation, 1);
+        assert_eq!(retry.generation, 2);
+        assert!(!state.apply_details(old.clone(), Ok(details(99))));
+        assert!(!state.apply_diff(old.clone(), Ok(diff("old"))));
+        assert!(!state.apply_ci(old, Ok(ci("failure"))));
+        assert_eq!(state.details(), &LoadState::Loading);
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert_eq!(state.ci(), &LoadState::Loading);
+
+        assert!(state.apply_details(retry.clone(), Ok(details(2))));
+        assert!(state.apply_diff(retry.clone(), Ok(diff("retry"))));
+        assert!(state.apply_ci(retry, Ok(ci("success"))));
+        assert_eq!(state.details().ready(), Some(&details(2)));
+        assert_eq!(state.diff().ready(), Some(&diff("retry")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+    }
+}

--- a/crates/stax-gui/src/state.rs
+++ b/crates/stax-gui/src/state.rs
@@ -38,6 +38,7 @@ pub struct WorkspaceState {
     selected_branch: Option<String>,
     details: LoadState<BranchDetails>,
     diff: LoadState<BranchDiff>,
+    diff_refreshing: bool,
     ci: LoadState<CiSummary>,
     generation: u64,
 }
@@ -56,6 +57,7 @@ impl WorkspaceState {
             selected_branch,
             details: LoadState::Idle,
             diff: LoadState::Idle,
+            diff_refreshing: false,
             ci: LoadState::Idle,
             generation: 0,
         }
@@ -77,6 +79,10 @@ impl WorkspaceState {
         &self.diff
     }
 
+    pub fn diff_is_refreshing(&self) -> bool {
+        self.diff_refreshing
+    }
+
     pub fn ci(&self) -> &LoadState<CiSummary> {
         &self.ci
     }
@@ -95,10 +101,14 @@ impl WorkspaceState {
             return None;
         }
 
+        let same_branch = self.selected_branch.as_deref() == Some(name);
         self.selected_branch = Some(name.to_owned());
         self.advance_generation();
         self.details = LoadState::Idle;
-        self.diff = LoadState::Idle;
+        if !same_branch || !matches!(self.diff, LoadState::Ready(_)) {
+            self.diff = LoadState::Idle;
+        }
+        self.diff_refreshing = false;
         self.ci = LoadState::Idle;
         Some(self.current_token(name))
     }
@@ -132,9 +142,15 @@ impl WorkspaceState {
     }
 
     pub fn replace_snapshot(&mut self, snapshot: RepositorySnapshot) {
+        let previous_repository = self.snapshot.repository_root.clone();
         let previous_selection = self.selected_branch.clone();
+        let previous_diff = match &self.diff {
+            LoadState::Ready(diff) => Some(diff.clone()),
+            LoadState::Idle | LoadState::Loading | LoadState::Failed(_) => None,
+        };
         self.snapshot = snapshot;
         self.selected_branch = previous_selection
+            .clone()
             .filter(|selected| {
                 self.snapshot
                     .branches
@@ -156,7 +172,14 @@ impl WorkspaceState {
             });
         self.advance_generation();
         self.details = LoadState::Idle;
-        self.diff = LoadState::Idle;
+        self.diff = if previous_repository == self.snapshot.repository_root
+            && previous_selection == self.selected_branch
+        {
+            previous_diff.map_or(LoadState::Idle, LoadState::Ready)
+        } else {
+            LoadState::Idle
+        };
+        self.diff_refreshing = false;
         self.ci = LoadState::Idle;
     }
 
@@ -175,7 +198,10 @@ impl WorkspaceState {
         let token = self.current_token(&summary.name);
 
         self.details = LoadState::Loading;
-        self.diff = LoadState::Loading;
+        if !matches!(self.diff, LoadState::Ready(_)) {
+            self.diff = LoadState::Loading;
+        }
+        self.diff_refreshing = true;
         self.ci = LoadState::Loading;
         Some((token, summary))
     }
@@ -192,6 +218,17 @@ impl WorkspaceState {
         true
     }
 
+    pub fn apply_cached_diff(&mut self, token: DetailRequestToken, diff: BranchDiff) -> bool {
+        if !self.matches(&token)
+            || !self.diff_refreshing
+            || !matches!(self.diff, LoadState::Loading)
+        {
+            return false;
+        }
+        self.diff = LoadState::Ready(diff);
+        true
+    }
+
     pub fn apply_diff(
         &mut self,
         token: DetailRequestToken,
@@ -201,6 +238,7 @@ impl WorkspaceState {
             return false;
         }
         self.diff = result.map_or_else(LoadState::Failed, LoadState::Ready);
+        self.diff_refreshing = false;
         true
     }
 
@@ -212,7 +250,21 @@ impl WorkspaceState {
         if !self.matches(&token) {
             return false;
         }
-        self.ci = result.map_or_else(LoadState::Failed, LoadState::Ready);
+        self.ci = match result {
+            Ok(summary) => {
+                if let Some(selected) = self.selected_branch.as_deref()
+                    && let Some(branch) = self
+                        .snapshot
+                        .branches
+                        .iter_mut()
+                        .find(|branch| branch.name == selected)
+                {
+                    branch.ci_state = summary.overall_status.clone();
+                }
+                LoadState::Ready(summary)
+            }
+            Err(error) => LoadState::Failed(error),
+        };
         true
     }
 
@@ -363,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn valid_selection_increments_generation_and_resets_hydration() {
+    fn valid_selection_retains_only_a_same_branch_ready_diff() {
         let mut state = WorkspaceState::new(snapshot(
             "/repo",
             "feature-a",
@@ -378,13 +430,15 @@ mod tests {
         assert_eq!(first, DetailRequestToken::new("/repo", "feature-a", 2));
         assert_eq!(state.generation(), 2);
         assert_eq!(state.details(), &LoadState::Idle);
-        assert_eq!(state.diff(), &LoadState::Idle);
+        assert_eq!(state.diff().ready(), Some(&diff("old")));
+        assert!(!state.diff_is_refreshing());
         assert_eq!(state.ci(), &LoadState::Idle);
 
         let second = state.select_branch("feature-b").unwrap();
         assert_eq!(second, DetailRequestToken::new("/repo", "feature-b", 3));
         assert_eq!(state.generation(), 3);
         assert_eq!(state.selected_branch(), Some("feature-b"));
+        assert_eq!(state.diff(), &LoadState::Idle);
     }
 
     #[test]
@@ -427,6 +481,55 @@ mod tests {
         assert_eq!(state.diff().error(), Some("diff failed"));
         assert_eq!(state.ci().error(), Some("ci failed"));
         assert_eq!(state.details().ready(), None);
+    }
+
+    #[test]
+    fn accepted_live_ci_success_replaces_cached_stack_row_status() {
+        let mut snapshot = snapshot("/repo", "feature-a", &[("feature-a", true)]);
+        snapshot.branches[0].ci_state = Some("failure".into());
+        let mut state = WorkspaceState::new(snapshot);
+        let (token, _) = state.begin_hydration().unwrap();
+
+        assert!(state.apply_ci(token, Ok(ci("success"))));
+
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+        assert_eq!(
+            state.snapshot().branches[0].ci_state.as_deref(),
+            Some("success")
+        );
+    }
+
+    #[test]
+    fn stale_live_ci_result_cannot_replace_cached_stack_row_status() {
+        let mut snapshot = snapshot("/repo", "feature-a", &[("feature-a", true)]);
+        snapshot.branches[0].ci_state = Some("failure".into());
+        let mut state = WorkspaceState::new(snapshot);
+        let (stale, _) = state.begin_hydration().unwrap();
+        let (_, _) = state.begin_hydration().unwrap();
+
+        assert!(!state.apply_ci(stale, Ok(ci("success"))));
+
+        assert_eq!(state.ci(), &LoadState::Loading);
+        assert_eq!(
+            state.snapshot().branches[0].ci_state.as_deref(),
+            Some("failure")
+        );
+    }
+
+    #[test]
+    fn live_ci_failure_retains_cached_stack_row_status() {
+        let mut snapshot = snapshot("/repo", "feature-a", &[("feature-a", true)]);
+        snapshot.branches[0].ci_state = Some("failure".into());
+        let mut state = WorkspaceState::new(snapshot);
+        let (token, _) = state.begin_hydration().unwrap();
+
+        assert!(state.apply_ci(token, Err("provider unavailable".into())));
+
+        assert_eq!(state.ci().error(), Some("provider unavailable"));
+        assert_eq!(
+            state.snapshot().branches[0].ci_state.as_deref(),
+            Some("failure")
+        );
     }
 
     #[test]
@@ -503,6 +606,88 @@ mod tests {
         assert_eq!(state.details().ready(), Some(&details(2)));
         assert_eq!(state.diff().ready(), Some(&diff("retry")));
         assert_eq!(state.ci().ready(), Some(&ci("success")));
+    }
+
+    #[test]
+    fn retrying_same_branch_retains_ready_diff_until_refresh_finishes() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "feature-a", &[("feature-a", true)]));
+        let (first, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(first, Ok(diff("existing patch"))));
+
+        let (retry, _) = state.begin_hydration().unwrap();
+
+        assert_eq!(state.diff().ready(), Some(&diff("existing patch")));
+        assert!(state.diff_is_refreshing());
+        assert!(state.apply_diff(retry, Ok(diff("replacement patch"))));
+        assert_eq!(state.diff().ready(), Some(&diff("replacement patch")));
+        assert!(!state.diff_is_refreshing());
+    }
+
+    #[test]
+    fn cached_diff_is_visible_during_refresh_and_final_failure_replaces_it() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "feature-a", &[("feature-a", true)]));
+        let (token, _) = state.begin_hydration().unwrap();
+
+        assert!(state.apply_cached_diff(token.clone(), diff("cached patch")));
+        assert_eq!(state.diff().ready(), Some(&diff("cached patch")));
+        assert!(state.diff_is_refreshing());
+
+        assert!(state.apply_diff(token, Err("fresh diff failed".into())));
+        assert_eq!(state.diff().error(), Some("fresh diff failed"));
+        assert!(!state.diff_is_refreshing());
+    }
+
+    #[test]
+    fn cached_diff_does_not_replace_a_ready_patch_retained_for_retry() {
+        let mut state = WorkspaceState::new(snapshot("/repo", "feature-a", &[("feature-a", true)]));
+        let (first, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(first, Ok(diff("visible patch"))));
+        let (retry, _) = state.begin_hydration().unwrap();
+
+        assert!(!state.apply_cached_diff(retry, diff("older cached patch")));
+
+        assert_eq!(state.diff().ready(), Some(&diff("visible patch")));
+        assert!(state.diff_is_refreshing());
+    }
+
+    #[test]
+    fn selecting_a_different_branch_never_retains_the_prior_patch() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        let (first, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(first, Ok(diff("feature-a patch"))));
+
+        state.select_branch("feature-b").unwrap();
+        let (_, _) = state.begin_hydration().unwrap();
+
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert!(state.diff_is_refreshing());
+    }
+
+    #[test]
+    fn snapshot_refresh_preserves_selected_branch_patch_while_rehydrating() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        state.select_branch("feature-b").unwrap();
+        let (first, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(first, Ok(diff("feature-b patch"))));
+
+        state.replace_snapshot(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-b", false), ("feature-a", true)],
+        ));
+        let (_, _) = state.begin_hydration().unwrap();
+
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+        assert_eq!(state.diff().ready(), Some(&diff("feature-b patch")));
+        assert!(state.diff_is_refreshing());
     }
 
     #[test]

--- a/crates/stax-gui/src/state.rs
+++ b/crates/stax-gui/src/state.rs
@@ -26,6 +26,12 @@ impl<T> LoadState<T> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionDirection {
+    Previous,
+    Next,
+}
+
 #[derive(Debug, Clone)]
 pub struct WorkspaceState {
     snapshot: RepositorySnapshot,
@@ -95,6 +101,63 @@ impl WorkspaceState {
         self.diff = LoadState::Idle;
         self.ci = LoadState::Idle;
         Some(self.current_token(name))
+    }
+
+    pub fn move_selection(&mut self, direction: SelectionDirection) -> bool {
+        let Some(selected) = self.selected_branch.as_deref() else {
+            return false;
+        };
+        let Some(index) = self
+            .snapshot
+            .branches
+            .iter()
+            .position(|branch| branch.name == selected)
+        else {
+            return false;
+        };
+        let next_index = match direction {
+            SelectionDirection::Previous => index.checked_sub(1),
+            SelectionDirection::Next => index
+                .checked_add(1)
+                .filter(|next| *next < self.snapshot.branches.len()),
+        };
+        let Some(next_name) = next_index
+            .and_then(|next| self.snapshot.branches.get(next))
+            .map(|branch| branch.name.clone())
+        else {
+            return false;
+        };
+
+        self.select_branch(&next_name).is_some()
+    }
+
+    pub fn replace_snapshot(&mut self, snapshot: RepositorySnapshot) {
+        let previous_selection = self.selected_branch.clone();
+        self.snapshot = snapshot;
+        self.selected_branch = previous_selection
+            .filter(|selected| {
+                self.snapshot
+                    .branches
+                    .iter()
+                    .any(|branch| branch.name == *selected)
+            })
+            .or_else(|| {
+                self.snapshot
+                    .branches
+                    .iter()
+                    .find(|branch| branch.name == self.snapshot.current_branch)
+                    .map(|branch| branch.name.clone())
+            })
+            .or_else(|| {
+                self.snapshot
+                    .branches
+                    .first()
+                    .map(|branch| branch.name.clone())
+            });
+        self.advance_generation();
+        self.details = LoadState::Idle;
+        self.diff = LoadState::Idle;
+        self.ci = LoadState::Idle;
     }
 
     pub fn begin_hydration(&mut self) -> Option<(DetailRequestToken, BranchSummary)> {
@@ -174,7 +237,7 @@ impl WorkspaceState {
 
 #[cfg(test)]
 mod tests {
-    use super::{LoadState, WorkspaceState};
+    use super::{LoadState, SelectionDirection, WorkspaceState};
     use stax::application::{
         BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, RepositorySnapshot,
     };
@@ -440,5 +503,70 @@ mod tests {
         assert_eq!(state.details().ready(), Some(&details(2)));
         assert_eq!(state.diff().ready(), Some(&diff("retry")));
         assert_eq!(state.ci().ready(), Some(&ci("success")));
+    }
+
+    #[test]
+    fn arrow_navigation_stops_at_boundaries_without_changing_current_branch() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-b",
+            &[("feature-a", false), ("feature-b", true), ("main", false)],
+        ));
+
+        assert!(state.move_selection(SelectionDirection::Previous));
+        assert_eq!(state.selected_branch(), Some("feature-a"));
+        assert_eq!(state.snapshot().current_branch, "feature-b");
+        let generation = state.generation();
+
+        assert!(!state.move_selection(SelectionDirection::Previous));
+        assert_eq!(state.selected_branch(), Some("feature-a"));
+        assert_eq!(state.generation(), generation);
+
+        assert!(state.move_selection(SelectionDirection::Next));
+        assert!(state.move_selection(SelectionDirection::Next));
+        assert_eq!(state.selected_branch(), Some("main"));
+        let generation = state.generation();
+
+        assert!(!state.move_selection(SelectionDirection::Next));
+        assert_eq!(state.selected_branch(), Some("main"));
+        assert_eq!(state.generation(), generation);
+        assert_eq!(state.snapshot().current_branch, "feature-b");
+    }
+
+    #[test]
+    fn refresh_preserves_selection_then_falls_back_to_current_or_first_branch() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        state.select_branch("feature-b").unwrap();
+
+        state.replace_snapshot(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-b", false), ("feature-a", true)],
+        ));
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+
+        state.replace_snapshot(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-c", false)],
+        ));
+        assert_eq!(state.selected_branch(), Some("feature-a"));
+
+        state.replace_snapshot(snapshot(
+            "/repo",
+            "detached",
+            &[("feature-c", false), ("feature-d", false)],
+        ));
+        assert_eq!(state.selected_branch(), Some("feature-c"));
+
+        state.replace_snapshot(snapshot("/repo", "detached", &[]));
+        assert_eq!(state.selected_branch(), None);
+        assert_eq!(state.details(), &LoadState::Idle);
+        assert_eq!(state.diff(), &LoadState::Idle);
+        assert_eq!(state.ci(), &LoadState::Idle);
     }
 }

--- a/crates/stax-gui/src/theme.rs
+++ b/crates/stax-gui/src/theme.rs
@@ -1,0 +1,174 @@
+use gpui::{Hsla, WindowAppearance, rgb};
+
+pub const SYSTEM_UI_FONT: &str = ".SystemUIFont";
+pub const MONOSPACE_FONT: &str = "Menlo";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Theme {
+    pub window: Hsla,
+    pub surface: Hsla,
+    pub surface_raised: Hsla,
+    pub surface_selected: Hsla,
+    pub border: Hsla,
+    pub border_strong: Hsla,
+    pub text: Hsla,
+    pub text_muted: Hsla,
+    pub accent: Hsla,
+    pub accent_text: Hsla,
+    pub focus: Hsla,
+    pub success: Hsla,
+    pub warning: Hsla,
+    pub danger: Hsla,
+    pub diff_addition: Hsla,
+    pub diff_deletion: Hsla,
+    pub diff_hunk: Hsla,
+    pub disabled_surface: Hsla,
+    pub disabled_text: Hsla,
+}
+
+impl Theme {
+    pub fn light() -> Self {
+        Self {
+            window: rgb(0xf3f3f4).into(),
+            surface: rgb(0xf9f9fa).into(),
+            surface_raised: rgb(0xffffff).into(),
+            surface_selected: rgb(0xe6eef9).into(),
+            border: rgb(0xd7d7da).into(),
+            border_strong: rgb(0xb8b8bd).into(),
+            text: rgb(0x202124).into(),
+            text_muted: rgb(0x62656a).into(),
+            accent: rgb(0x2b67ae).into(),
+            accent_text: rgb(0xffffff).into(),
+            focus: rgb(0x1f72cf).into(),
+            success: rgb(0x287a45).into(),
+            warning: rgb(0x915d10).into(),
+            danger: rgb(0xb13a36).into(),
+            diff_addition: rgb(0x1f7a3f).into(),
+            diff_deletion: rgb(0xb23832).into(),
+            diff_hunk: rgb(0x6750a4).into(),
+            disabled_surface: rgb(0xebebed).into(),
+            disabled_text: rgb(0x85878c).into(),
+        }
+    }
+
+    pub fn dark() -> Self {
+        Self {
+            window: rgb(0x202124).into(),
+            surface: rgb(0x27282b).into(),
+            surface_raised: rgb(0x2f3034).into(),
+            surface_selected: rgb(0x263e5d).into(),
+            border: rgb(0x414349).into(),
+            border_strong: rgb(0x5a5d64).into(),
+            text: rgb(0xf0f0f1).into(),
+            text_muted: rgb(0xb0b3b8).into(),
+            accent: rgb(0x7aadea).into(),
+            accent_text: rgb(0x142338).into(),
+            focus: rgb(0x83b7f2).into(),
+            success: rgb(0x70c78a).into(),
+            warning: rgb(0xe0b25d).into(),
+            danger: rgb(0xf58a83).into(),
+            diff_addition: rgb(0x79c991).into(),
+            diff_deletion: rgb(0xf08a84).into(),
+            diff_hunk: rgb(0xb8a5ed).into(),
+            disabled_surface: rgb(0x34363a).into(),
+            disabled_text: rgb(0x858990).into(),
+        }
+    }
+
+    pub fn for_appearance(appearance: WindowAppearance) -> Self {
+        match appearance {
+            WindowAppearance::Light | WindowAppearance::VibrantLight => Self::light(),
+            WindowAppearance::Dark | WindowAppearance::VibrantDark => Self::dark(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Theme;
+    use gpui::{Hsla, WindowAppearance};
+
+    fn relative_luminance(color: Hsla) -> f32 {
+        let color = color.to_rgb();
+        let linear = |channel: f32| {
+            if channel <= 0.04045 {
+                channel / 12.92
+            } else {
+                ((channel + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * linear(color.r) + 0.7152 * linear(color.g) + 0.0722 * linear(color.b)
+    }
+
+    fn contrast_ratio(foreground: Hsla, background: Hsla) -> f32 {
+        let foreground = relative_luminance(foreground);
+        let background = relative_luminance(background);
+        let (lighter, darker) = if foreground > background {
+            (foreground, background)
+        } else {
+            (background, foreground)
+        };
+        (lighter + 0.05) / (darker + 0.05)
+    }
+
+    #[test]
+    fn light_and_vibrant_light_use_the_light_graphite_theme() {
+        assert_eq!(
+            Theme::for_appearance(WindowAppearance::Light),
+            Theme::light()
+        );
+        assert_eq!(
+            Theme::for_appearance(WindowAppearance::VibrantLight),
+            Theme::light()
+        );
+    }
+
+    #[test]
+    fn dark_and_vibrant_dark_use_the_dark_graphite_theme() {
+        assert_eq!(Theme::for_appearance(WindowAppearance::Dark), Theme::dark());
+        assert_eq!(
+            Theme::for_appearance(WindowAppearance::VibrantDark),
+            Theme::dark()
+        );
+    }
+
+    #[test]
+    fn semantic_status_and_diff_tokens_remain_distinct() {
+        for theme in [Theme::light(), Theme::dark()] {
+            assert_ne!(theme.text, theme.text_muted);
+            assert_ne!(theme.success, theme.warning);
+            assert_ne!(theme.warning, theme.danger);
+            assert_ne!(theme.diff_addition, theme.diff_deletion);
+            assert_ne!(theme.focus, theme.surface_selected);
+        }
+    }
+
+    #[test]
+    fn small_status_text_meets_wcag_aa_on_normal_and_selected_rows() {
+        for (appearance, theme) in [("light", Theme::light()), ("dark", Theme::dark())] {
+            for (status, foreground) in [
+                ("accent", theme.accent),
+                ("muted", theme.text_muted),
+                ("success", theme.success),
+                ("warning", theme.warning),
+                ("danger", theme.danger),
+            ] {
+                for (surface, background) in [
+                    ("normal", theme.surface),
+                    ("selected", theme.surface_selected),
+                ] {
+                    let ratio = contrast_ratio(foreground, background);
+                    let required_ratio = if appearance == "light" && status == "warning" {
+                        4.6
+                    } else {
+                        4.5
+                    };
+                    assert!(
+                        ratio >= required_ratio,
+                        "{appearance} {status} text on {surface} surface has contrast {ratio:.2}:1; required {required_ratio:.1}:1"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/stax-gui/src/theme.rs
+++ b/crates/stax-gui/src/theme.rs
@@ -16,6 +16,7 @@ pub struct Theme {
     pub accent: Hsla,
     pub accent_text: Hsla,
     pub focus: Hsla,
+    pub focus_on_accent: Hsla,
     pub success: Hsla,
     pub warning: Hsla,
     pub danger: Hsla,
@@ -40,6 +41,7 @@ impl Theme {
             accent: rgb(0x2b67ae).into(),
             accent_text: rgb(0xffffff).into(),
             focus: rgb(0x1f72cf).into(),
+            focus_on_accent: rgb(0xffffff).into(),
             success: rgb(0x287a45).into(),
             warning: rgb(0x915d10).into(),
             danger: rgb(0xb13a36).into(),
@@ -64,6 +66,7 @@ impl Theme {
             accent: rgb(0x7aadea).into(),
             accent_text: rgb(0x142338).into(),
             focus: rgb(0x83b7f2).into(),
+            focus_on_accent: rgb(0x142338).into(),
             success: rgb(0x70c78a).into(),
             warning: rgb(0xe0b25d).into(),
             danger: rgb(0xf58a83).into(),
@@ -140,6 +143,29 @@ mod tests {
             assert_ne!(theme.warning, theme.danger);
             assert_ne!(theme.diff_addition, theme.diff_deletion);
             assert_ne!(theme.focus, theme.surface_selected);
+            assert_ne!(theme.focus_on_accent, theme.accent);
+        }
+    }
+
+    #[test]
+    fn keyboard_focus_treatment_meets_non_text_contrast() {
+        for (appearance, theme) in [("light", Theme::light()), ("dark", Theme::dark())] {
+            for (surface, background) in [
+                ("normal", theme.surface),
+                ("raised", theme.surface_raised),
+                ("selected", theme.surface_selected),
+            ] {
+                let ratio = contrast_ratio(theme.focus, background);
+                assert!(
+                    ratio >= 3.0,
+                    "{appearance} focus treatment on {surface} surface has contrast {ratio:.2}:1; required 3.0:1"
+                );
+            }
+            let primary_ratio = contrast_ratio(theme.focus_on_accent, theme.accent);
+            assert!(
+                primary_ratio >= 3.0,
+                "{appearance} focus treatment on primary surface has contrast {primary_ratio:.2}:1; required 3.0:1"
+            );
         }
     }
 

--- a/crates/stax-gui/src/views/app.rs
+++ b/crates/stax-gui/src/views/app.rs
@@ -1,0 +1,750 @@
+#[cfg(test)]
+use super::{changes_pane, inspector_pane, stack_pane};
+use super::{welcome::WelcomeView, workspace::WorkspaceView};
+use crate::preferences::RecentRepositories;
+use crate::state::SelectionDirection;
+use crate::theme::{SYSTEM_UI_FONT, Theme};
+use gpui::{
+    App, Context, Div, ElementId, FocusHandle, Focusable, InteractiveElement as _, IntoElement,
+    KeyBinding, ParentElement as _, PathPromptOptions, Render, SharedString, Stateful,
+    StatefulInteractiveElement as _, Styled as _, Window, actions, div, px,
+};
+use stax::application::{RepositorySession, RepositorySnapshot};
+use std::collections::VecDeque;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::Arc;
+
+actions!(
+    stax_gui,
+    [
+        SelectPreviousBranch,
+        SelectNextBranch,
+        OpenRepository,
+        RefreshRepository
+    ]
+);
+
+pub type PickerFuture = Pin<Box<dyn Future<Output = Result<Option<PathBuf>, String>> + 'static>>;
+
+pub trait SnapshotLoader: Send + Sync {
+    fn load(&self, path: &Path) -> Result<RepositorySnapshot, String>;
+}
+
+pub trait RepositoryPicker {
+    fn pick(&self, cx: &mut App) -> PickerFuture;
+}
+
+pub trait RecentRepositoryStore: Send + Sync {
+    fn load(&self) -> Result<Vec<PathBuf>, String>;
+    fn record(&self, path: &Path) -> Result<(), String>;
+}
+
+#[derive(Clone)]
+pub struct AppServices {
+    loader: Arc<dyn SnapshotLoader>,
+    picker: Rc<dyn RepositoryPicker>,
+    recents: Arc<dyn RecentRepositoryStore>,
+}
+
+impl AppServices {
+    pub fn new(
+        loader: Arc<dyn SnapshotLoader>,
+        picker: Rc<dyn RepositoryPicker>,
+        recents: Arc<dyn RecentRepositoryStore>,
+    ) -> Self {
+        Self {
+            loader,
+            picker,
+            recents,
+        }
+    }
+
+    pub(super) fn native() -> Self {
+        Self::new(
+            Arc::new(NativeSnapshotLoader),
+            Rc::new(NativeRepositoryPicker),
+            Arc::new(RecentRepositories::default()),
+        )
+    }
+}
+
+struct NativeSnapshotLoader;
+
+impl SnapshotLoader for NativeSnapshotLoader {
+    fn load(&self, path: &Path) -> Result<RepositorySnapshot, String> {
+        RepositorySession::open(path)
+            .and_then(|session| session.snapshot())
+            .map_err(|error| error.to_string())
+    }
+}
+
+struct NativeRepositoryPicker;
+
+impl RepositoryPicker for NativeRepositoryPicker {
+    fn pick(&self, cx: &mut App) -> PickerFuture {
+        let receiver = cx.prompt_for_paths(PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Open Repository".into()),
+        });
+        Box::pin(async move {
+            receiver
+                .await
+                .map_err(|_| "Open Repository dialog closed unexpectedly".to_string())?
+                .map_err(|error| format!("Open Repository dialog failed: {error}"))
+                .map(|paths| paths.and_then(|paths| paths.into_iter().next()))
+        })
+    }
+}
+
+impl RecentRepositoryStore for RecentRepositories {
+    fn load(&self) -> Result<Vec<PathBuf>, String> {
+        RecentRepositories::load(self).map_err(|error| error.to_string())
+    }
+
+    fn record(&self, path: &Path) -> Result<(), String> {
+        RecentRepositories::record(self, path).map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppModeKind {
+    Welcome,
+    Opening,
+    Workspace,
+    Error,
+}
+
+enum AppMode {
+    Welcome(WelcomeView),
+    Opening(WelcomeView),
+    Workspace(Box<WorkspaceView>),
+    Error(WelcomeView),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WelcomeModeKind {
+    Welcome,
+    Opening,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootLoadKind {
+    Open,
+    Refresh,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootLoadToken {
+    generation: u64,
+    path: PathBuf,
+    kind: RootLoadKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecentLoadToken {
+    generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecentWriteToken {
+    generation: u64,
+    path: PathBuf,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneMarkers {
+    pub stack: &'static str,
+    pub changes: &'static str,
+    pub inspector: &'static str,
+}
+
+#[cfg(test)]
+impl PaneMarkers {
+    pub const fn all() -> Self {
+        Self {
+            stack: stack_pane::PANE_MARKER,
+            changes: changes_pane::PANE_MARKER,
+            inspector: inspector_pane::PANE_MARKER,
+        }
+    }
+}
+
+pub struct AppView {
+    mode: AppMode,
+    focus_handle: FocusHandle,
+    services: AppServices,
+    recent_repositories: Vec<PathBuf>,
+    action_error: Option<String>,
+    recent_load_error: Option<String>,
+    recent_write_error: Option<String>,
+    recent_load_pending: bool,
+    recent_load_generation: u64,
+    recent_write_generation: u64,
+    recent_write_queue: VecDeque<RecentWriteToken>,
+    recent_write_in_flight: bool,
+    load_generation: u64,
+}
+
+impl AppView {
+    pub fn new(
+        repository: Option<PathBuf>,
+        services: AppServices,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let focus_handle = cx.focus_handle().tab_index(0).tab_stop(true);
+        focus_handle.focus(window);
+        window.set_window_title("Stax");
+
+        let mut view = Self {
+            mode: AppMode::Welcome(WelcomeView::new(Vec::new(), None, None, false)),
+            focus_handle,
+            services,
+            recent_repositories: Vec::new(),
+            action_error: None,
+            recent_load_error: None,
+            recent_write_error: None,
+            recent_load_pending: false,
+            recent_load_generation: 0,
+            recent_write_generation: 0,
+            recent_write_queue: VecDeque::new(),
+            recent_write_in_flight: false,
+            load_generation: 0,
+        };
+        view.mode = AppMode::Welcome(view.welcome(None, None));
+        view.load_recent_repositories(window, cx);
+        if let Some(repository) = repository {
+            view.open_repository(repository, window, cx);
+        }
+        view
+    }
+
+    #[cfg(test)]
+    pub fn mode_kind(&self) -> AppModeKind {
+        match self.mode {
+            AppMode::Welcome(_) => AppModeKind::Welcome,
+            AppMode::Opening(_) => AppModeKind::Opening,
+            AppMode::Workspace(_) => AppModeKind::Workspace,
+            AppMode::Error(_) => AppModeKind::Error,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn inline_error(&self) -> Option<&str> {
+        match &self.mode {
+            AppMode::Welcome(welcome) | AppMode::Opening(welcome) | AppMode::Error(welcome) => {
+                welcome.error()
+            }
+            AppMode::Workspace(workspace) => workspace.inline_error(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn recent_load_is_pending(&self) -> bool {
+        self.recent_load_pending
+    }
+
+    #[cfg(test)]
+    pub fn recent_repositories(&self) -> &[PathBuf] {
+        &self.recent_repositories
+    }
+
+    pub fn workspace(&self) -> Option<&WorkspaceView> {
+        match &self.mode {
+            AppMode::Workspace(workspace) => Some(workspace),
+            AppMode::Welcome(_) | AppMode::Opening(_) | AppMode::Error(_) => None,
+        }
+    }
+
+    fn workspace_mut(&mut self) -> Option<&mut WorkspaceView> {
+        match &mut self.mode {
+            AppMode::Workspace(workspace) => Some(workspace),
+            AppMode::Welcome(_) | AppMode::Opening(_) | AppMode::Error(_) => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn pane_markers(&self) -> Option<PaneMarkers> {
+        self.workspace().map(WorkspaceView::pane_markers)
+    }
+
+    pub fn pick_repository(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let picker = Rc::clone(&self.services.picker);
+        let future = picker.pick(cx);
+        cx.spawn_in(window, async move |this, cx| {
+            let result = future.await;
+            let _ = this.update_in(cx, |view, window, cx| match result {
+                Ok(Some(path)) => view.open_repository(path, window, cx),
+                Ok(None) => {}
+                Err(error) => {
+                    view.set_inline_error(error);
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
+    }
+
+    pub fn open_repository(&mut self, path: PathBuf, window: &mut Window, cx: &mut Context<Self>) {
+        self.start_load(path, RootLoadKind::Open, window, cx);
+    }
+
+    pub fn refresh_repository(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self
+            .workspace()
+            .is_some_and(WorkspaceView::refresh_is_loading)
+        {
+            return;
+        }
+        let Some(path) = self
+            .workspace()
+            .map(|workspace| workspace.state().snapshot().repository_root.clone())
+        else {
+            return;
+        };
+        self.start_load(path, RootLoadKind::Refresh, window, cx);
+    }
+
+    pub fn select_branch(&mut self, name: &str, cx: &mut Context<Self>) {
+        if self
+            .workspace_mut()
+            .is_some_and(|workspace| workspace.select_branch(name))
+        {
+            cx.notify();
+        }
+    }
+
+    pub fn begin_load(&mut self, path: PathBuf, kind: RootLoadKind) -> RootLoadToken {
+        self.load_generation = self
+            .load_generation
+            .checked_add(1)
+            .expect("root repository load generation exhausted");
+        match kind {
+            RootLoadKind::Open => {
+                self.action_error = None;
+                self.mode = AppMode::Opening(self.welcome(None, Some(path.clone())));
+            }
+            RootLoadKind::Refresh => {
+                if let Some(workspace) = self.workspace_mut() {
+                    workspace.begin_refresh();
+                }
+            }
+        }
+        RootLoadToken {
+            generation: self.load_generation,
+            path,
+            kind,
+        }
+    }
+
+    pub fn apply_load_result(
+        &mut self,
+        token: RootLoadToken,
+        result: Result<RepositorySnapshot, String>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if token.generation != self.load_generation {
+            return false;
+        }
+
+        match token.kind {
+            RootLoadKind::Open => match result {
+                Ok(snapshot) => {
+                    self.remember_recent(&snapshot.repository_root);
+                    self.action_error = None;
+                    self.mode =
+                        AppMode::Workspace(Box::new(WorkspaceView::from_snapshot(snapshot)));
+                    self.sync_storage_notice();
+                }
+                Err(error) => {
+                    self.action_error = Some(error.clone());
+                    self.mode = AppMode::Error(self.welcome(Some(error), None));
+                }
+            },
+            RootLoadKind::Refresh => {
+                let Some(workspace) = self.workspace_mut() else {
+                    return false;
+                };
+                if workspace.state().snapshot().repository_root != token.path {
+                    return false;
+                }
+                match result {
+                    Ok(snapshot) => workspace.apply_snapshot(snapshot),
+                    Err(error) => workspace.fail_refresh(error),
+                }
+            }
+        }
+        cx.notify();
+        true
+    }
+
+    fn start_load(
+        &mut self,
+        path: PathBuf,
+        kind: RootLoadKind,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let token = self.begin_load(path.clone(), kind);
+        let loader = Arc::clone(&self.services.loader);
+        let background = cx.background_executor().clone();
+        cx.notify();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let result = background.spawn(async move { loader.load(&path) }).await;
+            let recent_path = result
+                .as_ref()
+                .ok()
+                .map(|snapshot| snapshot.repository_root.clone());
+            let _ = this.update_in(cx, |view, window, cx| {
+                let accepted = view.apply_load_result(token.clone(), result, cx);
+                if accepted
+                    && token.kind == RootLoadKind::Open
+                    && let Some(path) = recent_path
+                {
+                    view.enqueue_recent_write(path, window, cx);
+                }
+            });
+        })
+        .detach();
+    }
+
+    fn load_recent_repositories(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let token = self.begin_recent_load();
+        let recents = Arc::clone(&self.services.recents);
+        let background = cx.background_executor().clone();
+        cx.notify();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let result = background.spawn(async move { recents.load() }).await;
+            let _ = this.update_in(cx, |view, _window, cx| {
+                view.apply_recent_load_result(token, result, cx);
+            });
+        })
+        .detach();
+    }
+
+    pub fn begin_recent_load(&mut self) -> RecentLoadToken {
+        self.recent_load_generation = self
+            .recent_load_generation
+            .checked_add(1)
+            .expect("recent repository load generation exhausted");
+        self.recent_load_pending = true;
+        self.sync_welcome_mode();
+        RecentLoadToken {
+            generation: self.recent_load_generation,
+        }
+    }
+
+    pub fn apply_recent_load_result(
+        &mut self,
+        token: RecentLoadToken,
+        result: Result<Vec<PathBuf>, String>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if token.generation != self.recent_load_generation {
+            return false;
+        }
+
+        self.recent_load_pending = false;
+        match result {
+            Ok(repositories) => {
+                self.recent_load_error = None;
+                for repository in repositories {
+                    if !self.recent_repositories.contains(&repository) {
+                        self.recent_repositories.push(repository);
+                    }
+                }
+                self.recent_repositories.truncate(10);
+            }
+            Err(error) => self.recent_load_error = Some(error),
+        }
+        self.sync_storage_notice();
+        self.sync_welcome_mode();
+        cx.notify();
+        true
+    }
+
+    pub fn begin_recent_write(&mut self, path: PathBuf) -> RecentWriteToken {
+        self.recent_write_generation = self
+            .recent_write_generation
+            .checked_add(1)
+            .expect("recent repository write generation exhausted");
+        RecentWriteToken {
+            generation: self.recent_write_generation,
+            path,
+        }
+    }
+
+    pub fn apply_recent_write_result(
+        &mut self,
+        token: RecentWriteToken,
+        result: Result<(), String>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if token.generation != self.recent_write_generation {
+            return false;
+        }
+
+        self.recent_write_error = result.err().map(|error| {
+            format!(
+                "Repository opened, but its recent entry was not saved for {}: {error}",
+                token.path.display()
+            )
+        });
+        self.sync_storage_notice();
+        self.sync_welcome_mode();
+        cx.notify();
+        true
+    }
+
+    pub(crate) fn enqueue_recent_write(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let token = self.begin_recent_write(path);
+        self.recent_write_queue.push_back(token);
+        self.start_next_recent_write(window, cx);
+    }
+
+    fn start_next_recent_write(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.recent_write_in_flight {
+            return;
+        }
+        let Some(token) = self.recent_write_queue.pop_front() else {
+            return;
+        };
+
+        self.recent_write_in_flight = true;
+        let path = token.path.clone();
+        let recents = Arc::clone(&self.services.recents);
+        let background = cx.background_executor().clone();
+        cx.spawn_in(window, async move |this, cx| {
+            let result = background.spawn(async move { recents.record(&path) }).await;
+            let _ = this.update_in(cx, |view, window, cx| {
+                view.recent_write_in_flight = false;
+                view.apply_recent_write_result(token, result, cx);
+                view.start_next_recent_write(window, cx);
+            });
+        })
+        .detach();
+    }
+
+    fn remember_recent(&mut self, path: &Path) {
+        self.recent_repositories
+            .retain(|repository| repository != path);
+        self.recent_repositories.insert(0, path.to_path_buf());
+        self.recent_repositories.truncate(10);
+    }
+
+    fn welcome(&self, error: Option<String>, opening: Option<PathBuf>) -> WelcomeView {
+        let storage_error = self.storage_error();
+        let error = match (storage_error, error.or_else(|| self.action_error.clone())) {
+            (Some(storage), Some(action)) => {
+                Some(format!("{action}\nRecent repositories: {storage}"))
+            }
+            (Some(storage), None) => Some(storage),
+            (None, action) => action,
+        };
+        WelcomeView::new(
+            self.recent_repositories.clone(),
+            error,
+            opening,
+            self.recent_load_pending,
+        )
+    }
+
+    fn set_inline_error(&mut self, error: String) {
+        match &mut self.mode {
+            AppMode::Welcome(welcome) | AppMode::Opening(welcome) | AppMode::Error(welcome) => {
+                self.action_error = Some(error.clone());
+                welcome.set_error(error);
+            }
+            AppMode::Workspace(workspace) => workspace.set_notice(error),
+        }
+    }
+
+    fn storage_error(&self) -> Option<String> {
+        match (&self.recent_load_error, &self.recent_write_error) {
+            (Some(load), Some(write)) => Some(format!("{load}\n{write}")),
+            (Some(load), None) => Some(load.clone()),
+            (None, Some(write)) => Some(write.clone()),
+            (None, None) => None,
+        }
+    }
+
+    fn sync_storage_notice(&mut self) {
+        let notice = self.storage_error();
+        if let Some(workspace) = self.workspace_mut() {
+            workspace.set_storage_notice(notice);
+        }
+    }
+
+    fn sync_welcome_mode(&mut self) {
+        let mode = match &self.mode {
+            AppMode::Welcome(_) => Some((WelcomeModeKind::Welcome, None)),
+            AppMode::Opening(welcome) => Some((
+                WelcomeModeKind::Opening,
+                welcome.opening_path().map(Path::to_path_buf),
+            )),
+            AppMode::Error(_) => Some((WelcomeModeKind::Error, None)),
+            AppMode::Workspace(_) => None,
+        };
+        let Some((kind, opening)) = mode else {
+            return;
+        };
+        let welcome = self.welcome(None, opening);
+        self.mode = match kind {
+            WelcomeModeKind::Welcome => AppMode::Welcome(welcome),
+            WelcomeModeKind::Opening => AppMode::Opening(welcome),
+            WelcomeModeKind::Error => AppMode::Error(welcome),
+        };
+    }
+
+    fn select_previous(
+        &mut self,
+        _: &SelectPreviousBranch,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self
+            .workspace_mut()
+            .is_some_and(|workspace| workspace.move_selection(SelectionDirection::Previous))
+        {
+            cx.notify();
+        }
+    }
+
+    fn select_next(&mut self, _: &SelectNextBranch, _: &mut Window, cx: &mut Context<Self>) {
+        if self
+            .workspace_mut()
+            .is_some_and(|workspace| workspace.move_selection(SelectionDirection::Next))
+        {
+            cx.notify();
+        }
+    }
+
+    fn open_action(&mut self, _: &OpenRepository, window: &mut Window, cx: &mut Context<Self>) {
+        self.pick_repository(window, cx);
+    }
+
+    fn refresh_action(
+        &mut self,
+        _: &RefreshRepository,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.refresh_repository(window, cx);
+    }
+}
+
+impl Focusable for AppView {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for AppView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::for_appearance(window.appearance());
+        let content = match &self.mode {
+            AppMode::Welcome(welcome) | AppMode::Opening(welcome) | AppMode::Error(welcome) => {
+                welcome.render(theme, cx)
+            }
+            AppMode::Workspace(workspace) => workspace.render(theme, cx),
+        };
+
+        div()
+            .id("stax-app")
+            .key_context("StaxApp")
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::select_previous))
+            .on_action(cx.listener(Self::select_next))
+            .on_action(cx.listener(Self::open_action))
+            .on_action(cx.listener(Self::refresh_action))
+            .size_full()
+            .border_1()
+            .border_color(if self.focus_handle.is_focused(window) {
+                theme.focus
+            } else {
+                theme.border
+            })
+            .font_family(SYSTEM_UI_FONT)
+            .bg(theme.window)
+            .text_color(theme.text)
+            .child(content)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlKind {
+    Primary,
+    Secondary,
+}
+
+pub fn control_button(
+    id: impl Into<ElementId>,
+    label: impl Into<SharedString>,
+    kind: ControlKind,
+    enabled: bool,
+    theme: Theme,
+) -> Stateful<Div> {
+    let label = label.into();
+    let base = div()
+        .id(id)
+        .h(px(28.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .px_3()
+        .rounded_md()
+        .border_1()
+        .text_xs()
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .child(label);
+
+    if !enabled {
+        return base
+            .border_color(theme.border)
+            .bg(theme.disabled_surface)
+            .text_color(theme.disabled_text);
+    }
+
+    let base = base
+        .focusable()
+        .tab_index(0)
+        .cursor_pointer()
+        .focus(move |style| style.border_color(theme.focus))
+        .active(|style| style.opacity(0.82));
+    match kind {
+        ControlKind::Primary => base
+            .border_color(theme.accent)
+            .bg(theme.accent)
+            .text_color(theme.accent_text)
+            .hover(move |style| style.bg(theme.accent.alpha(0.88))),
+        ControlKind::Secondary => base
+            .border_color(theme.border_strong)
+            .bg(theme.surface_raised)
+            .text_color(theme.text)
+            .hover(move |style| style.bg(theme.surface_selected)),
+    }
+}
+
+pub fn init(cx: &mut App) {
+    cx.bind_keys([
+        KeyBinding::new("up", SelectPreviousBranch, Some("StaxApp")),
+        KeyBinding::new("down", SelectNextBranch, Some("StaxApp")),
+        KeyBinding::new("cmd-o", OpenRepository, Some("StaxApp")),
+        KeyBinding::new("cmd-r", RefreshRepository, Some("StaxApp")),
+    ]);
+}

--- a/crates/stax-gui/src/views/app.rs
+++ b/crates/stax-gui/src/views/app.rs
@@ -1,6 +1,10 @@
 #[cfg(test)]
 use super::{changes_pane, inspector_pane, stack_pane};
 use super::{welcome::WelcomeView, workspace::WorkspaceView};
+use crate::hydration::{
+    BranchHydrationService, CiHydrationRequest, DetailsHydrationRequest, DiffHydrationRequest,
+    HydrationCoordinator, NativeBranchHydrationService,
+};
 use crate::preferences::RecentRepositories;
 use crate::state::SelectionDirection;
 use crate::theme::{SYSTEM_UI_FONT, Theme};
@@ -9,7 +13,7 @@ use gpui::{
     KeyBinding, ParentElement as _, PathPromptOptions, Render, SharedString, Stateful,
     StatefulInteractiveElement as _, Styled as _, Window, actions, div, px,
 };
-use stax::application::{RepositorySession, RepositorySnapshot};
+use stax::application::{BranchDiff, DetailRequestToken, RepositorySession, RepositorySnapshot};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -47,6 +51,7 @@ pub struct AppServices {
     loader: Arc<dyn SnapshotLoader>,
     picker: Rc<dyn RepositoryPicker>,
     recents: Arc<dyn RecentRepositoryStore>,
+    hydration: Arc<dyn BranchHydrationService>,
 }
 
 impl AppServices {
@@ -55,10 +60,25 @@ impl AppServices {
         picker: Rc<dyn RepositoryPicker>,
         recents: Arc<dyn RecentRepositoryStore>,
     ) -> Self {
+        Self::with_hydration(
+            loader,
+            picker,
+            recents,
+            Arc::new(NativeBranchHydrationService),
+        )
+    }
+
+    pub(super) fn with_hydration(
+        loader: Arc<dyn SnapshotLoader>,
+        picker: Rc<dyn RepositoryPicker>,
+        recents: Arc<dyn RecentRepositoryStore>,
+        hydration: Arc<dyn BranchHydrationService>,
+    ) -> Self {
         Self {
             loader,
             picker,
             recents,
+            hydration,
         }
     }
 
@@ -191,6 +211,7 @@ pub struct AppView {
     recent_write_queue: VecDeque<RecentWriteToken>,
     recent_write_in_flight: bool,
     load_generation: u64,
+    hydration_coordinator: HydrationCoordinator,
 }
 
 impl AppView {
@@ -218,6 +239,7 @@ impl AppView {
             recent_write_queue: VecDeque::new(),
             recent_write_in_flight: false,
             load_generation: 0,
+            hydration_coordinator: HydrationCoordinator::default(),
         };
         view.mode = AppMode::Welcome(view.welcome(None, None));
         view.load_recent_repositories(window, cx);
@@ -313,13 +335,200 @@ impl AppView {
         self.start_load(path, RootLoadKind::Refresh, window, cx);
     }
 
-    pub fn select_branch(&mut self, name: &str, cx: &mut Context<Self>) {
+    pub fn select_branch(&mut self, name: &str, window: &mut Window, cx: &mut Context<Self>) {
         if self
             .workspace_mut()
             .is_some_and(|workspace| workspace.select_branch(name))
         {
+            self.hydrate_selection(window, cx);
             cx.notify();
         }
+    }
+
+    pub(super) fn hydrate_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some((token, branch)) = self
+            .workspace_mut()
+            .and_then(WorkspaceView::begin_hydration)
+        else {
+            return;
+        };
+        self.hydration_coordinator.clear_queued_ci();
+        let details_request = self
+            .hydration_coordinator
+            .enqueue_details(token.clone(), branch.clone());
+        let diff_request = self
+            .hydration_coordinator
+            .enqueue_diff(token.clone(), branch.parent.clone());
+        if branch.parent.is_none()
+            && let Some(workspace) = self.workspace_mut()
+        {
+            workspace.apply_diff(
+                token.clone(),
+                Ok(BranchDiff {
+                    stat: Vec::new(),
+                    lines: Vec::new(),
+                }),
+            );
+        }
+        if let Some(request) = details_request {
+            self.start_details_hydration(request, window, cx);
+        }
+        if let Some(request) = diff_request {
+            self.start_diff_hydration(request, window, cx);
+        }
+        cx.notify();
+    }
+
+    fn start_details_hydration(
+        &mut self,
+        request: DetailsHydrationRequest,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let hydration = Arc::clone(&self.services.hydration);
+        let background = cx.background_executor().clone();
+        let token = request.token;
+        let future = hydration.load_details(token.repository.clone(), request.branch);
+        cx.spawn_in(window, async move |this, cx| {
+            let result = background.spawn(future).await;
+            let _ = this.update_in(cx, |view, window, cx| {
+                let follow_up = match &result {
+                    Ok(details) if details.has_remote => Ok(true),
+                    Ok(_) => Ok(false),
+                    Err(error) => Err(format!(
+                        "CI requires branch details: {error}. Fix the repository configuration, then refresh."
+                    )),
+                };
+                let accepted = view.workspace_mut().is_some_and(|workspace| {
+                    workspace.apply_details(token.clone(), result)
+                });
+                if accepted {
+                    match follow_up {
+                        Ok(true) => view.queue_ci_hydration(token, window, cx),
+                        Ok(false) => {
+                            if let Some(workspace) = view.workspace_mut() {
+                                workspace.apply_ci(
+                                    token,
+                                    Err(
+                                        "Push branch to see remote checks. Push the branch, then refresh."
+                                            .to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            if let Some(workspace) = view.workspace_mut() {
+                                workspace.apply_ci(token, Err(error));
+                            }
+                        }
+                    }
+                }
+                if let Some(next) = view.hydration_coordinator.finish_details() {
+                    view.start_details_hydration(next, window, cx);
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn start_diff_hydration(
+        &mut self,
+        request: DiffHydrationRequest,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(parent) = request.parent else {
+            if let Some(next) = self.hydration_coordinator.finish_diff() {
+                self.start_diff_hydration(next, window, cx);
+            }
+            return;
+        };
+        let hydration = Arc::clone(&self.services.hydration);
+        let background = cx.background_executor().clone();
+        let token = request.token;
+        let repository = token.repository.clone();
+        let branch = token.branch.clone();
+        let cache_future =
+            hydration.load_cached_diff(repository.clone(), branch.clone(), parent.clone());
+        cx.spawn_in(window, async move |this, cx| {
+            let cached = background.spawn(cache_future).await;
+            let continue_fresh = this
+                .update_in(cx, |view, window, cx| {
+                    let applied = cached.ok().flatten().is_some_and(|diff| {
+                        view.workspace_mut().is_some_and(|workspace| {
+                            workspace.apply_cached_diff(token.clone(), diff)
+                        })
+                    });
+                    let superseded = view.hydration_coordinator.diff_has_queued();
+                    if superseded && let Some(next) = view.hydration_coordinator.finish_diff() {
+                        view.start_diff_hydration(next, window, cx);
+                    }
+                    if applied || superseded {
+                        cx.notify();
+                    }
+                    !superseded
+                })
+                .unwrap_or(false);
+            if !continue_fresh {
+                return;
+            }
+
+            let fresh_future = hydration.load_diff(repository, branch, parent);
+            let result = background.spawn(fresh_future).await;
+            let _ = this.update_in(cx, |view, window, cx| {
+                let applied = view
+                    .workspace_mut()
+                    .is_some_and(|workspace| workspace.apply_diff(token, result));
+                if let Some(next) = view.hydration_coordinator.finish_diff() {
+                    view.start_diff_hydration(next, window, cx);
+                }
+                if applied {
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
+    }
+
+    fn queue_ci_hydration(
+        &mut self,
+        token: DetailRequestToken,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(request) = self.hydration_coordinator.enqueue_ci(token) {
+            self.start_ci_hydration(request, window, cx);
+        }
+    }
+
+    fn start_ci_hydration(
+        &mut self,
+        request: CiHydrationRequest,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let hydration = Arc::clone(&self.services.hydration);
+        let background = cx.background_executor().clone();
+        let token = request.token;
+        let repository = token.repository.clone();
+        let branch = token.branch.clone();
+        let future = hydration.load_ci(repository, branch);
+        cx.spawn_in(window, async move |this, cx| {
+            let result = background.spawn(future).await;
+            let _ = this.update_in(cx, |view, window, cx| {
+                let applied = view
+                    .workspace_mut()
+                    .is_some_and(|workspace| workspace.apply_ci(token, result));
+                if let Some(next) = view.hydration_coordinator.finish_ci() {
+                    view.start_ci_hydration(next, window, cx);
+                }
+                if applied {
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
     }
 
     pub fn begin_load(&mut self, path: PathBuf, kind: RootLoadKind) -> RootLoadToken {
@@ -400,6 +609,7 @@ impl AppView {
 
         cx.spawn_in(window, async move |this, cx| {
             let result = background.spawn(async move { loader.load(&path) }).await;
+            let should_hydrate = result.is_ok();
             let recent_path = result
                 .as_ref()
                 .ok()
@@ -411,6 +621,9 @@ impl AppView {
                     && let Some(path) = recent_path
                 {
                     view.enqueue_recent_write(path, window, cx);
+                }
+                if accepted && should_hydrate {
+                    view.hydrate_selection(window, cx);
                 }
             });
         })
@@ -614,22 +827,24 @@ impl AppView {
     fn select_previous(
         &mut self,
         _: &SelectPreviousBranch,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self
             .workspace_mut()
             .is_some_and(|workspace| workspace.move_selection(SelectionDirection::Previous))
         {
+            self.hydrate_selection(window, cx);
             cx.notify();
         }
     }
 
-    fn select_next(&mut self, _: &SelectNextBranch, _: &mut Window, cx: &mut Context<Self>) {
+    fn select_next(&mut self, _: &SelectNextBranch, window: &mut Window, cx: &mut Context<Self>) {
         if self
             .workspace_mut()
             .is_some_and(|workspace| workspace.move_selection(SelectionDirection::Next))
         {
+            self.hydrate_selection(window, cx);
             cx.notify();
         }
     }

--- a/crates/stax-gui/src/views/app.rs
+++ b/crates/stax-gui/src/views/app.rs
@@ -9,9 +9,9 @@ use crate::preferences::RecentRepositories;
 use crate::state::SelectionDirection;
 use crate::theme::{SYSTEM_UI_FONT, Theme};
 use gpui::{
-    App, Context, Div, ElementId, FocusHandle, Focusable, InteractiveElement as _, IntoElement,
-    KeyBinding, ParentElement as _, PathPromptOptions, Render, SharedString, Stateful,
-    StatefulInteractiveElement as _, Styled as _, Window, actions, div, px,
+    App, ClickEvent, Context, Div, ElementId, FocusHandle, Focusable, InteractiveElement as _,
+    IntoElement, KeyBinding, ParentElement as _, PathPromptOptions, Render, SharedString, Stateful,
+    StatefulInteractiveElement as _, StyleRefinement, Styled as _, Window, actions, div, px,
 };
 use stax::application::{BranchDiff, DetailRequestToken, RepositorySession, RepositorySnapshot};
 use std::collections::VecDeque;
@@ -915,6 +915,10 @@ pub fn control_button(
     theme: Theme,
 ) -> Stateful<Div> {
     let label = label.into();
+    let focus_color = match kind {
+        ControlKind::Primary => theme.focus_on_accent,
+        ControlKind::Secondary => theme.focus,
+    };
     let base = div()
         .id(id)
         .h(px(28.0))
@@ -939,7 +943,7 @@ pub fn control_button(
         .focusable()
         .tab_index(0)
         .cursor_pointer()
-        .focus(move |style| style.border_color(theme.focus))
+        .focus(move |style| style.border_2().border_color(focus_color))
         .active(|style| style.opacity(0.82));
     match kind {
         ControlKind::Primary => base
@@ -953,6 +957,23 @@ pub fn control_button(
             .text_color(theme.text)
             .hover(move |style| style.bg(theme.surface_selected)),
     }
+}
+
+pub fn activate_control(
+    control: Stateful<Div>,
+    cx: &Context<AppView>,
+    handler: impl Fn(&mut AppView, &mut Window, &mut Context<AppView>) + 'static,
+) -> Stateful<Div> {
+    control.on_click(
+        cx.listener(move |app: &mut AppView, _: &ClickEvent, window, cx| {
+            cx.stop_propagation();
+            handler(app, window, cx);
+        }),
+    )
+}
+
+pub fn control_focus_style(style: StyleRefinement, theme: Theme) -> StyleRefinement {
+    style.border_2().border_color(theme.focus)
 }
 
 pub fn init(cx: &mut App) {

--- a/crates/stax-gui/src/views/changes_pane.rs
+++ b/crates/stax-gui/src/views/changes_pane.rs
@@ -35,11 +35,31 @@ pub fn render(workspace: &WorkspaceView, theme: Theme, cx: &mut Context<AppView>
         .selected_branch()
         .unwrap_or("No branch selected");
     let state = diff_display_state(workspace.state().diff());
+    let mut heading_status = div().min_w_0().flex().items_center().justify_end().gap_2();
+    if workspace.state().diff_is_refreshing() {
+        heading_status = heading_status.child(
+            div()
+                .debug_selector(|| "changes-refreshing".into())
+                .flex_none()
+                .text_xs()
+                .text_color(theme.text_muted)
+                .child("Refreshing…"),
+        );
+    }
+    heading_status = heading_status.child(
+        div()
+            .min_w_0()
+            .truncate()
+            .font_family(MONOSPACE_FONT)
+            .text_xs()
+            .text_color(theme.text_muted)
+            .child(selected.to_string()),
+    );
 
     let body = match (state, workspace.state().diff()) {
         (DiffDisplayState::Idle, _) => state_message(
             "Changes are not loaded",
-            "Select a branch now; details and patches are hydrated in Task 7.",
+            "Select a branch or refresh the repository to load its patch.",
             theme,
         ),
         (DiffDisplayState::Loading, _) => state_message(
@@ -87,15 +107,7 @@ pub fn render(workspace: &WorkspaceView, theme: Theme, cx: &mut Context<AppView>
                         .font_weight(gpui::FontWeight::SEMIBOLD)
                         .child(PANE_HEADING),
                 )
-                .child(
-                    div()
-                        .min_w_0()
-                        .truncate()
-                        .font_family(MONOSPACE_FONT)
-                        .text_xs()
-                        .text_color(theme.text_muted)
-                        .child(selected.to_string()),
-                ),
+                .child(heading_status),
         )
         .child(body)
 }

--- a/crates/stax-gui/src/views/changes_pane.rs
+++ b/crates/stax-gui/src/views/changes_pane.rs
@@ -1,0 +1,373 @@
+use super::{AppView, WorkspaceView};
+use crate::state::LoadState;
+use crate::theme::{MONOSPACE_FONT, Theme};
+use gpui::{
+    Context, Div, InteractiveElement as _, ParentElement as _, SharedString, Styled as _, div, px,
+    uniform_list,
+};
+use stax::application::{BranchDiff, DiffLineKind};
+use std::ops::Range;
+
+pub const PANE_MARKER: &str = "stax-changes-pane";
+pub const PANE_HEADING: &str = "Changes";
+const DIFFSTAT_ROW_HEIGHT: f32 = 24.0;
+const DIFFSTAT_MAX_VISIBLE_ROWS: usize = 6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiffstatLayout {
+    total_rows: usize,
+    visible_rows: usize,
+    is_scrollable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiffDisplayState {
+    Idle,
+    Loading,
+    Failed,
+    ReadyEmpty,
+    Ready,
+}
+
+pub fn render(workspace: &WorkspaceView, theme: Theme, cx: &mut Context<AppView>) -> Div {
+    let selected = workspace
+        .state()
+        .selected_branch()
+        .unwrap_or("No branch selected");
+    let state = diff_display_state(workspace.state().diff());
+
+    let body = match (state, workspace.state().diff()) {
+        (DiffDisplayState::Idle, _) => state_message(
+            "Changes are not loaded",
+            "Select a branch now; details and patches are hydrated in Task 7.",
+            theme,
+        ),
+        (DiffDisplayState::Loading, _) => state_message(
+            "Loading changes…",
+            "The stack remains available while the patch loads.",
+            theme,
+        ),
+        (DiffDisplayState::Failed, LoadState::Failed(error)) => state_message(
+            "Changes could not be loaded",
+            &format!("{error} · Use Refresh Repository to retry."),
+            theme,
+        ),
+        (DiffDisplayState::ReadyEmpty, _) => state_message(
+            "No changes against parent",
+            "This branch currently has an empty diff.",
+            theme,
+        ),
+        (DiffDisplayState::Ready, LoadState::Ready(diff)) => render_ready_diff(diff, theme, cx),
+        _ => state_message("Changes unavailable", "Refresh Repository to retry.", theme),
+    };
+
+    div()
+        .debug_selector(|| PANE_MARKER.into())
+        .size_full()
+        .min_w_0()
+        .flex()
+        .flex_col()
+        .border_r_1()
+        .border_color(theme.border)
+        .bg(theme.surface_raised)
+        .child(
+            div()
+                .h(px(43.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap_2()
+                .px_3()
+                .border_b_1()
+                .border_color(theme.border)
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(PANE_HEADING),
+                )
+                .child(
+                    div()
+                        .min_w_0()
+                        .truncate()
+                        .font_family(MONOSPACE_FONT)
+                        .text_xs()
+                        .text_color(theme.text_muted)
+                        .child(selected.to_string()),
+                ),
+        )
+        .child(body)
+}
+
+fn render_ready_diff(diff: &BranchDiff, theme: Theme, cx: &mut Context<AppView>) -> Div {
+    let line_count = diff.lines.len();
+    let additions: usize = diff.stat.iter().map(|line| line.additions).sum();
+    let deletions: usize = diff.stat.iter().map(|line| line.deletions).sum();
+    let diffstat_layout = diffstat_layout(diff);
+    let file_summary = if diffstat_layout.is_scrollable {
+        format!(
+            "{} changed files · scroll summary",
+            diffstat_layout.total_rows
+        )
+    } else {
+        format!("{} changed files", diffstat_layout.total_rows)
+    };
+
+    let mut diffstat = div()
+        .flex_none()
+        .flex()
+        .flex_col()
+        .border_b_1()
+        .border_color(theme.border)
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .px_3()
+                .py_2()
+                .text_xs()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .child(file_summary)
+                .child(
+                    div()
+                        .flex()
+                        .gap_2()
+                        .child(
+                            div()
+                                .text_color(theme.diff_addition)
+                                .child(format!("+{additions} additions")),
+                        )
+                        .child(
+                            div()
+                                .text_color(theme.diff_deletion)
+                                .child(format!("−{deletions} deletions")),
+                        ),
+                ),
+        );
+
+    if diff.stat.is_empty() {
+        diffstat = diffstat.child(
+            div()
+                .px_3()
+                .pb_2()
+                .text_xs()
+                .text_color(theme.text_muted)
+                .child("No file summary available."),
+        );
+    } else {
+        diffstat = diffstat.child(
+            uniform_list(
+                "changes-diffstat-files",
+                diffstat_layout.total_rows,
+                cx.processor(move |app, range: Range<usize>, _window, _cx| {
+                    let Some(workspace) = app.workspace() else {
+                        return Vec::new();
+                    };
+                    let LoadState::Ready(diff) = workspace.state().diff() else {
+                        return Vec::new();
+                    };
+
+                    range
+                        .filter_map(|index| diff.stat.get(index).map(|line| (index, line)))
+                        .map(|(index, line)| {
+                            div()
+                                .id(SharedString::from(format!("diffstat-file-{index}")))
+                                .h(px(DIFFSTAT_ROW_HEIGHT))
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .gap_2()
+                                .px_3()
+                                .font_family(MONOSPACE_FONT)
+                                .text_xs()
+                                .child(div().min_w_0().truncate().child(line.file.clone()))
+                                .child(
+                                    div()
+                                        .flex_none()
+                                        .flex()
+                                        .gap_2()
+                                        .child(
+                                            div()
+                                                .text_color(theme.diff_addition)
+                                                .child(format!("+{}", line.additions)),
+                                        )
+                                        .child(
+                                            div()
+                                                .text_color(theme.diff_deletion)
+                                                .child(format!("−{}", line.deletions)),
+                                        ),
+                                )
+                        })
+                        .collect()
+                }),
+            )
+            .h(px(diffstat_layout.visible_rows as f32 * DIFFSTAT_ROW_HEIGHT))
+            .flex_none(),
+        );
+    }
+
+    div()
+        .flex()
+        .flex_1()
+        .min_h_0()
+        .flex_col()
+        .child(diffstat)
+        .child(
+            uniform_list(
+                "changes-patch-lines",
+                line_count,
+                cx.processor(move |app, range: Range<usize>, _window, _cx| {
+                    let Some(workspace) = app.workspace() else {
+                        return Vec::new();
+                    };
+                    let LoadState::Ready(diff) = workspace.state().diff() else {
+                        return Vec::new();
+                    };
+
+                    range
+                        .filter_map(|index| diff.lines.get(index).map(|line| (index, line)))
+                        .map(|(index, line)| {
+                            div()
+                                .id(SharedString::from(format!("patch-line-{index}")))
+                                .h(px(21.0))
+                                .w_full()
+                                .px_3()
+                                .font_family(MONOSPACE_FONT)
+                                .text_xs()
+                                .text_color(diff_line_color(line.kind, theme))
+                                .whitespace_nowrap()
+                                .child(line.content.clone())
+                        })
+                        .collect()
+                }),
+            )
+            .flex_1()
+            .min_h_0()
+            .bg(theme.surface_raised),
+        )
+}
+
+fn diffstat_layout(diff: &BranchDiff) -> DiffstatLayout {
+    let total_rows = diff.stat.len();
+    let visible_rows = total_rows.min(DIFFSTAT_MAX_VISIBLE_ROWS);
+    DiffstatLayout {
+        total_rows,
+        visible_rows,
+        is_scrollable: total_rows > visible_rows,
+    }
+}
+
+fn state_message(title: &str, detail: &str, theme: Theme) -> Div {
+    div()
+        .flex()
+        .flex_1()
+        .min_h_0()
+        .items_center()
+        .justify_center()
+        .p_5()
+        .child(
+            div()
+                .max_w(px(340.0))
+                .flex()
+                .flex_col()
+                .items_center()
+                .gap_2()
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(title.to_string()),
+                )
+                .child(
+                    div()
+                        .text_center()
+                        .text_xs()
+                        .text_color(theme.text_muted)
+                        .child(detail.to_string()),
+                ),
+        )
+}
+
+fn diff_display_state(state: &LoadState<BranchDiff>) -> DiffDisplayState {
+    match state {
+        LoadState::Idle => DiffDisplayState::Idle,
+        LoadState::Loading => DiffDisplayState::Loading,
+        LoadState::Failed(_) => DiffDisplayState::Failed,
+        LoadState::Ready(diff) if diff.stat.is_empty() && diff.lines.is_empty() => {
+            DiffDisplayState::ReadyEmpty
+        }
+        LoadState::Ready(_) => DiffDisplayState::Ready,
+    }
+}
+
+fn diff_line_color(kind: DiffLineKind, theme: Theme) -> gpui::Hsla {
+    match kind {
+        DiffLineKind::Addition => theme.diff_addition,
+        DiffLineKind::Deletion => theme.diff_deletion,
+        DiffLineKind::Hunk => theme.diff_hunk,
+        DiffLineKind::Header => theme.accent,
+        DiffLineKind::Context => theme.text_muted,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DIFFSTAT_MAX_VISIBLE_ROWS, DiffDisplayState, diff_display_state, diffstat_layout};
+    use crate::state::LoadState;
+    use stax::application::{BranchDiff, DiffLine, DiffLineKind, DiffStatLine};
+
+    #[test]
+    fn diff_load_states_have_stable_distinct_presentations() {
+        assert_eq!(diff_display_state(&LoadState::Idle), DiffDisplayState::Idle);
+        assert_eq!(
+            diff_display_state(&LoadState::Loading),
+            DiffDisplayState::Loading
+        );
+        assert_eq!(
+            diff_display_state(&LoadState::Failed("offline".into())),
+            DiffDisplayState::Failed
+        );
+        assert_eq!(
+            diff_display_state(&LoadState::Ready(BranchDiff {
+                stat: Vec::new(),
+                lines: Vec::new(),
+            })),
+            DiffDisplayState::ReadyEmpty
+        );
+        assert_eq!(
+            diff_display_state(&LoadState::Ready(BranchDiff {
+                stat: Vec::new(),
+                lines: vec![DiffLine {
+                    content: "+new".into(),
+                    kind: DiffLineKind::Addition,
+                }],
+            })),
+            DiffDisplayState::Ready
+        );
+    }
+
+    #[test]
+    fn large_diffstat_is_bounded_and_keeps_the_patch_region_available() {
+        let diff = BranchDiff {
+            stat: (0..500)
+                .map(|index| DiffStatLine {
+                    file: format!("src/file-{index:03}.rs"),
+                    additions: index,
+                    deletions: index / 2,
+                })
+                .collect(),
+            lines: vec![DiffLine {
+                content: "+patch remains visible".into(),
+                kind: DiffLineKind::Addition,
+            }],
+        };
+
+        let layout = diffstat_layout(&diff);
+
+        assert_eq!(layout.total_rows, 500);
+        assert_eq!(layout.visible_rows, DIFFSTAT_MAX_VISIBLE_ROWS);
+        assert!(layout.is_scrollable);
+    }
+}

--- a/crates/stax-gui/src/views/hydration_tests.rs
+++ b/crates/stax-gui/src/views/hydration_tests.rs
@@ -1,0 +1,847 @@
+use super::*;
+
+#[gpui::test]
+fn initial_workspace_hydration_dispatches_details_diff_and_ci(cx: &mut TestAppContext) {
+    let hydration = Arc::new(FixtureHydration::new(
+        |_, _| Ok(details(3, true)),
+        |_, _, _| Ok(None),
+        |_, _, _| Ok(diff("fresh patch")),
+        |_, _| Ok(ci("success")),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration.clone(),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    let calls = hydration.calls();
+    assert!(calls.contains(&HydrationCall::Details {
+        repository: PathBuf::from("/repo"),
+        branch: "feature-a".into(),
+    }));
+    assert!(calls.contains(&HydrationCall::CachedDiff {
+        branch: "feature-a".into(),
+        parent: "main".into(),
+    }));
+    assert!(calls.contains(&HydrationCall::Diff {
+        branch: "feature-a".into(),
+        parent: "main".into(),
+    }));
+    assert!(calls.contains(&HydrationCall::Ci {
+        repository: PathBuf::from("/repo"),
+        branch: "feature-a".into(),
+    }));
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.details().ready(), Some(&details(3, true)));
+        assert_eq!(state.diff().ready(), Some(&diff("fresh patch")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+    });
+}
+
+#[gpui::test]
+fn blocked_details_does_not_prevent_diff_completion(cx: &mut TestAppContext) {
+    let details_gate = Arc::new(Gate::default());
+    let diff_completed = Arc::new(AtomicBool::new(false));
+    let details_gate_for_service = Arc::clone(&details_gate);
+    let diff_completed_for_service = Arc::clone(&diff_completed);
+    let hydration = Arc::new(FixtureHydration::new_async(
+        move |_, _| {
+            let details_gate = Arc::clone(&details_gate_for_service);
+            Box::pin(async move {
+                details_gate.wait().await;
+                Ok(details(1, false))
+            })
+        },
+        |_, _, _| Box::pin(async { Ok(None) }),
+        move |_, _, _| {
+            let diff_completed = Arc::clone(&diff_completed_for_service);
+            Box::pin(async move {
+                diff_completed.store(true, Ordering::SeqCst);
+                Ok(diff("overlapping patch"))
+            })
+        },
+        |_, _| Box::pin(async { Ok(ci("success")) }),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let details_gate_for_release = Arc::clone(&details_gate);
+    let diff_completed_for_release = Arc::clone(&diff_completed);
+    let overlap_observed = Arc::new(AtomicBool::new(false));
+    let overlap_observed_for_release = Arc::clone(&overlap_observed);
+    let release = thread::spawn(move || {
+        assert!(details_gate_for_release.wait_until_started(Duration::from_secs(5)));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !diff_completed_for_release.load(Ordering::SeqCst) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+        overlap_observed_for_release.store(
+            diff_completed_for_release.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        details_gate_for_release.release();
+    });
+
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+    release.join().unwrap();
+    cx.run_until_parked();
+
+    assert!(overlap_observed.load(Ordering::SeqCst));
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.diff().ready(), Some(&diff("overlapping patch")));
+        assert_eq!(state.details().ready(), Some(&details(1, false)));
+    });
+}
+
+#[gpui::test]
+fn no_remote_skips_ci_service_and_shows_push_guidance(cx: &mut TestAppContext) {
+    let hydration = Arc::new(FixtureHydration::immediate_no_remote());
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration.clone(),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    assert!(
+        !hydration
+            .calls()
+            .iter()
+            .any(|call| matches!(call, HydrationCall::Ci { .. }))
+    );
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert!(
+            state
+                .ci()
+                .error()
+                .is_some_and(|error| error.contains("Push branch"))
+        );
+        assert!(state.details().ready().is_some());
+        assert!(state.diff().ready().is_some());
+    });
+}
+
+#[gpui::test]
+fn details_failure_does_not_discard_an_independent_diff_success(cx: &mut TestAppContext) {
+    let hydration = Arc::new(FixtureHydration::new(
+        |_, _| Err("details unavailable; verify repository config".into()),
+        |_, _, _| Ok(None),
+        |_, _, _| Ok(diff("independent patch")),
+        |_, _| panic!("CI must not run when details fail"),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(
+            state.details().error(),
+            Some("details unavailable; verify repository config")
+        );
+        assert_eq!(state.diff().ready(), Some(&diff("independent patch")));
+        assert!(
+            state
+                .ci()
+                .error()
+                .is_some_and(|error| error.contains("details"))
+        );
+    });
+}
+
+#[gpui::test]
+fn diff_failure_does_not_block_details_or_ci_success(cx: &mut TestAppContext) {
+    let hydration = Arc::new(FixtureHydration::new(
+        |_, _| Ok(details(2, true)),
+        |_, _, _| Ok(None),
+        |_, _, _| Err("diff refs changed; refresh again".into()),
+        |_, _| Ok(ci("success")),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.details().ready(), Some(&details(2, true)));
+        assert_eq!(
+            state.diff().error(),
+            Some("diff refs changed; refresh again")
+        );
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+    });
+}
+
+#[gpui::test]
+fn trunk_hydration_uses_an_immediate_empty_diff_without_diff_service_calls(
+    cx: &mut TestAppContext,
+) {
+    let trunk_snapshot = RepositorySnapshot {
+        repository_root: PathBuf::from("/repo"),
+        current_branch: "main".into(),
+        trunk: "main".into(),
+        branches: vec![branch("main", None, true, true)],
+    };
+    let hydration = Arc::new(FixtureHydration::immediate_no_remote());
+    let services = services_with_hydration(
+        Ok(trunk_snapshot),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration.clone(),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    assert!(!hydration.calls().iter().any(|call| matches!(
+        call,
+        HydrationCall::CachedDiff { .. } | HydrationCall::Diff { .. }
+    )));
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(
+            state.diff(),
+            &LoadState::Ready(BranchDiff {
+                stat: Vec::new(),
+                lines: Vec::new(),
+            })
+        );
+        assert!(!state.diff_is_refreshing());
+    });
+}
+
+#[gpui::test]
+fn rapid_branch_switch_rejects_late_details_and_diff_before_ci_dispatch(cx: &mut TestAppContext) {
+    let details_gate = Arc::new(Gate::default());
+    let diff_gate = Arc::new(Gate::default());
+    let details_gate_for_service = Arc::clone(&details_gate);
+    let diff_gate_for_service = Arc::clone(&diff_gate);
+    let hydration = Arc::new(FixtureHydration::new_async(
+        move |_, branch| {
+            let details_gate = Arc::clone(&details_gate_for_service);
+            Box::pin(async move {
+                if branch.name == "feature-a" {
+                    details_gate.wait().await;
+                    Ok(details(99, true))
+                } else {
+                    Ok(details(2, true))
+                }
+            })
+        },
+        |_, _, _| Box::pin(async { Ok(None) }),
+        move |_, branch, _| {
+            let diff_gate = Arc::clone(&diff_gate_for_service);
+            Box::pin(async move {
+                if branch == "feature-a" {
+                    diff_gate.wait().await;
+                    Ok(diff("stale feature-a patch"))
+                } else {
+                    Ok(diff("feature-b patch"))
+                }
+            })
+        },
+        |_, branch| {
+            Box::pin(async move {
+                assert_ne!(branch, "feature-a", "stale details must not dispatch CI");
+                Ok(ci("success"))
+            })
+        },
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration.clone(),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    assert!(details_gate.wait_until_started(Duration::from_secs(5)));
+    assert!(diff_gate.wait_until_started(Duration::from_secs(5)));
+
+    view.update_in(cx, |view, window, cx| {
+        view.select_branch("feature-b", window, cx);
+    });
+    cx.run_until_parked();
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+        assert_eq!(state.details(), &LoadState::Loading);
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert_eq!(state.ci(), &LoadState::Loading);
+    });
+
+    details_gate.release();
+    diff_gate.release();
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+        assert_eq!(state.details().ready(), Some(&details(2, true)));
+        assert_eq!(state.diff().ready(), Some(&diff("feature-b patch")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+    });
+    assert!(!hydration.calls().iter().any(|call| matches!(
+        call,
+        HydrationCall::Ci { branch, .. } if branch == "feature-a"
+    )));
+}
+
+#[gpui::test]
+fn same_branch_retry_rejects_older_diff_and_ci_completions(cx: &mut TestAppContext) {
+    let old_diff_gate = Arc::new(Gate::default());
+    let old_ci_gate = Arc::new(Gate::default());
+    let diff_calls = Arc::new(AtomicUsize::new(0));
+    let ci_calls = Arc::new(AtomicUsize::new(0));
+    let details_calls = Arc::new(AtomicUsize::new(0));
+    let hydration = Arc::new(FixtureHydration::new_async(
+        {
+            let details_calls = Arc::clone(&details_calls);
+            move |_, _| {
+                let call = details_calls.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move { Ok(details(call + 1, true)) })
+            }
+        },
+        |_, _, _| Box::pin(async { Ok(None) }),
+        {
+            let old_diff_gate = Arc::clone(&old_diff_gate);
+            let diff_calls = Arc::clone(&diff_calls);
+            move |_, _, _| {
+                let call = diff_calls.fetch_add(1, Ordering::SeqCst);
+                let old_diff_gate = Arc::clone(&old_diff_gate);
+                Box::pin(async move {
+                    if call == 0 {
+                        old_diff_gate.wait().await;
+                        Ok(diff("stale retry patch"))
+                    } else {
+                        Ok(diff("current retry patch"))
+                    }
+                })
+            }
+        },
+        {
+            let old_ci_gate = Arc::clone(&old_ci_gate);
+            let ci_calls = Arc::clone(&ci_calls);
+            move |_, _| {
+                let call = ci_calls.fetch_add(1, Ordering::SeqCst);
+                let old_ci_gate = Arc::clone(&old_ci_gate);
+                Box::pin(async move {
+                    if call == 0 {
+                        old_ci_gate.wait().await;
+                        Ok(ci("failure"))
+                    } else {
+                        Ok(ci("success"))
+                    }
+                })
+            }
+        },
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    assert!(old_diff_gate.wait_until_started(Duration::from_secs(5)));
+    assert!(old_ci_gate.wait_until_started(Duration::from_secs(5)));
+
+    view.update_in(cx, |view, window, cx| {
+        view.select_branch("feature-a", window, cx);
+    });
+    cx.run_until_parked();
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.details().ready(), Some(&details(2, true)));
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert_eq!(state.ci(), &LoadState::Loading);
+    });
+
+    old_diff_gate.release();
+    old_ci_gate.release();
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.details().ready(), Some(&details(2, true)));
+        assert_eq!(state.diff().ready(), Some(&diff("current retry patch")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+    });
+}
+
+#[gpui::test]
+fn rapid_selections_bound_details_and_diff_to_active_plus_latest(cx: &mut TestAppContext) {
+    let details_gate = Arc::new(Gate::default());
+    let cache_gate = Arc::new(Gate::default());
+    let details_active = Arc::new(AtomicUsize::new(0));
+    let details_max = Arc::new(AtomicUsize::new(0));
+    let cache_active = Arc::new(AtomicUsize::new(0));
+    let cache_max = Arc::new(AtomicUsize::new(0));
+    let hydration = Arc::new(FixtureHydration::new_async(
+        {
+            let gate = Arc::clone(&details_gate);
+            let active = Arc::clone(&details_active);
+            let max = Arc::clone(&details_max);
+            move |_, branch| {
+                let gate = Arc::clone(&gate);
+                let active = Arc::clone(&active);
+                let max = Arc::clone(&max);
+                Box::pin(async move {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    max.fetch_max(current, Ordering::SeqCst);
+                    if branch.name == "feature-a" {
+                        gate.wait().await;
+                    }
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok(details(
+                        if branch.name == "feature-b" { 2 } else { 1 },
+                        false,
+                    ))
+                })
+            }
+        },
+        {
+            let gate = Arc::clone(&cache_gate);
+            let active = Arc::clone(&cache_active);
+            let max = Arc::clone(&cache_max);
+            move |_, branch, _| {
+                let gate = Arc::clone(&gate);
+                let active = Arc::clone(&active);
+                let max = Arc::clone(&max);
+                Box::pin(async move {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    max.fetch_max(current, Ordering::SeqCst);
+                    if branch == "feature-a" {
+                        gate.wait().await;
+                    }
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok(None)
+                })
+            }
+        },
+        |_, branch, _| Box::pin(async move { Ok(diff(&format!("{branch} patch"))) }),
+        |_, _| panic!("branches without remotes must not load CI"),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration.clone(),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    assert!(details_gate.wait_until_started(Duration::from_secs(5)));
+    assert!(cache_gate.wait_until_started(Duration::from_secs(5)));
+
+    view.update_in(cx, |view, window, cx| {
+        for index in 0..50 {
+            let branch = if index % 2 == 0 {
+                "feature-b"
+            } else {
+                "feature-a"
+            };
+            view.select_branch(branch, window, cx);
+        }
+        view.select_branch("feature-b", window, cx);
+    });
+    cx.run_until_parked();
+
+    let calls = hydration.calls();
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| matches!(call, HydrationCall::Details { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| matches!(call, HydrationCall::CachedDiff { .. }))
+            .count(),
+        1
+    );
+    assert!(
+        !calls
+            .iter()
+            .any(|call| matches!(call, HydrationCall::Diff { .. }))
+    );
+
+    details_gate.release();
+    cache_gate.release();
+    cx.run_until_parked();
+
+    let calls = hydration.calls();
+    let detail_branches = calls
+        .iter()
+        .filter_map(|call| match call {
+            HydrationCall::Details { branch, .. } => Some(branch.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let cache_branches = calls
+        .iter()
+        .filter_map(|call| match call {
+            HydrationCall::CachedDiff { branch, .. } => Some(branch.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let diff_branches = calls
+        .iter()
+        .filter_map(|call| match call {
+            HydrationCall::Diff { branch, .. } => Some(branch.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(detail_branches, vec!["feature-a", "feature-b"]);
+    assert_eq!(cache_branches, vec!["feature-a", "feature-b"]);
+    assert_eq!(diff_branches, vec!["feature-b"]);
+    assert_eq!(details_max.load(Ordering::SeqCst), 1);
+    assert_eq!(cache_max.load(Ordering::SeqCst), 1);
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.selected_branch(), Some("feature-b"));
+        assert_eq!(state.details().ready(), Some(&details(2, false)));
+        assert_eq!(state.diff().ready(), Some(&diff("feature-b patch")));
+    });
+}
+
+#[gpui::test]
+fn rapid_same_branch_retries_bound_ci_to_active_plus_latest(cx: &mut TestAppContext) {
+    let ci_gate = Arc::new(Gate::default());
+    let ci_active = Arc::new(AtomicUsize::new(0));
+    let ci_max = Arc::new(AtomicUsize::new(0));
+    let ci_calls = Arc::new(AtomicUsize::new(0));
+    let hydration = Arc::new(FixtureHydration::new_async(
+        |_, _| Box::pin(async { Ok(details(1, true)) }),
+        |_, _, _| Box::pin(async { Ok(None) }),
+        |_, branch, _| Box::pin(async move { Ok(diff(&format!("{branch} patch"))) }),
+        {
+            let gate = Arc::clone(&ci_gate);
+            let active = Arc::clone(&ci_active);
+            let max = Arc::clone(&ci_max);
+            let calls = Arc::clone(&ci_calls);
+            move |_, _| {
+                let gate = Arc::clone(&gate);
+                let active = Arc::clone(&active);
+                let max = Arc::clone(&max);
+                let calls = Arc::clone(&calls);
+                Box::pin(async move {
+                    let call = calls.fetch_add(1, Ordering::SeqCst);
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    max.fetch_max(current, Ordering::SeqCst);
+                    if call == 0 {
+                        gate.wait().await;
+                    }
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok(ci(if call == 0 { "failure" } else { "success" }))
+                })
+            }
+        },
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    assert!(ci_gate.wait_until_started(Duration::from_secs(5)));
+
+    view.update_in(cx, |view, window, cx| {
+        for _ in 0..50 {
+            view.select_branch("feature-a", window, cx);
+        }
+    });
+    cx.run_until_parked();
+    assert_eq!(ci_calls.load(Ordering::SeqCst), 1);
+
+    ci_gate.release();
+    cx.run_until_parked();
+
+    assert_eq!(ci_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(ci_max.load(Ordering::SeqCst), 1);
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+        let selected = state
+            .snapshot()
+            .branches
+            .iter()
+            .find(|branch| branch.name == "feature-a")
+            .unwrap();
+        assert_eq!(selected.ci_state.as_deref(), Some("success"));
+    });
+}
+
+#[gpui::test]
+fn replacing_repository_rejects_old_path_hydration_results(cx: &mut TestAppContext) {
+    let old_details_gate = Arc::new(Gate::default());
+    let old_diff_gate = Arc::new(Gate::default());
+    let hydration = Arc::new(FixtureHydration::new_async(
+        {
+            let old_details_gate = Arc::clone(&old_details_gate);
+            move |repository, _| {
+                let old_details_gate = Arc::clone(&old_details_gate);
+                Box::pin(async move {
+                    if repository == Path::new("/repo") {
+                        old_details_gate.wait().await;
+                        Ok(details(99, true))
+                    } else {
+                        Ok(details(4, true))
+                    }
+                })
+            }
+        },
+        |_, _, _| Box::pin(async { Ok(None) }),
+        {
+            let old_diff_gate = Arc::clone(&old_diff_gate);
+            move |repository, _, _| {
+                let old_diff_gate = Arc::clone(&old_diff_gate);
+                Box::pin(async move {
+                    if repository == Path::new("/repo") {
+                        old_diff_gate.wait().await;
+                        Ok(diff("old repository patch"))
+                    } else {
+                        Ok(diff("new repository patch"))
+                    }
+                })
+            }
+        },
+        |_, _| Box::pin(async { Ok(ci("success")) }),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/unused")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+    view.update_in(cx, |view, window, cx| {
+        let token = view.begin_load(PathBuf::from("/repo"), RootLoadKind::Open);
+        assert!(view.apply_load_result(token, Ok(snapshot("/repo")), cx));
+        view.hydrate_selection(window, cx);
+    });
+    cx.run_until_parked();
+    assert!(old_details_gate.wait_until_started(Duration::from_secs(5)));
+    assert!(old_diff_gate.wait_until_started(Duration::from_secs(5)));
+
+    view.update_in(cx, |view, window, cx| {
+        let token = view.begin_load(PathBuf::from("/other"), RootLoadKind::Open);
+        assert!(view.apply_load_result(token, Ok(snapshot("/other")), cx));
+        view.hydrate_selection(window, cx);
+    });
+    cx.run_until_parked();
+    old_details_gate.release();
+    old_diff_gate.release();
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.snapshot().repository_root, PathBuf::from("/other"));
+        assert_eq!(state.details().ready(), Some(&details(4, true)));
+        assert_eq!(state.diff().ready(), Some(&diff("new repository patch")));
+        assert_eq!(state.ci().ready(), Some(&ci("success")));
+    });
+}
+
+#[gpui::test]
+fn refresh_retains_ready_diff_with_indicator_then_surfaces_failure(cx: &mut TestAppContext) {
+    let refresh_diff_gate = Arc::new(Gate::default());
+    let diff_calls = Arc::new(AtomicUsize::new(0));
+    let hydration = Arc::new(FixtureHydration::new_async(
+        |_, _| Box::pin(async { Ok(details(1, false)) }),
+        |_, _, _| Box::pin(async { Ok(None) }),
+        {
+            let refresh_diff_gate = Arc::clone(&refresh_diff_gate);
+            let diff_calls = Arc::clone(&diff_calls);
+            move |_, _, _| {
+                let call = diff_calls.fetch_add(1, Ordering::SeqCst);
+                let refresh_diff_gate = Arc::clone(&refresh_diff_gate);
+                Box::pin(async move {
+                    if call == 0 {
+                        Ok(diff("visible patch"))
+                    } else {
+                        refresh_diff_gate.wait().await;
+                        Err("fresh diff failed".into())
+                    }
+                })
+            }
+        },
+        |_, _| Box::pin(async { Ok(ci("success")) }),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+
+    view.update_in(cx, |view, window, cx| {
+        view.refresh_repository(window, cx);
+    });
+    cx.run_until_parked();
+    assert!(refresh_diff_gate.wait_until_started(Duration::from_secs(5)));
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.selected_branch(), Some("feature-a"));
+        assert_eq!(state.diff().ready(), Some(&diff("visible patch")));
+        assert!(state.diff_is_refreshing());
+    });
+    assert!(cx.debug_bounds("changes-refreshing").is_some());
+
+    refresh_diff_gate.release();
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.diff().error(), Some("fresh diff failed"));
+        assert!(!state.diff_is_refreshing());
+    });
+}
+
+#[gpui::test]
+fn cached_diff_is_shown_for_new_selection_until_fresh_diff_replaces_it(cx: &mut TestAppContext) {
+    let feature_b_diff_gate = Arc::new(Gate::default());
+    let hydration = Arc::new(FixtureHydration::new_async(
+        |_, branch| Box::pin(async move { Ok(details(1, branch.name == "feature-b")) }),
+        |_, branch, _| {
+            Box::pin(
+                async move { Ok((branch == "feature-b").then(|| diff("cached feature-b patch"))) },
+            )
+        },
+        {
+            let feature_b_diff_gate = Arc::clone(&feature_b_diff_gate);
+            move |_, branch, _| {
+                let feature_b_diff_gate = Arc::clone(&feature_b_diff_gate);
+                Box::pin(async move {
+                    if branch == "feature-b" {
+                        feature_b_diff_gate.wait().await;
+                        Ok(diff("fresh feature-b patch"))
+                    } else {
+                        Ok(diff("feature-a patch"))
+                    }
+                })
+            }
+        },
+        |_, _| Box::pin(async { Ok(ci("success")) }),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+
+    view.update_in(cx, |view, window, cx| {
+        view.select_branch("feature-b", window, cx);
+    });
+    cx.run_until_parked();
+    assert!(feature_b_diff_gate.wait_until_started(Duration::from_secs(5)));
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.diff().ready(), Some(&diff("cached feature-b patch")));
+        assert!(state.diff_is_refreshing());
+    });
+
+    feature_b_diff_gate.release();
+    cx.run_until_parked();
+
+    cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        assert_eq!(state.diff().ready(), Some(&diff("fresh feature-b patch")));
+        assert!(!state.diff_is_refreshing());
+    });
+}
+
+#[gpui::test]
+fn hydration_completion_after_window_close_is_harmless(cx: &mut TestAppContext) {
+    let details_gate = Arc::new(Gate::default());
+    let diff_gate = Arc::new(Gate::default());
+    let hydration = Arc::new(FixtureHydration::new_async(
+        {
+            let details_gate = Arc::clone(&details_gate);
+            move |_, _| {
+                let details_gate = Arc::clone(&details_gate);
+                Box::pin(async move {
+                    details_gate.wait().await;
+                    Ok(details(1, true))
+                })
+            }
+        },
+        |_, _, _| Box::pin(async { Ok(None) }),
+        {
+            let diff_gate = Arc::clone(&diff_gate);
+            move |_, _, _| {
+                let diff_gate = Arc::clone(&diff_gate);
+                Box::pin(async move {
+                    diff_gate.wait().await;
+                    Ok(diff("late patch"))
+                })
+            }
+        },
+        |_, _| Box::pin(async { Ok(ci("success")) }),
+    ));
+    let services = services_with_hydration(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+        hydration,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    assert!(details_gate.wait_until_started(Duration::from_secs(5)));
+    assert!(diff_gate.wait_until_started(Duration::from_secs(5)));
+
+    cx.update(|window, _| window.remove_window());
+    drop(view);
+    details_gate.release();
+    diff_gate.release();
+    cx.run_until_parked();
+}

--- a/crates/stax-gui/src/views/inspector_pane.rs
+++ b/crates/stax-gui/src/views/inspector_pane.rs
@@ -1,0 +1,401 @@
+use super::{ControlKind, WorkspaceView, control_button};
+use crate::state::LoadState;
+use crate::theme::{MONOSPACE_FONT, Theme};
+use gpui::{
+    Div, InteractiveElement as _, ParentElement as _, StatefulInteractiveElement as _, Styled as _,
+    div, px,
+};
+use stax::application::{BranchDetails, BranchSummary, CiSummary};
+
+pub const PANE_MARKER: &str = "stax-inspector-pane";
+pub const PANE_HEADING: &str = "Inspector";
+
+pub fn render(
+    workspace: &WorkspaceView,
+    theme: Theme,
+    _cx: &mut gpui::Context<super::AppView>,
+) -> Div {
+    let selected = workspace.state().selected_branch().and_then(|selected| {
+        workspace
+            .state()
+            .snapshot()
+            .branches
+            .iter()
+            .find(|branch| branch.name == selected)
+    });
+
+    let content = match selected {
+        Some(branch) => render_selected(workspace, branch, theme),
+        None => div()
+            .flex()
+            .flex_1()
+            .items_center()
+            .justify_center()
+            .p_5()
+            .text_center()
+            .text_sm()
+            .text_color(theme.text_muted)
+            .child("No branch is available to inspect."),
+    };
+
+    div()
+        .debug_selector(|| PANE_MARKER.into())
+        .size_full()
+        .min_w_0()
+        .flex()
+        .flex_col()
+        .bg(theme.surface)
+        .child(
+            div()
+                .h(px(43.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .px_3()
+                .border_b_1()
+                .border_color(theme.border)
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(PANE_HEADING),
+                ),
+        )
+        .child(
+            div()
+                .id("inspector-scroll")
+                .flex()
+                .flex_1()
+                .min_h_0()
+                .flex_col()
+                .overflow_y_scroll()
+                .child(content),
+        )
+}
+
+fn render_selected(workspace: &WorkspaceView, branch: &BranchSummary, theme: Theme) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .gap_4()
+        .p_3()
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_1()
+                .child(
+                    div()
+                        .font_family(MONOSPACE_FONT)
+                        .text_base()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(branch.name.clone()),
+                )
+                .child(
+                    div()
+                        .font_family(MONOSPACE_FONT)
+                        .text_xs()
+                        .text_color(theme.text_muted)
+                        .child(format!(
+                            "Parent: {}",
+                            branch.parent.as_deref().unwrap_or("No parent (trunk)")
+                        )),
+                ),
+        )
+        .child(render_branch_health(branch, theme))
+        .child(render_details(workspace.state().details(), theme))
+        .child(render_pull_request(branch, theme))
+        .child(render_ci(workspace.state().ci(), branch, theme))
+        .child(render_disabled_actions(theme))
+}
+
+fn render_branch_health(branch: &BranchSummary, theme: Theme) -> Div {
+    let (label, color) = if branch.is_trunk {
+        ("Trunk branch", theme.text_muted)
+    } else if branch.needs_restack {
+        ("Restack needed", theme.warning)
+    } else {
+        ("Restack health: up to date", theme.success)
+    };
+
+    section(
+        "Stack health",
+        theme,
+        div().text_sm().text_color(color).child(label.to_string()),
+    )
+}
+
+fn render_details(details: &LoadState<BranchDetails>, theme: Theme) -> Div {
+    let body = match details {
+        LoadState::Idle => div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .text_sm()
+            .child("Branch details not loaded.")
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.text_muted)
+                    .child("Details hydration is wired in Task 7."),
+            ),
+        LoadState::Loading => div()
+            .text_sm()
+            .text_color(theme.text_muted)
+            .child("Loading divergence and commits…"),
+        LoadState::Failed(error) => div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .text_sm()
+            .text_color(theme.danger)
+            .child("Branch details failed to load.")
+            .child(error.clone())
+            .child("Use Refresh Repository to retry."),
+        LoadState::Ready(details) => {
+            let remote = if details.has_remote {
+                format!(
+                    "Remote: {} unpushed · {} unpulled",
+                    details.unpushed, details.unpulled
+                )
+            } else {
+                "Remote: not published".to_string()
+            };
+            let mut ready = div()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .text_sm()
+                .child(format!(
+                    "Divergence: {} ahead · {} behind",
+                    details.ahead, details.behind
+                ))
+                .child(remote)
+                .child(
+                    div()
+                        .text_xs()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .text_color(theme.text_muted)
+                        .child(format!("COMMITS · {}", details.commits.len())),
+                );
+            if details.commits.is_empty() {
+                ready = ready.child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.text_muted)
+                        .child("No commits ahead of parent."),
+                );
+            } else {
+                ready = ready.children(details.commits.iter().map(|commit| {
+                    div()
+                        .font_family(MONOSPACE_FONT)
+                        .text_xs()
+                        .child(format!("• {commit}"))
+                }));
+            }
+            ready
+        }
+    };
+
+    section("Branch details", theme, body)
+}
+
+fn render_pull_request(branch: &BranchSummary, theme: Theme) -> Div {
+    let body = match branch.pr_number {
+        Some(number) => div().text_sm().child(format!(
+            "PR #{number} · {}",
+            branch.pr_state.as_deref().unwrap_or("state unavailable")
+        )),
+        None => div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .text_sm()
+            .child("No pull request cached.")
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.text_muted)
+                    .child("Submit and Open PR become available in phase 2."),
+            ),
+    };
+    section("Pull request", theme, body)
+}
+
+fn render_ci(ci: &LoadState<CiSummary>, branch: &BranchSummary, theme: Theme) -> Div {
+    let body = match ci {
+        LoadState::Idle => div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .text_sm()
+            .child(
+                branch
+                    .ci_state
+                    .as_ref()
+                    .map(|state| format!("Cached CI: {state}"))
+                    .unwrap_or_else(|| "CI details not loaded.".into()),
+            )
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.text_muted)
+                    .child("Live CI hydration is wired in Task 7."),
+            ),
+        LoadState::Loading => div()
+            .text_sm()
+            .text_color(theme.text_muted)
+            .child("Loading CI checks…"),
+        LoadState::Failed(error) => div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .text_sm()
+            .text_color(theme.danger)
+            .child("CI checks are unavailable.")
+            .child(error.clone())
+            .child("Check authentication or network access, then refresh."),
+        LoadState::Ready(summary) => div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .text_sm()
+            .child(format!(
+                "Status: {}",
+                summary.overall_status.as_deref().unwrap_or("unknown")
+            ))
+            .child(format!(
+                "{} passed · {} failed · {} running · {} queued · {} skipped",
+                summary.passed, summary.failed, summary.running, summary.queued, summary.skipped
+            )),
+    };
+    section("Continuous integration", theme, body)
+}
+
+fn render_disabled_actions(theme: Theme) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .pt_1()
+        .child(
+            div()
+                .text_xs()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(theme.text_muted)
+                .child("STACK ACTIONS · READ-ONLY"),
+        )
+        .child(control_button(
+            "inspector-checkout",
+            "Checkout — Available in phase 2",
+            ControlKind::Secondary,
+            false,
+            theme,
+        ))
+        .child(control_button(
+            "inspector-restack",
+            "Restack — Available in phase 2",
+            ControlKind::Secondary,
+            false,
+            theme,
+        ))
+        .child(control_button(
+            "inspector-submit",
+            "Submit — Available in phase 2",
+            ControlKind::Secondary,
+            false,
+            theme,
+        ))
+        .child(control_button(
+            "inspector-open-pr",
+            "Open PR — Available in phase 2",
+            ControlKind::Secondary,
+            false,
+            theme,
+        ))
+}
+
+fn section(title: &str, theme: Theme, body: Div) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .pb_3()
+        .border_b_1()
+        .border_color(theme.border)
+        .child(
+            div()
+                .text_xs()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(theme.text_muted)
+                .child(title.to_uppercase()),
+        )
+        .child(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_ci, render_details};
+    use crate::state::LoadState;
+    use crate::theme::Theme;
+    use stax::application::{BranchDetails, BranchSummary, CiSummary};
+
+    #[test]
+    fn every_details_load_state_builds_without_panicking() {
+        let theme = Theme::light();
+        let states = [
+            LoadState::Idle,
+            LoadState::Loading,
+            LoadState::Failed("offline".into()),
+            LoadState::Ready(BranchDetails {
+                ahead: 1,
+                behind: 2,
+                has_remote: true,
+                unpushed: 1,
+                unpulled: 0,
+                commits: vec!["Add cockpit".into()],
+            }),
+        ];
+
+        for state in states {
+            let _ = render_details(&state, theme);
+        }
+    }
+
+    #[test]
+    fn every_ci_load_state_builds_without_panicking() {
+        let theme = Theme::dark();
+        let branch = BranchSummary {
+            name: "feature".into(),
+            parent: Some("main".into()),
+            column: 0,
+            is_current: true,
+            is_trunk: false,
+            needs_restack: false,
+            pr_number: None,
+            pr_state: None,
+            ci_state: Some("success".into()),
+        };
+        let states = [
+            LoadState::Idle,
+            LoadState::Loading,
+            LoadState::Failed("authentication required".into()),
+            LoadState::Ready(CiSummary {
+                overall_status: Some("success".into()),
+                total: 2,
+                passed: 2,
+                failed: 0,
+                running: 0,
+                queued: 0,
+                skipped: 0,
+                started_at: None,
+                completed_at: None,
+                average_secs: Some(60),
+            }),
+        ];
+
+        for state in states {
+            let _ = render_ci(&state, &branch, theme);
+        }
+    }
+}

--- a/crates/stax-gui/src/views/inspector_pane.rs
+++ b/crates/stax-gui/src/views/inspector_pane.rs
@@ -137,7 +137,7 @@ fn render_details(details: &LoadState<BranchDetails>, theme: Theme) -> Div {
                 div()
                     .text_xs()
                     .text_color(theme.text_muted)
-                    .child("Details hydration is wired in Task 7."),
+                    .child("Select a branch or refresh the repository to load details."),
             ),
         LoadState::Loading => div()
             .text_sm()
@@ -240,7 +240,7 @@ fn render_ci(ci: &LoadState<CiSummary>, branch: &BranchSummary, theme: Theme) ->
                 div()
                     .text_xs()
                     .text_color(theme.text_muted)
-                    .child("Live CI hydration is wired in Task 7."),
+                    .child("Select a published branch or refresh to load live checks."),
             ),
         LoadState::Loading => div()
             .text_sm()
@@ -254,7 +254,7 @@ fn render_ci(ci: &LoadState<CiSummary>, branch: &BranchSummary, theme: Theme) ->
             .text_color(theme.danger)
             .child("CI checks are unavailable.")
             .child(error.clone())
-            .child("Check authentication or network access, then refresh."),
+            .child("Resolve the message above, then refresh the repository."),
         LoadState::Ready(summary) => div()
             .flex()
             .flex_col()

--- a/crates/stax-gui/src/views/mod.rs
+++ b/crates/stax-gui/src/views/mod.rs
@@ -1,36 +1,45 @@
-use gpui::{
-    App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
-};
+mod app;
+mod changes_pane;
+mod inspector_pane;
+mod stack_pane;
+mod welcome;
+mod workspace;
+
+#[cfg(test)]
+mod tests;
+
+use anyhow::Context as _;
+use gpui::{App, AppContext as _, Bounds, WindowBounds, WindowOptions, px, size};
 use std::path::PathBuf;
 
-struct Placeholder {
+use app::AppServices;
+pub use app::{AppView, ControlKind, control_button, init};
+pub use workspace::WorkspaceView;
+
+#[cfg(test)]
+pub use app::{
+    AppModeKind, PaneMarkers, PickerFuture, RecentRepositoryStore, RepositoryPicker, RootLoadKind,
+    SnapshotLoader,
+};
+
+pub fn open_initial_window(repository: Option<PathBuf>, cx: &mut App) -> anyhow::Result<()> {
+    open_window_with_services(repository, AppServices::native(), cx)
+}
+
+fn open_window_with_services(
     repository: Option<PathBuf>,
-}
-
-impl Render for Placeholder {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .size_full()
-            .flex()
-            .items_center()
-            .justify_center()
-            .child(
-                self.repository
-                    .as_ref()
-                    .map(|path| format!("Stax · {}", path.display()))
-                    .unwrap_or_else(|| "Stax".to_string()),
-            )
-    }
-}
-
-pub fn open_initial_window(repository: Option<PathBuf>, cx: &mut App) {
+    services: AppServices,
+    cx: &mut App,
+) -> anyhow::Result<()> {
     let bounds = Bounds::centered(None, size(px(1100.0), px(720.0)), cx);
     cx.open_window(
         WindowOptions {
             window_bounds: Some(WindowBounds::Windowed(bounds)),
+            window_min_size: Some(size(px(820.0), px(520.0))),
             ..Default::default()
         },
-        move |_, cx| cx.new(|_| Placeholder { repository }),
+        move |window, cx| cx.new(|cx| AppView::new(repository, services, window, cx)),
     )
-    .expect("open Stax window");
+    .context("failed to open the Stax window")?;
+    Ok(())
 }

--- a/crates/stax-gui/src/views/mod.rs
+++ b/crates/stax-gui/src/views/mod.rs
@@ -1,0 +1,36 @@
+use gpui::{
+    App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
+};
+use std::path::PathBuf;
+
+struct Placeholder {
+    repository: Option<PathBuf>,
+}
+
+impl Render for Placeholder {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(
+                self.repository
+                    .as_ref()
+                    .map(|path| format!("Stax · {}", path.display()))
+                    .unwrap_or_else(|| "Stax".to_string()),
+            )
+    }
+}
+
+pub fn open_initial_window(repository: Option<PathBuf>, cx: &mut App) {
+    let bounds = Bounds::centered(None, size(px(1100.0), px(720.0)), cx);
+    cx.open_window(
+        WindowOptions {
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            ..Default::default()
+        },
+        move |_, cx| cx.new(|_| Placeholder { repository }),
+    )
+    .expect("open Stax window");
+}

--- a/crates/stax-gui/src/views/mod.rs
+++ b/crates/stax-gui/src/views/mod.rs
@@ -13,7 +13,7 @@ use gpui::{App, AppContext as _, Bounds, WindowBounds, WindowOptions, px, size};
 use std::path::PathBuf;
 
 use app::AppServices;
-pub use app::{AppView, ControlKind, control_button, init};
+pub use app::{AppView, ControlKind, activate_control, control_button, control_focus_style, init};
 pub use workspace::WorkspaceView;
 
 #[cfg(test)]

--- a/crates/stax-gui/src/views/stack_pane.rs
+++ b/crates/stax-gui/src/views/stack_pane.rs
@@ -1,4 +1,4 @@
-use super::{AppView, WorkspaceView};
+use super::{AppView, WorkspaceView, activate_control, control_focus_style};
 use crate::theme::{MONOSPACE_FONT, Theme};
 use gpui::{
     Context, Div, InteractiveElement as _, ParentElement as _, SharedString, Stateful,
@@ -101,11 +101,11 @@ fn render_branch_row(
     let statuses = branch_status_parts(&branch);
     let indentation = px(10.0 + branch.column.min(8) as f32 * 14.0);
 
-    div()
+    let row = div()
         .id(SharedString::from(format!("stack-branch-{}", branch.name)))
         .focusable()
         .tab_index(branch_index as isize + 20)
-        .focus(move |style| style.border_color(theme.focus))
+        .focus(move |style| control_focus_style(style, theme))
         .h(px(54.0))
         .w_full()
         .min_w_0()
@@ -171,10 +171,11 @@ fn render_branch_row(
                                 .child(label)
                         })),
                 ),
-        )
-        .on_click(cx.listener(move |app, _, window, cx| {
-            app.select_branch(&branch_name, window, cx);
-        }))
+        );
+
+    activate_control(row, cx, move |app, window, cx| {
+        app.select_branch(&branch_name, window, cx);
+    })
 }
 
 fn topology_label(branch: &BranchSummary) -> String {

--- a/crates/stax-gui/src/views/stack_pane.rs
+++ b/crates/stax-gui/src/views/stack_pane.rs
@@ -172,8 +172,8 @@ fn render_branch_row(
                         })),
                 ),
         )
-        .on_click(cx.listener(move |app, _, _window, cx| {
-            app.select_branch(&branch_name, cx);
+        .on_click(cx.listener(move |app, _, window, cx| {
+            app.select_branch(&branch_name, window, cx);
         }))
 }
 

--- a/crates/stax-gui/src/views/stack_pane.rs
+++ b/crates/stax-gui/src/views/stack_pane.rs
@@ -1,0 +1,264 @@
+use super::{AppView, WorkspaceView};
+use crate::theme::{MONOSPACE_FONT, Theme};
+use gpui::{
+    Context, Div, InteractiveElement as _, ParentElement as _, SharedString, Stateful,
+    StatefulInteractiveElement as _, Styled as _, div, px, uniform_list,
+};
+use stax::application::BranchSummary;
+use std::ops::Range;
+
+pub const PANE_MARKER: &str = "stax-stack-pane";
+pub const PANE_HEADING: &str = "Stack";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatusTone {
+    Muted,
+    Accent,
+    Success,
+    Warning,
+    Danger,
+}
+
+pub fn render(workspace: &WorkspaceView, theme: Theme, cx: &mut Context<AppView>) -> Div {
+    let branch_count = workspace.state().snapshot().branches.len();
+
+    div()
+        .debug_selector(|| PANE_MARKER.into())
+        .size_full()
+        .min_w_0()
+        .flex()
+        .flex_col()
+        .border_r_1()
+        .border_color(theme.border)
+        .bg(theme.surface)
+        .child(
+            div()
+                .h(px(43.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .justify_between()
+                .px_3()
+                .border_b_1()
+                .border_color(theme.border)
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .child(PANE_HEADING),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.text_muted)
+                        .child(format!("{branch_count} branches")),
+                ),
+        )
+        .child(
+            uniform_list(
+                "stack-branch-list",
+                branch_count,
+                cx.processor(move |app, range: Range<usize>, _window, cx| {
+                    let Some(workspace) = app.workspace() else {
+                        return Vec::new();
+                    };
+                    let selected = workspace.state().selected_branch().map(str::to_string);
+                    let rows: Vec<_> = range
+                        .filter_map(|index| {
+                            workspace
+                                .state()
+                                .snapshot()
+                                .branches
+                                .get(index)
+                                .cloned()
+                                .map(|branch| (index, branch))
+                        })
+                        .collect();
+
+                    rows.into_iter()
+                        .map(|(index, branch)| {
+                            render_branch_row(branch, selected.as_deref(), index, theme, cx)
+                        })
+                        .collect()
+                }),
+            )
+            .track_scroll(workspace.stack_scroll_handle().clone())
+            .flex_1()
+            .min_h_0(),
+        )
+}
+
+fn render_branch_row(
+    branch: BranchSummary,
+    selected: Option<&str>,
+    branch_index: usize,
+    theme: Theme,
+    cx: &mut Context<AppView>,
+) -> Stateful<Div> {
+    let is_selected = selected == Some(branch.name.as_str());
+    let branch_name = branch.name.clone();
+    let topology = topology_label(&branch);
+    let statuses = branch_status_parts(&branch);
+    let indentation = px(10.0 + branch.column.min(8) as f32 * 14.0);
+
+    div()
+        .id(SharedString::from(format!("stack-branch-{}", branch.name)))
+        .focusable()
+        .tab_index(branch_index as isize + 20)
+        .focus(move |style| style.border_color(theme.focus))
+        .h(px(54.0))
+        .w_full()
+        .min_w_0()
+        .flex()
+        .items_center()
+        .gap_2()
+        .pl(indentation)
+        .pr_2()
+        .border_1()
+        .border_color(if is_selected {
+            theme.accent
+        } else {
+            theme.border
+        })
+        .bg(if is_selected {
+            theme.surface_selected
+        } else {
+            theme.surface
+        })
+        .cursor_pointer()
+        .hover(move |style| style.bg(theme.surface_selected))
+        .child(
+            div()
+                .flex_none()
+                .w(px(38.0))
+                .font_family(MONOSPACE_FONT)
+                .text_xs()
+                .text_color(if branch.is_current {
+                    theme.accent
+                } else {
+                    theme.text_muted
+                })
+                .child(topology),
+        )
+        .child(
+            div()
+                .min_w_0()
+                .flex()
+                .flex_1()
+                .flex_col()
+                .gap_1()
+                .child(
+                    div()
+                        .truncate()
+                        .font_family(MONOSPACE_FONT)
+                        .text_sm()
+                        .font_weight(if is_selected {
+                            gpui::FontWeight::SEMIBOLD
+                        } else {
+                            gpui::FontWeight::NORMAL
+                        })
+                        .child(branch.name.clone()),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .children(statuses.into_iter().map(|(label, tone)| {
+                            div()
+                                .text_xs()
+                                .text_color(status_color(tone, theme))
+                                .child(label)
+                        })),
+                ),
+        )
+        .on_click(cx.listener(move |app, _, _window, cx| {
+            app.select_branch(&branch_name, cx);
+        }))
+}
+
+fn topology_label(branch: &BranchSummary) -> String {
+    let connector = if branch.is_trunk { "◆" } else { "●" };
+    if branch.column == 0 {
+        connector.to_string()
+    } else {
+        format!(
+            "{}╰{connector}",
+            "│".repeat(branch.column.saturating_sub(1))
+        )
+    }
+}
+
+fn branch_status_parts(branch: &BranchSummary) -> Vec<(String, StatusTone)> {
+    let mut statuses = Vec::new();
+    if branch.is_current {
+        statuses.push(("Current".into(), StatusTone::Accent));
+    }
+    if branch.is_trunk {
+        statuses.push(("Trunk".into(), StatusTone::Muted));
+    }
+    if branch.needs_restack {
+        statuses.push(("Restack needed".into(), StatusTone::Warning));
+    }
+    if let Some(number) = branch.pr_number {
+        let state = branch.pr_state.as_deref().unwrap_or("unknown");
+        statuses.push((format!("PR #{number} · {state}"), StatusTone::Accent));
+    }
+    if let Some(state) = &branch.ci_state {
+        let tone = match state.to_ascii_lowercase().as_str() {
+            "success" | "passed" => StatusTone::Success,
+            "failure" | "failed" | "error" => StatusTone::Danger,
+            "pending" | "queued" | "running" | "in_progress" => StatusTone::Warning,
+            _ => StatusTone::Muted,
+        };
+        statuses.push((format!("CI: {state}"), tone));
+    }
+    if statuses.is_empty() {
+        statuses.push(("Local branch".into(), StatusTone::Muted));
+    }
+    statuses
+}
+
+fn status_color(tone: StatusTone, theme: Theme) -> gpui::Hsla {
+    match tone {
+        StatusTone::Muted => theme.text_muted,
+        StatusTone::Accent => theme.accent,
+        StatusTone::Success => theme.success,
+        StatusTone::Warning => theme.warning,
+        StatusTone::Danger => theme.danger,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StatusTone, branch_status_parts, topology_label};
+    use stax::application::BranchSummary;
+
+    fn branch() -> BranchSummary {
+        BranchSummary {
+            name: "feature".into(),
+            parent: Some("main".into()),
+            column: 2,
+            is_current: true,
+            is_trunk: false,
+            needs_restack: true,
+            pr_number: Some(17),
+            pr_state: Some("open".into()),
+            ci_state: Some("failure".into()),
+        }
+    }
+
+    #[test]
+    fn branch_metadata_is_expressed_with_text_not_color_alone() {
+        let statuses = branch_status_parts(&branch());
+        assert!(statuses.contains(&("Current".into(), StatusTone::Accent)));
+        assert!(statuses.contains(&("Restack needed".into(), StatusTone::Warning)));
+        assert!(statuses.contains(&("PR #17 · open".into(), StatusTone::Accent)));
+        assert!(statuses.contains(&("CI: failure".into(), StatusTone::Danger)));
+    }
+
+    #[test]
+    fn topology_uses_column_connectors() {
+        assert_eq!(topology_label(&branch()), "│╰●");
+    }
+}

--- a/crates/stax-gui/src/views/tests.rs
+++ b/crates/stax-gui/src/views/tests.rs
@@ -1,0 +1,567 @@
+use super::{
+    AppModeKind, AppServices, AppView, PaneMarkers, PickerFuture, RecentRepositoryStore,
+    RepositoryPicker, RootLoadKind, SnapshotLoader,
+};
+use gpui::{App, TestAppContext};
+use stax::application::{BranchSummary, RepositorySnapshot};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+    mpsc,
+};
+use std::thread;
+use std::time::Duration;
+
+#[derive(Clone)]
+struct FixtureLoader {
+    result: Result<RepositorySnapshot, String>,
+}
+
+impl SnapshotLoader for FixtureLoader {
+    fn load(&self, _path: &Path) -> Result<RepositorySnapshot, String> {
+        self.result.clone()
+    }
+}
+
+struct FixturePicker {
+    result: Result<Option<PathBuf>, String>,
+}
+
+impl RepositoryPicker for FixturePicker {
+    fn pick(&self, _cx: &mut App) -> PickerFuture {
+        let result = self.result.clone();
+        Box::pin(async move { result })
+    }
+}
+
+#[derive(Default)]
+struct FixtureRecents {
+    paths: Mutex<Vec<PathBuf>>,
+    load_error: Option<String>,
+    record_error: Option<String>,
+    record_attempts: AtomicUsize,
+}
+
+impl RecentRepositoryStore for FixtureRecents {
+    fn load(&self) -> Result<Vec<PathBuf>, String> {
+        self.load_error.as_ref().map_or_else(
+            || Ok(self.paths.lock().unwrap().clone()),
+            |error| Err(error.clone()),
+        )
+    }
+
+    fn record(&self, path: &Path) -> Result<(), String> {
+        self.record_attempts.fetch_add(1, Ordering::SeqCst);
+        if let Some(error) = &self.record_error {
+            return Err(error.clone());
+        }
+        self.paths.lock().unwrap().insert(0, path.to_path_buf());
+        Ok(())
+    }
+}
+
+fn branch(name: &str, parent: Option<&str>, current: bool, trunk: bool) -> BranchSummary {
+    BranchSummary {
+        name: name.into(),
+        parent: parent.map(str::to_string),
+        column: if trunk { 0 } else { 1 },
+        is_current: current,
+        is_trunk: trunk,
+        needs_restack: name == "feature-b",
+        pr_number: (name == "feature-a").then_some(42),
+        pr_state: (name == "feature-a").then(|| "open".into()),
+        ci_state: (name == "feature-a").then(|| "success".into()),
+    }
+}
+
+fn snapshot(path: &str) -> RepositorySnapshot {
+    RepositorySnapshot {
+        repository_root: PathBuf::from(path),
+        current_branch: "feature-a".into(),
+        trunk: "main".into(),
+        branches: vec![
+            branch("feature-b", Some("feature-a"), false, false),
+            branch("feature-a", Some("main"), true, false),
+            branch("main", None, false, true),
+        ],
+    }
+}
+
+fn services(
+    loader: Result<RepositorySnapshot, String>,
+    picker: Result<Option<PathBuf>, String>,
+    recents: Arc<FixtureRecents>,
+) -> AppServices {
+    AppServices::new(
+        Arc::new(FixtureLoader { result: loader }),
+        Rc::new(FixturePicker { result: picker }),
+        recents,
+    )
+}
+
+#[gpui::test]
+fn no_path_renders_the_welcome_mode_without_panicking(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Welcome
+    );
+    assert_eq!(
+        cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
+        None
+    );
+}
+
+#[gpui::test]
+fn recent_repositories_load_after_the_welcome_first_paint(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents {
+        paths: Mutex::new(vec![PathBuf::from("/recent/repo")]),
+        ..Default::default()
+    });
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    cx.run_until_parked();
+    assert_eq!(
+        cx.update(|_, app| view.read(app).recent_repositories().to_vec()),
+        vec![PathBuf::from("/recent/repo")]
+    );
+
+    let token = view.update_in(cx, |view, _window, cx| {
+        let token = view.begin_recent_load();
+        cx.notify();
+        token
+    });
+    cx.run_until_parked();
+    assert!(cx.update(|_, app| view.read(app).recent_load_is_pending()));
+    assert!(cx.debug_bounds("recent-repositories-loading").is_some());
+
+    view.update_in(cx, |view, _window, cx| {
+        assert!(view.apply_recent_load_result(token, Ok(vec![PathBuf::from("/recent/repo")]), cx,));
+    });
+    assert!(!cx.update(|_, app| view.read(app).recent_load_is_pending()));
+}
+
+#[gpui::test]
+fn stale_recent_load_results_cannot_replace_newer_results(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    view.update_in(cx, |view, _window, cx| {
+        let first = view.begin_recent_load();
+        let second = view.begin_recent_load();
+        assert!(!view.apply_recent_load_result(first, Ok(vec![PathBuf::from("/stale")]), cx,));
+        assert!(view.apply_recent_load_result(second, Ok(vec![PathBuf::from("/current")]), cx,));
+    });
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).recent_repositories().to_vec()),
+        vec![PathBuf::from("/current")]
+    );
+}
+
+#[gpui::test]
+fn initial_path_loads_a_workspace_and_records_recents_after_success(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), Arc::clone(&recents));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Workspace
+    );
+    assert_eq!(
+        cx.update(|_, app| view.read(app).pane_markers()),
+        Some(PaneMarkers::all())
+    );
+    for marker in [
+        PaneMarkers::all().stack,
+        PaneMarkers::all().changes,
+        PaneMarkers::all().inspector,
+    ] {
+        assert!(
+            cx.debug_bounds(marker).is_some(),
+            "{marker} was not rendered"
+        );
+    }
+    assert_eq!(
+        recents.paths.lock().unwrap().as_slice(),
+        &[PathBuf::from("/repo")]
+    );
+}
+
+#[gpui::test]
+fn invalid_initial_path_returns_to_actionable_welcome_error(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(
+        Err("not a git repository; choose another folder".into()),
+        Ok(None),
+        recents,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/invalid")), services, window, cx)
+    });
+
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Error
+    );
+    assert!(cx.update(|_, app| {
+        view.read(app)
+            .inline_error()
+            .is_some_and(|error| error.contains("choose another folder"))
+    }));
+}
+
+#[gpui::test]
+fn picker_cancellation_leaves_the_current_mode_unchanged(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    view.update_in(cx, |view, window, cx| {
+        view.pick_repository(window, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Welcome
+    );
+    assert_eq!(
+        cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
+        None
+    );
+}
+
+#[gpui::test]
+fn picker_errors_are_inline_and_nonfatal(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(
+        Ok(snapshot("/repo")),
+        Err("folder picker unavailable".into()),
+        recents,
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    view.update_in(cx, |view, window, cx| {
+        view.pick_repository(window, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Welcome
+    );
+    assert_eq!(
+        cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
+        Some("folder picker unavailable".to_string())
+    );
+}
+
+#[gpui::test]
+fn recent_storage_errors_stay_inline_with_open_choices(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents {
+        load_error: Some("recent repository storage is unreadable".into()),
+        ..Default::default()
+    });
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Welcome
+    );
+    assert_eq!(
+        cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
+        Some("recent repository storage is unreadable".to_string())
+    );
+}
+
+#[gpui::test]
+fn recent_record_errors_do_not_block_a_successful_workspace(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents {
+        record_error: Some("preferences directory is read-only".into()),
+        ..Default::default()
+    });
+    let services = services(Ok(snapshot("/repo")), Ok(None), Arc::clone(&recents));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Workspace
+    );
+    assert!(cx.update(|_, app| {
+        view.read(app)
+            .inline_error()
+            .is_some_and(|error| error.contains("recent entry was not saved"))
+    }));
+    assert!(recents.paths.lock().unwrap().is_empty());
+}
+
+#[gpui::test]
+fn recent_write_completion_survives_an_intervening_refresh(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    view.update_in(cx, |view, _window, cx| {
+        let write = view.begin_recent_write(PathBuf::from("/repo"));
+        let _refresh = view.begin_load(PathBuf::from("/repo"), RootLoadKind::Refresh);
+
+        assert!(view.apply_recent_write_result(
+            write,
+            Err("delayed recent write failed".into()),
+            cx,
+        ));
+    });
+
+    assert!(cx.update(|_, app| {
+        view.read(app)
+            .inline_error()
+            .is_some_and(|error| error.contains("delayed recent write failed"))
+    }));
+}
+
+#[gpui::test]
+fn only_newest_recent_write_controls_error_presentation(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    view.update_in(cx, |view, _window, cx| {
+        let first = view.begin_recent_write(PathBuf::from("/first"));
+        let second = view.begin_recent_write(PathBuf::from("/second"));
+        assert!(view.apply_recent_write_result(second, Err("newest write failed".into()), cx,));
+        assert!(!view.apply_recent_write_result(first, Ok(()), cx));
+        assert!(
+            view.inline_error()
+                .is_some_and(|error| error.contains("newest write failed"))
+        );
+
+        let third = view.begin_recent_write(PathBuf::from("/third"));
+        assert!(view.apply_recent_write_result(third, Ok(()), cx));
+        assert_eq!(view.inline_error(), None);
+    });
+}
+
+#[gpui::test]
+fn every_accepted_open_attempts_a_locked_recent_write(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), Arc::clone(&recents));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/first")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    view.update_in(cx, |view, window, cx| {
+        view.open_repository(PathBuf::from("/second"), window, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(recents.record_attempts.load(Ordering::SeqCst), 2);
+}
+
+#[gpui::test]
+fn accepted_recent_writes_are_serialized_in_fifo_order(cx: &mut TestAppContext) {
+    struct BlockingOrderedRecents {
+        paths: Mutex<Vec<PathBuf>>,
+        call_order: Mutex<Vec<PathBuf>>,
+        first_started: mpsc::Sender<()>,
+        release_first: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl RecentRepositoryStore for BlockingOrderedRecents {
+        fn load(&self) -> Result<Vec<PathBuf>, String> {
+            Ok(self.paths.lock().unwrap().clone())
+        }
+
+        fn record(&self, path: &Path) -> Result<(), String> {
+            self.call_order.lock().unwrap().push(path.to_path_buf());
+            if path == Path::new("/repo-a") {
+                self.first_started.send(()).unwrap();
+                self.release_first.lock().unwrap().recv().unwrap();
+            }
+            let mut paths = self.paths.lock().unwrap();
+            paths.retain(|existing| existing != path);
+            paths.insert(0, path.to_path_buf());
+            Ok(())
+        }
+    }
+
+    let (first_started_tx, first_started_rx) = mpsc::channel();
+    let (release_first_tx, release_first_rx) = mpsc::channel();
+    let recents = Arc::new(BlockingOrderedRecents {
+        paths: Mutex::new(Vec::new()),
+        call_order: Mutex::new(Vec::new()),
+        first_started: first_started_tx,
+        release_first: Mutex::new(release_first_rx),
+    });
+    let services = AppServices::new(
+        Arc::new(FixtureLoader {
+            result: Ok(snapshot("/repo")),
+        }),
+        Rc::new(FixturePicker { result: Ok(None) }),
+        recents.clone(),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+    cx.run_until_parked();
+
+    view.update_in(cx, |view, window, cx| {
+        let first = view.begin_load(PathBuf::from("/repo-a"), RootLoadKind::Open);
+        assert!(view.apply_load_result(first, Ok(snapshot("/repo-a")), cx));
+        view.enqueue_recent_write(PathBuf::from("/repo-a"), window, cx);
+
+        let second = view.begin_load(PathBuf::from("/repo-b"), RootLoadKind::Open);
+        assert!(view.apply_load_result(second, Ok(snapshot("/repo-b")), cx));
+        view.enqueue_recent_write(PathBuf::from("/repo-b"), window, cx);
+    });
+
+    let recents_for_release = Arc::clone(&recents);
+    let release = thread::spawn(move || {
+        first_started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("first recent write did not start");
+        assert_eq!(
+            recents_for_release.call_order.lock().unwrap().as_slice(),
+            &[PathBuf::from("/repo-a")]
+        );
+        release_first_tx.send(()).unwrap();
+    });
+    cx.run_until_parked();
+    release.join().unwrap();
+
+    assert_eq!(
+        recents.call_order.lock().unwrap().as_slice(),
+        &[PathBuf::from("/repo-a"), PathBuf::from("/repo-b")]
+    );
+    assert_eq!(
+        recents.paths.lock().unwrap().as_slice(),
+        &[PathBuf::from("/repo-b"), PathBuf::from("/repo-a")]
+    );
+    assert_eq!(
+        cx.update(|_, app| view.read(app).recent_repositories().to_vec()),
+        vec![PathBuf::from("/repo-b"), PathBuf::from("/repo-a")]
+    );
+}
+
+#[gpui::test]
+fn arrow_keys_move_selection_without_changing_the_checked_out_branch(cx: &mut TestAppContext) {
+    cx.update(super::init);
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+
+    cx.simulate_keystrokes("up up up");
+
+    let (selection, current) = cx.update(|_, app| {
+        let workspace = view.read(app).workspace().unwrap();
+        (
+            workspace.state().selected_branch().map(str::to_string),
+            workspace.state().snapshot().current_branch.clone(),
+        )
+    });
+    assert_eq!(selection.as_deref(), Some("feature-b"));
+    assert_eq!(current, "feature-a");
+}
+
+#[gpui::test]
+fn stale_root_repository_results_are_rejected(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents::default());
+    let services = services(Ok(snapshot("/repo")), Ok(None), recents);
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+
+    let (first, second) = view.update_in(cx, |view, _window, _cx| {
+        let first = view.begin_load(PathBuf::from("/first"), RootLoadKind::Open);
+        let second = view.begin_load(PathBuf::from("/second"), RootLoadKind::Open);
+        (first, second)
+    });
+    view.update_in(cx, |view, _window, cx| {
+        assert!(!view.apply_load_result(first, Ok(snapshot("/first")), cx));
+        assert!(view.apply_load_result(second, Ok(snapshot("/second")), cx));
+    });
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Workspace
+    );
+    assert_eq!(
+        cx.update(|_, app| {
+            view.read(app)
+                .workspace()
+                .unwrap()
+                .state()
+                .snapshot()
+                .repository_root
+                .clone()
+        }),
+        PathBuf::from("/second")
+    );
+}
+
+#[gpui::test]
+fn repeated_refresh_requests_spawn_only_one_snapshot_read(cx: &mut TestAppContext) {
+    struct CountingLoader {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SnapshotLoader for CountingLoader {
+        fn load(&self, _path: &Path) -> Result<RepositorySnapshot, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(snapshot("/repo"))
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let services = AppServices::new(
+        Arc::new(CountingLoader {
+            calls: Arc::clone(&calls),
+        }),
+        Rc::new(FixturePicker { result: Ok(None) }),
+        Arc::new(FixtureRecents::default()),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    view.update_in(cx, |view, window, cx| {
+        view.refresh_repository(window, cx);
+        view.refresh_repository(window, cx);
+        assert!(view.workspace().unwrap().refresh_is_loading());
+    });
+    cx.run_until_parked();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(!cx.update(|_, app| { view.read(app).workspace().unwrap().refresh_is_loading() }));
+}

--- a/crates/stax-gui/src/views/tests.rs
+++ b/crates/stax-gui/src/views/tests.rs
@@ -2,17 +2,26 @@ use super::{
     AppModeKind, AppServices, AppView, PaneMarkers, PickerFuture, RecentRepositoryStore,
     RepositoryPicker, RootLoadKind, SnapshotLoader,
 };
+use crate::hydration::{BranchHydrationService, HydrationFuture};
+use crate::state::LoadState;
 use gpui::{App, TestAppContext};
-use stax::application::{BranchSummary, RepositorySnapshot};
+use stax::application::{
+    BranchDetails, BranchDiff, BranchSummary, CiSummary, DiffLine, DiffLineKind, RepositorySnapshot,
+};
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
+    Arc, Condvar, Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc,
 };
+use std::task::{Context as TaskContext, Poll, Waker};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+#[path = "hydration_tests.rs"]
+mod hydration_tests;
 
 #[derive(Clone)]
 struct FixtureLoader {
@@ -62,6 +71,252 @@ impl RecentRepositoryStore for FixtureRecents {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HydrationCall {
+    Details { repository: PathBuf, branch: String },
+    CachedDiff { branch: String, parent: String },
+    Diff { branch: String, parent: String },
+    Ci { repository: PathBuf, branch: String },
+}
+
+type DetailsHandler =
+    dyn Fn(PathBuf, BranchSummary) -> HydrationFuture<BranchDetails> + Send + Sync;
+type CachedDiffHandler =
+    dyn Fn(PathBuf, String, String) -> HydrationFuture<Option<BranchDiff>> + Send + Sync;
+type DiffHandler = dyn Fn(PathBuf, String, String) -> HydrationFuture<BranchDiff> + Send + Sync;
+type CiHandler = dyn Fn(PathBuf, String) -> HydrationFuture<CiSummary> + Send + Sync;
+
+struct FixtureHydration {
+    calls: Mutex<Vec<HydrationCall>>,
+    details: Arc<DetailsHandler>,
+    cached_diff: Arc<CachedDiffHandler>,
+    diff: Arc<DiffHandler>,
+    ci: Arc<CiHandler>,
+}
+
+impl FixtureHydration {
+    fn new(
+        details: impl Fn(&Path, &BranchSummary) -> Result<BranchDetails, String> + Send + Sync + 'static,
+        cached_diff: impl Fn(&Path, &str, &str) -> Result<Option<BranchDiff>, String>
+        + Send
+        + Sync
+        + 'static,
+        diff: impl Fn(&Path, &str, &str) -> Result<BranchDiff, String> + Send + Sync + 'static,
+        ci: impl Fn(&Path, &str) -> Result<CiSummary, String> + Send + Sync + 'static,
+    ) -> Self {
+        let details = Arc::new(details);
+        let cached_diff = Arc::new(cached_diff);
+        let diff = Arc::new(diff);
+        let ci = Arc::new(ci);
+        Self::new_async(
+            move |repository, branch| {
+                let details = Arc::clone(&details);
+                Box::pin(async move { details(&repository, &branch) })
+            },
+            move |repository, branch, parent| {
+                let cached_diff = Arc::clone(&cached_diff);
+                Box::pin(async move { cached_diff(&repository, &branch, &parent) })
+            },
+            move |repository, branch, parent| {
+                let diff = Arc::clone(&diff);
+                Box::pin(async move { diff(&repository, &branch, &parent) })
+            },
+            move |repository, branch| {
+                let ci = Arc::clone(&ci);
+                Box::pin(async move { ci(&repository, &branch) })
+            },
+        )
+    }
+
+    fn new_async(
+        details: impl Fn(PathBuf, BranchSummary) -> HydrationFuture<BranchDetails>
+        + Send
+        + Sync
+        + 'static,
+        cached_diff: impl Fn(PathBuf, String, String) -> HydrationFuture<Option<BranchDiff>>
+        + Send
+        + Sync
+        + 'static,
+        diff: impl Fn(PathBuf, String, String) -> HydrationFuture<BranchDiff> + Send + Sync + 'static,
+        ci: impl Fn(PathBuf, String) -> HydrationFuture<CiSummary> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            details: Arc::new(details),
+            cached_diff: Arc::new(cached_diff),
+            diff: Arc::new(diff),
+            ci: Arc::new(ci),
+        }
+    }
+
+    fn immediate_no_remote() -> Self {
+        Self::new(
+            |_, _| Ok(details(1, false)),
+            |_, _, _| Ok(None),
+            |_, branch, _| Ok(diff(&format!("{branch} patch"))),
+            |_, _| Ok(ci("success")),
+        )
+    }
+
+    fn calls(&self) -> Vec<HydrationCall> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl BranchHydrationService for FixtureHydration {
+    fn load_details(
+        &self,
+        repository: PathBuf,
+        branch: BranchSummary,
+    ) -> HydrationFuture<BranchDetails> {
+        self.calls.lock().unwrap().push(HydrationCall::Details {
+            repository: repository.clone(),
+            branch: branch.name.clone(),
+        });
+        (self.details)(repository, branch)
+    }
+
+    fn load_cached_diff(
+        &self,
+        repository: PathBuf,
+        branch: String,
+        parent: String,
+    ) -> HydrationFuture<Option<BranchDiff>> {
+        self.calls.lock().unwrap().push(HydrationCall::CachedDiff {
+            branch: branch.clone(),
+            parent: parent.clone(),
+        });
+        (self.cached_diff)(repository, branch, parent)
+    }
+
+    fn load_diff(
+        &self,
+        repository: PathBuf,
+        branch: String,
+        parent: String,
+    ) -> HydrationFuture<BranchDiff> {
+        self.calls.lock().unwrap().push(HydrationCall::Diff {
+            branch: branch.clone(),
+            parent: parent.clone(),
+        });
+        (self.diff)(repository, branch, parent)
+    }
+
+    fn load_ci(&self, repository: PathBuf, branch: String) -> HydrationFuture<CiSummary> {
+        self.calls.lock().unwrap().push(HydrationCall::Ci {
+            repository: repository.clone(),
+            branch: branch.clone(),
+        });
+        (self.ci)(repository, branch)
+    }
+}
+
+#[derive(Default)]
+struct GateState {
+    started: bool,
+    released: bool,
+    waker: Option<Waker>,
+}
+
+#[derive(Default)]
+struct Gate {
+    state: Mutex<GateState>,
+    changed: Condvar,
+}
+
+impl Gate {
+    fn wait(self: &Arc<Self>) -> GateWait {
+        GateWait {
+            gate: Arc::clone(self),
+        }
+    }
+
+    fn wait_until_started(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut state = self.state.lock().unwrap();
+        while !state.started {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (next, timed_out) = self.changed.wait_timeout(state, remaining).unwrap();
+            state = next;
+            if timed_out.timed_out() && !state.started {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn release(&self) {
+        let waker = {
+            let mut state = self.state.lock().unwrap();
+            state.released = true;
+            self.changed.notify_all();
+            state.waker.take()
+        };
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+struct GateWait {
+    gate: Arc<Gate>,
+}
+
+impl std::future::Future for GateWait {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        let mut state = self.gate.state.lock().unwrap();
+        state.started = true;
+        self.gate.changed.notify_all();
+        if state.released {
+            Poll::Ready(())
+        } else {
+            state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+fn details(ahead: usize, has_remote: bool) -> BranchDetails {
+    BranchDetails {
+        ahead,
+        behind: 0,
+        has_remote,
+        unpushed: usize::from(has_remote),
+        unpulled: 0,
+        commits: vec![format!("commit-{ahead}")],
+    }
+}
+
+fn diff(content: &str) -> BranchDiff {
+    BranchDiff {
+        stat: Vec::new(),
+        lines: vec![DiffLine {
+            content: content.to_string(),
+            kind: DiffLineKind::Context,
+        }],
+    }
+}
+
+fn ci(status: &str) -> CiSummary {
+    CiSummary {
+        overall_status: Some(status.to_string()),
+        total: 1,
+        passed: usize::from(status == "success"),
+        failed: usize::from(status == "failure"),
+        running: 0,
+        queued: 0,
+        skipped: 0,
+        started_at: None,
+        completed_at: None,
+        average_secs: None,
+    }
+}
+
 fn branch(name: &str, parent: Option<&str>, current: bool, trunk: bool) -> BranchSummary {
     BranchSummary {
         name: name.into(),
@@ -94,10 +349,25 @@ fn services(
     picker: Result<Option<PathBuf>, String>,
     recents: Arc<FixtureRecents>,
 ) -> AppServices {
-    AppServices::new(
+    services_with_hydration(
+        loader,
+        picker,
+        recents,
+        Arc::new(FixtureHydration::immediate_no_remote()),
+    )
+}
+
+fn services_with_hydration(
+    loader: Result<RepositorySnapshot, String>,
+    picker: Result<Option<PathBuf>, String>,
+    recents: Arc<FixtureRecents>,
+    hydration: Arc<dyn BranchHydrationService>,
+) -> AppServices {
+    AppServices::with_hydration(
         Arc::new(FixtureLoader { result: loader }),
         Rc::new(FixturePicker { result: picker }),
         recents,
+        hydration,
     )
 }
 
@@ -270,6 +540,30 @@ fn picker_errors_are_inline_and_nonfatal(cx: &mut TestAppContext) {
     assert_eq!(
         cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
         Some("folder picker unavailable".to_string())
+    );
+}
+
+#[gpui::test]
+fn latest_picker_error_takes_precedence_over_an_older_refresh_failure(cx: &mut TestAppContext) {
+    let services = services(
+        Ok(snapshot("/repo")),
+        Err("latest folder picker failure".into()),
+        Arc::new(FixtureRecents::default()),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+
+    view.update_in(cx, |view, window, cx| {
+        let refresh = view.begin_load(PathBuf::from("/repo"), RootLoadKind::Refresh);
+        assert!(view.apply_load_result(refresh, Err("older refresh failure".into()), cx));
+        view.pick_repository(window, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
+        Some("latest folder picker failure".to_string())
     );
 }
 
@@ -542,12 +836,13 @@ fn repeated_refresh_requests_spawn_only_one_snapshot_read(cx: &mut TestAppContex
     }
 
     let calls = Arc::new(AtomicUsize::new(0));
-    let services = AppServices::new(
+    let services = AppServices::with_hydration(
         Arc::new(CountingLoader {
             calls: Arc::clone(&calls),
         }),
         Rc::new(FixturePicker { result: Ok(None) }),
         Arc::new(FixtureRecents::default()),
+        Arc::new(FixtureHydration::immediate_no_remote()),
     );
     let (view, cx) = cx.add_window_view(|window, cx| {
         AppView::new(Some(PathBuf::from("/repo")), services, window, cx)

--- a/crates/stax-gui/src/views/tests.rs
+++ b/crates/stax-gui/src/views/tests.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::hydration::{BranchHydrationService, HydrationFuture};
 use crate::state::LoadState;
-use gpui::{App, TestAppContext};
+use gpui::{App, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, MouseButton, TestAppContext};
 use stax::application::{
     BranchDetails, BranchDiff, BranchSummary, CiSummary, DiffLine, DiffLineKind, RepositorySnapshot,
 };
@@ -36,10 +36,25 @@ impl SnapshotLoader for FixtureLoader {
 
 struct FixturePicker {
     result: Result<Option<PathBuf>, String>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl FixturePicker {
+    fn new(result: Result<Option<PathBuf>, String>) -> Self {
+        Self {
+            result,
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn with_calls(result: Result<Option<PathBuf>, String>, calls: Arc<AtomicUsize>) -> Self {
+        Self { result, calls }
+    }
 }
 
 impl RepositoryPicker for FixturePicker {
     fn pick(&self, _cx: &mut App) -> PickerFuture {
+        self.calls.fetch_add(1, Ordering::SeqCst);
         let result = self.result.clone();
         Box::pin(async move { result })
     }
@@ -365,7 +380,7 @@ fn services_with_hydration(
 ) -> AppServices {
     AppServices::with_hydration(
         Arc::new(FixtureLoader { result: loader }),
-        Rc::new(FixturePicker { result: picker }),
+        Rc::new(FixturePicker::new(picker)),
         recents,
         hydration,
     )
@@ -386,6 +401,171 @@ fn no_path_renders_the_welcome_mode_without_panicking(cx: &mut TestAppContext) {
     assert_eq!(
         cx.update(|_, app| view.read(app).inline_error().map(str::to_string)),
         None
+    );
+}
+
+#[gpui::test]
+fn keyboard_welcome_open_activates_once_for_enter_and_space(cx: &mut TestAppContext) {
+    cx.update(super::init);
+    let picker_calls = Arc::new(AtomicUsize::new(0));
+    let services = AppServices::with_hydration(
+        Arc::new(FixtureLoader {
+            result: Ok(snapshot("/repo")),
+        }),
+        Rc::new(FixturePicker::with_calls(
+            Ok(None),
+            Arc::clone(&picker_calls),
+        )),
+        Arc::new(FixtureRecents::default()),
+        Arc::new(FixtureHydration::immediate_no_remote()),
+    );
+    let (_view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+    cx.run_until_parked();
+
+    cx.simulate_keystrokes("enter space");
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+
+    cx.update(|window, _| window.focus_next());
+    cx.simulate_keystrokes("enter");
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+        is_held: true,
+    });
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+
+    cx.simulate_keystrokes("space");
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 2);
+}
+
+#[gpui::test]
+fn mouse_welcome_open_activates_on_release_and_retains_keyboard_focus(cx: &mut TestAppContext) {
+    cx.update(super::init);
+    let picker_calls = Arc::new(AtomicUsize::new(0));
+    let services = AppServices::with_hydration(
+        Arc::new(FixtureLoader {
+            result: Ok(snapshot("/repo")),
+        }),
+        Rc::new(FixturePicker::with_calls(
+            Ok(None),
+            Arc::clone(&picker_calls),
+        )),
+        Arc::new(FixtureRecents::default()),
+        Arc::new(FixtureHydration::immediate_no_remote()),
+    );
+    let (_view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+    cx.run_until_parked();
+    let position = cx
+        .debug_bounds("welcome-open-repository-control")
+        .expect("welcome Open Repository control was not rendered")
+        .center();
+
+    cx.simulate_mouse_move(position, None, Modifiers::default());
+    cx.simulate_mouse_down(position, MouseButton::Left, Modifiers::default());
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_mouse_up(position, MouseButton::Left, Modifiers::default());
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+
+    cx.simulate_keystrokes("enter");
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 2);
+}
+
+#[gpui::test]
+fn keyboard_recent_repository_row_enter_activates_once(cx: &mut TestAppContext) {
+    assert_recent_repository_row_key_activates_once("enter", cx);
+}
+
+#[gpui::test]
+fn keyboard_recent_repository_row_space_activates_once(cx: &mut TestAppContext) {
+    assert_recent_repository_row_key_activates_once("space", cx);
+}
+
+fn assert_recent_repository_row_key_activates_once(key: &str, cx: &mut TestAppContext) {
+    cx.update(super::init);
+    let recents = Arc::new(FixtureRecents {
+        paths: Mutex::new(vec![PathBuf::from("/recent/repo")]),
+        ..Default::default()
+    });
+    let services = services(Ok(snapshot("/recent/repo")), Ok(None), Arc::clone(&recents));
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+    cx.run_until_parked();
+
+    cx.update(|window, _| {
+        window.focus_next();
+        window.focus_next();
+    });
+    cx.simulate_keystrokes(key);
+    assert_eq!(recents.record_attempts.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse(key).unwrap(),
+        is_held: true,
+    });
+    assert_eq!(recents.record_attempts.load(Ordering::SeqCst), 0);
+
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse(key).unwrap(),
+    });
+    assert_eq!(recents.record_attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Workspace
+    );
+}
+
+#[gpui::test]
+fn mouse_recent_repository_row_activates_once_on_release(cx: &mut TestAppContext) {
+    let recents = Arc::new(FixtureRecents {
+        paths: Mutex::new(vec![PathBuf::from("/recent/repo")]),
+        ..Default::default()
+    });
+    let services = services(Ok(snapshot("/recent/repo")), Ok(None), Arc::clone(&recents));
+    let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
+    cx.run_until_parked();
+    let position = cx
+        .debug_bounds("recent-repository-control-0")
+        .expect("first recent repository control was not rendered")
+        .center();
+
+    cx.simulate_mouse_move(position, None, Modifiers::default());
+    cx.simulate_mouse_down(position, MouseButton::Left, Modifiers::default());
+    assert_eq!(recents.record_attempts.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Welcome
+    );
+
+    cx.simulate_mouse_up(position, MouseButton::Left, Modifiers::default());
+    assert_eq!(recents.record_attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        cx.update(|_, app| view.read(app).mode_kind()),
+        AppModeKind::Workspace
     );
 }
 
@@ -721,7 +901,7 @@ fn accepted_recent_writes_are_serialized_in_fifo_order(cx: &mut TestAppContext) 
         Arc::new(FixtureLoader {
             result: Ok(snapshot("/repo")),
         }),
-        Rc::new(FixturePicker { result: Ok(None) }),
+        Rc::new(FixturePicker::new(Ok(None))),
         recents.clone(),
     );
     let (view, cx) = cx.add_window_view(|window, cx| AppView::new(None, services, window, cx));
@@ -789,6 +969,202 @@ fn arrow_keys_move_selection_without_changing_the_checked_out_branch(cx: &mut Te
 }
 
 #[gpui::test]
+fn keyboard_workspace_controls_activate_once_and_skip_disabled_controls(cx: &mut TestAppContext) {
+    struct CountingLoader {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SnapshotLoader for CountingLoader {
+        fn load(&self, _path: &Path) -> Result<RepositorySnapshot, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(snapshot("/repo"))
+        }
+    }
+
+    cx.update(super::init);
+    let load_calls = Arc::new(AtomicUsize::new(0));
+    let picker_calls = Arc::new(AtomicUsize::new(0));
+    let services = AppServices::with_hydration(
+        Arc::new(CountingLoader {
+            calls: Arc::clone(&load_calls),
+        }),
+        Rc::new(FixturePicker::with_calls(
+            Ok(None),
+            Arc::clone(&picker_calls),
+        )),
+        Arc::new(FixtureRecents::default()),
+        Arc::new(FixtureHydration::immediate_no_remote()),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(load_calls.load(Ordering::SeqCst), 1);
+
+    view.update_in(cx, |view, _window, cx| {
+        let _ = view.begin_load(PathBuf::from("/repo"), RootLoadKind::Refresh);
+        cx.notify();
+    });
+    cx.update(|window, _| window.focus_next());
+    cx.simulate_keystrokes("enter");
+    assert_eq!(load_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(load_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    assert_eq!(load_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+}
+
+#[gpui::test]
+fn keyboard_refresh_activates_once_for_enter_and_space(cx: &mut TestAppContext) {
+    struct CountingLoader {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SnapshotLoader for CountingLoader {
+        fn load(&self, _path: &Path) -> Result<RepositorySnapshot, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(snapshot("/repo"))
+        }
+    }
+
+    cx.update(super::init);
+    let calls = Arc::new(AtomicUsize::new(0));
+    let picker_calls = Arc::new(AtomicUsize::new(0));
+    let services = AppServices::with_hydration(
+        Arc::new(CountingLoader {
+            calls: Arc::clone(&calls),
+        }),
+        Rc::new(FixturePicker::with_calls(
+            Ok(None),
+            Arc::clone(&picker_calls),
+        )),
+        Arc::new(FixtureRecents::default()),
+        Arc::new(FixtureHydration::immediate_no_remote()),
+    );
+    let (_view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    cx.update(|window, _| window.focus_next());
+    cx.simulate_keystrokes("enter");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    cx.simulate_keystrokes("space");
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+
+    cx.update(|window, _| window.focus_next());
+    cx.simulate_keystrokes("enter");
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 0);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+
+    cx.simulate_keystrokes("space");
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+        is_held: true,
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 1);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+    });
+    assert_eq!(picker_calls.load(Ordering::SeqCst), 2);
+}
+
+#[gpui::test]
+fn keyboard_stack_row_activates_once_for_enter_and_space(cx: &mut TestAppContext) {
+    cx.update(super::init);
+    let services = services(
+        Ok(snapshot("/repo")),
+        Ok(None),
+        Arc::new(FixtureRecents::default()),
+    );
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        AppView::new(Some(PathBuf::from("/repo")), services, window, cx)
+    });
+    cx.run_until_parked();
+    let initial_generation =
+        cx.update(|_, app| view.read(app).workspace().unwrap().state().generation());
+
+    cx.update(|window, _| {
+        window.focus_next();
+        window.focus_next();
+        window.focus_next();
+    });
+    cx.simulate_keystrokes("enter");
+    let generation = cx.update(|_, app| view.read(app).workspace().unwrap().state().generation());
+    assert_eq!(generation, initial_generation);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+        is_held: true,
+    });
+    let generation = cx.update(|_, app| view.read(app).workspace().unwrap().state().generation());
+    assert_eq!(generation, initial_generation);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("enter").unwrap(),
+    });
+    let (selection, generation) = cx.update(|_, app| {
+        let state = view.read(app).workspace().unwrap().state();
+        (
+            state.selected_branch().map(str::to_string),
+            state.generation(),
+        )
+    });
+    assert_eq!(selection.as_deref(), Some("feature-b"));
+    assert_eq!(generation, initial_generation + 2);
+
+    cx.simulate_keystrokes("space");
+    let generation = cx.update(|_, app| view.read(app).workspace().unwrap().state().generation());
+    assert_eq!(generation, initial_generation + 2);
+    cx.simulate_event(KeyDownEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+        is_held: true,
+    });
+    let generation = cx.update(|_, app| view.read(app).workspace().unwrap().state().generation());
+    assert_eq!(generation, initial_generation + 2);
+    cx.simulate_event(KeyUpEvent {
+        keystroke: Keystroke::parse("space").unwrap(),
+    });
+    let generation = cx.update(|_, app| view.read(app).workspace().unwrap().state().generation());
+    assert_eq!(generation, initial_generation + 4);
+}
+
+#[gpui::test]
 fn stale_root_repository_results_are_rejected(cx: &mut TestAppContext) {
     let recents = Arc::new(FixtureRecents::default());
     let services = services(Ok(snapshot("/repo")), Ok(None), recents);
@@ -840,7 +1216,7 @@ fn repeated_refresh_requests_spawn_only_one_snapshot_read(cx: &mut TestAppContex
         Arc::new(CountingLoader {
             calls: Arc::clone(&calls),
         }),
-        Rc::new(FixturePicker { result: Ok(None) }),
+        Rc::new(FixturePicker::new(Ok(None))),
         Arc::new(FixtureRecents::default()),
         Arc::new(FixtureHydration::immediate_no_remote()),
     );

--- a/crates/stax-gui/src/views/welcome.rs
+++ b/crates/stax-gui/src/views/welcome.rs
@@ -1,0 +1,271 @@
+use super::{AppView, ControlKind, control_button};
+use crate::theme::{SYSTEM_UI_FONT, Theme};
+use gpui::{
+    Context, Div, InteractiveElement as _, ParentElement as _, Stateful,
+    StatefulInteractiveElement as _, Styled as _, div, px,
+};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct WelcomeView {
+    recent_repositories: Vec<PathBuf>,
+    error: Option<String>,
+    opening: Option<PathBuf>,
+    recent_loading: bool,
+}
+
+impl WelcomeView {
+    pub fn new(
+        recent_repositories: Vec<PathBuf>,
+        error: Option<String>,
+        opening: Option<PathBuf>,
+        recent_loading: bool,
+    ) -> Self {
+        Self {
+            recent_repositories,
+            error,
+            opening,
+            recent_loading,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    pub fn set_error(&mut self, error: String) {
+        self.error = Some(error);
+    }
+
+    pub fn opening_path(&self) -> Option<&Path> {
+        self.opening.as_deref()
+    }
+
+    pub fn render(&self, theme: Theme, cx: &mut Context<AppView>) -> Div {
+        let open_button = control_button(
+            "welcome-open-repository",
+            "Open Repository",
+            ControlKind::Primary,
+            true,
+            theme,
+        )
+        .on_click(cx.listener(|app, _, window, cx| {
+            app.pick_repository(window, cx);
+        }));
+
+        let mut content = div()
+            .w(px(620.0))
+            .max_w_full()
+            .flex()
+            .flex_col()
+            .gap_4()
+            .p_8()
+            .rounded_lg()
+            .border_1()
+            .border_color(theme.border)
+            .bg(theme.surface_raised)
+            .child(
+                div()
+                    .flex()
+                    .items_end()
+                    .justify_between()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .text_2xl()
+                                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                                    .child("Stax"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(theme.text_muted)
+                                    .child("A native, read-only view of your stacked branches."),
+                            ),
+                    )
+                    .child(open_button),
+            );
+
+        if let Some(path) = &self.opening {
+            content = content.child(
+                div()
+                    .px_3()
+                    .py_2()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(theme.accent)
+                    .bg(theme.surface_selected)
+                    .text_sm()
+                    .child(format!("Opening {}…", path.display())),
+            );
+        }
+
+        if let Some(error) = &self.error {
+            content = content.child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .px_3()
+                    .py_2()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(theme.danger)
+                    .text_sm()
+                    .child(
+                        div()
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_color(theme.danger)
+                            .child("Repository could not be opened"),
+                    )
+                    .child(error.clone())
+                    .child(
+                        div()
+                            .text_color(theme.text_muted)
+                            .child("Choose Open Repository or select another recent repository."),
+                    ),
+            );
+        }
+
+        content = content.child(
+            div()
+                .pt_2()
+                .text_xs()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(theme.text_muted)
+                .child("RECENT REPOSITORIES"),
+        );
+
+        if self.recent_loading {
+            content = content.child(
+                div()
+                    .debug_selector(|| "recent-repositories-loading".into())
+                    .px_3()
+                    .py_4()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(theme.border)
+                    .text_sm()
+                    .text_color(theme.text_muted)
+                    .child("Loading recent repositories…"),
+            );
+        } else if self.recent_repositories.is_empty() {
+            content = content.child(
+                div()
+                    .px_3()
+                    .py_4()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(theme.border)
+                    .text_sm()
+                    .text_color(theme.text_muted)
+                    .child("No recent repositories yet."),
+            );
+        } else {
+            content = content.children(
+                self.recent_repositories
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(index, path)| recent_repository_row(index, path, theme, cx)),
+            );
+        }
+
+        div()
+            .debug_selector(|| "stax-welcome".into())
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .p_6()
+            .font_family(SYSTEM_UI_FONT)
+            .bg(theme.window)
+            .text_color(theme.text)
+            .child(content)
+    }
+}
+
+fn recent_repository_row(
+    index: usize,
+    path: PathBuf,
+    theme: Theme,
+    cx: &mut Context<AppView>,
+) -> Stateful<Div> {
+    let name = repository_name(&path);
+    let display_path = path.display().to_string();
+    let open_path = path.clone();
+
+    div()
+        .id(("recent-repository", index))
+        .focusable()
+        .tab_index(index as isize + 1)
+        .focus(move |style| style.border_color(theme.focus).bg(theme.surface_selected))
+        .w_full()
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap_3()
+        .px_3()
+        .py_2()
+        .rounded_md()
+        .border_1()
+        .border_color(theme.border)
+        .bg(theme.surface)
+        .cursor_pointer()
+        .hover(move |style| style.bg(theme.surface_selected))
+        .child(
+            div()
+                .min_w_0()
+                .flex()
+                .flex_col()
+                .gap_0p5()
+                .child(
+                    div()
+                        .truncate()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::MEDIUM)
+                        .child(name),
+                )
+                .child(
+                    div()
+                        .truncate()
+                        .text_xs()
+                        .text_color(theme.text_muted)
+                        .child(display_path),
+                ),
+        )
+        .child(
+            div()
+                .flex_none()
+                .text_xs()
+                .text_color(theme.accent)
+                .child("Open"),
+        )
+        .on_click(cx.listener(move |app, _, window, cx| {
+            app.open_repository(open_path.clone(), window, cx);
+        }))
+}
+
+fn repository_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("Repository")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::repository_name;
+    use std::path::Path;
+
+    #[test]
+    fn recent_repository_name_uses_the_path_basename() {
+        assert_eq!(repository_name(Path::new("/tmp/stax")), "stax");
+    }
+}

--- a/crates/stax-gui/src/views/welcome.rs
+++ b/crates/stax-gui/src/views/welcome.rs
@@ -1,4 +1,4 @@
-use super::{AppView, ControlKind, control_button};
+use super::{AppView, ControlKind, activate_control, control_button, control_focus_style};
 use crate::theme::{SYSTEM_UI_FONT, Theme};
 use gpui::{
     Context, Div, InteractiveElement as _, ParentElement as _, Stateful,
@@ -43,16 +43,18 @@ impl WelcomeView {
     }
 
     pub fn render(&self, theme: Theme, cx: &mut Context<AppView>) -> Div {
-        let open_button = control_button(
-            "welcome-open-repository",
-            "Open Repository",
-            ControlKind::Primary,
-            true,
-            theme,
-        )
-        .on_click(cx.listener(|app, _, window, cx| {
-            app.pick_repository(window, cx);
-        }));
+        let open_button = activate_control(
+            control_button(
+                "welcome-open-repository",
+                "Open Repository",
+                ControlKind::Primary,
+                true,
+                theme,
+            )
+            .debug_selector(|| "welcome-open-repository-control".into()),
+            cx,
+            |app, window, cx| app.pick_repository(window, cx),
+        );
 
         let mut content = div()
             .w(px(620.0))
@@ -200,11 +202,12 @@ fn recent_repository_row(
     let display_path = path.display().to_string();
     let open_path = path.clone();
 
-    div()
+    let row = div()
         .id(("recent-repository", index))
+        .debug_selector(move || format!("recent-repository-control-{index}"))
         .focusable()
         .tab_index(index as isize + 1)
-        .focus(move |style| style.border_color(theme.focus).bg(theme.surface_selected))
+        .focus(move |style| control_focus_style(style, theme).bg(theme.surface_selected))
         .w_full()
         .flex()
         .items_center()
@@ -245,10 +248,11 @@ fn recent_repository_row(
                 .text_xs()
                 .text_color(theme.accent)
                 .child("Open"),
-        )
-        .on_click(cx.listener(move |app, _, window, cx| {
-            app.open_repository(open_path.clone(), window, cx);
-        }))
+        );
+
+    activate_control(row, cx, move |app, window, cx| {
+        app.open_repository(open_path.clone(), window, cx);
+    })
 }
 
 fn repository_name(path: &Path) -> String {

--- a/crates/stax-gui/src/views/workspace.rs
+++ b/crates/stax-gui/src/views/workspace.rs
@@ -1,11 +1,14 @@
 #[cfg(test)]
 use super::PaneMarkers;
-use super::{AppView, ControlKind, changes_pane, control_button, inspector_pane, stack_pane};
+use super::{
+    AppView, ControlKind, activate_control, changes_pane, control_button, inspector_pane,
+    stack_pane,
+};
 use crate::state::{SelectionDirection, WorkspaceState};
 use crate::theme::{SYSTEM_UI_FONT, Theme};
 use gpui::{
-    Context, Div, InteractiveElement as _, ParentElement as _, ScrollStrategy,
-    StatefulInteractiveElement as _, Styled as _, UniformListScrollHandle, div, px, relative,
+    Context, Div, InteractiveElement as _, ParentElement as _, ScrollStrategy, Styled as _,
+    UniformListScrollHandle, div, px, relative,
 };
 use stax::application::{
     BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, RepositorySnapshot,
@@ -205,23 +208,24 @@ impl WorkspaceView {
             theme,
         );
         let refresh = if refresh_enabled {
-            refresh.on_click(cx.listener(|app, _, window, cx| {
+            activate_control(refresh, cx, |app, window, cx| {
                 app.refresh_repository(window, cx);
-            }))
+            })
         } else {
             refresh
         };
 
-        let open = control_button(
-            "toolbar-open",
-            "Open Repository",
-            ControlKind::Secondary,
-            true,
-            theme,
-        )
-        .on_click(cx.listener(|app, _, window, cx| {
-            app.pick_repository(window, cx);
-        }));
+        let open = activate_control(
+            control_button(
+                "toolbar-open",
+                "Open Repository",
+                ControlKind::Secondary,
+                true,
+                theme,
+            ),
+            cx,
+            |app, window, cx| app.pick_repository(window, cx),
+        );
 
         let disabled_action = control_button(
             "toolbar-submit-stack",

--- a/crates/stax-gui/src/views/workspace.rs
+++ b/crates/stax-gui/src/views/workspace.rs
@@ -1,0 +1,412 @@
+#[cfg(test)]
+use super::PaneMarkers;
+use super::{AppView, ControlKind, changes_pane, control_button, inspector_pane, stack_pane};
+use crate::state::{SelectionDirection, WorkspaceState};
+use crate::theme::{SYSTEM_UI_FONT, Theme};
+use gpui::{
+    Context, Div, InteractiveElement as _, ParentElement as _, ScrollStrategy,
+    StatefulInteractiveElement as _, Styled as _, UniformListScrollHandle, div, px, relative,
+};
+use stax::application::RepositorySnapshot;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshState {
+    Idle,
+    Loading,
+    Failed(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceView {
+    state: WorkspaceState,
+    refresh: RefreshState,
+    notice: Option<String>,
+    storage_notice: Option<String>,
+    stack_scroll_handle: UniformListScrollHandle,
+    stack_scroll_target: Option<usize>,
+}
+
+impl WorkspaceView {
+    pub fn from_snapshot(snapshot: RepositorySnapshot) -> Self {
+        let mut workspace = Self {
+            state: WorkspaceState::new(snapshot),
+            refresh: RefreshState::Idle,
+            notice: None,
+            storage_notice: None,
+            stack_scroll_handle: UniformListScrollHandle::new(),
+            stack_scroll_target: None,
+        };
+        workspace.scroll_selection_into_view();
+        workspace
+    }
+
+    pub fn state(&self) -> &WorkspaceState {
+        &self.state
+    }
+
+    #[cfg(test)]
+    pub fn pane_markers(&self) -> PaneMarkers {
+        PaneMarkers::all()
+    }
+
+    pub fn select_branch(&mut self, name: &str) -> bool {
+        let selected = self.state.select_branch(name).is_some();
+        if selected {
+            self.scroll_selection_into_view();
+        }
+        selected
+    }
+
+    pub fn move_selection(&mut self, direction: SelectionDirection) -> bool {
+        let moved = self.state.move_selection(direction);
+        if moved {
+            self.scroll_selection_into_view();
+        }
+        moved
+    }
+
+    pub fn begin_refresh(&mut self) {
+        self.refresh = RefreshState::Loading;
+        self.notice = None;
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: RepositorySnapshot) {
+        self.state.replace_snapshot(snapshot);
+        self.scroll_selection_into_view();
+        self.refresh = RefreshState::Idle;
+        self.notice = None;
+    }
+
+    pub fn fail_refresh(&mut self, error: String) {
+        self.refresh = RefreshState::Failed(error);
+    }
+
+    pub fn set_notice(&mut self, notice: String) {
+        self.notice = Some(notice);
+    }
+
+    pub fn set_storage_notice(&mut self, notice: Option<String>) {
+        self.storage_notice = notice;
+    }
+
+    pub fn refresh_is_loading(&self) -> bool {
+        self.refresh == RefreshState::Loading
+    }
+
+    pub fn stack_scroll_handle(&self) -> &UniformListScrollHandle {
+        &self.stack_scroll_handle
+    }
+
+    #[cfg(test)]
+    pub fn stack_scroll_target(&self) -> Option<usize> {
+        self.stack_scroll_target
+    }
+
+    pub fn inline_error(&self) -> Option<&str> {
+        let refresh_error = match &self.refresh {
+            RefreshState::Failed(error) => Some(error.as_str()),
+            RefreshState::Idle | RefreshState::Loading => None,
+        };
+        refresh_error
+            .or(self.notice.as_deref())
+            .or(self.storage_notice.as_deref())
+    }
+
+    pub fn render(&self, theme: Theme, cx: &mut Context<AppView>) -> Div {
+        div()
+            .debug_selector(|| "stax-workspace".into())
+            .size_full()
+            .min_w_0()
+            .flex()
+            .flex_col()
+            .font_family(SYSTEM_UI_FONT)
+            .bg(theme.window)
+            .text_color(theme.text)
+            .child(self.render_toolbar(theme, cx))
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .min_h_0()
+                    .min_w_0()
+                    .child(
+                        stack_pane::render(self, theme, cx)
+                            .w(relative(0.29))
+                            .flex_none(),
+                    )
+                    .child(
+                        changes_pane::render(self, theme, cx)
+                            .w(relative(0.43))
+                            .flex_none(),
+                    )
+                    .child(
+                        inspector_pane::render(self, theme, cx)
+                            .w(relative(0.28))
+                            .flex_none(),
+                    ),
+            )
+    }
+
+    fn render_toolbar(&self, theme: Theme, cx: &mut Context<AppView>) -> Div {
+        let snapshot = self.state.snapshot();
+        let repository_name = repository_name(&snapshot.repository_root);
+        let refresh_label = match &self.refresh {
+            RefreshState::Idle => "Refresh Repository",
+            RefreshState::Loading => "Refreshing…",
+            RefreshState::Failed(_) => "Retry Refresh",
+        };
+        let refresh_enabled = self.refresh != RefreshState::Loading;
+
+        let refresh = control_button(
+            "toolbar-refresh",
+            refresh_label,
+            ControlKind::Secondary,
+            refresh_enabled,
+            theme,
+        );
+        let refresh = if refresh_enabled {
+            refresh.on_click(cx.listener(|app, _, window, cx| {
+                app.refresh_repository(window, cx);
+            }))
+        } else {
+            refresh
+        };
+
+        let open = control_button(
+            "toolbar-open",
+            "Open Repository",
+            ControlKind::Secondary,
+            true,
+            theme,
+        )
+        .on_click(cx.listener(|app, _, window, cx| {
+            app.pick_repository(window, cx);
+        }));
+
+        let disabled_action = control_button(
+            "toolbar-submit-stack",
+            "Submit Stack — Phase 2",
+            ControlKind::Secondary,
+            false,
+            theme,
+        );
+
+        let mut toolbar = div()
+            .h(px(58.0))
+            .flex_none()
+            .flex()
+            .items_center()
+            .justify_between()
+            .gap_3()
+            .px_4()
+            .border_b_1()
+            .border_color(theme.border)
+            .bg(theme.surface_raised)
+            .child(
+                div()
+                    .min_w_0()
+                    .flex()
+                    .items_center()
+                    .gap_3()
+                    .child(
+                        div()
+                            .min_w_0()
+                            .flex()
+                            .flex_col()
+                            .child(
+                                div()
+                                    .truncate()
+                                    .text_sm()
+                                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                                    .child(repository_name),
+                            )
+                            .child(
+                                div()
+                                    .truncate()
+                                    .text_xs()
+                                    .text_color(theme.text_muted)
+                                    .child(snapshot.repository_root.display().to_string()),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .px_2()
+                            .py_1()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(theme.border)
+                            .bg(theme.surface)
+                            .text_xs()
+                            .child(format!("Current branch: {}", snapshot.current_branch)),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .px_2()
+                            .py_1()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(theme.accent)
+                            .bg(theme.surface_selected)
+                            .text_xs()
+                            .text_color(theme.accent)
+                            .child("Read-only · Phase 1"),
+                    ),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(disabled_action)
+                    .child(refresh)
+                    .child(open),
+            );
+
+        if let Some(error) = self.inline_error() {
+            toolbar = toolbar.child(
+                div()
+                    .max_w(px(300.0))
+                    .truncate()
+                    .text_xs()
+                    .text_color(theme.danger)
+                    .child(format!("Action needed: {error}")),
+            );
+        }
+
+        toolbar
+    }
+
+    fn scroll_selection_into_view(&mut self) {
+        let Some(selected) = self.state.selected_branch() else {
+            return;
+        };
+        let Some(index) = self
+            .state
+            .snapshot()
+            .branches
+            .iter()
+            .position(|branch| branch.name == selected)
+        else {
+            return;
+        };
+
+        self.stack_scroll_target = Some(index);
+        self.stack_scroll_handle
+            .scroll_to_item(index, ScrollStrategy::Center);
+    }
+}
+
+fn repository_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("Repository")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RefreshState, WorkspaceView};
+    use stax::application::{BranchSummary, RepositorySnapshot};
+    use std::path::PathBuf;
+
+    fn empty_snapshot() -> RepositorySnapshot {
+        RepositorySnapshot {
+            repository_root: PathBuf::from("/repo"),
+            current_branch: "main".into(),
+            trunk: "main".into(),
+            branches: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn refresh_failure_is_actionable_without_replacing_workspace_state() {
+        let mut workspace = WorkspaceView::from_snapshot(empty_snapshot());
+        workspace.begin_refresh();
+        assert_eq!(workspace.refresh, RefreshState::Loading);
+
+        workspace.fail_refresh("repository is temporarily unavailable".into());
+
+        assert_eq!(
+            workspace.inline_error(),
+            Some("repository is temporarily unavailable")
+        );
+        assert_eq!(
+            workspace.state().snapshot().repository_root,
+            PathBuf::from("/repo")
+        );
+    }
+
+    #[test]
+    fn selecting_a_branch_beyond_the_viewport_requests_stack_scrolling() {
+        let mut snapshot = empty_snapshot();
+        snapshot.branches = (0..100)
+            .map(|index| BranchSummary {
+                name: format!("branch-{index:03}"),
+                parent: (index > 0).then(|| format!("branch-{:03}", index - 1)),
+                column: index,
+                is_current: index == 0,
+                is_trunk: index == 0,
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                ci_state: None,
+            })
+            .collect();
+        snapshot.current_branch = "branch-000".into();
+        let mut workspace = WorkspaceView::from_snapshot(snapshot);
+
+        assert!(workspace.select_branch("branch-080"));
+
+        assert_eq!(workspace.stack_scroll_target(), Some(80));
+        assert_eq!(
+            workspace.stack_scroll_handle().logical_scroll_top_index(),
+            80
+        );
+    }
+
+    #[test]
+    fn initial_current_branch_is_requested_visible_in_a_long_stack() {
+        let mut snapshot = empty_snapshot();
+        snapshot.branches = (0..100)
+            .map(|index| BranchSummary {
+                name: format!("branch-{index:03}"),
+                parent: (index > 0).then(|| format!("branch-{:03}", index - 1)),
+                column: index,
+                is_current: index == 80,
+                is_trunk: index == 0,
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                ci_state: None,
+            })
+            .collect();
+        snapshot.current_branch = "branch-080".into();
+
+        let workspace = WorkspaceView::from_snapshot(snapshot);
+
+        assert_eq!(workspace.stack_scroll_target(), Some(80));
+        assert_eq!(
+            workspace.stack_scroll_handle().logical_scroll_top_index(),
+            80
+        );
+    }
+
+    #[test]
+    fn refresh_failure_takes_precedence_over_older_storage_notice() {
+        let mut workspace = WorkspaceView::from_snapshot(empty_snapshot());
+        workspace.set_storage_notice(Some("recent repository write failed earlier".into()));
+        workspace.begin_refresh();
+
+        workspace.fail_refresh("latest refresh could not read the repository".into());
+
+        assert_eq!(
+            workspace.inline_error(),
+            Some("latest refresh could not read the repository")
+        );
+    }
+}

--- a/crates/stax-gui/src/views/workspace.rs
+++ b/crates/stax-gui/src/views/workspace.rs
@@ -7,7 +7,9 @@ use gpui::{
     Context, Div, InteractiveElement as _, ParentElement as _, ScrollStrategy,
     StatefulInteractiveElement as _, Styled as _, UniformListScrollHandle, div, px, relative,
 };
-use stax::application::RepositorySnapshot;
+use stax::application::{
+    BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, RepositorySnapshot,
+};
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,6 +68,42 @@ impl WorkspaceView {
         moved
     }
 
+    pub(super) fn begin_hydration(&mut self) -> Option<(DetailRequestToken, BranchSummary)> {
+        self.state.begin_hydration()
+    }
+
+    pub(super) fn apply_details(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<BranchDetails, String>,
+    ) -> bool {
+        self.state.apply_details(token, result)
+    }
+
+    pub(super) fn apply_cached_diff(
+        &mut self,
+        token: DetailRequestToken,
+        diff: BranchDiff,
+    ) -> bool {
+        self.state.apply_cached_diff(token, diff)
+    }
+
+    pub(super) fn apply_diff(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<BranchDiff, String>,
+    ) -> bool {
+        self.state.apply_diff(token, result)
+    }
+
+    pub(super) fn apply_ci(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<CiSummary, String>,
+    ) -> bool {
+        self.state.apply_ci(token, result)
+    }
+
     pub fn begin_refresh(&mut self) {
         self.refresh = RefreshState::Loading;
         self.notice = None;
@@ -108,8 +146,9 @@ impl WorkspaceView {
             RefreshState::Failed(error) => Some(error.as_str()),
             RefreshState::Idle | RefreshState::Loading => None,
         };
-        refresh_error
-            .or(self.notice.as_deref())
+        self.notice
+            .as_deref()
+            .or(refresh_error)
             .or(self.storage_notice.as_deref())
     }
 
@@ -408,5 +447,26 @@ mod tests {
             workspace.inline_error(),
             Some("latest refresh could not read the repository")
         );
+    }
+
+    #[test]
+    fn latest_action_notice_takes_precedence_over_an_older_refresh_failure() {
+        let mut workspace = WorkspaceView::from_snapshot(empty_snapshot());
+        workspace.begin_refresh();
+        workspace.fail_refresh("older refresh failure".into());
+
+        workspace.set_notice("latest picker failure".into());
+
+        assert_eq!(workspace.inline_error(), Some("latest picker failure"));
+    }
+
+    #[test]
+    fn beginning_a_refresh_clears_the_previous_action_notice() {
+        let mut workspace = WorkspaceView::from_snapshot(empty_snapshot());
+        workspace.set_notice("old picker failure".into());
+
+        workspace.begin_refresh();
+
+        assert_eq!(workspace.inline_error(), None);
     }
 }

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -235,6 +235,21 @@ Accepted values: `"github"`, `"gitlab"`, `"gitea"`, `"forgejo"` (Forgejo is trea
 
 Auto-detection fallback: hostnames containing `gitlab` → GitLab, `gitea`/`forgejo` → Gitea, otherwise → GitHub.
 
+### Automatic CI hydration trust
+
+The TUI and desktop app may refresh CI automatically after opening a repository.
+For those credential-bearing requests, repository-local `stax.toml` may select
+only `remote.name`. The following values are accepted only from global
+`~/.config/stax/config.toml`: `remote.base_url`, `remote.api_base_url`,
+`remote.forge`, and all `[auth]` settings.
+
+GitHub.com, GitLab.com, and Gitea.com use built-in trusted API mappings.
+Self-hosted or enterprise remotes must set a matching global
+`remote.base_url`; if the API uses a different hostname, set the relationship
+explicitly with global `remote.api_base_url`. For GitHub Enterprise,
+`auth.gh_hostname` must match the Git remote hostname. Automatic hydration
+rejects mismatches before looking up a token or making a request.
+
 ## Auth tokens by forge
 
 | Forge | Auth sources (checked in order) |

--- a/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+++ b/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
@@ -17,6 +17,8 @@
 ### Root library
 
 - Modify `Cargo.toml` — workspace metadata and shared package fields.
+- Modify `Cargo.lock` — lock the GUI package and GPUI dependency graph.
+- Modify `.github/workflows/rust-tests.yml` — compile and lint the GUI on macOS.
 - Modify `src/lib.rs` — expose the new application module.
 - Create `src/application/mod.rs` — public module boundary and re-exports.
 - Create `src/application/model.rs` — UI-neutral snapshots, details, diff, CI, and request tokens.
@@ -47,6 +49,8 @@
 
 **Files:**
 - Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `.github/workflows/rust-tests.yml`
 - Create: `crates/stax-gui/Cargo.toml`
 - Create: `crates/stax-gui/src/main.rs`
 - Create: `crates/stax-gui/src/lib.rs`
@@ -109,6 +113,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Native macOS desktop app for stax"
+publish = false
 
 [[bin]]
 name = "stax-gui"
@@ -195,22 +200,124 @@ pub fn open_initial_window(repository: Option<PathBuf>, cx: &mut App) {
 }
 ```
 
-- [ ] **Step 5: Verify workspace isolation**
+- [ ] **Step 5: Extend the tracked workspace lockfile minimally**
+
+Keep the existing tracked `Cargo.lock`; do not delete or regenerate it. Run the
+GUI check once without `--locked` so Cargo resolves only packages missing from
+the new workspace member:
+
+```bash
+cargo check -p stax-gui
+git diff -- Cargo.lock
+```
+
+Expected: Cargo preserves existing compatible package selections and adds
+`stax-gui`, GPUI 0.2.2, and the GUI's missing transitive graph. Review any
+existing-package version change individually. GPUI 0.2.2 requires
+`core-foundation =0.10.0` on macOS, so replacing the previously locked 0.10.1
+with 0.10.0 is the one expected constrained change. Step 7 then proves the
+result is complete with `--locked`.
+
+- [ ] **Step 6: Add a macOS GUI compile gate**
+
+Add a separate job to `.github/workflows/rust-tests.yml` using the repository's
+existing checkout, Rust 1.96.1, and `Swatinem/rust-cache` conventions. Override
+the Linux-only mold linker flags for this job. Because Clippy also lints the
+local `stax` path dependency, mirror the reviewed legacy allowances from
+`scripts/lint.sh` while keeping every other warning fatal:
+
+```yaml
+  gui-quality:
+    name: GPUI Compile and Clippy
+    runs-on: macos-latest
+    env:
+      RUSTFLAGS: ""
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.1
+          components: clippy
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: macos-latest-gui
+      - name: Check GPUI package
+        run: cargo check -p stax-gui --locked
+      - name: Lint GPUI package
+        # Clippy also lints the local stax path dependency. Mirror the reviewed
+        # legacy allowances from scripts/lint.sh while keeping other warnings fatal.
+        run: |
+          cargo clippy -p stax-gui --all-targets --locked -- \
+            -D warnings \
+            -A clippy::assertions_on_constants \
+            -A clippy::bool_assert_comparison \
+            -A clippy::clone_on_copy \
+            -A clippy::collapsible_if \
+            -A clippy::collapsible_match \
+            -A clippy::double_comparisons \
+            -A clippy::if_same_then_else \
+            -A clippy::items_after_test_module \
+            -A clippy::len_zero \
+            -A clippy::let_and_return \
+            -A clippy::manual_checked_ops \
+            -A clippy::needless_borrow \
+            -A clippy::needless_lifetimes \
+            -A clippy::too_many_arguments \
+            -A clippy::to_string_in_format_args \
+            -A clippy::type_complexity \
+            -A clippy::unnecessary_map_or \
+            -A clippy::unnecessary_sort_by \
+            -A clippy::useless_format \
+            -A clippy::useless_vec
+```
+
+Keep the existing Linux quality and test jobs unchanged.
+
+- [ ] **Step 7: Verify workspace isolation**
 
 Run:
 
 ```bash
-cargo metadata --no-deps --format-version 1
-cargo check
-cargo check -p stax-gui
+lock_before="$(git hash-object Cargo.lock)"
+cargo metadata --no-deps --format-version 1 --locked
+cargo check --locked
+cargo check -p stax-gui --locked
+cargo clippy -p stax-gui --all-targets --locked -- \
+  -D warnings \
+  -A clippy::assertions_on_constants \
+  -A clippy::bool_assert_comparison \
+  -A clippy::clone_on_copy \
+  -A clippy::collapsible_if \
+  -A clippy::collapsible_match \
+  -A clippy::double_comparisons \
+  -A clippy::if_same_then_else \
+  -A clippy::items_after_test_module \
+  -A clippy::len_zero \
+  -A clippy::let_and_return \
+  -A clippy::manual_checked_ops \
+  -A clippy::needless_borrow \
+  -A clippy::needless_lifetimes \
+  -A clippy::too_many_arguments \
+  -A clippy::to_string_in_format_args \
+  -A clippy::type_complexity \
+  -A clippy::unnecessary_map_or \
+  -A clippy::unnecessary_sort_by \
+  -A clippy::useless_format \
+  -A clippy::useless_vec
+test "$lock_before" = "$(git hash-object Cargo.lock)"
 ```
 
-Expected: metadata lists `stax` and `stax-gui`; default `cargo check` checks the root package; explicit GUI check passes.
+Expected: metadata lists `stax` and `stax-gui`; default `cargo check` checks the
+root package; explicit GUI check and clippy pass; none of the commands change
+the tracked lockfile.
 
-- [ ] **Step 6: Commit the scaffold**
+- [ ] **Step 8: Commit the scaffold**
 
 ```bash
-git add Cargo.toml crates/stax-gui
+git add Cargo.toml Cargo.lock .github/workflows/rust-tests.yml crates/stax-gui
 git commit -m "feat: scaffold the GPUI desktop app"
 ```
 
@@ -1029,8 +1136,29 @@ Run:
 ```bash
 cargo fmt --all
 cargo fmt --all -- --check
-cargo clippy -p stax-gui --all-targets -- -D warnings
-cargo clippy -p stax --lib --bins -- -D warnings
+make lint
+cargo clippy -p stax-gui --all-targets --locked -- \
+  -D warnings \
+  -A clippy::assertions_on_constants \
+  -A clippy::bool_assert_comparison \
+  -A clippy::clone_on_copy \
+  -A clippy::collapsible_if \
+  -A clippy::collapsible_match \
+  -A clippy::double_comparisons \
+  -A clippy::if_same_then_else \
+  -A clippy::items_after_test_module \
+  -A clippy::len_zero \
+  -A clippy::let_and_return \
+  -A clippy::manual_checked_ops \
+  -A clippy::needless_borrow \
+  -A clippy::needless_lifetimes \
+  -A clippy::too_many_arguments \
+  -A clippy::to_string_in_format_args \
+  -A clippy::type_complexity \
+  -A clippy::unnecessary_map_or \
+  -A clippy::unnecessary_sort_by \
+  -A clippy::useless_format \
+  -A clippy::useless_vec
 ```
 
 Expected: all commands pass.
@@ -1078,8 +1206,8 @@ Verify:
 If formatting or verification changed tracked files, commit only those fixes:
 
 ```bash
-git add Cargo.toml src/application src/tui/app.rs tests \
-  crates/stax-gui
+git add Cargo.toml Cargo.lock .github/workflows/rust-tests.yml \
+  src/application src/tui/app.rs tests crates/stax-gui
 git commit -m "fix: harden the GPUI read-only cockpit"
 ```
 

--- a/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+++ b/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
@@ -949,7 +949,9 @@ git commit -m "fix: harden GUI state persistence"
 
 **Files:**
 - Create: `crates/stax-gui/src/theme.rs`
-- Create: `crates/stax-gui/src/views/mod.rs`
+- Create: `crates/stax-gui/src/views/mod.rs` (focused module exports and window entry)
+- Create: `crates/stax-gui/src/views/app.rs` (root mode, services, generations, and async coordination)
+- Create: `crates/stax-gui/src/views/tests.rs` (GPUI root behavior and hardening tests)
 - Create: `crates/stax-gui/src/views/welcome.rs`
 - Create: `crates/stax-gui/src/views/workspace.rs`
 - Create: `crates/stax-gui/src/views/stack_pane.rs`
@@ -976,6 +978,13 @@ fn workspace_window_renders_all_three_panes(mut cx: &mut gpui::TestAppContext) {
 ```
 
 Also expose test-only pane markers from `WorkspaceView` and assert stack, changes, and inspector are all present.
+
+Cover the hardened coordination seams as well: independent root-load, recent-load, and
+recent-write generations; delayed recent-write completion after refresh; stale/new recent-write
+ordering; repeated refresh gating; long-stack scroll requests; bounded large diffstats; background
+recent-load success/failure; numerical WCAG AA contrast on normal and selected row surfaces; a
+deterministic blocking-store FIFO persistence case; initial current-branch visibility in a
+100-branch stack; and refresh-error precedence over older storage notices.
 
 - [ ] **Step 2: Run and verify failure**
 
@@ -1019,6 +1028,8 @@ Provide `Theme::light()` and `Theme::dark()`. Views consume only semantic fields
 - `WelcomeView` with a visible actionable error when path validation fails.
 
 Use `WindowOptions` with 1100×720 centered bounds and a minimum size of 820×520.
+Return the GPUI window-open error instead of panicking. The application bootstrap logs startup
+failure and asks GPUI to quit through its normal platform routine.
 
 - [ ] **Step 5: Implement the welcome view**
 
@@ -1034,6 +1045,14 @@ let receiver = cx.prompt_for_paths(PathPromptOptions {
 ```
 
 Await the receiver in a detached GPUI task, record a successful selection, and replace the welcome window root with `WorkspaceView`. Cancellation leaves the welcome view unchanged; picker errors render inline.
+
+Load and canonicalize recent repositories on GPUI's background executor so the welcome window can
+paint a stable loading state first. Apply results on the foreground entity with a dedicated recent
+load generation. Persist successful opens with a separate recent-write generation: root refreshes
+must not suppress write completion, while newer writes may supersede older error presentation.
+Queue accepted recent writes per `AppView` and run only one background `record` at a time so lock
+acquisition cannot invert acceptance order. Completing A starts queued B, leaving the newer B first
+on disk without blocking the UI thread.
 
 - [ ] **Step 6: Implement the cockpit**
 
@@ -1060,13 +1079,22 @@ Use `uniform_list` for branches and patch lines. The stack pane shows topology i
 
 Clicking a branch selects it without checkout.
 
+Retain a `UniformListScrollHandle` in `WorkspaceView` and request scrolling after click or keyboard
+selection changes, including construction so the initial/current branch is visible in long stacks.
+Gate `refresh_repository` itself while a refresh is loading so toolbar, Cmd-R, and repeated callers
+share the same concurrency rule. An active refresh failure takes precedence over older storage
+notices in the toolbar. Render diffstat files in a bounded
+`uniform_list` (six visible rows) so the patch keeps its flex space even for hundreds of files.
+Status colors for small text must meet WCAG AA 4.5:1 against both normal and selected semantic
+surfaces in light and dark appearances.
+
 - [ ] **Step 7: Run GPUI tests and compile the app**
 
 Run:
 
 ```bash
 cargo nextest run -p stax-gui views::
-cargo check -p stax-gui
+cargo check -p stax-gui --locked
 ```
 
 Expected: tests and check pass.

--- a/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+++ b/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
@@ -24,9 +24,14 @@
 - Create `src/application/model.rs` — UI-neutral snapshots, details, diff, CI, and request tokens.
 - Create `src/application/repository.rs` — path validation, local snapshots, branch details, and diff loading/cache.
 - Create `src/application/ci.rs` — provider-neutral CI loading and summary calculation.
+- Modify `src/config/mod.rs` — add the network-safe automatic hydration config path.
+- Modify `src/remote.rs` — validate Git host, forge, and API trust before credential lookup.
+- Modify `src/forge/mod.rs` and `src/github/client.rs` — build automatic clients only from validated remotes and host-bound auth.
+- Modify `src/cache.rs` — tag persistent CI states with their exact commit revision.
 - Modify `src/tui/app.rs` — consume the shared model/loaders instead of owning duplicate read logic.
 - Create `tests/application_session_tests.rs` — public API integration coverage.
 - Modify `tests/all_tests.rs` — register the consolidated integration-test module.
+- Modify `docs/configuration/index.md` — document automatic hydration's global trust boundary.
 
 ### GPUI application
 
@@ -1109,8 +1114,33 @@ git commit -m "feat: render the native stack cockpit"
 ### Task 7: Hydrate branch details, diffs, and CI asynchronously
 
 **Files:**
+- Create: `crates/stax-gui/src/hydration.rs`
+- Modify: `crates/stax-gui/src/lib.rs`
+- Modify: `crates/stax-gui/src/views/app.rs`
+- Modify: `crates/stax-gui/src/views/changes_pane.rs`
+- Modify: `crates/stax-gui/src/views/inspector_pane.rs`
+- Modify: `crates/stax-gui/src/views/stack_pane.rs`
+- Modify: `crates/stax-gui/src/views/tests.rs`
+- Create: `crates/stax-gui/src/views/hydration_tests.rs`
 - Modify: `crates/stax-gui/src/views/workspace.rs`
 - Modify: `crates/stax-gui/src/state.rs`
+- Modify: `src/application/ci.rs`
+- Modify: `src/application/repository.rs`
+- Modify: `src/cache.rs`
+- Modify: `src/config/mod.rs`
+- Modify: `src/config/tests.rs`
+- Modify: `src/forge/mod.rs`
+- Modify: `src/github/client.rs`
+- Modify: `src/remote.rs`
+- Modify: `src/commands/ci.rs`
+- Modify: `src/commands/log.rs`
+- Modify: `src/commands/ready.rs`
+- Modify: `src/commands/status.rs`
+- Modify: `src/commands/sync.rs`
+- Modify: `src/commands/tmux.rs`
+- Modify: `src/commands/watch.rs`
+- Modify: `src/tui/app.rs`
+- Modify: `tests/application_session_tests.rs`
 
 - [ ] **Step 1: Add stale async-result tests**
 
@@ -1128,67 +1158,78 @@ Expected: failure because `WorkspaceView::hydrate_selection` does not exist.
 
 - [ ] **Step 3: Implement one generation-scoped hydration path**
 
-Use the GPUI background executor for blocking Git/network work and apply results on the entity:
+Use an injectable branch-hydration service whose production implementation opens
+`RepositorySession` only inside futures dispatched to GPUI's background executor.
+Capture only owned repository paths, branch summaries/names, parents, and the
+`Send + Sync` service across those tasks; no `GitRepo`, window, or GPUI context
+crosses the background boundary.
 
-```rust
-fn hydrate_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-    let Some((token, branch)) = self.state.begin_hydration() else {
-        return;
-    };
-    let path = token.repository.clone();
-    let parent = branch.parent.clone();
-    let background = cx.background_executor().clone();
+Call `WorkspaceState::begin_hydration` exactly once per selection request.
+Details and diff use independent coordinator streams so blocked details cannot
+delay the patch. Each expensive stream owns at most one active request plus one
+latest queued request; repeated selections replace the queued request. The diff
+stream performs its bounded cache lookup before its fresh calculation and skips
+a superseded fresh stage when possible. CI is separately bounded and starts only
+after the matching details result succeeds with `has_remote = true`. A no-parent
+branch applies an immediate empty diff without invoking either diff service
+method. Details failures and local-only branches produce independent actionable
+CI failures without suppressing a successful diff.
 
-    cx.spawn_in(window, async move |this, cx| {
-        let result = background
-            .spawn(async move {
-                let session = RepositorySession::open(&path)?;
-                let details = session.branch_details(&branch)?;
-                let diff = match parent {
-                    Some(parent) => Some(session.diff(&branch.name, &parent)?),
-                    None => None,
-                };
-                let ci = if details.has_remote {
-                    session.load_ci(&branch.name).map_err(|error| error.to_string())
-                } else {
-                    Err("Push branch to see remote checks".to_string())
-                };
-                anyhow::Ok((details, diff, ci))
-            })
-            .await;
+Apply every completion through the repository/branch/generation-gated state
+methods and notify only accepted results. `WorkspaceState` keeps a private
+`diff_refreshing` flag: retrying the same branch or refreshing a snapshot that
+preserves the selection retains an existing ready diff while showing a subtle
+refresh indicator. A new selection clears prior-branch content, a matching
+cached diff may fill an otherwise-loading pane, and the final fresh result
+replaces the retained/cached content or surfaces its failure.
 
-        this.update_in(cx, |view, _window, cx| {
-            match result {
-                Ok((details, diff, ci)) => {
-                    view.state
-                        .apply_details(token.clone(), Ok(details));
-                    view.state.apply_diff(
-                        token.clone(),
-                        Ok(diff.unwrap_or(BranchDiff {
-                            stat: Vec::new(),
-                            lines: Vec::new(),
-                        })),
-                    );
-                    view.state.apply_ci(token, ci);
-                }
-                Err(error) => {
-                    let message = error.to_string();
-                    view.state
-                        .apply_details(token.clone(), Err(message.clone()));
-                    view.state
-                        .apply_diff(token.clone(), Err(message.clone()));
-                    view.state.apply_ci(token, Err(message));
-                }
-            }
-            cx.notify();
-        })?;
-        anyhow::Ok(())
-    })
-    .detach();
-}
-```
+The production fresh stage calls `RepositorySession::refresh_diff`, which
+captures one immutable `DiffTarget`, bypasses any matching disk entry, computes
+the live stat and patch, and persists the result best-effort. `cached_diff`
+remains the early presentation path and `diff` remains cache-first for existing
+callers. Production tests seed a deliberately incorrect matching entry and
+assert cache-first presentation followed by the recomputed Git result.
 
-Adapt captures to the final shared types so no `GitRepo` or GPUI context crosses threads. Call hydration after initial snapshot load and every selection change. Preserve cached diff content while refreshing.
+Call hydration after initial open, every click/arrow selection, and each
+successful snapshot refresh. Successful `RepositorySession::load_ci` calls also
+update the shared repository-local `CiCache` best-effort in the application
+layer; persistence failure does not discard the live summary, and the TUI must
+not write the same result a second time. An accepted live `CiSummary` also
+updates the selected `BranchSummary::ci_state` through `WorkspaceState`; stale
+or failed results retain the prior cached row status.
+
+Automatic TUI/GUI CI hydration uses a separate network-safe config loader.
+Repository `stax.toml` may choose only the Git remote name; auth settings,
+forge overrides, web/API base URLs, and credential lookup behavior come from
+global config. Before any token lookup or client construction, hydration checks
+the actual Git remote host against the resolved forge and API endpoint.
+GitHub.com, GitLab.com, and Gitea.com use their built-in provider/API
+relationships. Custom or enterprise hosts require a matching global
+`remote.base_url`; cross-host API endpoints require an explicit global
+`remote.api_base_url`. GitHub auth lookup is bound to the validated Git host,
+and a mismatched global `auth.gh_hostname` is rejected before invoking `gh`.
+Authenticated clients either stop redirects that leave the original
+scheme/host/port or strip credentials before following them. Trust errors are
+sanitized and never include credentials or repository URL paths.
+
+`CiCache` and `TuiDiffCache` use shared-lock strict reads and exclusive
+load/update/persist transactions on dedicated `fs4` lock files. Writers reject
+malformed JSON without replacing it, write a flushed and synced same-directory
+temporary file, atomically replace on Unix/macOS, and rely on the same lock for
+reader/writer exclusion on platforms whose replacement operation differs.
+All CLI (`ci`, `log`, `ready`, `status`, `sync`, `tmux`, and `watch`),
+application/GUI, and TUI consumers resolve `GitRepo::common_git_dir()` so linked
+worktrees share one CI cache. Production writers use lock-scoped,
+field-specific transactions for CI-only, PR/draft-only, combined branch
+refresh, and bulk refresh/cleanup/timestamp updates; whole-snapshot `save`
+remains test-only. Every CI update stores the exact fetched commit SHA in the
+serde-default optional `ci_revision` field. Snapshot, CLI, TUI, and GUI readers
+show cached CI only when that revision matches the branch's current commit;
+legacy entries with no revision and mismatched/stale results are ignored.
+PR-only transactions preserve both CI state and revision. A stale writer may
+still finish after a branch moves, but its old SHA tag prevents the result from
+being presented as current. The optional field keeps existing cache JSON
+readable without a migration.
 
 - [ ] **Step 4: Run GUI state and view tests**
 

--- a/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+++ b/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
@@ -1,0 +1,1097 @@
+# Stax GUI Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver a macOS GPUI application that opens one stax repository and provides a responsive, read-only three-pane stack, patch, branch, PR, and CI cockpit.
+
+**Architecture:** Keep the existing root package as the default workspace member and add a separate `stax-gui` crate pinned to GPUI 0.2.2. Extract repository snapshots, branch details, diffs, and CI summaries into a presentation-neutral `stax::application` module used by both the TUI and GUI. Keep GPUI entities limited to selection, loading, error, and pane state; run Git and network reads on GPUI's background executor and reject stale results with generation tokens.
+
+**Tech Stack:** Rust 1.96, GPUI 0.2.2 with the macOS `font-kit` feature, git2, Tokio, serde/serde_json, existing stax caches and forge clients, cargo-nextest.
+
+**Stacking:** Base this phase branch on `docs/gpui-gui-design` / PR #607. This phase is the first implementation PR; phases 2–4 receive their own plans and branches after this API is verified.
+
+---
+
+## File map
+
+### Root library
+
+- Modify `Cargo.toml` — workspace metadata and shared package fields.
+- Modify `src/lib.rs` — expose the new application module.
+- Create `src/application/mod.rs` — public module boundary and re-exports.
+- Create `src/application/model.rs` — UI-neutral snapshots, details, diff, CI, and request tokens.
+- Create `src/application/repository.rs` — path validation, local snapshots, branch details, and diff loading/cache.
+- Create `src/application/ci.rs` — provider-neutral CI loading and summary calculation.
+- Modify `src/tui/app.rs` — consume the shared model/loaders instead of owning duplicate read logic.
+- Create `tests/application_session_tests.rs` — public API integration coverage.
+- Modify `tests/all_tests.rs` — register the consolidated integration-test module.
+
+### GPUI application
+
+- Create `crates/stax-gui/Cargo.toml` — isolated GUI dependencies.
+- Create `crates/stax-gui/src/main.rs` — argument parsing and process entry.
+- Create `crates/stax-gui/src/lib.rs` — application bootstrap.
+- Create `crates/stax-gui/src/state.rs` — pure workspace state and stale-result guards.
+- Create `crates/stax-gui/src/preferences.rs` — recent repositories with deterministic test path injection.
+- Create `crates/stax-gui/src/theme.rs` — native graphite light/dark tokens.
+- Create `crates/stax-gui/src/views/mod.rs` — view exports.
+- Create `crates/stax-gui/src/views/welcome.rs` — recent repositories and folder picker.
+- Create `crates/stax-gui/src/views/workspace.rs` — root cockpit and async coordination.
+- Create `crates/stax-gui/src/views/stack_pane.rs` — virtualized branch tree.
+- Create `crates/stax-gui/src/views/changes_pane.rs` — virtualized diffstat and patch.
+- Create `crates/stax-gui/src/views/inspector_pane.rs` — selected branch, commits, PR, and CI.
+
+## 1. Workspace and GPUI bootstrap
+
+### Task 1: Add the isolated GUI package
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `crates/stax-gui/Cargo.toml`
+- Create: `crates/stax-gui/src/main.rs`
+- Create: `crates/stax-gui/src/lib.rs`
+
+- [ ] **Step 1: Verify the package does not exist**
+
+Run:
+
+```bash
+cargo check -p stax-gui
+```
+
+Expected: failure containing `package ID specification 'stax-gui' did not match any packages`.
+
+- [ ] **Step 2: Convert the root manifest into a workspace**
+
+Add above `[package]` and move shared package values to workspace metadata:
+
+```toml
+[workspace]
+members = [".", "crates/stax-gui"]
+default-members = ["."]
+resolver = "2"
+
+[workspace.package]
+version = "0.94.0"
+edition = "2024"
+rust-version = "1.96"
+license = "MIT"
+authors = ["Cesar Ferreira"]
+repository = "https://github.com/cesarferreira/stax"
+```
+
+Change the matching root package keys to:
+
+```toml
+[package]
+name = "stax"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+```
+
+Keep `default-run`, `description`, binary declarations, profiles, and existing dependencies unchanged.
+
+- [ ] **Step 3: Add the GUI manifest**
+
+Create `crates/stax-gui/Cargo.toml`:
+
+```toml
+[package]
+name = "stax-gui"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Native macOS desktop app for stax"
+
+[[bin]]
+name = "stax-gui"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+dirs = "6"
+gpui = { version = "=0.2.2", default-features = false, features = ["font-kit"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+stax = { path = "../.." }
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+- [ ] **Step 4: Add the smallest launchable application**
+
+Create `crates/stax-gui/src/main.rs`:
+
+```rust
+use std::path::PathBuf;
+
+fn main() {
+    let repository = std::env::args_os().nth(1).map(PathBuf::from);
+    stax_gui::run(repository);
+}
+```
+
+Create `crates/stax-gui/src/lib.rs`:
+
+```rust
+use gpui::{App, Application};
+use std::path::PathBuf;
+
+pub fn run(repository: Option<PathBuf>) {
+    Application::new().run(move |cx: &mut App| {
+        crate::views::open_initial_window(repository.clone(), cx);
+        cx.activate(true);
+    });
+}
+```
+
+Temporarily add `mod views` with this launch surface. Task 6 replaces the
+`Placeholder` body while preserving the function:
+
+```rust
+use gpui::{
+    App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
+};
+use std::path::PathBuf;
+
+struct Placeholder {
+    repository: Option<PathBuf>,
+}
+
+impl Render for Placeholder {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(
+                self.repository
+                    .as_ref()
+                    .map(|path| format!("Stax · {}", path.display()))
+                    .unwrap_or_else(|| "Stax".to_string()),
+            )
+    }
+}
+
+pub fn open_initial_window(repository: Option<PathBuf>, cx: &mut App) {
+    let bounds = Bounds::centered(None, size(px(1100.0), px(720.0)), cx);
+    cx.open_window(
+        WindowOptions {
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            ..Default::default()
+        },
+        move |_, cx| cx.new(|_| Placeholder { repository }),
+    )
+    .expect("open Stax window");
+}
+```
+
+- [ ] **Step 5: Verify workspace isolation**
+
+Run:
+
+```bash
+cargo metadata --no-deps --format-version 1
+cargo check
+cargo check -p stax-gui
+```
+
+Expected: metadata lists `stax` and `stax-gui`; default `cargo check` checks the root package; explicit GUI check passes.
+
+- [ ] **Step 6: Commit the scaffold**
+
+```bash
+git add Cargo.toml crates/stax-gui
+git commit -m "feat: scaffold the GPUI desktop app"
+```
+
+## 2. Shared read model
+
+### Task 2: Define presentation-neutral repository types
+
+**Files:**
+- Create: `src/application/mod.rs`
+- Create: `src/application/model.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Write model tests**
+
+Add unit tests in `src/application/model.rs` proving:
+
+```rust
+fn check(name: &str, status: &str, conclusion: Option<&str>) -> CheckRunInfo {
+    CheckRunInfo {
+        name: name.into(),
+        status: status.into(),
+        conclusion: conclusion.map(str::to_string),
+        url: None,
+        started_at: None,
+        completed_at: None,
+        elapsed_secs: None,
+        average_secs: None,
+        completion_percent: None,
+    }
+}
+
+#[test]
+fn request_tokens_match_only_the_same_repository_branch_and_generation() {
+    let token = DetailRequestToken::new("/repo", "feature", 7);
+    assert!(token.matches("/repo", "feature", 7));
+    assert!(!token.matches("/repo", "feature", 8));
+    assert!(!token.matches("/repo", "other", 7));
+}
+
+#[test]
+fn ci_summary_counts_terminal_and_active_checks() {
+    let summary = CiSummary::from_checks(
+        Some("pending".into()),
+        &[
+            check("build", "completed", Some("success")),
+            check("lint", "completed", Some("failure")),
+            check("test", "in_progress", None),
+        ],
+        Some(120),
+    );
+    assert_eq!(summary.total, 3);
+    assert_eq!(summary.passed, 1);
+    assert_eq!(summary.failed, 1);
+    assert_eq!(summary.running, 1);
+    assert!(summary.is_active());
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm the module is missing**
+
+Run:
+
+```bash
+cargo nextest run --lib application::model::
+```
+
+Expected: compilation fails because `application` and its types do not exist.
+
+- [ ] **Step 3: Add the shared types**
+
+Define and re-export these exact public shapes:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositorySnapshot {
+    pub repository_root: PathBuf,
+    pub current_branch: String,
+    pub trunk: String,
+    pub branches: Vec<BranchSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchSummary {
+    pub name: String,
+    pub parent: Option<String>,
+    pub column: usize,
+    pub is_current: bool,
+    pub is_trunk: bool,
+    pub needs_restack: bool,
+    pub pr_number: Option<u64>,
+    pub pr_state: Option<String>,
+    pub ci_state: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchDetails {
+    pub ahead: usize,
+    pub behind: usize,
+    pub has_remote: bool,
+    pub unpushed: usize,
+    pub unpulled: usize,
+    pub commits: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchDiff {
+    pub stat: Vec<DiffStatLine>,
+    pub lines: Vec<DiffLine>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffStatLine {
+    pub file: String,
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub content: String,
+    pub kind: DiffLineKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Header,
+    Addition,
+    Deletion,
+    Context,
+    Hunk,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetailRequestToken {
+    pub repository: PathBuf,
+    pub branch: String,
+    pub generation: u64,
+}
+```
+
+Move the existing `BranchCiSummary` behavior from `src/tui/app.rs` into a public `CiSummary` in this module, preserving count, elapsed, percentage, ETA, and active/complete semantics.
+
+Add `pub mod application;` to `src/lib.rs`. `src/application/mod.rs` re-exports model types while keeping loaders in focused submodules.
+
+- [ ] **Step 4: Run model tests**
+
+Run:
+
+```bash
+cargo nextest run --lib application::model::
+```
+
+Expected: all model tests pass.
+
+- [ ] **Step 5: Commit the model**
+
+```bash
+git add src/lib.rs src/application
+git commit -m "refactor: add a shared desktop read model"
+```
+
+### Task 3: Load repository snapshots through a public session
+
+**Files:**
+- Create: `src/application/repository.rs`
+- Create: `tests/application_session_tests.rs`
+- Modify: `tests/all_tests.rs`
+- Modify: `src/application/mod.rs`
+
+- [ ] **Step 1: Register failing integration tests**
+
+Register `application_session_tests.rs` in `tests/all_tests.rs`, then add:
+
+```rust
+use crate::common::TestRepo;
+use stax::application::RepositorySession;
+
+#[test]
+fn snapshot_orders_tracked_stacks_before_trunk() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["first", "second"]);
+
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+
+    assert_eq!(snapshot.current_branch, "second");
+    assert_eq!(snapshot.trunk, "main");
+    assert_eq!(
+        snapshot.branches.iter().map(|branch| branch.name.as_str()).collect::<Vec<_>>(),
+        vec!["second", "first", "main"],
+    );
+}
+
+#[test]
+fn opening_a_non_repository_reports_the_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let error = RepositorySession::open(dir.path()).unwrap_err().to_string();
+    assert!(error.contains(&dir.path().display().to_string()));
+    assert!(error.contains("git repository"));
+}
+```
+
+- [ ] **Step 2: Run the integration tests and verify failure**
+
+Run:
+
+```bash
+cargo nextest run application_session_tests::
+```
+
+Expected: compilation fails because `RepositorySession` does not exist.
+
+- [ ] **Step 3: Implement `RepositorySession` and snapshot ordering**
+
+Use:
+
+```rust
+#[derive(Debug)]
+pub struct RepositorySession {
+    repository_root: PathBuf,
+    git_dir: PathBuf,
+    common_git_dir: PathBuf,
+}
+
+impl RepositorySession {
+    pub fn open(path: impl AsRef<Path>) -> anyhow::Result<Self>;
+    pub fn repository_root(&self) -> &Path;
+    pub fn snapshot(&self) -> anyhow::Result<RepositorySnapshot>;
+    pub fn branch_details(&self, branch: &BranchSummary) -> anyhow::Result<BranchDetails>;
+    pub fn diff(&self, branch: &str, parent: &str) -> anyhow::Result<BranchDiff>;
+}
+```
+
+`open` uses `GitRepo::open_from_path`, canonicalizes `workdir`, and stores the Git and common-Git directories. `snapshot` uses `StackSnapshot::load`, `CiCache`, and the TUI's existing iterative post-order traversal so children appear above parents and trunk remains last. Sort sibling names for deterministic output and guard cycles with `visiting` and `emitted` sets.
+
+`branch_details` preserves the existing calculations: ahead/behind, remote presence, remote divergence, and at most ten commits.
+
+`diff` first checks `TuiDiffCache` using parent, branch, merge-base OIDs; on a miss it calculates diffstat and patch, classifies each line, writes the same cache file, and returns the typed result.
+
+- [ ] **Step 4: Add details and diff integration coverage**
+
+Add tests that:
+
+1. Create a two-commit feature branch and assert ahead count and commit messages.
+2. Modify one file and assert diffstat additions/deletions and `DiffLineKind::Addition`.
+3. Call `diff` twice and assert the second value equals the first, proving cache serialization round-trips.
+4. Request details for trunk and assert an empty commit list without panic.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+cargo nextest run application_session_tests::
+```
+
+Expected: all application session tests pass.
+
+- [ ] **Step 6: Commit repository reads**
+
+```bash
+git add src/application tests/application_session_tests.rs tests/all_tests.rs
+git commit -m "feat: expose repository snapshots for desktop clients"
+```
+
+### Task 4: Share CI and diff loading with the TUI
+
+**Files:**
+- Create: `src/application/ci.rs`
+- Modify: `src/application/repository.rs`
+- Modify: `src/application/mod.rs`
+- Modify: `src/tui/app.rs`
+
+- [ ] **Step 1: Add failing CI loader tests**
+
+Add unit tests in `src/application/ci.rs`:
+
+```rust
+fn check(name: &str, status: &str, conclusion: Option<&str>) -> CheckRunInfo {
+    CheckRunInfo {
+        name: name.into(),
+        status: status.into(),
+        conclusion: conclusion.map(str::to_string),
+        url: None,
+        started_at: None,
+        completed_at: None,
+        elapsed_secs: None,
+        average_secs: None,
+        completion_percent: None,
+    }
+}
+
+fn test_session_without_remote() -> (tempfile::TempDir, RepositorySession) {
+    let dir = tempfile::tempdir().unwrap();
+    git2::Repository::init(dir.path()).unwrap();
+    let session = RepositorySession::open(dir.path()).unwrap();
+    (dir, session)
+}
+
+#[test]
+fn branch_without_remote_returns_an_actionable_unavailable_state() {
+    let (_dir, session) = test_session_without_remote();
+    let result = session.load_ci("main");
+    let error = result.unwrap_err().to_string();
+    assert!(error.contains("configure a git remote"));
+}
+
+#[test]
+fn completed_checks_report_one_hundred_percent() {
+    let summary = CiSummary::from_checks(
+        Some("success".into()),
+        &[check("build", "completed", Some("success"))],
+        Some(60),
+    );
+    assert_eq!(summary.progress_percent(Utc::now()), Some(100));
+    assert_eq!(summary.eta_secs(Utc::now()), Some(0));
+}
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run:
+
+```bash
+cargo nextest run --lib application::ci::
+```
+
+Expected: failure because `RepositorySession::load_ci` is absent.
+
+- [ ] **Step 3: Implement provider-neutral CI loading**
+
+Add:
+
+```rust
+impl RepositorySession {
+    pub fn load_ci(&self, branch: &str) -> anyhow::Result<CiSummary> {
+        let repo = self.open_repo()?;
+        let config = Config::load()?;
+        let remote = RemoteInfo::from_repo(&repo, &config)?;
+        let sha = repo.branch_commit(branch)?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let (overall, checks) = runtime.block_on(async {
+            ForgeClient::new(&remote)?.fetch_checks(&repo, &sha).await
+        })?;
+        let average = history::estimate_run_average(&repo, &checks)
+            .or_else(|| checks.iter().filter_map(|check| check.average_secs).max());
+        Ok(CiSummary::from_checks(overall, &checks, average))
+    }
+}
+```
+
+Map missing remote/config/auth/network failures with context that can be shown directly in the inspector.
+
+- [ ] **Step 4: Remove duplicate read logic from the TUI**
+
+In `src/tui/app.rs`:
+
+- Import shared `BranchDetails`, `BranchDiff`, `CiSummary`, `DiffLine`, `DiffLineKind`, and `DiffStatLine`.
+- Replace local branch-details, diff, cache-conversion, and CI-summary implementations with calls to `RepositorySession`.
+- Keep TUI-only mode, selection, pane, receiver, and refresh scheduling state in `App`.
+- Preserve existing cache file names and refresh intervals.
+- Convert `BranchSummary` into the TUI's richer `BranchDisplay` only where TUI-only mutable hydration fields are needed.
+
+No TUI command behavior or key binding changes in this task.
+
+- [ ] **Step 5: Run shared and TUI tests**
+
+Run:
+
+```bash
+cargo nextest run --lib application:: tui::app::
+cargo nextest run application_session_tests:: tui_commands_tests::
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 6: Commit the shared loaders**
+
+```bash
+git add src/application src/tui/app.rs
+git commit -m "refactor: share desktop data loaders with the TUI"
+```
+
+## 3. Testable GUI state
+
+### Task 5: Add selection, generations, and recent repositories
+
+**Files:**
+- Create: `crates/stax-gui/src/state.rs`
+- Create: `crates/stax-gui/src/preferences.rs`
+- Modify: `crates/stax-gui/src/lib.rs`
+
+- [ ] **Step 1: Write pure state tests**
+
+Add:
+
+```rust
+fn snapshot() -> RepositorySnapshot {
+    RepositorySnapshot {
+        repository_root: PathBuf::from("/repo"),
+        current_branch: "first".into(),
+        trunk: "main".into(),
+        branches: vec![
+            BranchSummary {
+                name: "first".into(),
+                parent: Some("main".into()),
+                column: 0,
+                is_current: true,
+                is_trunk: false,
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                ci_state: None,
+            },
+            BranchSummary {
+                name: "second".into(),
+                parent: Some("first".into()),
+                column: 0,
+                is_current: false,
+                is_trunk: false,
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                ci_state: None,
+            },
+        ],
+    }
+}
+
+fn diff(content: &str) -> BranchDiff {
+    BranchDiff {
+        stat: Vec::new(),
+        lines: vec![DiffLine {
+            content: content.into(),
+            kind: DiffLineKind::Context,
+        }],
+    }
+}
+
+#[test]
+fn selecting_a_branch_invalidates_older_detail_results() {
+    let mut state = WorkspaceState::new(snapshot());
+    let first = state.select_branch("first").unwrap();
+    let second = state.select_branch("second").unwrap();
+
+    assert!(!state.apply_diff(first, Ok(diff("old"))));
+    assert!(state.apply_diff(second, Ok(diff("new"))));
+    assert_eq!(state.diff.ready().unwrap().lines[0].content, "new");
+}
+
+#[test]
+fn recent_repositories_are_canonical_deduplicated_and_bounded() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = RecentRepositories::at(temp.path().join("recent.json"));
+    for index in 0..12 {
+        let repository = temp.path().join(format!("repo-{index}"));
+        std::fs::create_dir(&repository).unwrap();
+        store.record(repository).unwrap();
+    }
+    let recent = store.load().unwrap();
+    assert_eq!(recent.len(), 10);
+    assert_eq!(recent[0], temp.path().join("repo-11"));
+}
+```
+
+- [ ] **Step 2: Run GUI tests and verify failure**
+
+Run:
+
+```bash
+cargo nextest run -p stax-gui
+```
+
+Expected: compilation fails because state and preference types are absent.
+
+- [ ] **Step 3: Implement deterministic workspace state**
+
+Use:
+
+```rust
+pub enum LoadState<T> {
+    Idle,
+    Loading,
+    Ready(T),
+    Failed(String),
+}
+
+impl<T> LoadState<T> {
+    pub fn ready(&self) -> Option<&T> {
+        match self {
+            Self::Ready(value) => Some(value),
+            Self::Idle | Self::Loading | Self::Failed(_) => None,
+        }
+    }
+}
+
+pub struct WorkspaceState {
+    pub snapshot: RepositorySnapshot,
+    pub selected_branch: String,
+    pub details: LoadState<BranchDetails>,
+    pub diff: LoadState<BranchDiff>,
+    pub ci: LoadState<CiSummary>,
+    generation: u64,
+}
+```
+
+Implement these methods:
+
+```rust
+impl WorkspaceState {
+    pub fn select_branch(&mut self, name: &str) -> Option<DetailRequestToken>;
+    pub fn begin_hydration(&mut self) -> Option<(DetailRequestToken, BranchSummary)>;
+    pub fn apply_details(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<BranchDetails, String>,
+    ) -> bool;
+    pub fn apply_diff(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<BranchDiff, String>,
+    ) -> bool;
+    pub fn apply_ci(
+        &mut self,
+        token: DetailRequestToken,
+        result: Result<CiSummary, String>,
+    ) -> bool;
+}
+```
+
+`select_branch` validates the branch, increments `generation`, resets the three
+load states, and returns a token. `begin_hydration` marks the three fields
+loading and returns the current token plus a cloned branch. Each `apply_*`
+method returns `false` without mutation unless repository, branch, and
+generation all match; a matching `Err` becomes `LoadState::Failed`.
+
+- [ ] **Step 4: Implement recent repositories**
+
+`RecentRepositories::default_path` uses:
+
+```rust
+dirs::data_dir()
+    .unwrap_or_else(std::env::temp_dir)
+    .join("stax")
+    .join("gui")
+    .join("recent-repositories.json")
+```
+
+Persist a JSON array using write-to-temporary-file then rename. Canonicalize existing paths, remove duplicates, put the newest first, cap at ten, and ignore missing paths when loading.
+
+- [ ] **Step 5: Run GUI state tests**
+
+Run:
+
+```bash
+cargo nextest run -p stax-gui state:: preferences::
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit state and preferences**
+
+```bash
+git add crates/stax-gui/src
+git commit -m "feat: add deterministic GUI workspace state"
+```
+
+## 4. Native graphite cockpit
+
+### Task 6: Build the welcome window and three panes
+
+**Files:**
+- Create: `crates/stax-gui/src/theme.rs`
+- Create: `crates/stax-gui/src/views/mod.rs`
+- Create: `crates/stax-gui/src/views/welcome.rs`
+- Create: `crates/stax-gui/src/views/workspace.rs`
+- Create: `crates/stax-gui/src/views/stack_pane.rs`
+- Create: `crates/stax-gui/src/views/changes_pane.rs`
+- Create: `crates/stax-gui/src/views/inspector_pane.rs`
+- Modify: `crates/stax-gui/src/lib.rs`
+
+- [ ] **Step 1: Add GPUI render smoke tests**
+
+Use GPUI's test context:
+
+```rust
+#[gpui::test]
+fn welcome_window_renders(mut cx: &mut gpui::TestAppContext) {
+    cx.add_window(|window, cx| WelcomeView::new(window, cx));
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+fn workspace_window_renders_all_three_panes(mut cx: &mut gpui::TestAppContext) {
+    cx.add_window(|window, cx| WorkspaceView::from_snapshot(snapshot(), window, cx));
+    cx.run_until_parked();
+}
+```
+
+Also expose test-only pane markers from `WorkspaceView` and assert stack, changes, and inspector are all present.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run:
+
+```bash
+cargo nextest run -p stax-gui views::
+```
+
+Expected: compilation fails because the views do not exist.
+
+- [ ] **Step 3: Add the graphite theme**
+
+Define `Theme` with semantic tokens rather than colors in views:
+
+```rust
+pub struct Theme {
+    pub window: Hsla,
+    pub surface: Hsla,
+    pub surface_selected: Hsla,
+    pub border: Hsla,
+    pub text: Hsla,
+    pub text_muted: Hsla,
+    pub accent: Hsla,
+    pub success: Hsla,
+    pub warning: Hsla,
+    pub danger: Hsla,
+    pub diff_addition: Hsla,
+    pub diff_deletion: Hsla,
+}
+```
+
+Provide `Theme::light()` and `Theme::dark()`. Views consume only semantic fields. Use SF system UI for controls and the platform monospace font for branch metadata and patches.
+
+- [ ] **Step 4: Implement initial window routing**
+
+`open_initial_window` opens:
+
+- `WorkspaceView` when a repository argument successfully loads.
+- `WelcomeView` when no path is supplied.
+- `WelcomeView` with a visible actionable error when path validation fails.
+
+Use `WindowOptions` with 1100×720 centered bounds and a minimum size of 820×520.
+
+- [ ] **Step 5: Implement the welcome view**
+
+Render the Stax name, one Open Repository button, and recent repository rows. The button calls:
+
+```rust
+let receiver = cx.prompt_for_paths(PathPromptOptions {
+    files: false,
+    directories: true,
+    multiple: false,
+    prompt: Some("Open Repository".into()),
+});
+```
+
+Await the receiver in a detached GPUI task, record a successful selection, and replace the welcome window root with `WorkspaceView`. Cancellation leaves the welcome view unchanged; picker errors render inline.
+
+- [ ] **Step 6: Implement the cockpit**
+
+Render a toolbar plus a horizontal flex row with fixed initial proportions:
+
+```rust
+div()
+    .size_full()
+    .flex()
+    .flex_col()
+    .child(self.render_toolbar(cx))
+    .child(
+        div()
+            .flex()
+            .flex_1()
+            .min_h_0()
+            .child(stack_pane::render(&self.state, &self.theme, cx).w(relative(0.29)))
+            .child(changes_pane::render(&self.state, &self.theme, cx).w(relative(0.43)))
+            .child(inspector_pane::render(&self.state, &self.theme, cx).w(relative(0.28))),
+    )
+```
+
+Use `uniform_list` for branches and patch lines. The stack pane shows topology indentation plus current, restack, PR, and CI status. The changes pane shows diffstat and line-kind colors. The inspector shows parent, remote divergence, commits, PR, CI counts, loading/error states, and read-only disabled action buttons labelled for phase 2.
+
+Clicking a branch selects it without checkout.
+
+- [ ] **Step 7: Run GPUI tests and compile the app**
+
+Run:
+
+```bash
+cargo nextest run -p stax-gui views::
+cargo check -p stax-gui
+```
+
+Expected: tests and check pass.
+
+- [ ] **Step 8: Commit the visual shell**
+
+```bash
+git add crates/stax-gui/src
+git commit -m "feat: render the native stack cockpit"
+```
+
+### Task 7: Hydrate branch details, diffs, and CI asynchronously
+
+**Files:**
+- Modify: `crates/stax-gui/src/views/workspace.rs`
+- Modify: `crates/stax-gui/src/state.rs`
+
+- [ ] **Step 1: Add stale async-result tests**
+
+Create a deterministic loader test that starts branch A, switches to branch B before A completes, then resolves A and B. Assert only B populates details, diff, and CI. Add a failure test asserting an error populates `LoadState::Failed` without clearing the snapshot.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run:
+
+```bash
+cargo nextest run -p stax-gui stale_ async_
+```
+
+Expected: failure because `WorkspaceView::hydrate_selection` does not exist.
+
+- [ ] **Step 3: Implement one generation-scoped hydration path**
+
+Use the GPUI background executor for blocking Git/network work and apply results on the entity:
+
+```rust
+fn hydrate_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    let Some((token, branch)) = self.state.begin_hydration() else {
+        return;
+    };
+    let path = token.repository.clone();
+    let parent = branch.parent.clone();
+    let background = cx.background_executor().clone();
+
+    cx.spawn_in(window, async move |this, cx| {
+        let result = background
+            .spawn(async move {
+                let session = RepositorySession::open(&path)?;
+                let details = session.branch_details(&branch)?;
+                let diff = match parent {
+                    Some(parent) => Some(session.diff(&branch.name, &parent)?),
+                    None => None,
+                };
+                let ci = if details.has_remote {
+                    session.load_ci(&branch.name).map_err(|error| error.to_string())
+                } else {
+                    Err("Push branch to see remote checks".to_string())
+                };
+                anyhow::Ok((details, diff, ci))
+            })
+            .await;
+
+        this.update_in(cx, |view, _window, cx| {
+            match result {
+                Ok((details, diff, ci)) => {
+                    view.state
+                        .apply_details(token.clone(), Ok(details));
+                    view.state.apply_diff(
+                        token.clone(),
+                        Ok(diff.unwrap_or(BranchDiff {
+                            stat: Vec::new(),
+                            lines: Vec::new(),
+                        })),
+                    );
+                    view.state.apply_ci(token, ci);
+                }
+                Err(error) => {
+                    let message = error.to_string();
+                    view.state
+                        .apply_details(token.clone(), Err(message.clone()));
+                    view.state
+                        .apply_diff(token.clone(), Err(message.clone()));
+                    view.state.apply_ci(token, Err(message));
+                }
+            }
+            cx.notify();
+        })?;
+        anyhow::Ok(())
+    })
+    .detach();
+}
+```
+
+Adapt captures to the final shared types so no `GitRepo` or GPUI context crosses threads. Call hydration after initial snapshot load and every selection change. Preserve cached diff content while refreshing.
+
+- [ ] **Step 4: Run GUI state and view tests**
+
+Run:
+
+```bash
+cargo nextest run -p stax-gui
+cargo check -p stax-gui
+```
+
+Expected: all GUI tests pass and no stale result mutates current selection.
+
+- [ ] **Step 5: Commit async hydration**
+
+```bash
+git add crates/stax-gui/src
+git commit -m "feat: hydrate desktop branch details asynchronously"
+```
+
+## 5. Phase verification and first implementation PR
+
+### Task 8: Validate behavior and open the stacked PR
+
+**Files:**
+- Modify only files required by formatting, lints, or failures discovered below.
+
+- [ ] **Step 1: Format and lint**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy -p stax-gui --all-targets -- -D warnings
+cargo clippy -p stax --lib --bins -- -D warnings
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cargo nextest run --lib application:: tui::app::
+cargo nextest run application_session_tests:: tui_commands_tests::
+cargo nextest run -p stax-gui
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 3: Run the repository-standard full suite**
+
+Ensure Docker Desktop is running, then run:
+
+```bash
+make test
+```
+
+Expected: the complete suite passes through the Docker path. If Docker reports that its API socket is unavailable, stop and ask for Docker Desktop to be launched; do not fall back to native full-suite execution.
+
+- [ ] **Step 4: Perform a manual macOS smoke test**
+
+Run:
+
+```bash
+cargo run -p stax-gui -- "$(pwd)"
+```
+
+Verify:
+
+1. The window opens at the expected size.
+2. The stack pane selects without checking out.
+3. The patch and inspector hydrate without freezing the window.
+4. Rapidly selecting branches never shows details for an older selection.
+5. Closing and reopening through the welcome screen preserves recent repositories.
+
+- [ ] **Step 5: Commit verification-only fixes**
+
+If formatting or verification changed tracked files, commit only those fixes:
+
+```bash
+git add Cargo.toml src/application src/tui/app.rs tests \
+  crates/stax-gui
+git commit -m "fix: harden the GPUI read-only cockpit"
+```
+
+Skip this commit when verification produced no file changes.
+
+- [ ] **Step 6: Push and open the stacked PR**
+
+Push the phase branch and open it with base `docs/gpui-gui-design`. The PR summary must call out:
+
+- Shared read APIs now power TUI and GUI.
+- GPUI remains excluded from default CLI builds.
+- The GUI is intentionally read-only until phase 2.
+- No user installation docs change because no packaged app or `st gui` launcher ships in phase 1.
+
+Return the PR URL and stop at the phase boundary before writing the phase 2 plan.

--- a/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+++ b/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
@@ -708,9 +708,13 @@ git commit -m "refactor: share desktop data loaders with the TUI"
 **Files:**
 - Create: `crates/stax-gui/src/state.rs`
 - Create: `crates/stax-gui/src/preferences.rs`
+- Modify: `crates/stax-gui/Cargo.toml`
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `src/commands/worktree/pool.rs`
 - Modify: `crates/stax-gui/src/lib.rs`
 
-- [ ] **Step 1: Write pure state tests**
+- [ ] **Step 1: Write pure state and persistence tests**
 
 Add:
 
@@ -765,7 +769,18 @@ fn selecting_a_branch_invalidates_older_detail_results() {
 
     assert!(!state.apply_diff(first, Ok(diff("old"))));
     assert!(state.apply_diff(second, Ok(diff("new"))));
-    assert_eq!(state.diff.ready().unwrap().lines[0].content, "new");
+    assert_eq!(state.diff().ready().unwrap().lines[0].content, "new");
+}
+
+#[test]
+fn retrying_hydration_invalidates_the_first_same_branch_request() {
+    let mut state = WorkspaceState::new(snapshot());
+    let (first, _) = state.begin_hydration().unwrap();
+    let (retry, _) = state.begin_hydration().unwrap();
+
+    assert!(!state.apply_diff(first, Ok(diff("old"))));
+    assert!(state.apply_diff(retry, Ok(diff("retry"))));
+    assert_eq!(state.diff().ready().unwrap().lines[0].content, "retry");
 }
 
 #[test]
@@ -783,6 +798,14 @@ fn recent_repositories_are_canonical_deduplicated_and_bounded() {
 }
 ```
 
+Access state only through read-only accessors. Cover empty snapshots and invalid
+selection, stale repository/branch/generation tokens for every result type, and
+success and failure load states. Persistence tests must also cover missing and
+malformed files, canonical aliases stored directly in JSON, persisted regular
+files, a deterministic non-`NotFound` canonicalization error, Unix permissions,
+temporary-file cleanup, and synchronized concurrent processes that both record
+repositories without losing either entry.
+
 - [ ] **Step 2: Run GUI tests and verify failure**
 
 Run:
@@ -791,7 +814,8 @@ Run:
 cargo nextest run -p stax-gui
 ```
 
-Expected: compilation fails because state and preference types are absent.
+Expected: compilation fails because the private-state accessors, per-hydration
+invalidation, strict persistence behavior, and locking support are absent.
 
 - [ ] **Step 3: Implement deterministic workspace state**
 
@@ -812,14 +836,16 @@ impl<T> LoadState<T> {
             Self::Idle | Self::Loading | Self::Failed(_) => None,
         }
     }
+
+    pub fn error(&self) -> Option<&str>;
 }
 
 pub struct WorkspaceState {
-    pub snapshot: RepositorySnapshot,
-    pub selected_branch: String,
-    pub details: LoadState<BranchDetails>,
-    pub diff: LoadState<BranchDiff>,
-    pub ci: LoadState<CiSummary>,
+    snapshot: RepositorySnapshot,
+    selected_branch: Option<String>,
+    details: LoadState<BranchDetails>,
+    diff: LoadState<BranchDiff>,
+    ci: LoadState<CiSummary>,
     generation: u64,
 }
 ```
@@ -828,6 +854,12 @@ Implement these methods:
 
 ```rust
 impl WorkspaceState {
+    pub fn snapshot(&self) -> &RepositorySnapshot;
+    pub fn selected_branch(&self) -> Option<&str>;
+    pub fn details(&self) -> &LoadState<BranchDetails>;
+    pub fn diff(&self) -> &LoadState<BranchDiff>;
+    pub fn ci(&self) -> &LoadState<CiSummary>;
+    pub fn generation(&self) -> u64;
     pub fn select_branch(&mut self, name: &str) -> Option<DetailRequestToken>;
     pub fn begin_hydration(&mut self) -> Option<(DetailRequestToken, BranchSummary)>;
     pub fn apply_details(
@@ -849,12 +881,26 @@ impl WorkspaceState {
 ```
 
 `select_branch` validates the branch, increments `generation`, resets the three
-load states, and returns a token. `begin_hydration` marks the three fields
-loading and returns the current token plus a cloned branch. Each `apply_*`
-method returns `false` without mutation unless repository, branch, and
-generation all match; a matching `Err` becomes `LoadState::Failed`.
+load states, and returns a token. `begin_hydration` also increments the
+generation before marking the three fields loading and returning a new token
+plus a cloned branch, so a same-branch retry invalidates the earlier request.
+No mutable fields are exposed: callers can only observe state through accessors
+and mutate it through controlled transitions. Each `apply_*` method returns
+`false` without mutation unless repository, branch, and generation all match;
+a matching `Err` becomes `LoadState::Failed`.
 
-- [ ] **Step 4: Implement recent repositories**
+- [ ] **Step 4: Implement locked, durable recent repositories**
+
+Add the latest `fs4` release through Cargo and migrate the existing root
+consumer to the same version so the lockfile contains only one `fs4`:
+
+```bash
+cargo add fs4 --package stax-gui
+cargo add fs4@1.1.0 --package stax
+```
+
+Update the warm-worktree pool's lock calls to the `fs4` 1.1 API without
+changing its transaction semantics.
 
 `RecentRepositories::default_path` uses:
 
@@ -866,7 +912,19 @@ dirs::data_dir()
     .join("recent-repositories.json")
 ```
 
-Persist a JSON array using write-to-temporary-file then rename. Canonicalize existing paths, remove duplicates, put the newest first, cap at ten, and ignore missing paths when loading.
+Persist a JSON array using a same-directory temporary file and atomic rename.
+Use a dedicated lock file in the private preferences directory and hold an
+exclusive cross-process lock through the complete load/update/save transaction;
+the lock guard releases through RAII. Canonicalize existing paths, ignore only
+`NotFound`, return contextual errors for all other filesystem failures, include
+directories only, remove canonical duplicates, put the newest first, and cap at
+ten. Malformed JSON remains an actionable `Result` error for Task 6 to present
+nonfatally; loading never silently repairs or rewrites it.
+
+Create or restrict the preferences directory to mode `0700` on Unix, keep lock
+and temporary/data files at `0600`, flush and sync the temporary file before
+rename, and sync the parent directory after rename where supported. A
+successful save must leave only the data and dedicated lock files.
 
 - [ ] **Step 5: Run GUI state tests**
 
@@ -881,8 +939,8 @@ Expected: all tests pass.
 - [ ] **Step 6: Commit state and preferences**
 
 ```bash
-git add crates/stax-gui/src
-git commit -m "feat: add deterministic GUI workspace state"
+git add Cargo.toml Cargo.lock src/commands/worktree/pool.rs crates/stax-gui docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+git commit -m "fix: harden GUI state persistence"
 ```
 
 ## 4. Native graphite cockpit

--- a/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
+++ b/docs/superpowers/plans/2026-07-12-stax-gui-phase-1.md
@@ -18,7 +18,7 @@
 
 - Modify `Cargo.toml` — workspace metadata and shared package fields.
 - Modify `Cargo.lock` — lock the GUI package and GPUI dependency graph.
-- Modify `.github/workflows/rust-tests.yml` — compile and lint the GUI on macOS.
+- Modify `.github/workflows/rust-tests.yml` — compile, test, and lint the GUI on macOS.
 - Modify `src/lib.rs` — expose the new application module.
 - Create `src/application/mod.rs` — public module boundary and re-exports.
 - Create `src/application/model.rs` — UI-neutral snapshots, details, diff, CI, and request tokens.
@@ -223,13 +223,15 @@ existing-package version change individually. GPUI 0.2.2 requires
 with 0.10.0 is the one expected constrained change. Step 7 then proves the
 result is complete with `--locked`.
 
-- [ ] **Step 6: Add a macOS GUI compile gate**
+- [ ] **Step 6: Add a macOS GUI compile, test, and lint gate**
 
 Add a separate job to `.github/workflows/rust-tests.yml` using the repository's
 existing checkout, Rust 1.96.1, and `Swatinem/rust-cache` conventions. Override
-the Linux-only mold linker flags for this job. Because Clippy also lints the
-local `stax` path dependency, mirror the reviewed legacy allowances from
-`scripts/lint.sh` while keeping every other warning fatal:
+the Linux-only mold linker flags for this job. Install the repository's pinned
+`cargo-nextest` 0.9.114 release and make the complete `stax-gui` test package a
+required macOS gate. Because Clippy also lints the local `stax` path dependency,
+mirror the reviewed legacy allowances from `scripts/lint.sh` while keeping
+every other warning fatal:
 
 ```yaml
   gui-quality:
@@ -245,12 +247,18 @@ local `stax` path dependency, mirror the reviewed legacy allowances from
         with:
           toolchain: 1.96.1
           components: clippy
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.114
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
           key: macos-latest-gui
       - name: Check GPUI package
         run: cargo check -p stax-gui --locked
+      - name: Test GPUI package
+        run: cargo nextest run -p stax-gui --locked
       - name: Lint GPUI package
         # Clippy also lints the local stax path dependency. Mirror the reviewed
         # legacy allowances from scripts/lint.sh while keeping other warnings fatal.
@@ -989,7 +997,15 @@ recent-write generations; delayed recent-write completion after refresh; stale/n
 ordering; repeated refresh gating; long-stack scroll requests; bounded large diffstats; background
 recent-load success/failure; numerical WCAG AA contrast on normal and selected row surfaces; a
 deterministic blocking-store FIFO persistence case; initial current-branch visibility in a
-100-branch stack; and refresh-error precedence over older storage notices.
+100-branch stack; refresh-error precedence over older storage notices; and focused Enter/Space
+activation for welcome, recent-repository, toolbar, and stack-row controls. Keyboard tests must
+assert that key-down and held repeats do not activate, the matching key-up produces exactly one
+underlying action through GPUI's semantic `ClickEvent::Keyboard`, focus elsewhere remains inert,
+and disabled controls are skipped. Mouse regression tests must resolve control hitboxes through
+debug bounds and simulate move/down/up events, proving mouse-down is inert, mouse-up in the same
+hitbox activates exactly once, and mouse focus preserves keyboard parity. Theme tests must enforce
+at least 3:1 contrast for the two-pixel focus treatment on normal, selected, and primary control
+surfaces.
 
 - [ ] **Step 2: Run and verify failure**
 
@@ -1082,7 +1098,15 @@ div()
 
 Use `uniform_list` for branches and patch lines. The stack pane shows topology indentation plus current, restack, PR, and CI status. The changes pane shows diffstat and line-kind colors. The inspector shows parent, remote divergence, commits, PR, CI counts, loading/error states, and read-only disabled action buttons labelled for phase 2.
 
-Clicking a branch selects it without checkout.
+Clicking a branch selects it without checkout. Every enabled Phase 1 control is a tab stop and uses
+the shared activation helper's single `on_click` handler for mouse clicks and both Enter and Space.
+GPUI synthesizes `ClickEvent::Keyboard` for the focused clickable element on an unmodified matching
+key-up, so key-down and held repeats remain inert and one semantic release invokes one action.
+Mouse activation likewise requires down and up in the same hitbox and reaches the same handler.
+Disabled Phase 2 controls remain outside the focus order and have no activation handler. Buttons
+and rows use a two-pixel theme focus border; primary controls use the contrasting
+`focus_on_accent` token. Arrow-key branch selection and Cmd-R/Cmd-O remain bound at the `StaxApp`
+context.
 
 Retain a `UniformListScrollHandle` in `WorkspaceView` and request scrolling after click or keyboard
 selection changes, including construction so the initial/current branch is visible in long stacks.
@@ -1098,11 +1122,12 @@ surfaces in light and dark appearances.
 Run:
 
 ```bash
-cargo nextest run -p stax-gui views::
+cargo nextest run -p stax-gui keyboard --locked
+cargo nextest run -p stax-gui --locked
 cargo check -p stax-gui --locked
 ```
 
-Expected: tests and check pass.
+Expected: keyboard integration tests, the complete GUI package, and the check pass.
 
 - [ ] **Step 8: Commit the visual shell**
 
@@ -1236,8 +1261,8 @@ readable without a migration.
 Run:
 
 ```bash
-cargo nextest run -p stax-gui
-cargo check -p stax-gui
+cargo nextest run -p stax-gui --locked
+cargo check -p stax-gui --locked
 ```
 
 Expected: all GUI tests pass and no stale result mutates current selection.

--- a/src/application/ci.rs
+++ b/src/application/ci.rs
@@ -1,0 +1,277 @@
+use super::{CiSummary, RepositorySession};
+use crate::ci::history;
+use crate::config::Config;
+use crate::forge::ForgeClient;
+use crate::remote::RemoteInfo;
+use anyhow::{Context, Result, anyhow};
+use std::future::Future;
+
+impl RepositorySession {
+    /// Loads provider-neutral CI state for a branch in this repository.
+    ///
+    /// # Blocking
+    ///
+    /// This creates and blocks a Tokio runtime, so callers must run it on a
+    /// dedicated background thread outside any existing Tokio runtime.
+    pub fn load_ci(&self, branch: &str) -> Result<CiSummary> {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return Err(anyhow!(
+                "RepositorySession::load_ci is a blocking API and cannot run inside an existing \
+                 Tokio runtime; call it from a dedicated background thread"
+            ));
+        }
+
+        let repo = self.open_repo()?;
+        let config = Config::load_for_repo(self.repository_root()).map_err(|_| {
+            anyhow!(
+                "Failed to load stax config for repository '{}'; check the global config and repository stax.toml",
+                self.repository_root().display()
+            )
+        })?;
+        let remote_name = config.remote_name().to_string();
+        let remote = RemoteInfo::from_repo(&repo, &config).map_err(|_| {
+            anyhow!(
+                "Unable to load CI for branch '{branch}': configure a git remote named \
+                 '{remote_name}' with a supported GitHub, GitLab, or Gitea URL"
+            )
+        })?;
+        let sha = repo.branch_commit(branch).map_err(|_| {
+            anyhow!(
+                "Unable to resolve branch '{branch}' to a commit while loading CI; \
+                 refresh the repository and verify the branch still exists"
+            )
+        })?;
+
+        let forge = remote.forge;
+        let repo_ref = &repo;
+        let sha_ref = sha.as_str();
+        let (overall_status, checks) = run_in_tokio_runtime_with(
+            || tokio::runtime::Runtime::new().map_err(Into::into),
+            || {
+                let client = ForgeClient::new_with_config(&remote, &config)
+                    .map_err(|error| provider_error(branch, forge, &error))?;
+                Ok(async move {
+                    client
+                        .fetch_checks(repo_ref, sha_ref)
+                        .await
+                        .map_err(|error| provider_error(branch, forge, &error))
+                })
+            },
+        )
+        .with_context(|| format!("Failed to load CI for branch '{branch}'"))?;
+
+        let average_secs = history::estimate_run_average(&repo, &checks)
+            .or_else(|| checks.iter().filter_map(|check| check.average_secs).max());
+        Ok(CiSummary::from_checks(
+            overall_status,
+            &checks,
+            average_secs,
+        ))
+    }
+}
+
+fn run_in_tokio_runtime_with<T, R, F, Fut>(runtime_factory: R, operation: F) -> Result<T>
+where
+    R: FnOnce() -> Result<tokio::runtime::Runtime>,
+    F: FnOnce() -> Result<Fut>,
+    Fut: Future<Output = Result<T>>,
+{
+    let runtime = runtime_factory()?;
+    runtime.block_on(async move {
+        let future = operation()?;
+        future.await
+    })
+}
+
+fn provider_error(
+    branch: &str,
+    forge: crate::remote::ForgeType,
+    error: &anyhow::Error,
+) -> anyhow::Error {
+    let message = error.to_string().to_ascii_lowercase();
+    if message.contains("auth")
+        || message.contains("token")
+        || message.contains("unauthorized")
+        || message.contains("401")
+        || message.contains("403")
+        || message.contains("bad credentials")
+    {
+        anyhow!(
+            "{forge} authentication failed while loading CI for branch '{branch}'; \
+             run `stax auth` or refresh the configured provider credentials"
+        )
+    } else if message.contains("timeout")
+        || message.contains("connect")
+        || message.contains("network")
+        || message.contains("dns")
+        || message.contains("request")
+    {
+        anyhow!(
+            "Could not reach {forge} while loading CI for branch '{branch}'; \
+             check the network connection and provider URL"
+        )
+    } else {
+        anyhow!(
+            "{forge} could not load CI for branch '{branch}'; \
+             verify the provider configuration and credentials"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_in_tokio_runtime_with;
+    use crate::application::RepositorySession;
+    use anyhow::{Result, anyhow};
+    use std::env;
+    use std::future::{Ready, ready};
+    use std::path::Path;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use tempfile::TempDir;
+
+    struct ConfigDirGuard {
+        previous: Option<String>,
+    }
+
+    impl ConfigDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = env::var("STAX_CONFIG_DIR").ok();
+            unsafe { env::set_var("STAX_CONFIG_DIR", path) };
+            Self { previous }
+        }
+    }
+
+    impl Drop for ConfigDirGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(previous) => unsafe { env::set_var("STAX_CONFIG_DIR", previous) },
+                None => unsafe { env::remove_var("STAX_CONFIG_DIR") },
+            }
+        }
+    }
+
+    fn test_session(remote_url: Option<&str>) -> (TempDir, RepositorySession, ConfigDirGuard) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut options = git2::RepositoryInitOptions::new();
+        options.initial_head("main");
+        let repo = git2::Repository::init_opts(dir.path(), &options).unwrap();
+        if let Some(url) = remote_url {
+            repo.remote("origin", url).unwrap();
+        }
+
+        let config_dir = dir.path().join("isolated-config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[remote]\nname = \"origin\"\n",
+        )
+        .unwrap();
+        let guard = ConfigDirGuard::set(&config_dir);
+        let session = RepositorySession::open(dir.path()).unwrap();
+        (dir, session, guard)
+    }
+
+    #[test]
+    fn repository_without_remote_returns_actionable_configure_remote_error() {
+        let (_dir, session, _config) = test_session(None);
+
+        let error = session.load_ci("main").unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("configure a git remote"));
+        assert!(message.contains("origin"));
+    }
+
+    #[test]
+    fn unresolved_branch_returns_actionable_branch_context_before_network() {
+        let (_dir, session, _config) = test_session(Some("https://example.invalid/owner/repo.git"));
+
+        let error = session.load_ci("missing-branch").unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("missing-branch"));
+        assert!(message.contains("resolve"));
+    }
+
+    #[test]
+    fn load_ci_inside_existing_runtime_returns_actionable_error_without_panicking() {
+        let (_dir, session, _config) = test_session(None);
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            runtime.block_on(async { session.load_ci("main") })
+        }));
+
+        assert!(outcome.is_ok(), "load_ci must not panic inside Tokio");
+        let error = outcome.unwrap().unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("blocking"));
+        assert!(message.contains("background thread"));
+    }
+
+    #[test]
+    fn runtime_is_available_to_setup_and_async_work() {
+        let setup_has_runtime = Arc::new(AtomicBool::new(false));
+        let future_has_runtime = Arc::new(AtomicBool::new(false));
+        let setup_has_runtime_clone = Arc::clone(&setup_has_runtime);
+        let future_has_runtime_clone = Arc::clone(&future_has_runtime);
+
+        let result = run_in_tokio_runtime_with(
+            || tokio::runtime::Runtime::new().map_err(Into::into),
+            || {
+                setup_has_runtime_clone.store(
+                    tokio::runtime::Handle::try_current().is_ok(),
+                    Ordering::SeqCst,
+                );
+                Ok(async move {
+                    future_has_runtime_clone.store(
+                        tokio::runtime::Handle::try_current().is_ok(),
+                        Ordering::SeqCst,
+                    );
+                    Ok::<_, anyhow::Error>(42usize)
+                })
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result, 42);
+        assert!(setup_has_runtime.load(Ordering::SeqCst));
+        assert!(future_has_runtime.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn runtime_factory_errors_propagate_without_panicking() {
+        let error = run_in_tokio_runtime_with::<(), _, _, Ready<Result<()>>>(
+            || Err(anyhow!("runtime factory failed")),
+            || Ok(ready(Ok(()))),
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("runtime factory failed"));
+    }
+
+    #[test]
+    fn runtime_setup_errors_propagate_without_panicking() {
+        let error = run_in_tokio_runtime_with::<(), _, _, Ready<Result<()>>>(
+            || tokio::runtime::Runtime::new().map_err(Into::into),
+            || Err(anyhow!("runtime setup failed")),
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("runtime setup failed"));
+    }
+
+    #[test]
+    fn async_fetch_errors_propagate_without_panicking() {
+        let error = run_in_tokio_runtime_with(
+            || tokio::runtime::Runtime::new().map_err(Into::into),
+            || Ok(async { Err::<(), _>(anyhow!("fetch failed")) }),
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("fetch failed"));
+    }
+}

--- a/src/application/ci.rs
+++ b/src/application/ci.rs
@@ -1,8 +1,9 @@
 use super::{CiSummary, RepositorySession};
+use crate::cache::CiCache;
 use crate::ci::history;
 use crate::config::Config;
 use crate::forge::ForgeClient;
-use crate::remote::RemoteInfo;
+use crate::remote::TrustedRemoteInfo;
 use anyhow::{Context, Result, anyhow};
 use std::future::Future;
 
@@ -13,6 +14,10 @@ impl RepositorySession {
     ///
     /// This creates and blocks a Tokio runtime, so callers must run it on a
     /// dedicated background thread outside any existing Tokio runtime.
+    ///
+    /// Successful live results are written to the shared repository-local CI
+    /// cache on a best-effort basis. A cache persistence failure never changes
+    /// the successful result returned to the caller.
     pub fn load_ci(&self, branch: &str) -> Result<CiSummary> {
         if tokio::runtime::Handle::try_current().is_ok() {
             return Err(anyhow!(
@@ -22,19 +27,25 @@ impl RepositorySession {
         }
 
         let repo = self.open_repo()?;
-        let config = Config::load_for_repo(self.repository_root()).map_err(|_| {
+        let config = Config::load_for_automatic_network(self.repository_root()).map_err(|_| {
             anyhow!(
                 "Failed to load stax config for repository '{}'; check the global config and repository stax.toml",
                 self.repository_root().display()
             )
         })?;
         let remote_name = config.remote_name().to_string();
-        let remote = RemoteInfo::from_repo(&repo, &config).map_err(|_| {
-            anyhow!(
-                "Unable to load CI for branch '{branch}': configure a git remote named \
-                 '{remote_name}' with a supported GitHub, GitLab, or Gitea URL"
-            )
+        let trusted_remote = TrustedRemoteInfo::from_repo(&repo, &config).map_err(|error| {
+            let message = error.to_string();
+            if message.starts_with("Automatic CI hydration") {
+                anyhow!(message)
+            } else {
+                anyhow!(
+                    "Unable to load CI for branch '{branch}': configure a git remote named \
+                         '{remote_name}' with a supported GitHub, GitLab, or Gitea URL"
+                )
+            }
         })?;
+        let remote = trusted_remote.remote();
         let sha = repo.branch_commit(branch).map_err(|_| {
             anyhow!(
                 "Unable to resolve branch '{branch}' to a commit while loading CI; \
@@ -48,7 +59,7 @@ impl RepositorySession {
         let (overall_status, checks) = run_in_tokio_runtime_with(
             || tokio::runtime::Runtime::new().map_err(Into::into),
             || {
-                let client = ForgeClient::new_with_config(&remote, &config)
+                let client = ForgeClient::new_for_automatic(&trusted_remote, &config)
                     .map_err(|error| provider_error(branch, forge, &error))?;
                 Ok(async move {
                     client
@@ -62,11 +73,23 @@ impl RepositorySession {
 
         let average_secs = history::estimate_run_average(&repo, &checks)
             .or_else(|| checks.iter().filter_map(|check| check.average_secs).max());
-        Ok(CiSummary::from_checks(
-            overall_status,
-            &checks,
-            average_secs,
-        ))
+        let summary = CiSummary::from_checks(overall_status, &checks, average_secs);
+        Ok(self.cache_ci_summary_best_effort(branch, &sha, summary))
+    }
+
+    fn cache_ci_summary_best_effort(
+        &self,
+        branch: &str,
+        revision: &str,
+        summary: CiSummary,
+    ) -> CiSummary {
+        let _ = CiCache::update_branch_ci(
+            self.cache_dir(),
+            branch,
+            revision,
+            summary.overall_status.clone(),
+        );
+        summary
     }
 }
 
@@ -121,16 +144,25 @@ fn provider_error(
 #[cfg(test)]
 mod tests {
     use super::run_in_tokio_runtime_with;
-    use crate::application::RepositorySession;
+    use crate::application::{CiSummary, RepositorySession};
+    use crate::cache::CiCache;
     use anyhow::{Result, anyhow};
     use std::env;
+    use std::fs;
     use std::future::{Ready, ready};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::path::Path;
     use std::sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc,
     };
+    use std::thread;
+    use std::time::Duration;
     use tempfile::TempDir;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     struct ConfigDirGuard {
         previous: Option<String>,
@@ -149,6 +181,230 @@ mod tests {
             match self.previous.take() {
                 Some(previous) => unsafe { env::set_var("STAX_CONFIG_DIR", previous) },
                 None => unsafe { env::remove_var("STAX_CONFIG_DIR") },
+            }
+        }
+    }
+
+    struct HomeConfigGuard {
+        previous_home: Option<String>,
+        previous_stax_config_dir: Option<String>,
+    }
+
+    impl HomeConfigGuard {
+        fn set(path: &Path) -> Self {
+            let previous_home = env::var("HOME").ok();
+            let previous_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+            unsafe {
+                env::set_var("HOME", path);
+                env::remove_var("STAX_CONFIG_DIR");
+            }
+            Self {
+                previous_home,
+                previous_stax_config_dir,
+            }
+        }
+    }
+
+    impl Drop for HomeConfigGuard {
+        fn drop(&mut self) {
+            match self.previous_home.take() {
+                Some(previous) => unsafe { env::set_var("HOME", previous) },
+                None => unsafe { env::remove_var("HOME") },
+            }
+            match self.previous_stax_config_dir.take() {
+                Some(previous) => unsafe { env::set_var("STAX_CONFIG_DIR", previous) },
+                None => unsafe { env::remove_var("STAX_CONFIG_DIR") },
+            }
+        }
+    }
+
+    fn commit_file(repo: &git2::Repository, contents: &str) -> String {
+        fs::write(repo.workdir().unwrap().join("tracked.txt"), contents).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("tracked.txt")).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let signature = git2::Signature::now("Test User", "test@example.com").unwrap();
+        let parents = repo
+            .head()
+            .ok()
+            .and_then(|head| head.peel_to_commit().ok())
+            .into_iter()
+            .collect::<Vec<_>>();
+        let parent_refs = parents.iter().collect::<Vec<_>>();
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "test commit",
+            &tree,
+            &parent_refs,
+        )
+        .unwrap()
+        .to_string()
+    }
+
+    struct RecordingListener {
+        endpoint: String,
+        request_count: Arc<AtomicUsize>,
+        authorization_seen: Arc<AtomicBool>,
+        stop: mpsc::Sender<()>,
+        worker: Option<thread::JoinHandle<()>>,
+    }
+
+    impl RecordingListener {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let endpoint = format!("http://{}", listener.local_addr().unwrap());
+            let request_count = Arc::new(AtomicUsize::new(0));
+            let authorization_seen = Arc::new(AtomicBool::new(false));
+            let worker_count = Arc::clone(&request_count);
+            let worker_authorization = Arc::clone(&authorization_seen);
+            let (stop, stop_rx) = mpsc::channel();
+            let worker = thread::spawn(move || {
+                let body = r#"{"total_count":0,"check_runs":[]}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                loop {
+                    if stop_rx.try_recv().is_ok() {
+                        break;
+                    }
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            stream
+                                .set_read_timeout(Some(Duration::from_secs(2)))
+                                .unwrap();
+                            let mut request = [0u8; 8192];
+                            let size = stream.read(&mut request).unwrap_or(0);
+                            let request = String::from_utf8_lossy(&request[..size]);
+                            worker_count.fetch_add(1, Ordering::SeqCst);
+                            if request.to_ascii_lowercase().contains("\nauthorization:") {
+                                worker_authorization.store(true, Ordering::SeqCst);
+                            }
+                            let _ = stream.write_all(response.as_bytes());
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+            Self {
+                endpoint,
+                request_count,
+                authorization_seen,
+                stop,
+                worker: Some(worker),
+            }
+        }
+    }
+
+    impl Drop for RecordingListener {
+        fn drop(&mut self) {
+            let _ = self.stop.send(());
+            if let Some(worker) = self.worker.take() {
+                worker.join().unwrap();
+            }
+        }
+    }
+
+    struct BlockingCheckRunsServer {
+        endpoint: String,
+        request_received: mpsc::Receiver<()>,
+        release_response: Option<mpsc::Sender<()>>,
+        stop: mpsc::Sender<()>,
+        worker: Option<thread::JoinHandle<()>>,
+    }
+
+    impl BlockingCheckRunsServer {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let endpoint = format!("http://{}", listener.local_addr().unwrap());
+            let (request_received_tx, request_received) = mpsc::channel();
+            let (release_response, release_response_rx) = mpsc::channel();
+            let (stop, stop_rx) = mpsc::channel();
+            let worker = thread::spawn(move || {
+                let mut served = 0;
+                while served < 2 && stop_rx.try_recv().is_err() {
+                    let (mut stream, _) = match listener.accept() {
+                        Ok(connection) => connection,
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(5));
+                            continue;
+                        }
+                        Err(_) => break,
+                    };
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(2)))
+                        .unwrap();
+                    let mut request = [0u8; 8192];
+                    let size = stream.read(&mut request).unwrap_or(0);
+                    let request = String::from_utf8_lossy(&request[..size]);
+                    let is_check_runs = request.contains("/check-runs");
+
+                    if served == 0 {
+                        request_received_tx.send(()).unwrap();
+                        loop {
+                            if release_response_rx
+                                .recv_timeout(Duration::from_millis(10))
+                                .is_ok()
+                                || stop_rx.try_recv().is_ok()
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+                    let body = if is_check_runs {
+                        r#"{"total_count":1,"check_runs":[{"id":1,"name":"tests","status":"completed","conclusion":"success"}]}"#
+                    } else {
+                        "[]"
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    served += 1;
+                }
+            });
+
+            Self {
+                endpoint,
+                request_received,
+                release_response: Some(release_response),
+                stop,
+                worker: Some(worker),
+            }
+        }
+
+        fn wait_until_request_is_in_flight(&self) {
+            self.request_received
+                .recv_timeout(Duration::from_secs(5))
+                .expect("CI request did not reach the mock server");
+        }
+
+        fn release(&mut self) {
+            self.release_response.take().unwrap().send(()).unwrap();
+        }
+    }
+
+    impl Drop for BlockingCheckRunsServer {
+        fn drop(&mut self) {
+            if let Some(release) = self.release_response.take() {
+                let _ = release.send(());
+            }
+            let _ = self.stop.send(());
+            if let Some(worker) = self.worker.take() {
+                worker.join().unwrap();
             }
         }
     }
@@ -174,6 +430,21 @@ mod tests {
         (dir, session, guard)
     }
 
+    fn ci_summary(status: &str) -> CiSummary {
+        CiSummary {
+            overall_status: Some(status.to_string()),
+            total: 1,
+            passed: 1,
+            failed: 0,
+            running: 0,
+            queued: 0,
+            skipped: 0,
+            started_at: None,
+            completed_at: None,
+            average_secs: Some(30),
+        }
+    }
+
     #[test]
     fn repository_without_remote_returns_actionable_configure_remote_error() {
         let (_dir, session, _config) = test_session(None);
@@ -187,7 +458,7 @@ mod tests {
 
     #[test]
     fn unresolved_branch_returns_actionable_branch_context_before_network() {
-        let (_dir, session, _config) = test_session(Some("https://example.invalid/owner/repo.git"));
+        let (_dir, session, _config) = test_session(Some("https://github.com/owner/repo.git"));
 
         let error = session.load_ci("missing-branch").unwrap_err();
         let message = format!("{error:#}");
@@ -210,6 +481,221 @@ mod tests {
         let message = format!("{error:#}");
         assert!(message.contains("blocking"));
         assert!(message.contains("background thread"));
+    }
+
+    #[test]
+    fn ci_cache_persistence_failure_keeps_the_live_successful_summary() {
+        let (dir, session, _config) = test_session(None);
+        std::fs::write(dir.path().join(".git").join("stax"), "not a directory").unwrap();
+        let expected = ci_summary("success");
+
+        let actual = session.cache_ci_summary_best_effort("main", "revision-a", expected.clone());
+
+        assert_eq!(actual, expected);
+        assert!(!dir.path().join(".git/stax/ci-cache.json").exists());
+    }
+
+    #[test]
+    fn in_flight_ci_result_is_cached_for_its_captured_revision_and_ignored_after_branch_moves() {
+        let mut server = BlockingCheckRunsServer::start();
+        let dir = tempfile::tempdir().unwrap();
+        let mut options = git2::RepositoryInitOptions::new();
+        options.initial_head("main");
+        let repo = git2::Repository::init_opts(dir.path(), &options).unwrap();
+        let old_revision = commit_file(&repo, "old\n");
+        repo.remote(
+            "origin",
+            &format!("{}/owner/repository.git", server.endpoint),
+        )
+        .unwrap();
+        let home = dir.path().join("home");
+        let config_dir = home.join(".config").join("stax");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "[remote]\nname = \"origin\"\nbase_url = \"{}\"\napi_base_url = \"{}\"\nforge = \"github\"\n\
+                 [auth]\nuse_gh_cli = false\n",
+                server.endpoint, server.endpoint
+            ),
+        )
+        .unwrap();
+        fs::write(config_dir.join(".credentials"), "in-flight-secret").unwrap();
+        let _home = HomeConfigGuard::set(&home);
+        let session = RepositorySession::open(dir.path()).unwrap();
+        let loading_session = session.clone();
+        let load = thread::spawn(move || loading_session.load_ci("main"));
+
+        server.wait_until_request_is_in_flight();
+        let current_revision = commit_file(&repo, "new\n");
+        server.release();
+        let summary = load.join().unwrap().unwrap();
+
+        assert_eq!(summary.overall_status.as_deref(), Some("success"));
+        let cache = CiCache::load(session.cache_dir());
+        assert_eq!(
+            cache.get_ci_state_for_revision("main", &old_revision),
+            Some("success".to_string())
+        );
+        assert_eq!(
+            cache.get_ci_state_for_revision("main", &current_revision),
+            None
+        );
+
+        let current_snapshot = session.snapshot().unwrap();
+        assert_eq!(current_snapshot.branches[0].ci_state, None);
+    }
+
+    #[test]
+    fn github_redirect_does_not_forward_authorization_to_an_untrusted_origin() {
+        let attacker = RecordingListener::start();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let trusted = runtime.block_on(MockServer::start());
+        runtime.block_on(
+            Mock::given(method("GET"))
+                .respond_with(
+                    ResponseTemplate::new(302)
+                        .insert_header("Location", format!("{}/redirected", attacker.endpoint)),
+                )
+                .mount(&trusted),
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut options = git2::RepositoryInitOptions::new();
+        options.initial_head("main");
+        let repo = git2::Repository::init_opts(dir.path(), &options).unwrap();
+        commit_file(&repo, "initial\n");
+        repo.remote("origin", &format!("{}/owner/repo.git", trusted.uri()))
+            .unwrap();
+        let home = dir.path().join("home");
+        let config_dir = home.join(".config").join("stax");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "[remote]\nname = \"origin\"\nbase_url = \"{}\"\napi_base_url = \"{}\"\nforge = \"github\"\n\
+                 [auth]\nuse_gh_cli = false\n",
+                trusted.uri(),
+                trusted.uri()
+            ),
+        )
+        .unwrap();
+        fs::write(config_dir.join(".credentials"), "github-redirect-secret").unwrap();
+        let _home = HomeConfigGuard::set(&home);
+        let session = RepositorySession::open(dir.path()).unwrap();
+
+        let _ = session.load_ci("main");
+        let trusted_requests = runtime
+            .block_on(trusted.received_requests())
+            .unwrap_or_default();
+
+        assert!(!trusted_requests.is_empty());
+        assert!(
+            trusted_requests
+                .iter()
+                .all(|request| request.headers.contains_key("authorization"))
+        );
+        assert!(attacker.request_count.load(Ordering::SeqCst) > 0);
+        assert!(!attacker.authorization_seen.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn repo_local_network_overrides_cannot_reach_a_mock_listener() {
+        let listener = RecordingListener::start();
+        let dir = tempfile::tempdir().unwrap();
+        let mut options = git2::RepositoryInitOptions::new();
+        options.initial_head("main");
+        let repo = git2::Repository::init_opts(dir.path(), &options).unwrap();
+        commit_file(&repo, "initial\n");
+        repo.remote(
+            "origin",
+            &format!("{}/owner/private-repo.git", listener.endpoint),
+        )
+        .unwrap();
+        let home = dir.path().join("home");
+        let config_dir = home.join(".config").join("stax");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            "[remote]\nname = \"origin\"\n",
+        )
+        .unwrap();
+        let secret = "automatic-hydration-secret";
+        fs::write(config_dir.join(".credentials"), secret).unwrap();
+        fs::write(
+            dir.path().join("stax.toml"),
+            format!(
+                "[remote]\nname = \"origin\"\nbase_url = \"{}\"\napi_base_url = \"{}\"\nforge = \"github\"\n\
+                 [auth]\nuse_gh_cli = false\nallow_github_token_env = true\ngh_hostname = \"127.0.0.1\"\n",
+                listener.endpoint, listener.endpoint
+            ),
+        )
+        .unwrap();
+        let _home = HomeConfigGuard::set(&home);
+        let session = RepositorySession::open(dir.path()).unwrap();
+
+        let result = session.load_ci("main");
+
+        assert!(
+            listener.request_count.load(Ordering::SeqCst) == 0,
+            "untrusted listener received a request"
+        );
+        assert!(!listener.authorization_seen.load(Ordering::SeqCst));
+        let message = format!("{:#}", result.unwrap_err());
+        assert!(message.contains("untrusted"));
+        assert!(message.contains("global"));
+        assert!(!message.contains(secret));
+    }
+
+    #[test]
+    fn globally_trusted_custom_host_can_load_ci() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let server = runtime.block_on(MockServer::start());
+        runtime.block_on(
+            Mock::given(method("GET"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "total_count": 0,
+                    "check_runs": []
+                })))
+                .mount(&server),
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut options = git2::RepositoryInitOptions::new();
+        options.initial_head("main");
+        let repo = git2::Repository::init_opts(dir.path(), &options).unwrap();
+        commit_file(&repo, "initial\n");
+        repo.remote("origin", &format!("{}/owner/repo.git", server.uri()))
+            .unwrap();
+        let home = dir.path().join("home");
+        let config_dir = home.join(".config").join("stax");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "[remote]\nname = \"origin\"\nbase_url = \"{}\"\napi_base_url = \"{}\"\nforge = \"github\"\n\
+                 [auth]\nuse_gh_cli = false\n",
+                server.uri(),
+                server.uri()
+            ),
+        )
+        .unwrap();
+        fs::write(config_dir.join(".credentials"), "trusted-custom-secret").unwrap();
+        let _home = HomeConfigGuard::set(&home);
+        let session = RepositorySession::open(dir.path()).unwrap();
+
+        let summary = session.load_ci("main").unwrap();
+        let requests = runtime
+            .block_on(server.received_requests())
+            .unwrap_or_default();
+
+        assert_eq!(summary.overall_status, None);
+        assert!(!requests.is_empty());
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.headers.contains_key("authorization"))
+        );
     }
 
     #[test]

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,6 +1,8 @@
 mod model;
+mod repository;
 
 pub use model::{
     BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, DiffLine,
     DiffLineKind, DiffStatLine, RepositorySnapshot,
 };
+pub use repository::RepositorySession;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,3 +1,4 @@
+mod ci;
 mod model;
 mod repository;
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,0 +1,6 @@
+mod model;
+
+pub use model::{
+    BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, DiffLine,
+    DiffLineKind, DiffStatLine, RepositorySnapshot,
+};

--- a/src/application/model.rs
+++ b/src/application/model.rs
@@ -1,0 +1,433 @@
+use crate::ci::CheckRunInfo;
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+
+/// A presentation-neutral view of a repository and its stacked branches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositorySnapshot {
+    pub repository_root: PathBuf,
+    pub current_branch: String,
+    pub trunk: String,
+    pub branches: Vec<BranchSummary>,
+}
+
+/// Repository metadata needed to render a branch in a stack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchSummary {
+    pub name: String,
+    pub parent: Option<String>,
+    pub column: usize,
+    pub is_current: bool,
+    pub is_trunk: bool,
+    pub needs_restack: bool,
+    pub pr_number: Option<u64>,
+    /// Forge-provided pull request state, preserved without normalization.
+    pub pr_state: Option<String>,
+    /// Forge-provided CI state, preserved without normalization.
+    pub ci_state: Option<String>,
+}
+
+/// Commit and remote divergence details for one branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchDetails {
+    pub ahead: usize,
+    pub behind: usize,
+    pub has_remote: bool,
+    pub unpushed: usize,
+    pub unpulled: usize,
+    pub commits: Vec<String>,
+}
+
+/// Diffstat and patch lines for a branch relative to its parent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchDiff {
+    pub stat: Vec<DiffStatLine>,
+    pub lines: Vec<DiffLine>,
+}
+
+/// Per-file additions and deletions from a diffstat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffStatLine {
+    pub file: String,
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+/// One classified line of patch output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub content: String,
+    pub kind: DiffLineKind,
+}
+
+/// Presentation-neutral classification of a patch line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Header,
+    Addition,
+    Deletion,
+    Context,
+    Hunk,
+}
+
+/// Identifies the repository selection generation that requested branch details.
+///
+/// Repository paths are stored as supplied and compared lexically; the token
+/// does not canonicalize paths or resolve symlinks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetailRequestToken {
+    pub repository: PathBuf,
+    pub branch: String,
+    pub generation: u64,
+}
+
+impl DetailRequestToken {
+    /// Creates a token for one repository, branch, and selection generation.
+    pub fn new(repository: impl Into<PathBuf>, branch: impl Into<String>, generation: u64) -> Self {
+        Self {
+            repository: repository.into(),
+            branch: branch.into(),
+            generation,
+        }
+    }
+
+    /// Returns whether all fields exactly match, including the lexical path.
+    pub fn matches(&self, repository: impl AsRef<Path>, branch: &str, generation: u64) -> bool {
+        self.repository.as_path() == repository.as_ref()
+            && self.branch == branch
+            && self.generation == generation
+    }
+}
+
+/// Provider-neutral aggregate status and timing for a branch's CI checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CiSummary {
+    /// Forge-provided aggregate status, preserved without normalization.
+    pub overall_status: Option<String>,
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub running: usize,
+    pub queued: usize,
+    pub skipped: usize,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub average_secs: Option<u64>,
+}
+
+impl CiSummary {
+    #[allow(dead_code)]
+    pub(crate) fn from_checks(
+        overall_status: Option<String>,
+        checks: &[CheckRunInfo],
+        average_secs: Option<u64>,
+    ) -> Self {
+        let mut passed = 0;
+        let mut failed = 0;
+        let mut running = 0;
+        let mut queued = 0;
+        let mut skipped = 0;
+
+        for check in checks {
+            match check.status.as_str() {
+                "completed" => match check.conclusion.as_deref() {
+                    Some("success") => passed += 1,
+                    Some("skipped") | Some("neutral") | Some("cancelled") => skipped += 1,
+                    _ => failed += 1,
+                },
+                "in_progress" => running += 1,
+                "queued" | "waiting" | "requested" | "pending" => queued += 1,
+                _ => queued += 1,
+            }
+        }
+
+        let started_at = checks
+            .iter()
+            .filter_map(|check| parse_ci_timestamp(check.started_at.as_deref()))
+            .min();
+        let completed_at = if checks.iter().all(|check| check.status == "completed") {
+            checks
+                .iter()
+                .filter_map(|check| parse_ci_timestamp(check.completed_at.as_deref()))
+                .max()
+        } else {
+            None
+        };
+
+        Self {
+            overall_status,
+            total: checks.len(),
+            passed,
+            failed,
+            running,
+            queued,
+            skipped,
+            started_at,
+            completed_at,
+            average_secs,
+        }
+    }
+
+    /// Returns whether the forge reported at least one check.
+    pub fn has_checks(&self) -> bool {
+        self.total > 0
+    }
+
+    /// Returns the number of terminal checks, including skipped checks.
+    pub fn completed_count(&self) -> usize {
+        self.passed + self.failed + self.skipped
+    }
+
+    /// Returns whether any incomplete checks are running or queued.
+    pub fn is_active(&self) -> bool {
+        !self.is_complete() && (self.running > 0 || self.queued > 0)
+    }
+
+    /// Returns whether every reported check has reached a terminal state.
+    pub fn is_complete(&self) -> bool {
+        self.total > 0 && self.completed_count() == self.total
+    }
+
+    /// Estimates completion from elapsed time and the historical average.
+    ///
+    /// Complete runs report 100%. Active runs require a valid start timestamp
+    /// and average duration, and are capped at 99% until checks complete.
+    pub fn progress_percent(&self, now: DateTime<Utc>) -> Option<u8> {
+        if self.is_complete() {
+            return Some(100);
+        }
+
+        let average_secs = self.average_secs?;
+        let elapsed_secs = self.elapsed_secs(now)?;
+        if average_secs == 0 {
+            return Some(99);
+        }
+
+        Some(if elapsed_secs >= average_secs {
+            99
+        } else {
+            ((elapsed_secs * 100) / average_secs).min(99) as u8
+        })
+    }
+
+    /// Returns elapsed wall-clock seconds, clamped to zero.
+    ///
+    /// Active runs use `now`. Complete runs require both valid start and
+    /// completion timestamps; missing or malformed timestamps return `None`.
+    pub fn elapsed_secs(&self, now: DateTime<Utc>) -> Option<u64> {
+        let started_at = self.started_at?;
+        let finished_at = if self.is_complete() {
+            self.completed_at?
+        } else {
+            now
+        };
+        Some(
+            finished_at
+                .signed_duration_since(started_at)
+                .num_seconds()
+                .max(0) as u64,
+        )
+    }
+
+    /// Estimates remaining seconds from elapsed time and the historical average.
+    ///
+    /// Complete runs return zero only when their elapsed timing is valid.
+    /// Active runs return `None` when the start timestamp or average is absent.
+    pub fn eta_secs(&self, now: DateTime<Utc>) -> Option<u64> {
+        if self.is_complete() {
+            self.elapsed_secs(now)?;
+            return Some(0);
+        }
+
+        let average_secs = self.average_secs?;
+        let elapsed_secs = self.elapsed_secs(now)?;
+        Some(average_secs.saturating_sub(elapsed_secs))
+    }
+}
+
+#[allow(dead_code)]
+fn parse_ci_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
+    value.and_then(|timestamp| timestamp.parse::<DateTime<Utc>>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CiSummary, DetailRequestToken};
+    use crate::ci::CheckRunInfo;
+    use chrono::{TimeZone, Utc};
+
+    fn check(name: &str, status: &str, conclusion: Option<&str>) -> CheckRunInfo {
+        CheckRunInfo {
+            name: name.into(),
+            status: status.into(),
+            conclusion: conclusion.map(str::to_string),
+            url: None,
+            started_at: None,
+            completed_at: None,
+            elapsed_secs: None,
+            average_secs: None,
+            completion_percent: None,
+        }
+    }
+
+    #[test]
+    fn request_tokens_match_only_the_same_repository_branch_and_generation() {
+        let token = DetailRequestToken::new("/repo", "feature", 7);
+
+        assert!(token.matches("/repo", "feature", 7));
+        assert!(!token.matches("/other-repo", "feature", 7));
+        assert!(!token.matches("/repo", "other", 7));
+        assert!(!token.matches("/repo", "feature", 8));
+    }
+
+    #[test]
+    fn ci_summary_counts_terminal_and_active_checks() {
+        let summary = CiSummary::from_checks(
+            Some("pending".into()),
+            &[
+                check("build", "completed", Some("success")),
+                check("lint", "completed", Some("failure")),
+                check("docs", "completed", Some("neutral")),
+                check("test", "in_progress", None),
+                check("deploy", "waiting", None),
+                check("scan", "requested", None),
+                check("custom", "unknown", None),
+            ],
+            Some(120),
+        );
+
+        assert_eq!(summary.overall_status.as_deref(), Some("pending"));
+        assert_eq!(summary.total, 7);
+        assert_eq!(summary.passed, 1);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.running, 1);
+        assert_eq!(summary.queued, 3);
+        assert_eq!(summary.average_secs, Some(120));
+        assert_eq!(summary.completed_count(), 3);
+        assert!(summary.has_checks());
+        assert!(summary.is_active());
+        assert!(!summary.is_complete());
+    }
+
+    #[test]
+    fn empty_ci_summary_has_no_progress_or_activity() {
+        let summary = CiSummary::from_checks(None, &[], None);
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 12, 0, 0).unwrap();
+
+        assert!(!summary.has_checks());
+        assert_eq!(summary.completed_count(), 0);
+        assert!(!summary.is_active());
+        assert!(!summary.is_complete());
+        assert_eq!(summary.started_at, None);
+        assert_eq!(summary.completed_at, None);
+        assert_eq!(summary.elapsed_secs(now), None);
+        assert_eq!(summary.progress_percent(now), None);
+        assert_eq!(summary.eta_secs(now), None);
+    }
+
+    #[test]
+    fn completed_ci_summary_reports_final_progress_and_timestamps() {
+        let mut build = check("build", "completed", Some("success"));
+        build.started_at = Some("2026-07-12T10:00:00Z".into());
+        build.completed_at = Some("2026-07-12T10:02:00Z".into());
+        let mut test = check("test", "completed", Some("skipped"));
+        test.started_at = Some("2026-07-12T10:01:00Z".into());
+        test.completed_at = Some("2026-07-12T10:04:00Z".into());
+
+        let summary = CiSummary::from_checks(Some("success".into()), &[build, test], Some(300));
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 11, 0, 0).unwrap();
+
+        assert!(summary.is_complete());
+        assert!(!summary.is_active());
+        assert_eq!(
+            summary.started_at,
+            Some(Utc.with_ymd_and_hms(2026, 7, 12, 10, 0, 0).unwrap())
+        );
+        assert_eq!(
+            summary.completed_at,
+            Some(Utc.with_ymd_and_hms(2026, 7, 12, 10, 4, 0).unwrap())
+        );
+        assert_eq!(summary.elapsed_secs(now), Some(240));
+        assert_eq!(summary.progress_percent(now), Some(100));
+        assert_eq!(summary.eta_secs(now), Some(0));
+    }
+
+    #[test]
+    fn active_ci_summary_reports_elapsed_progress_and_eta() {
+        let mut running = check("build", "in_progress", None);
+        running.started_at = Some("2026-07-12T10:00:00Z".into());
+        let summary = CiSummary::from_checks(Some("pending".into()), &[running], Some(900));
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 10, 5, 0).unwrap();
+
+        assert_eq!(summary.elapsed_secs(now), Some(300));
+        assert_eq!(summary.progress_percent(now), Some(33));
+        assert_eq!(summary.eta_secs(now), Some(600));
+    }
+
+    #[test]
+    fn completed_ci_summary_without_valid_completion_time_has_no_elapsed_or_eta() {
+        for completed_at in [None, Some("not-a-timestamp".to_string())] {
+            let mut completed = check("build", "completed", Some("success"));
+            completed.started_at = Some("2026-07-12T10:00:00Z".into());
+            completed.completed_at = completed_at;
+            let summary = CiSummary::from_checks(Some("success".into()), &[completed], Some(300));
+            let now = Utc.with_ymd_and_hms(2026, 7, 12, 10, 5, 0).unwrap();
+            let later = Utc.with_ymd_and_hms(2026, 7, 12, 11, 0, 0).unwrap();
+
+            assert!(summary.is_complete());
+            assert_eq!(summary.elapsed_secs(now), None);
+            assert_eq!(summary.elapsed_secs(later), None);
+            assert_eq!(summary.eta_secs(now), None);
+            assert_eq!(summary.eta_secs(later), None);
+            assert_eq!(summary.progress_percent(now), Some(100));
+        }
+    }
+
+    #[test]
+    fn active_ci_progress_is_capped_below_one_hundred() {
+        let mut running = check("build", "in_progress", None);
+        running.started_at = Some("2026-07-12T10:00:00Z".into());
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 10, 5, 0).unwrap();
+
+        let zero_average =
+            CiSummary::from_checks(Some("pending".into()), &[running.clone()], Some(0));
+        assert_eq!(zero_average.progress_percent(now), Some(99));
+        assert_eq!(zero_average.eta_secs(now), Some(0));
+
+        let overdue = CiSummary::from_checks(Some("pending".into()), &[running], Some(60));
+        assert_eq!(overdue.progress_percent(now), Some(99));
+        assert_ne!(overdue.progress_percent(now), Some(100));
+        assert_eq!(overdue.eta_secs(now), Some(0));
+    }
+
+    #[test]
+    fn active_ci_elapsed_time_clamps_negative_durations_to_zero() {
+        let mut running = check("build", "in_progress", None);
+        running.started_at = Some("2026-07-12T10:05:00Z".into());
+        let summary = CiSummary::from_checks(Some("pending".into()), &[running], Some(900));
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 10, 0, 0).unwrap();
+
+        assert_eq!(summary.elapsed_secs(now), Some(0));
+        assert_eq!(summary.progress_percent(now), Some(0));
+        assert_eq!(summary.eta_secs(now), Some(900));
+    }
+
+    #[test]
+    fn invalid_and_missing_timestamps_degrade_to_unknown_timing() {
+        let mut running = check("build", "in_progress", None);
+        running.started_at = Some("not-a-timestamp".into());
+        running.completed_at = Some("also-not-a-timestamp".into());
+        let queued = check("test", "queued", None);
+
+        let summary = CiSummary::from_checks(Some("pending".into()), &[running, queued], Some(120));
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 12, 0, 0).unwrap();
+
+        assert!(summary.is_active());
+        assert_eq!(summary.started_at, None);
+        assert_eq!(summary.completed_at, None);
+        assert_eq!(summary.elapsed_secs(now), None);
+        assert_eq!(summary.progress_percent(now), None);
+        assert_eq!(summary.eta_secs(now), None);
+    }
+}

--- a/src/application/model.rs
+++ b/src/application/model.rs
@@ -116,7 +116,6 @@ pub struct CiSummary {
 }
 
 impl CiSummary {
-    #[allow(dead_code)]
     pub(crate) fn from_checks(
         overall_status: Option<String>,
         checks: &[CheckRunInfo],
@@ -245,7 +244,6 @@ impl CiSummary {
     }
 }
 
-#[allow(dead_code)]
 fn parse_ci_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
     value.and_then(|timestamp| timestamp.parse::<DateTime<Utc>>().ok())
 }

--- a/src/application/repository.rs
+++ b/src/application/repository.rs
@@ -6,6 +6,7 @@ use crate::cache::{CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffC
 use crate::config::Config;
 use crate::engine::{Stack, StackSnapshot};
 use crate::git::GitRepo;
+use crate::git::repo::DiffTarget;
 use anyhow::{Context, Result, anyhow};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -77,6 +78,10 @@ impl RepositorySession {
         &self.repository_root
     }
 
+    pub(super) fn cache_dir(&self) -> &Path {
+        &self.common_git_dir
+    }
+
     /// Loads the current stack, branch metadata, and cached CI states.
     pub fn snapshot(&self) -> Result<RepositorySnapshot> {
         let repo = self.open_repo()?;
@@ -86,8 +91,23 @@ impl RepositorySession {
                 self.repository_root.display()
             )
         })?;
-        let ci_cache = CiCache::load(&self.git_dir);
-        let branches = ordered_branches(&snapshot.stack, &snapshot.current_branch, &ci_cache)?;
+        let ci_cache = CiCache::load(&self.common_git_dir);
+        let branch_revisions = snapshot
+            .stack
+            .branches
+            .keys()
+            .filter_map(|branch| {
+                repo.branch_commit(branch)
+                    .ok()
+                    .map(|revision| (branch.clone(), revision))
+            })
+            .collect::<HashMap<_, _>>();
+        let branches = ordered_branches(
+            &snapshot.stack,
+            &snapshot.current_branch,
+            &ci_cache,
+            &branch_revisions,
+        )?;
 
         Ok(RepositorySnapshot {
             repository_root: self.repository_root.clone(),
@@ -161,46 +181,40 @@ impl RepositorySession {
             &target.branch_oid,
             &target.merge_base_oid,
         );
-        let cache = TuiDiffCache::load(&self.common_git_dir);
-        if let Some(diff) = cache.get(&key) {
-            return Ok(branch_diff_from_disk(diff));
+        if let Ok(Some(diff)) = TuiDiffCache::read_persisted(&self.common_git_dir, &key) {
+            return Ok(branch_diff_from_disk(&diff));
         }
 
-        let stat = repo
-            .diff_stat_at_target(branch, parent, &target)
-            .with_context(|| {
-                format!(
-                    "Failed to calculate diff stat for branch '{}' against parent '{}'",
-                    branch, parent
-                )
-            })?
-            .into_iter()
-            .map(|(file, additions, deletions)| DiffStatLine {
-                file,
-                additions,
-                deletions,
-            })
-            .collect();
-        let lines = repo
-            .diff_against_target(branch, parent, &target)
-            .with_context(|| {
-                format!(
-                    "Failed to calculate patch for branch '{}' against parent '{}'",
-                    branch, parent
-                )
-            })?
-            .into_iter()
-            .map(|content| DiffLine {
-                kind: classify_diff_line(&content),
-                content,
-            })
-            .collect();
-        let diff = BranchDiff { stat, lines };
+        let diff = calculate_diff_at_target(&repo, branch, parent, &target)?;
+        let _ =
+            TuiDiffCache::insert_persisted(&self.common_git_dir, key, branch_diff_to_disk(&diff));
 
-        let mut cache = cache;
-        cache.insert(key, branch_diff_to_disk(&diff));
-        let _ = cache.save(&self.common_git_dir);
+        Ok(diff)
+    }
 
+    /// Recalculates a branch diff even when a matching disk cache entry exists.
+    ///
+    /// The immutable object IDs are captured once before calculation. Cache
+    /// persistence remains best-effort so a live diff is never discarded when
+    /// the cache is unavailable or malformed.
+    pub fn refresh_diff(&self, branch: &str, parent: &str) -> Result<BranchDiff> {
+        let repo = self.open_repo()?;
+        let target = repo.resolve_diff_target(branch, parent).with_context(|| {
+            format!(
+                "Failed to prepare refreshed diff for branch '{}' against parent '{}'",
+                branch, parent
+            )
+        })?;
+        let key = TuiDiffCache::key(
+            parent,
+            branch,
+            &target.parent_oid,
+            &target.branch_oid,
+            &target.merge_base_oid,
+        );
+        let diff = calculate_diff_at_target(&repo, branch, parent, &target)?;
+        let _ =
+            TuiDiffCache::insert_persisted(&self.common_git_dir, key, branch_diff_to_disk(&diff));
         Ok(diff)
     }
 
@@ -220,8 +234,8 @@ impl RepositorySession {
             &target.branch_oid,
             &target.merge_base_oid,
         );
-        let cache = TuiDiffCache::load(&self.common_git_dir);
-        Ok(cache.get(&key).map(branch_diff_from_disk))
+        TuiDiffCache::read_persisted(&self.common_git_dir, &key)
+            .map(|diff| diff.as_ref().map(branch_diff_from_disk))
     }
 
     pub(super) fn open_repo(&self) -> Result<GitRepo> {
@@ -233,6 +247,44 @@ impl RepositorySession {
             )
         })
     }
+}
+
+fn calculate_diff_at_target(
+    repo: &GitRepo,
+    branch: &str,
+    parent: &str,
+    target: &DiffTarget,
+) -> Result<BranchDiff> {
+    let stat = repo
+        .diff_stat_at_target(branch, parent, target)
+        .with_context(|| {
+            format!(
+                "Failed to calculate diff stat for branch '{}' against parent '{}'",
+                branch, parent
+            )
+        })?
+        .into_iter()
+        .map(|(file, additions, deletions)| DiffStatLine {
+            file,
+            additions,
+            deletions,
+        })
+        .collect();
+    let lines = repo
+        .diff_against_target(branch, parent, target)
+        .with_context(|| {
+            format!(
+                "Failed to calculate patch for branch '{}' against parent '{}'",
+                branch, parent
+            )
+        })?
+        .into_iter()
+        .map(|content| DiffLine {
+            kind: classify_diff_line(&content),
+            content,
+        })
+        .collect();
+    Ok(BranchDiff { stat, lines })
 }
 
 fn canonicalize_repository_path(path: &Path, label: &str, supplied_path: &Path) -> Result<PathBuf> {
@@ -249,6 +301,7 @@ fn ordered_branches(
     stack: &Stack,
     current_branch: &str,
     ci_cache: &CiCache,
+    branch_revisions: &HashMap<String, String>,
 ) -> Result<Vec<BranchSummary>> {
     let trunk = &stack.trunk;
     let mut branches = Vec::new();
@@ -261,13 +314,22 @@ fn ordered_branches(
     if !trunk_children.is_empty() {
         trunk_children.sort();
         for (column, root) in trunk_children.iter().enumerate() {
-            collect_branches(&mut branches, stack, current_branch, ci_cache, root, column);
+            collect_branches(
+                &mut branches,
+                stack,
+                current_branch,
+                ci_cache,
+                branch_revisions,
+                root,
+                column,
+            );
         }
     }
     branches.push(branch_summary(
         stack,
         current_branch,
         ci_cache,
+        branch_revisions,
         trunk,
         0,
         true,
@@ -281,6 +343,7 @@ fn collect_branches(
     stack: &Stack,
     current_branch: &str,
     ci_cache: &CiCache,
+    branch_revisions: &HashMap<String, String>,
     branch: &str,
     base_column: usize,
 ) {
@@ -307,6 +370,7 @@ fn collect_branches(
                     stack,
                     current_branch,
                     ci_cache,
+                    branch_revisions,
                     &frame.branch,
                     frame.column,
                     false,
@@ -369,6 +433,7 @@ fn branch_summary(
     stack: &Stack,
     current_branch: &str,
     ci_cache: &CiCache,
+    branch_revisions: &HashMap<String, String>,
     branch: &str,
     column: usize,
     is_trunk: bool,
@@ -383,7 +448,9 @@ fn branch_summary(
         needs_restack: info.map(|branch| branch.needs_restack).unwrap_or(false),
         pr_number: info.and_then(|branch| branch.pr_number),
         pr_state: info.and_then(|branch| branch.pr_state.clone()),
-        ci_state: ci_cache.get_ci_state(branch),
+        ci_state: branch_revisions
+            .get(branch)
+            .and_then(|revision| ci_cache.get_ci_state_for_revision(branch, revision)),
     }
 }
 

--- a/src/application/repository.rs
+++ b/src/application/repository.rs
@@ -3,9 +3,10 @@ use super::{
     RepositorySnapshot,
 };
 use crate::cache::{CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache};
+use crate::config::Config;
 use crate::engine::{Stack, StackSnapshot};
 use crate::git::GitRepo;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -103,13 +104,23 @@ impl RepositorySession {
     /// still an error because no trustworthy details can be produced.
     pub fn branch_details(&self, branch: &BranchSummary) -> Result<BranchDetails> {
         let repo = self.open_repo()?;
+        let config = Config::load_for_repo(self.repository_root()).map_err(|_| {
+            anyhow!(
+                "Failed to load stax config for branch details in repository '{}'; \
+                 check the global config and repository stax.toml",
+                self.repository_root().display()
+            )
+        })?;
+        let remote_name = config.remote_name();
         let (ahead, behind) = branch
             .parent
             .as_deref()
             .and_then(|parent| repo.commits_ahead_behind(parent, &branch.name).ok())
             .unwrap_or((0, 0));
-        let has_remote = repo.has_remote(&branch.name);
-        let (unpushed, unpulled) = repo.commits_vs_remote(&branch.name).unwrap_or((0, 0));
+        let has_remote = repo.has_remote_named(remote_name, &branch.name);
+        let (unpushed, unpulled) = repo
+            .commits_vs_remote_named(remote_name, &branch.name)
+            .unwrap_or((0, 0));
         let commits = branch
             .parent
             .as_deref()
@@ -193,7 +204,27 @@ impl RepositorySession {
         Ok(diff)
     }
 
-    fn open_repo(&self) -> Result<GitRepo> {
+    /// Returns a cached branch diff without calculating diffstat or patch data.
+    pub fn cached_diff(&self, branch: &str, parent: &str) -> Result<Option<BranchDiff>> {
+        let repo = self.open_repo()?;
+        let target = repo.resolve_diff_target(branch, parent).with_context(|| {
+            format!(
+                "Failed to prepare cached diff lookup for branch '{}' against parent '{}'",
+                branch, parent
+            )
+        })?;
+        let key = TuiDiffCache::key(
+            parent,
+            branch,
+            &target.parent_oid,
+            &target.branch_oid,
+            &target.merge_base_oid,
+        );
+        let cache = TuiDiffCache::load(&self.common_git_dir);
+        Ok(cache.get(&key).map(branch_diff_from_disk))
+    }
+
+    pub(super) fn open_repo(&self) -> Result<GitRepo> {
         GitRepo::open_from_path(&self.git_dir).with_context(|| {
             format!(
                 "Failed to reopen git repository '{}' for root '{}'",

--- a/src/application/repository.rs
+++ b/src/application/repository.rs
@@ -1,0 +1,438 @@
+use super::{
+    BranchDetails, BranchDiff, BranchSummary, DiffLine, DiffLineKind, DiffStatLine,
+    RepositorySnapshot,
+};
+use crate::cache::{CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache};
+use crate::engine::{Stack, StackSnapshot};
+use crate::git::GitRepo;
+use anyhow::{Context, Result};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// A reusable, thread-friendly handle to repository-backed application data.
+///
+/// The session stores only canonical paths and reopens libgit2 state for each
+/// operation, so callers can safely recreate it inside background tasks.
+#[derive(Debug, Clone)]
+pub struct RepositorySession {
+    repository_root: PathBuf,
+    git_dir: PathBuf,
+    common_git_dir: PathBuf,
+}
+
+impl RepositorySession {
+    /// Opens a normal repository root or linked-worktree root.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let supplied_path = path.as_ref();
+        let repo = GitRepo::open_from_path(supplied_path).with_context(|| {
+            format!(
+                "Failed to open git repository from '{}'",
+                supplied_path.display()
+            )
+        })?;
+        let workdir = repo.workdir().with_context(|| {
+            format!(
+                "Git repository at '{}' has no working directory",
+                supplied_path.display()
+            )
+        })?;
+        let repository_root = std::fs::canonicalize(workdir).with_context(|| {
+            format!(
+                "Failed to canonicalize git repository root '{}' opened from '{}'",
+                workdir.display(),
+                supplied_path.display()
+            )
+        })?;
+        let git_dir = canonicalize_repository_path(
+            repo.git_dir().with_context(|| {
+                format!(
+                    "Failed to locate git directory for '{}'",
+                    supplied_path.display()
+                )
+            })?,
+            "git directory",
+            supplied_path,
+        )?;
+        let common_git_dir = canonicalize_repository_path(
+            &repo.common_git_dir().with_context(|| {
+                format!(
+                    "Failed to locate common git directory for '{}'",
+                    supplied_path.display()
+                )
+            })?,
+            "common git directory",
+            supplied_path,
+        )?;
+
+        Ok(Self {
+            repository_root,
+            git_dir,
+            common_git_dir,
+        })
+    }
+
+    /// Returns the canonical working-tree root represented by this session.
+    pub fn repository_root(&self) -> &Path {
+        &self.repository_root
+    }
+
+    /// Loads the current stack, branch metadata, and cached CI states.
+    pub fn snapshot(&self) -> Result<RepositorySnapshot> {
+        let repo = self.open_repo()?;
+        let snapshot = StackSnapshot::load(&repo).with_context(|| {
+            format!(
+                "Failed to load repository snapshot for '{}'",
+                self.repository_root.display()
+            )
+        })?;
+        let ci_cache = CiCache::load(&self.git_dir);
+        let branches = ordered_branches(&snapshot.stack, &snapshot.current_branch, &ci_cache)?;
+
+        Ok(RepositorySnapshot {
+            repository_root: self.repository_root.clone(),
+            current_branch: snapshot.current_branch,
+            trunk: snapshot.stack.trunk,
+            branches,
+        })
+    }
+
+    /// Loads commit and remote divergence details for one branch.
+    ///
+    /// Optional, potentially expensive calculations degrade to zero or empty
+    /// values, matching the existing TUI behavior. Reopening the repository is
+    /// still an error because no trustworthy details can be produced.
+    pub fn branch_details(&self, branch: &BranchSummary) -> Result<BranchDetails> {
+        let repo = self.open_repo()?;
+        let (ahead, behind) = branch
+            .parent
+            .as_deref()
+            .and_then(|parent| repo.commits_ahead_behind(parent, &branch.name).ok())
+            .unwrap_or((0, 0));
+        let has_remote = repo.has_remote(&branch.name);
+        let (unpushed, unpulled) = repo.commits_vs_remote(&branch.name).unwrap_or((0, 0));
+        let commits = branch
+            .parent
+            .as_deref()
+            .and_then(|parent| repo.commits_between(parent, &branch.name).ok())
+            .unwrap_or_default()
+            .into_iter()
+            .take(10)
+            .collect();
+
+        Ok(BranchDetails {
+            ahead,
+            behind,
+            has_remote,
+            unpushed,
+            unpulled,
+            commits,
+        })
+    }
+
+    /// Loads a branch's merge-base diff and the compatible TUI disk cache.
+    ///
+    /// Ref resolution and diff calculation errors remain actionable errors.
+    /// Cache persistence is deliberately best-effort: once calculation
+    /// succeeds, a cache write failure never discards the successfully loaded
+    /// diff.
+    pub fn diff(&self, branch: &str, parent: &str) -> Result<BranchDiff> {
+        let repo = self.open_repo()?;
+        let target = repo.resolve_diff_target(branch, parent).with_context(|| {
+            format!(
+                "Failed to prepare diff for branch '{}' against parent '{}'",
+                branch, parent
+            )
+        })?;
+        let key = TuiDiffCache::key(
+            parent,
+            branch,
+            &target.parent_oid,
+            &target.branch_oid,
+            &target.merge_base_oid,
+        );
+        let cache = TuiDiffCache::load(&self.common_git_dir);
+        if let Some(diff) = cache.get(&key) {
+            return Ok(branch_diff_from_disk(diff));
+        }
+
+        let stat = repo
+            .diff_stat_at_target(branch, parent, &target)
+            .with_context(|| {
+                format!(
+                    "Failed to calculate diff stat for branch '{}' against parent '{}'",
+                    branch, parent
+                )
+            })?
+            .into_iter()
+            .map(|(file, additions, deletions)| DiffStatLine {
+                file,
+                additions,
+                deletions,
+            })
+            .collect();
+        let lines = repo
+            .diff_against_target(branch, parent, &target)
+            .with_context(|| {
+                format!(
+                    "Failed to calculate patch for branch '{}' against parent '{}'",
+                    branch, parent
+                )
+            })?
+            .into_iter()
+            .map(|content| DiffLine {
+                kind: classify_diff_line(&content),
+                content,
+            })
+            .collect();
+        let diff = BranchDiff { stat, lines };
+
+        let mut cache = cache;
+        cache.insert(key, branch_diff_to_disk(&diff));
+        let _ = cache.save(&self.common_git_dir);
+
+        Ok(diff)
+    }
+
+    fn open_repo(&self) -> Result<GitRepo> {
+        GitRepo::open_from_path(&self.git_dir).with_context(|| {
+            format!(
+                "Failed to reopen git repository '{}' for root '{}'",
+                self.git_dir.display(),
+                self.repository_root.display()
+            )
+        })
+    }
+}
+
+fn canonicalize_repository_path(path: &Path, label: &str, supplied_path: &Path) -> Result<PathBuf> {
+    std::fs::canonicalize(path).with_context(|| {
+        format!(
+            "Failed to canonicalize {label} '{}' for git repository '{}'",
+            path.display(),
+            supplied_path.display()
+        )
+    })
+}
+
+fn ordered_branches(
+    stack: &Stack,
+    current_branch: &str,
+    ci_cache: &CiCache,
+) -> Result<Vec<BranchSummary>> {
+    let trunk = &stack.trunk;
+    let mut branches = Vec::new();
+    let mut trunk_children = stack
+        .branches
+        .get(trunk)
+        .map(|branch| branch.children.clone())
+        .unwrap_or_default();
+
+    if !trunk_children.is_empty() {
+        trunk_children.sort();
+        for (column, root) in trunk_children.iter().enumerate() {
+            collect_branches(&mut branches, stack, current_branch, ci_cache, root, column);
+        }
+    }
+    branches.push(branch_summary(
+        stack,
+        current_branch,
+        ci_cache,
+        trunk,
+        0,
+        true,
+    ));
+    validate_emitted_topology(stack, &branches)?;
+    Ok(branches)
+}
+
+fn collect_branches(
+    result: &mut Vec<BranchSummary>,
+    stack: &Stack,
+    current_branch: &str,
+    ci_cache: &CiCache,
+    branch: &str,
+    base_column: usize,
+) {
+    #[derive(Clone)]
+    struct Frame {
+        branch: String,
+        column: usize,
+        expanded: bool,
+    }
+
+    let mut stack_frames = vec![Frame {
+        branch: branch.to_string(),
+        column: base_column,
+        expanded: false,
+    }];
+    let mut visiting = HashSet::new();
+    let mut emitted = HashSet::new();
+
+    while let Some(frame) = stack_frames.pop() {
+        if frame.expanded {
+            visiting.remove(&frame.branch);
+            if emitted.insert(frame.branch.clone()) {
+                result.push(branch_summary(
+                    stack,
+                    current_branch,
+                    ci_cache,
+                    &frame.branch,
+                    frame.column,
+                    false,
+                ));
+            }
+            continue;
+        }
+
+        if emitted.contains(&frame.branch) || !visiting.insert(frame.branch.clone()) {
+            continue;
+        }
+
+        stack_frames.push(Frame {
+            branch: frame.branch.clone(),
+            column: frame.column,
+            expanded: true,
+        });
+
+        if let Some(info) = stack.branches.get(&frame.branch) {
+            let mut children = info.children.iter().collect::<Vec<_>>();
+            children.sort();
+            for (index, child) in children.into_iter().enumerate().rev() {
+                if emitted.contains(child) || visiting.contains(child) {
+                    continue;
+                }
+                stack_frames.push(Frame {
+                    branch: child.clone(),
+                    column: frame.column + index,
+                    expanded: false,
+                });
+            }
+        }
+    }
+}
+
+fn validate_emitted_topology(stack: &Stack, branches: &[BranchSummary]) -> Result<()> {
+    let mut emitted_counts = HashMap::new();
+    for branch in branches {
+        *emitted_counts.entry(branch.name.as_str()).or_insert(0usize) += 1;
+    }
+
+    let mut affected = stack
+        .branches
+        .keys()
+        .filter(|name| emitted_counts.get(name.as_str()).copied() != Some(1))
+        .cloned()
+        .collect::<Vec<_>>();
+    affected.sort();
+    if !affected.is_empty() {
+        anyhow::bail!(
+            "Invalid stack topology: every branch must be reachable from trunk '{}' and emitted exactly once; affected branches: {}",
+            stack.trunk,
+            affected.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn branch_summary(
+    stack: &Stack,
+    current_branch: &str,
+    ci_cache: &CiCache,
+    branch: &str,
+    column: usize,
+    is_trunk: bool,
+) -> BranchSummary {
+    let info = stack.branches.get(branch);
+    BranchSummary {
+        name: branch.to_string(),
+        parent: info.and_then(|branch| branch.parent.clone()),
+        column,
+        is_current: branch == current_branch,
+        is_trunk,
+        needs_restack: info.map(|branch| branch.needs_restack).unwrap_or(false),
+        pr_number: info.and_then(|branch| branch.pr_number),
+        pr_state: info.and_then(|branch| branch.pr_state.clone()),
+        ci_state: ci_cache.get_ci_state(branch),
+    }
+}
+
+fn classify_diff_line(line: &str) -> DiffLineKind {
+    if line.starts_with("+++") || line.starts_with("---") {
+        DiffLineKind::Header
+    } else if line.starts_with('+') {
+        DiffLineKind::Addition
+    } else if line.starts_with('-') {
+        DiffLineKind::Deletion
+    } else if line.starts_with("@@") {
+        DiffLineKind::Hunk
+    } else if line.starts_with("diff ") || line.starts_with("index ") {
+        DiffLineKind::Header
+    } else {
+        DiffLineKind::Context
+    }
+}
+
+fn diff_line_kind_name(kind: DiffLineKind) -> &'static str {
+    match kind {
+        DiffLineKind::Header => "header",
+        DiffLineKind::Addition => "addition",
+        DiffLineKind::Deletion => "deletion",
+        DiffLineKind::Context => "context",
+        DiffLineKind::Hunk => "hunk",
+    }
+}
+
+fn diff_line_kind_from_name(name: &str, content: &str) -> DiffLineKind {
+    match name {
+        "header" => DiffLineKind::Header,
+        "addition" => DiffLineKind::Addition,
+        "deletion" => DiffLineKind::Deletion,
+        "context" => DiffLineKind::Context,
+        "hunk" => DiffLineKind::Hunk,
+        _ => classify_diff_line(content),
+    }
+}
+
+fn branch_diff_to_disk(diff: &BranchDiff) -> DiskCachedDiff {
+    DiskCachedDiff {
+        stat: diff
+            .stat
+            .iter()
+            .map(|line| DiskDiffStat {
+                file: line.file.clone(),
+                additions: line.additions,
+                deletions: line.deletions,
+            })
+            .collect(),
+        lines: diff
+            .lines
+            .iter()
+            .map(|line| DiskDiffLine {
+                content: line.content.clone(),
+                line_type: diff_line_kind_name(line.kind).to_string(),
+            })
+            .collect(),
+    }
+}
+
+fn branch_diff_from_disk(diff: &DiskCachedDiff) -> BranchDiff {
+    BranchDiff {
+        stat: diff
+            .stat
+            .iter()
+            .map(|line| DiffStatLine {
+                file: line.file.clone(),
+                additions: line.additions,
+                deletions: line.deletions,
+            })
+            .collect(),
+        lines: diff
+            .lines
+            .iter()
+            .map(|line| DiffLine {
+                content: line.content.clone(),
+                kind: diff_line_kind_from_name(&line.line_type, &line.content),
+            })
+            .collect(),
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,14 +1,130 @@
-use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use anyhow::{Context, Result};
+use fs4::FileExt;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::collections::HashMap;
-use std::fs;
-use std::path::PathBuf;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::NamedTempFile;
 
 const MAX_TUI_DIFF_CACHE_ENTRIES: usize = 128;
 
+enum LockMode {
+    Shared,
+    Exclusive,
+}
+
+struct CacheLock {
+    file: File,
+}
+
+impl Drop for CacheLock {
+    fn drop(&mut self) {
+        let _ = <File as FileExt>::unlock(&self.file);
+    }
+}
+
+fn acquire_cache_lock(cache_path: &Path, mode: LockMode) -> Result<CacheLock> {
+    let parent = cache_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create cache directory {}", parent.display()))?;
+    let file_name = cache_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("cache");
+    let lock_path = parent.join(format!(".{file_name}.lock"));
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open cache lock {}", lock_path.display()))?;
+    match mode {
+        LockMode::Shared => <File as FileExt>::lock_shared(&file),
+        LockMode::Exclusive => <File as FileExt>::lock(&file),
+    }
+    .with_context(|| format!("failed to lock cache {}", cache_path.display()))?;
+    Ok(CacheLock { file })
+}
+
+fn load_json_unlocked<T>(path: &Path) -> Result<T>
+where
+    T: DeserializeOwned + Default,
+{
+    let contents = match fs::read(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(T::default()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read cache {}", path.display()));
+        }
+    };
+    serde_json::from_slice(&contents)
+        .with_context(|| format!("failed to parse cache {}", path.display()))
+}
+
+fn persist_json_atomic<T>(path: &Path, value: &T) -> Result<()>
+where
+    T: Serialize,
+{
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temporary = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary cache in {}", parent.display()))?;
+    serde_json::to_writer_pretty(temporary.as_file_mut(), value)
+        .with_context(|| format!("failed to serialize cache {}", path.display()))?;
+    temporary
+        .as_file_mut()
+        .write_all(b"\n")
+        .with_context(|| format!("failed to write cache {}", path.display()))?;
+    temporary
+        .as_file_mut()
+        .flush()
+        .with_context(|| format!("failed to flush cache {}", path.display()))?;
+    temporary
+        .as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync cache {}", path.display()))?;
+    let persisted = temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to atomically replace cache {}", path.display()))?;
+    drop(persisted);
+    sync_parent_directory(parent)?;
+    Ok(())
+}
+
+fn sync_parent_directory(parent: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let directory = File::open(parent)
+            .with_context(|| format!("failed to open cache directory {}", parent.display()))?;
+        match directory.sync_all() {
+            Ok(()) => {}
+            #[cfg(target_os = "macos")]
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to sync cache directory {}", parent.display())
+                });
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = parent;
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BranchCacheEntry {
+    #[serde(default)]
+    pub ci_revision: Option<String>,
     pub ci_state: Option<String>,
     pub pr_state: Option<String>,
     pub updated_at: u64,
@@ -29,35 +145,98 @@ impl CiCache {
 
     /// Load cache from disk
     pub fn load(git_dir: &std::path::Path) -> Self {
-        let path = Self::cache_path(git_dir);
-        if !path.exists() {
-            return Self::default();
-        }
-
-        fs::read_to_string(&path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
+        Self::load_strict(git_dir).unwrap_or_default()
     }
 
-    /// Save cache to disk
+    pub(crate) fn load_strict(git_dir: &std::path::Path) -> Result<Self> {
+        let path = Self::cache_path(git_dir);
+        let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
+        load_json_unlocked(&path)
+    }
+
+    /// Persist an exact snapshot for isolated tests.
+    #[cfg(test)]
     pub fn save(&self, git_dir: &std::path::Path) -> Result<()> {
         let path = Self::cache_path(git_dir);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let json = serde_json::to_string_pretty(self)?;
-        fs::write(&path, json)?;
-        Ok(())
+        let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
+        persist_json_atomic(&path, self)
     }
 
-    /// Get cached CI state for a branch
-    pub fn get_ci_state(&self, branch: &str) -> Option<String> {
-        self.branches.get(branch).and_then(|e| e.ci_state.clone())
+    fn transaction(git_dir: &std::path::Path, update: impl FnOnce(&mut Self)) -> Result<()> {
+        let path = Self::cache_path(git_dir);
+        let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
+        let mut stored = load_json_unlocked::<Self>(&path)?;
+        update(&mut stored);
+        persist_json_atomic(&path, &stored)
     }
 
-    /// Update cache entry for a branch
-    pub fn update(&mut self, branch: &str, ci_state: Option<String>, pr_state: Option<String>) {
+    /// Atomically update one branch while preserving all other cached entries.
+    pub(crate) fn update_branch_ci(
+        git_dir: &std::path::Path,
+        branch: &str,
+        revision: &str,
+        ci_state: Option<String>,
+    ) -> Result<()> {
+        Self::transaction(git_dir, |stored| {
+            stored.update_ci(branch, revision, ci_state)
+        })
+    }
+
+    /// Atomically update one branch's pull-request state while preserving CI.
+    pub(crate) fn update_branch_pr(
+        git_dir: &std::path::Path,
+        branch: &str,
+        pr_state: Option<String>,
+    ) -> Result<()> {
+        Self::transaction(git_dir, |stored| stored.update_pr(branch, pr_state))
+    }
+
+    /// Atomically refresh both live fields and the cache timestamp for one branch.
+    pub(crate) fn refresh_branch_states(
+        git_dir: &std::path::Path,
+        branch: &str,
+        revision: &str,
+        ci_state: Option<String>,
+        pr_state: Option<String>,
+    ) -> Result<()> {
+        Self::transaction(git_dir, |stored| {
+            stored.update(branch, revision, ci_state, pr_state);
+            stored.mark_refreshed();
+        })
+    }
+
+    /// Atomically replace the refreshed branch set in one cache transaction.
+    pub(crate) fn refresh_branches(
+        git_dir: &std::path::Path,
+        updates: &[(String, String, Option<String>, Option<String>)],
+        valid_branches: &[String],
+    ) -> Result<()> {
+        Self::transaction(git_dir, |stored| {
+            for (branch, revision, ci_state, pr_state) in updates {
+                stored.update(branch, revision, ci_state.clone(), pr_state.clone());
+            }
+            stored.cleanup(valid_branches);
+            stored.mark_refreshed();
+        })
+    }
+
+    /// Get cached CI state only when it belongs to the branch's current commit.
+    pub fn get_ci_state_for_revision(&self, branch: &str, revision: &str) -> Option<String> {
+        self.branches.get(branch).and_then(|entry| {
+            (entry.ci_revision.as_deref() == Some(revision))
+                .then(|| entry.ci_state.clone())
+                .flatten()
+        })
+    }
+
+    /// Update both cached fields for one exact branch revision.
+    pub fn update(
+        &mut self,
+        branch: &str,
+        revision: &str,
+        ci_state: Option<String>,
+        pr_state: Option<String>,
+    ) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -66,11 +245,43 @@ impl CiCache {
         self.branches.insert(
             branch.to_string(),
             BranchCacheEntry {
+                ci_revision: Some(revision.to_string()),
                 ci_state,
                 pr_state,
                 updated_at: now,
             },
         );
+    }
+
+    /// Update only CI state while retaining any cached pull-request state.
+    pub fn update_ci(&mut self, branch: &str, revision: &str, ci_state: Option<String>) {
+        let pr_state = self
+            .branches
+            .get(branch)
+            .and_then(|entry| entry.pr_state.clone());
+        self.update(branch, revision, ci_state, pr_state);
+    }
+
+    /// Update only pull-request state while retaining cached CI and its revision.
+    fn update_pr(&mut self, branch: &str, pr_state: Option<String>) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if let Some(entry) = self.branches.get_mut(branch) {
+            entry.pr_state = pr_state;
+            entry.updated_at = now;
+        } else {
+            self.branches.insert(
+                branch.to_string(),
+                BranchCacheEntry {
+                    ci_revision: None,
+                    ci_state: None,
+                    pr_state,
+                    updated_at: now,
+                },
+            );
+        }
     }
 
     /// Mark cache as refreshed
@@ -133,26 +344,48 @@ impl TuiDiffCache {
         format!("v1:{parent_oid}:{branch_oid}:{merge_base_oid}")
     }
 
+    #[cfg(test)]
     pub fn load(git_dir: &std::path::Path) -> Self {
-        let path = Self::cache_path(git_dir);
-        if !path.exists() {
-            return Self::default();
-        }
-
-        fs::read_to_string(&path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
+        Self::load_strict(git_dir).unwrap_or_default()
     }
 
+    pub(crate) fn load_strict(git_dir: &std::path::Path) -> Result<Self> {
+        let path = Self::cache_path(git_dir);
+        let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
+        load_json_unlocked(&path)
+    }
+
+    #[cfg(test)]
     pub fn save(&self, git_dir: &std::path::Path) -> Result<()> {
         let path = Self::cache_path(git_dir);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
+        let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
+        let mut stored = load_json_unlocked::<Self>(&path)?;
+        for (key, entry) in &self.entries {
+            stored.entries.insert(key.clone(), entry.clone());
         }
-        let json = serde_json::to_string_pretty(self)?;
-        fs::write(&path, json)?;
-        Ok(())
+        stored.prune_old_entries();
+        persist_json_atomic(&path, &stored)
+    }
+
+    pub(crate) fn read_persisted(
+        git_dir: &std::path::Path,
+        key: &str,
+    ) -> Result<Option<DiskCachedDiff>> {
+        let cache = Self::load_strict(git_dir)?;
+        Ok(cache.get(key).cloned())
+    }
+
+    /// Atomically insert one diff while preserving all other cached entries.
+    pub(crate) fn insert_persisted(
+        git_dir: &std::path::Path,
+        key: String,
+        diff: DiskCachedDiff,
+    ) -> Result<()> {
+        let path = Self::cache_path(git_dir);
+        let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
+        let mut stored = load_json_unlocked::<Self>(&path)?;
+        stored.insert(key, diff);
+        persist_json_atomic(&path, &stored)
     }
 
     pub fn get(&self, key: &str) -> Option<&DiskCachedDiff> {
@@ -288,7 +521,19 @@ fn current_unix_time() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
     use tempfile::TempDir;
+
+    fn disk_diff(content: &str) -> DiskCachedDiff {
+        DiskCachedDiff {
+            stat: Vec::new(),
+            lines: vec![DiskDiffLine {
+                content: content.to_string(),
+                line_type: "context".to_string(),
+            }],
+        }
+    }
 
     #[test]
     fn test_cache_path() {
@@ -318,6 +563,7 @@ mod tests {
         let mut cache = CiCache::default();
         cache.update(
             "feature-1",
+            "revision-1",
             Some("success".to_string()),
             Some("OPEN".to_string()),
         );
@@ -326,7 +572,7 @@ mod tests {
         let loaded = CiCache::load(temp.path());
         assert!(loaded.branches.contains_key("feature-1"));
         assert_eq!(
-            loaded.get_ci_state("feature-1"),
+            loaded.get_ci_state_for_revision("feature-1", "revision-1"),
             Some("success".to_string())
         );
     }
@@ -336,24 +582,105 @@ mod tests {
         let mut cache = CiCache::default();
         cache.update(
             "branch-1",
+            "revision-1",
             Some("pending".to_string()),
             Some("DRAFT".to_string()),
         );
 
         assert!(cache.branches.contains_key("branch-1"));
         let entry = cache.branches.get("branch-1").unwrap();
+        assert_eq!(entry.ci_revision.as_deref(), Some("revision-1"));
         assert_eq!(entry.ci_state, Some("pending".to_string()));
         assert_eq!(entry.pr_state, Some("DRAFT".to_string()));
         assert!(entry.updated_at > 0);
     }
 
     #[test]
+    fn updating_ci_preserves_the_cached_pull_request_state() {
+        let mut cache = CiCache::default();
+        cache.update(
+            "branch-1",
+            "revision-1",
+            Some("pending".to_string()),
+            Some("OPEN".to_string()),
+        );
+
+        cache.update_ci("branch-1", "revision-2", Some("success".to_string()));
+
+        let entry = cache.branches.get("branch-1").unwrap();
+        assert_eq!(entry.ci_revision.as_deref(), Some("revision-2"));
+        assert_eq!(entry.ci_state.as_deref(), Some("success"));
+        assert_eq!(entry.pr_state.as_deref(), Some("OPEN"));
+    }
+
+    #[test]
     fn test_cache_get_ci_state() {
         let mut cache = CiCache::default();
-        assert_eq!(cache.get_ci_state("nonexistent"), None);
+        assert_eq!(
+            cache.get_ci_state_for_revision("nonexistent", "revision"),
+            None
+        );
 
-        cache.update("feature", Some("success".to_string()), None);
-        assert_eq!(cache.get_ci_state("feature"), Some("success".to_string()));
+        cache.update("feature", "revision", Some("success".to_string()), None);
+        assert_eq!(
+            cache.get_ci_state_for_revision("feature", "revision"),
+            Some("success".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_ci_cache_entries_are_not_current_for_any_revision() {
+        let entry: BranchCacheEntry =
+            serde_json::from_str(r#"{"ci_state":"success","pr_state":"OPEN","updated_at":123}"#)
+                .unwrap();
+        let mut cache = CiCache::default();
+        cache.branches.insert("feature".to_string(), entry);
+
+        assert_eq!(cache.get_ci_state_for_revision("feature", "deadbeef"), None);
+        assert_eq!(
+            cache
+                .branches
+                .get("feature")
+                .and_then(|entry| entry.ci_revision.as_deref()),
+            None
+        );
+    }
+
+    #[test]
+    fn ci_cache_lookup_requires_the_exact_commit_revision() {
+        let mut cache = CiCache::default();
+        cache.update_ci("feature", "revision-a", Some("success".to_string()));
+
+        assert_eq!(
+            cache
+                .get_ci_state_for_revision("feature", "revision-a")
+                .as_deref(),
+            Some("success")
+        );
+        assert_eq!(
+            cache.get_ci_state_for_revision("feature", "revision-b"),
+            None
+        );
+    }
+
+    #[test]
+    fn pull_request_only_transaction_preserves_ci_revision_and_state() {
+        let temp = TempDir::new().unwrap();
+        CiCache::update_branch_ci(
+            temp.path(),
+            "feature",
+            "revision-a",
+            Some("success".to_string()),
+        )
+        .unwrap();
+
+        CiCache::update_branch_pr(temp.path(), "feature", Some("DRAFT".to_string())).unwrap();
+
+        let cache = CiCache::load_strict(temp.path()).unwrap();
+        let entry = cache.branches.get("feature").unwrap();
+        assert_eq!(entry.ci_revision.as_deref(), Some("revision-a"));
+        assert_eq!(entry.ci_state.as_deref(), Some("success"));
+        assert_eq!(entry.pr_state.as_deref(), Some("DRAFT"));
     }
 
     #[test]
@@ -366,10 +693,10 @@ mod tests {
     #[test]
     fn test_cache_cleanup() {
         let mut cache = CiCache::default();
-        cache.update("keep-1", Some("success".to_string()), None);
-        cache.update("keep-2", Some("success".to_string()), None);
-        cache.update("remove-1", Some("failure".to_string()), None);
-        cache.update("remove-2", Some("pending".to_string()), None);
+        cache.update("keep-1", "revision", Some("success".to_string()), None);
+        cache.update("keep-2", "revision", Some("success".to_string()), None);
+        cache.update("remove-1", "revision", Some("failure".to_string()), None);
+        cache.update("remove-2", "revision", Some("pending".to_string()), None);
 
         let valid = vec!["keep-1".to_string(), "keep-2".to_string()];
         cache.cleanup(&valid);
@@ -383,8 +710,8 @@ mod tests {
     #[test]
     fn test_cache_cleanup_empty_valid() {
         let mut cache = CiCache::default();
-        cache.update("branch-1", Some("success".to_string()), None);
-        cache.update("branch-2", Some("success".to_string()), None);
+        cache.update("branch-1", "revision", Some("success".to_string()), None);
+        cache.update("branch-2", "revision", Some("success".to_string()), None);
 
         cache.cleanup(&[]);
         assert!(cache.branches.is_empty());
@@ -393,6 +720,7 @@ mod tests {
     #[test]
     fn test_branch_cache_entry_serialization() {
         let entry = BranchCacheEntry {
+            ci_revision: Some("revision-1".to_string()),
             ci_state: Some("success".to_string()),
             pr_state: Some("OPEN".to_string()),
             updated_at: 1234567890,
@@ -403,6 +731,7 @@ mod tests {
         assert!(json.contains("1234567890"));
 
         let deserialized: BranchCacheEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.ci_revision, entry.ci_revision);
         assert_eq!(deserialized.ci_state, entry.ci_state);
         assert_eq!(deserialized.pr_state, entry.pr_state);
         assert_eq!(deserialized.updated_at, entry.updated_at);
@@ -413,6 +742,7 @@ mod tests {
         let mut cache = CiCache::default();
         cache.update(
             "branch",
+            "revision",
             Some("success".to_string()),
             Some("MERGED".to_string()),
         );
@@ -423,5 +753,307 @@ mod tests {
 
         assert_eq!(deserialized.branches.len(), 1);
         assert!(deserialized.last_refresh > 0);
+    }
+
+    #[test]
+    fn concurrent_ci_transactions_preserve_different_branches() {
+        let temp = TempDir::new().unwrap();
+        let root = Arc::new(temp.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(3));
+        let writers = [("feature-a", "success"), ("feature-b", "failure")]
+            .into_iter()
+            .map(|(branch, status)| {
+                let root = Arc::clone(&root);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    CiCache::update_branch_ci(
+                        &root,
+                        branch,
+                        &format!("revision-{branch}"),
+                        Some(status.to_string()),
+                    )
+                    .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+
+        let cache = CiCache::load_strict(&root).unwrap();
+        assert_eq!(
+            cache
+                .get_ci_state_for_revision("feature-a", "revision-feature-a")
+                .as_deref(),
+            Some("success")
+        );
+        assert_eq!(
+            cache
+                .get_ci_state_for_revision("feature-b", "revision-feature-b")
+                .as_deref(),
+            Some("failure")
+        );
+    }
+
+    #[test]
+    fn stale_snapshot_writer_cannot_revert_newer_ci_or_pr_fields() {
+        let temp = TempDir::new().unwrap();
+        CiCache::refresh_branch_states(
+            temp.path(),
+            "branch-a",
+            "revision-a-old",
+            Some("pending".into()),
+            Some("DRAFT".into()),
+        )
+        .unwrap();
+        CiCache::refresh_branch_states(
+            temp.path(),
+            "branch-b",
+            "revision-b-old",
+            Some("pending".into()),
+            Some("DRAFT".into()),
+        )
+        .unwrap();
+        let mut stale = CiCache::load_strict(temp.path()).unwrap();
+
+        CiCache::refresh_branch_states(
+            temp.path(),
+            "branch-a",
+            "revision-a-new",
+            Some("success".into()),
+            Some("OPEN".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            stale
+                .branches
+                .get("branch-a")
+                .and_then(|entry| entry.ci_state.as_deref()),
+            Some("pending")
+        );
+
+        let stale_branch_b = stale.branches.get_mut("branch-b").unwrap();
+        stale_branch_b.ci_state = Some("failure".into());
+        stale_branch_b.pr_state = Some("MERGED".into());
+        let stale_branch_b_ci = stale_branch_b.ci_state.clone();
+        let stale_branch_b_pr = stale_branch_b.pr_state.clone();
+        CiCache::update_branch_ci(temp.path(), "branch-b", "revision-b-old", stale_branch_b_ci)
+            .unwrap();
+        CiCache::update_branch_pr(temp.path(), "branch-b", stale_branch_b_pr).unwrap();
+
+        let current = CiCache::load_strict(temp.path()).unwrap();
+        let branch_a = current.branches.get("branch-a").unwrap();
+        assert_eq!(branch_a.ci_state.as_deref(), Some("success"));
+        assert_eq!(branch_a.pr_state.as_deref(), Some("OPEN"));
+        let branch_b = current.branches.get("branch-b").unwrap();
+        assert_eq!(branch_b.ci_state.as_deref(), Some("failure"));
+        assert_eq!(branch_b.pr_state.as_deref(), Some("MERGED"));
+    }
+
+    #[test]
+    fn linked_worktrees_share_ci_cache_and_preserve_concurrent_field_updates() {
+        let temp = TempDir::new().unwrap();
+        let repo = git2::Repository::init(temp.path()).unwrap();
+        let signature = git2::Signature::now("Test User", "test@example.com").unwrap();
+        let mut index = repo.index().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &signature, &signature, "initial", &tree, &[])
+            .unwrap();
+        drop(tree);
+        drop(index);
+        let linked_path = temp.path().join("linked");
+        repo.worktree("linked", &linked_path, None).unwrap();
+        drop(repo);
+
+        let main_repo = crate::git::GitRepo::open_from_path(temp.path()).unwrap();
+        let linked_repo = crate::git::GitRepo::open_from_path(&linked_path).unwrap();
+        let main_cache_dir = main_repo.common_git_dir().unwrap();
+        let linked_cache_dir = linked_repo.common_git_dir().unwrap();
+        assert_eq!(main_cache_dir, linked_cache_dir);
+
+        CiCache::update_branch_ci(
+            &main_cache_dir,
+            "main-write",
+            "main-revision",
+            Some("success".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            CiCache::load_strict(&linked_cache_dir)
+                .unwrap()
+                .get_ci_state_for_revision("main-write", "main-revision")
+                .as_deref(),
+            Some("success")
+        );
+        CiCache::update_branch_pr(&linked_cache_dir, "linked-write", Some("DRAFT".into())).unwrap();
+        assert_eq!(
+            CiCache::load_strict(&main_cache_dir)
+                .unwrap()
+                .branches
+                .get("linked-write")
+                .and_then(|entry| entry.pr_state.as_deref()),
+            Some("DRAFT")
+        );
+
+        let main_cache_dir = Arc::new(main_cache_dir);
+        let linked_cache_dir = Arc::new(linked_cache_dir);
+        let barrier = Arc::new(Barrier::new(3));
+        let ci_writer = {
+            let cache_dir = Arc::clone(&main_cache_dir);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                CiCache::update_branch_ci(
+                    &cache_dir,
+                    "shared",
+                    "shared-revision",
+                    Some("success".into()),
+                )
+                .unwrap();
+            })
+        };
+        let pr_writer = {
+            let cache_dir = Arc::clone(&linked_cache_dir);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                CiCache::update_branch_pr(&cache_dir, "shared", Some("OPEN".into())).unwrap();
+            })
+        };
+
+        barrier.wait();
+        ci_writer.join().unwrap();
+        pr_writer.join().unwrap();
+
+        let current = CiCache::load_strict(&main_cache_dir).unwrap();
+        let shared = current.branches.get("shared").unwrap();
+        assert_eq!(shared.ci_state.as_deref(), Some("success"));
+        assert_eq!(shared.pr_state.as_deref(), Some("OPEN"));
+    }
+
+    #[test]
+    fn concurrent_diff_transactions_preserve_different_keys() {
+        let temp = TempDir::new().unwrap();
+        let root = Arc::new(temp.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(3));
+        let writers = [("key-a", "patch-a"), ("key-b", "patch-b")]
+            .into_iter()
+            .map(|(key, content)| {
+                let root = Arc::clone(&root);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    TuiDiffCache::insert_persisted(&root, key.to_string(), disk_diff(content))
+                        .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+
+        let cache = TuiDiffCache::load_strict(&root).unwrap();
+        assert_eq!(cache.get("key-a"), Some(&disk_diff("patch-a")));
+        assert_eq!(cache.get("key-b"), Some(&disk_diff("patch-b")));
+    }
+
+    #[test]
+    fn malformed_ci_cache_is_not_clobbered_by_transaction() {
+        let temp = TempDir::new().unwrap();
+        let path = CiCache::cache_path(temp.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let malformed = b"{\"branches\":";
+        fs::write(&path, malformed).unwrap();
+
+        let error =
+            CiCache::update_branch_ci(temp.path(), "feature", "revision", Some("success".into()))
+                .unwrap_err();
+
+        assert!(error.to_string().contains("parse"));
+        assert_eq!(fs::read(path).unwrap(), malformed);
+    }
+
+    #[test]
+    fn malformed_diff_cache_is_not_clobbered_by_transaction() {
+        let temp = TempDir::new().unwrap();
+        let path = TuiDiffCache::cache_path(temp.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let malformed = b"{\"entries\":";
+        fs::write(&path, malformed).unwrap();
+
+        let error = TuiDiffCache::insert_persisted(temp.path(), "key".into(), disk_diff("patch"))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("parse"));
+        assert_eq!(fs::read(path).unwrap(), malformed);
+    }
+
+    #[test]
+    fn shared_lock_readers_never_observe_partial_ci_json() {
+        let temp = TempDir::new().unwrap();
+        CiCache::update_branch_ci(temp.path(), "seed", "seed-revision", Some("pending".into()))
+            .unwrap();
+        let root = Arc::new(temp.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(2));
+        let writer_root = Arc::clone(&root);
+        let writer_barrier = Arc::clone(&barrier);
+        let writer = thread::spawn(move || {
+            writer_barrier.wait();
+            for index in 0..100 {
+                CiCache::update_branch_ci(
+                    &writer_root,
+                    &format!("branch-{index}"),
+                    &format!("revision-{index}"),
+                    Some("success".into()),
+                )
+                .unwrap();
+            }
+        });
+
+        barrier.wait();
+        for _ in 0..100 {
+            let cache = CiCache::load_strict(&root).unwrap();
+            assert_eq!(
+                cache
+                    .get_ci_state_for_revision("seed", "seed-revision")
+                    .as_deref(),
+                Some("pending")
+            );
+        }
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn shared_lock_readers_never_observe_partial_diff_json() {
+        let temp = TempDir::new().unwrap();
+        TuiDiffCache::insert_persisted(temp.path(), "seed".into(), disk_diff("seed")).unwrap();
+        let root = Arc::new(temp.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(2));
+        let writer_root = Arc::clone(&root);
+        let writer_barrier = Arc::clone(&barrier);
+        let writer = thread::spawn(move || {
+            writer_barrier.wait();
+            for index in 0..100 {
+                TuiDiffCache::insert_persisted(
+                    &writer_root,
+                    format!("key-{index}"),
+                    disk_diff(&format!("patch-{index}")),
+                )
+                .unwrap();
+            }
+        });
+
+        barrier.wait();
+        for _ in 0..100 {
+            let cache = TuiDiffCache::load_strict(&root).unwrap();
+            assert_eq!(cache.get("seed"), Some(&disk_diff("seed")));
+        }
+        writer.join().unwrap();
     }
 }

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -1409,27 +1409,31 @@ fn format_duration(secs: u64) -> String {
 }
 
 pub(crate) fn update_ci_cache(repo: &GitRepo, stack: &Stack, statuses: &[BranchCiStatus]) {
-    let git_dir = match repo.git_dir() {
+    let cache_dir = match repo.common_git_dir() {
         Ok(path) => path,
         Err(_) => return,
     };
 
-    let mut cache = CiCache::load(git_dir);
-    for status in statuses {
-        let pr_state = status.pr_is_draft.map(|is_draft| {
-            if is_draft {
-                "DRAFT".to_string()
-            } else {
-                "OPEN".to_string()
-            }
-        });
-        cache.update(&status.branch, status.overall_status.clone(), pr_state);
-    }
-
+    let updates = statuses
+        .iter()
+        .map(|status| {
+            let pr_state = status.pr_is_draft.map(|is_draft| {
+                if is_draft {
+                    "DRAFT".to_string()
+                } else {
+                    "OPEN".to_string()
+                }
+            });
+            (
+                status.branch.clone(),
+                status.sha.clone(),
+                status.overall_status.clone(),
+                pr_state,
+            )
+        })
+        .collect::<Vec<_>>();
     let valid_branches: Vec<String> = stack.branches.keys().cloned().collect();
-    cache.cleanup(&valid_branches);
-    cache.mark_refreshed();
-    let _ = cache.save(git_dir);
+    let _ = CiCache::refresh_branches(&cache_dir, &updates, &valid_branches);
 }
 
 /// Fetch all checks (both check runs and commit statuses), deduplicated
@@ -2085,6 +2089,31 @@ mod tests {
             pr_title: None,
             pr_review_decision: None,
         }
+    }
+
+    #[test]
+    fn ci_cache_write_uses_the_fetched_status_revision() {
+        let (_temp, repo, sha_b1, _sha_b2) = git_repo_with_two_branches();
+        let stack = test_stack_for_ci_fetch(201, 202);
+        let status = BranchCiStatus {
+            branch: "b1".to_string(),
+            sha: sha_b1.clone(),
+            sha_short: sha_b1.chars().take(7).collect(),
+            overall_status: Some("success".to_string()),
+            check_runs: Vec::new(),
+            pr_number: Some(201),
+            pr_is_draft: Some(false),
+            pr_title: None,
+            pr_review_decision: None,
+        };
+
+        update_ci_cache(&repo, &stack, &[status]);
+
+        let cache = CiCache::load(&repo.common_git_dir().unwrap());
+        let entry = cache.branches.get("b1").unwrap();
+        assert_eq!(entry.ci_revision.as_deref(), Some(sha_b1.as_str()));
+        assert_eq!(entry.ci_state.as_deref(), Some("success"));
+        assert_eq!(entry.pr_state.as_deref(), Some("OPEN"));
     }
 
     #[test]

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -71,7 +71,7 @@ pub fn run(
     let workdir = repo.workdir()?;
     let config = Config::load()?;
     let has_tracked = stack.branches.len() > 1;
-    let git_dir = repo.git_dir()?;
+    let cache_dir = repo.common_git_dir()?;
 
     let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
     let remote_branches = remote::get_remote_branches(workdir, config.remote_name())
@@ -141,12 +141,17 @@ pub fn run(
     ordered_branches.push(stack.trunk.clone());
 
     // Load CI cache (refresh happens in `stax ci`)
-    let cache = CiCache::load(git_dir);
+    let cache = CiCache::load(&cache_dir);
 
     // Build CI states from cache
     let ci_states: HashMap<String, String> = ordered_branches
         .iter()
-        .filter_map(|b| cache.get_ci_state(b).map(|s| (b.clone(), s)))
+        .filter_map(|branch| {
+            let revision = repo.branch_commit(branch).ok()?;
+            cache
+                .get_ci_state_for_revision(branch, &revision)
+                .map(|state| (branch.clone(), state))
+        })
         .collect();
 
     let mut branch_logs: Vec<BranchLogJson> = Vec::new();

--- a/src/commands/ready.rs
+++ b/src/commands/ready.rs
@@ -365,23 +365,32 @@ pub(crate) async fn fetch_row_for_branch(
         .await
         .with_context(|| format!("Failed to fetch live readiness for PR #{}", pr_number))?;
 
+    let ci_revision = status.head_sha.clone();
     let ci_summary = CiSummary::from_checks(status.ci_status.clone(), &[]);
     let mut row = PrReadinessRow::from_status(&branch.name, status, ci_summary);
     row.pr_url = Some(remote.pr_url(pr_number));
-    let _ = warm_caches_for_ready_row(repo, &row);
+    let _ = warm_caches_for_ready_row(repo, &row, &ci_revision);
     Ok(Some(row))
 }
 
-pub(crate) fn warm_caches_for_ready_row(repo: &GitRepo, row: &PrReadinessRow) -> Result<()> {
-    let git_dir = repo.git_dir()?;
-    let mut cache = CiCache::load(git_dir);
-    cache.update(
-        &row.branch,
-        Some(row.ci_status.clone()),
-        Some(ready_row_pr_cache_state(row)),
-    );
-    cache.mark_refreshed();
-    cache.save(git_dir)?;
+pub(crate) fn warm_caches_for_ready_row(
+    repo: &GitRepo,
+    row: &PrReadinessRow,
+    ci_revision: &str,
+) -> Result<()> {
+    let cache_dir = repo.common_git_dir()?;
+    let pr_state = ready_row_pr_cache_state(row);
+    if ci_revision.trim().is_empty() {
+        CiCache::update_branch_pr(&cache_dir, &row.branch, Some(pr_state))?;
+    } else {
+        CiCache::refresh_branch_states(
+            &cache_dir,
+            &row.branch,
+            ci_revision,
+            Some(row.ci_status.clone()),
+            Some(pr_state),
+        )?;
+    }
 
     if let Some(mut meta) = BranchMetadata::read(repo.inner(), &row.branch)? {
         meta.pr_info = Some(PrInfo {
@@ -960,10 +969,11 @@ mod tests {
             CiSummary::passed(),
         );
 
-        warm_caches_for_ready_row(&repo, &row).expect("warm cache");
+        warm_caches_for_ready_row(&repo, &row, "abc123").expect("warm cache");
 
-        let cache = CiCache::load(repo.git_dir().expect("git dir"));
+        let cache = CiCache::load(&repo.common_git_dir().expect("common git dir"));
         let entry = cache.branches.get(branch).expect("cache entry");
+        assert_eq!(entry.ci_revision.as_deref(), Some("abc123"));
         assert_eq!(entry.ci_state.as_deref(), Some("success"));
         assert_eq!(entry.pr_state.as_deref(), Some("draft"));
 
@@ -974,5 +984,43 @@ mod tests {
         assert_eq!(pr.number, 123);
         assert_eq!(pr.state, "open");
         assert_eq!(pr.is_draft, Some(true));
+    }
+
+    #[test]
+    fn ready_row_from_linked_worktree_warms_the_common_ci_cache() {
+        let (temp, main_repo) = temp_repo();
+        let linked_path = temp.path().join("linked");
+        run_git(
+            temp.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature/linked-cache",
+                linked_path.to_str().unwrap(),
+            ],
+        );
+        let linked_repo = GitRepo::open_from_path(&linked_path).expect("open linked repo");
+        let row = PrReadinessRow::from_status(
+            "feature/linked-cache",
+            status(|s| {
+                s.state = "open".to_string();
+                s.is_draft = true;
+                s.ci_status = CiStatus::Success;
+            }),
+            CiSummary::passed(),
+        );
+
+        warm_caches_for_ready_row(&linked_repo, &row, "abc123").expect("warm linked cache");
+
+        let cache = CiCache::load(&main_repo.common_git_dir().expect("common git dir"));
+        let entry = cache
+            .branches
+            .get("feature/linked-cache")
+            .expect("common cache entry");
+        assert_eq!(entry.ci_revision.as_deref(), Some("abc123"));
+        assert_eq!(entry.ci_state.as_deref(), Some("success"));
+        assert_eq!(entry.pr_state.as_deref(), Some("draft"));
+        assert!(cache.last_refresh > 0);
     }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -95,7 +95,7 @@ pub fn run(
     let config = Config::load()?;
     let workdir = repo.workdir()?;
     let has_tracked = stack.branches.len() > 1;
-    let git_dir = repo.git_dir()?;
+    let cache_dir = repo.common_git_dir()?;
 
     let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
 
@@ -162,12 +162,17 @@ pub fn run(
     let missing_parent_by_branch = collect_missing_parent_branches(&repo, &stack);
 
     // Load CI cache (refresh happens in `stax ci`)
-    let cache = CiCache::load(git_dir);
+    let cache = CiCache::load(&cache_dir);
 
     // Build CI states from cache
     let ci_states: HashMap<String, String> = ordered_branches
         .iter()
-        .filter_map(|b| cache.get_ci_state(b).map(|s| (b.clone(), s)))
+        .filter_map(|branch| {
+            let revision = repo.branch_commit(branch).ok()?;
+            cache
+                .get_ci_state_for_revision(branch, &revision)
+                .map(|state| (branch.clone(), state))
+        })
         .collect();
 
     let mut branch_statuses: Vec<BranchStatusJson> = Vec::new();

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1794,15 +1794,13 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
             return Some(started_at.elapsed());
         }
     };
-    let git_dir = match repo.git_dir() {
+    let cache_dir = match repo.common_git_dir() {
         Ok(p) => p,
         Err(_) => {
             LiveTimer::maybe_finish_skipped(timer, "skipped");
             return Some(started_at.elapsed());
         }
     };
-    let mut cache = CiCache::load(&git_dir);
-    let mut cache_dirty = false;
 
     let live_prs = rt.block_on(async {
         stream::iter(
@@ -1823,12 +1821,7 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
             continue;
         };
 
-        apply_live_pr_state(repo, &stack, &mut cache, &branch_name, &live_pr);
-        cache_dirty = true;
-    }
-
-    if cache_dirty {
-        let _ = cache.save(&git_dir);
+        apply_live_pr_state(repo, &stack, &cache_dir, &branch_name, &live_pr);
     }
 
     LiveTimer::maybe_finish_timed(timer);
@@ -1838,7 +1831,7 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
 fn apply_live_pr_state(
     repo: &GitRepo,
     stack: &Stack,
-    cache: &mut CiCache,
+    cache_dir: &Path,
     branch_name: &str,
     live_pr: &ForgePrInfo,
 ) {
@@ -1873,11 +1866,7 @@ fn apply_live_pr_state(
         let _ = meta.write(repo.inner(), branch_name);
     }
 
-    let existing_ci = cache
-        .branches
-        .get(branch_name)
-        .and_then(|e| e.ci_state.clone());
-    cache.update(branch_name, existing_ci, Some(pr_state));
+    let _ = CiCache::update_branch_pr(cache_dir, branch_name, Some(pr_state));
 }
 
 fn sync_fetch_refs(

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -107,9 +107,12 @@ fn run_status() -> Result<()> {
     let pr_number = info.and_then(|b| b.pr_number);
     let pr_state = info.and_then(|b| b.pr_state.as_deref());
 
-    let git_dir = repo.git_dir()?;
-    let cache = CiCache::load(git_dir);
-    let ci_state_owned = cache.get_ci_state(&current);
+    let cache_dir = repo.common_git_dir()?;
+    let cache = CiCache::load(&cache_dir);
+    let ci_state_owned = repo
+        .branch_commit(&current)
+        .ok()
+        .and_then(|revision| cache.get_ci_state_for_revision(&current, &revision));
     let ci_state = ci_state_owned.as_deref();
 
     // Prefer cache pr_state over metadata: cache is refreshed on every CI fetch,

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -30,7 +30,7 @@ pub fn run(current_only: bool, interval: Option<u64>) -> Result<()> {
         // Reload stack each iteration to pick up local branch changes
         let stack = Stack::load(&repo)?;
         let current = repo.current_branch()?;
-        let git_dir = repo.git_dir()?;
+        let cache_dir = repo.common_git_dir()?;
         let workdir = repo.workdir()?;
 
         let branches_to_watch: Vec<String> = if current_only {
@@ -59,7 +59,7 @@ pub fn run(current_only: bool, interval: Option<u64>) -> Result<()> {
                 }
                 Err(_) => {
                     // Fall back to cached data on network errors
-                    load_ci_from_cache(git_dir, &branches_to_watch)
+                    load_ci_from_cache(&repo, &cache_dir, &branches_to_watch)
                 }
             }
         } else {
@@ -223,29 +223,36 @@ fn render_watch_table(
     println!("  {}  {} {}", trunk_marker, trunk_cloud, trunk.dimmed());
 }
 
-fn load_ci_from_cache(git_dir: &std::path::Path, branches: &[String]) -> Vec<BranchCiStatus> {
-    let cache = CiCache::load(git_dir);
+fn load_ci_from_cache(
+    repo: &GitRepo,
+    cache_dir: &std::path::Path,
+    branches: &[String],
+) -> Vec<BranchCiStatus> {
+    let cache = CiCache::load(cache_dir);
     branches
         .iter()
-        .filter_map(|b| {
-            cache.get_ci_state(b).map(|_| {
-                let pr_is_draft = cache
-                    .branches
-                    .get(b.as_str())
-                    .and_then(|e| e.pr_state.as_deref())
-                    .map(|s| s.eq_ignore_ascii_case("draft"));
-                BranchCiStatus {
-                    branch: b.clone(),
-                    sha: String::new(),
-                    sha_short: String::new(),
-                    overall_status: cache.get_ci_state(b),
-                    check_runs: vec![],
-                    pr_number: None,
-                    pr_is_draft,
-                    pr_title: None,
-                    pr_review_decision: None,
-                }
-            })
+        .filter_map(|branch| {
+            let revision = repo.branch_commit(branch).ok()?;
+            cache
+                .get_ci_state_for_revision(branch, &revision)
+                .map(|overall_status| {
+                    let pr_is_draft = cache
+                        .branches
+                        .get(branch.as_str())
+                        .and_then(|e| e.pr_state.as_deref())
+                        .map(|s| s.eq_ignore_ascii_case("draft"));
+                    BranchCiStatus {
+                        branch: branch.clone(),
+                        sha_short: revision.chars().take(7).collect(),
+                        sha: revision,
+                        overall_status: Some(overall_status),
+                        check_runs: vec![],
+                        pr_number: None,
+                        pr_is_draft,
+                        pr_title: None,
+                        pr_review_decision: None,
+                    }
+                })
         })
         .collect()
 }

--- a/src/commands/worktree/pool.rs
+++ b/src/commands/worktree/pool.rs
@@ -9,7 +9,7 @@
 //! `st lane` invocations don't race on the same slot.
 
 use anyhow::{Context, Result};
-use fs4::fs_std::FileExt;
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
@@ -132,7 +132,7 @@ pub fn with_lock<T>(dir: &Path, f: impl FnOnce(&mut Pool) -> Result<T>) -> Resul
         .truncate(false)
         .open(lock_path(dir))
         .with_context(|| format!("Failed to open pool lock in {}", dir.display()))?;
-    FileExt::lock_exclusive(&lock_file).context("Failed to acquire pool lock")?;
+    <std::fs::File as FileExt>::lock(&lock_file).context("Failed to acquire pool lock")?;
 
     let result = (|| {
         let mut pool = load(dir)?;
@@ -141,7 +141,7 @@ pub fn with_lock<T>(dir: &Path, f: impl FnOnce(&mut Pool) -> Result<T>) -> Resul
         Ok(value)
     })();
 
-    let _ = FileExt::unlock(&lock_file);
+    let _ = <std::fs::File as FileExt>::unlock(&lock_file);
     result
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -518,6 +518,25 @@ impl Config {
         }
     }
 
+    /// Load global config with the selected repository's `stax.toml` overlay.
+    ///
+    /// `STAX_CONFIG_DIR` intentionally keeps its existing test-isolation
+    /// behavior and disables repository overlays.
+    pub(crate) fn load_for_repo(root: &Path) -> Result<Self> {
+        let path = Self::path()?;
+        let config = Self::load_path_or_default(&path)?;
+        if std::env::var("STAX_CONFIG_DIR").is_ok() {
+            return Ok(config);
+        }
+
+        let repo_path = root.join("stax.toml");
+        if repo_path.exists() {
+            Self::load_with_overlay(config, &repo_path)
+        } else {
+            Ok(config)
+        }
+    }
+
     fn load_path_or_default(path: &Path) -> Result<Self> {
         if path.exists() {
             let content = fs::read_to_string(path)?;
@@ -581,6 +600,10 @@ impl Config {
     pub fn github_token_with_source() -> Option<(GitHubAuthSource, String)> {
         let auth_config = Self::load().map(|c| c.auth).unwrap_or_default();
         Self::resolve_github_auth_with_config(&auth_config)
+    }
+
+    pub(crate) fn github_token_with_source_for_config(&self) -> Option<(GitHubAuthSource, String)> {
+        Self::resolve_github_auth_with_config(&self.auth)
     }
 
     /// Get the saved credentials-file token written by `stax auth`.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,18 @@ pub struct Config {
     pub restack: RestackConfig,
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct AutomaticRepoConfig {
+    #[serde(default)]
+    remote: AutomaticRepoRemoteConfig,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AutomaticRepoRemoteConfig {
+    #[serde(default)]
+    name: Option<String>,
+}
+
 /// User-configurable restack behaviour.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RestackConfig {
@@ -537,6 +549,38 @@ impl Config {
         }
     }
 
+    /// Load config for automatic credential-bearing repository hydration.
+    ///
+    /// Repository-local config may select the non-secret Git remote name, but
+    /// network destinations, provider selection, and auth settings are loaded
+    /// only from the trusted global config.
+    pub(crate) fn load_for_automatic_network(root: &Path) -> Result<Self> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        if std::env::var("STAX_CONFIG_DIR").is_ok() {
+            return Ok(config);
+        }
+
+        let repo_path = root.join("stax.toml");
+        if !repo_path.exists() {
+            return Ok(config);
+        }
+
+        let repo_content = fs::read_to_string(&repo_path)
+            .with_context(|| format!("Failed to read repo config {}", repo_path.display()))?;
+        let repo_config: AutomaticRepoConfig = toml::from_str(&repo_content)
+            .with_context(|| format!("Failed to parse repo config {}", repo_path.display()))?;
+        if let Some(remote_name) = repo_config
+            .remote
+            .name
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+        {
+            config.remote.name = remote_name;
+        }
+        Ok(config)
+    }
+
     fn load_path_or_default(path: &Path) -> Result<Self> {
         if path.exists() {
             let content = fs::read_to_string(path)?;
@@ -602,8 +646,48 @@ impl Config {
         Self::resolve_github_auth_with_config(&auth_config)
     }
 
-    pub(crate) fn github_token_with_source_for_config(&self) -> Option<(GitHubAuthSource, String)> {
-        Self::resolve_github_auth_with_config(&self.auth)
+    /// Resolve GitHub auth for a validated automatic network destination.
+    ///
+    /// The gh CLI lookup is always scoped to the validated Git remote host. An
+    /// explicitly configured global hostname must match before gh is executed.
+    pub(crate) fn github_token_with_source_for_host(
+        &self,
+        validated_host: &str,
+    ) -> Result<Option<(GitHubAuthSource, String)>> {
+        if self
+            .auth
+            .gh_hostname
+            .as_deref()
+            .and_then(Self::normalize_token)
+            .is_some_and(|configured| !configured.eq_ignore_ascii_case(validated_host))
+        {
+            anyhow::bail!(
+                "Configured GitHub auth hostname does not match the validated Git remote \
+                 hostname; update global auth.gh_hostname before automatic CI hydration"
+            );
+        }
+
+        if let Some(token) = Self::read_env_token("STAX_GITHUB_TOKEN") {
+            return Ok(Some((GitHubAuthSource::StaxGithubTokenEnv, token)));
+        }
+
+        if let Some(token) = Self::token_from_credentials_file() {
+            return Ok(Some((GitHubAuthSource::CredentialsFile, token)));
+        }
+
+        if self.auth.use_gh_cli {
+            if let Some(token) = Self::token_from_gh_cli(Some(validated_host))? {
+                return Ok(Some((GitHubAuthSource::GhCli, token)));
+            }
+        }
+
+        if self.auth.allow_github_token_env {
+            if let Some(token) = Self::read_env_token("GITHUB_TOKEN") {
+                return Ok(Some((GitHubAuthSource::GithubTokenEnv, token)));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Get the saved credentials-file token written by `stax auth`.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -36,6 +36,84 @@ fn restore_env_var(name: &str, value: Option<String>) {
     }
 }
 
+#[test]
+fn config_load_for_repo_uses_selected_root_outside_process_cwd() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_dir = temp_dir.path().join("selected-repo");
+    let elsewhere = temp_dir.path().join("elsewhere");
+    let home_dir = temp_dir.path().join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&elsewhere).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        "[ui]\ntips = true\n[remote]\nname = \"global\"\n",
+    )
+    .unwrap();
+    fs::write(
+        repo_dir.join("stax.toml"),
+        "[ui]\ntips = false\n[remote]\nname = \"selected\"\n",
+    )
+    .unwrap();
+
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
+    env::set_current_dir(&elsewhere).unwrap();
+
+    let config = Config::load_for_repo(&repo_dir).unwrap();
+
+    assert!(!config.ui.tips);
+    assert_eq!(config.remote_name(), "selected");
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+}
+
+#[test]
+fn config_load_for_repo_preserves_stax_config_dir_isolation() {
+    let _guard = env_lock();
+
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_dir = temp_dir.path().join("selected-repo");
+    let elsewhere = temp_dir.path().join("elsewhere");
+    let override_dir = temp_dir.path().join("isolated-config");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&elsewhere).unwrap();
+    fs::create_dir_all(&override_dir).unwrap();
+    fs::write(
+        override_dir.join("config.toml"),
+        "[ui]\ntips = true\n[remote]\nname = \"isolated\"\n",
+    )
+    .unwrap();
+    fs::write(
+        repo_dir.join("stax.toml"),
+        "[ui]\ntips = false\n[remote]\nname = \"repo-overlay\"\n",
+    )
+    .unwrap();
+
+    unsafe { env::set_var("STAX_CONFIG_DIR", &override_dir) };
+    env::set_current_dir(&elsewhere).unwrap();
+
+    let config = Config::load_for_repo(&repo_dir).unwrap();
+
+    assert!(config.ui.tips);
+    assert_eq!(config.remote_name(), "isolated");
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+}
+
 #[cfg(unix)]
 fn write_mock_gh(home: &Path, script_body: &str) -> String {
     use std::os::unix::fs::PermissionsExt;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -114,6 +114,75 @@ fn config_load_for_repo_preserves_stax_config_dir_isolation() {
     restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
 }
 
+#[test]
+fn automatic_network_config_only_accepts_repo_local_remote_name() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_dir = temp_dir.path().join("selected-repo");
+    let home_dir = temp_dir.path().join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        r#"
+[remote]
+name = "global"
+base_url = "https://git.trusted.example"
+api_base_url = "https://api.trusted.example/v1"
+forge = "gitea"
+
+[auth]
+use_gh_cli = false
+allow_github_token_env = false
+gh_hostname = "git.trusted.example"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        repo_dir.join("stax.toml"),
+        r#"
+[remote]
+name = "selected"
+base_url = "http://attacker.invalid"
+api_base_url = "http://attacker.invalid/api"
+forge = "github"
+
+[auth]
+use_gh_cli = true
+allow_github_token_env = true
+gh_hostname = "attacker.invalid"
+"#,
+    )
+    .unwrap();
+
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
+
+    let config = Config::load_for_automatic_network(&repo_dir).unwrap();
+
+    assert_eq!(config.remote_name(), "selected");
+    assert_eq!(config.remote.base_url, "https://git.trusted.example");
+    assert_eq!(
+        config.remote.api_base_url.as_deref(),
+        Some("https://api.trusted.example/v1")
+    );
+    assert_eq!(config.remote.forge, Some(ForgeType::Gitea));
+    assert!(!config.auth.use_gh_cli);
+    assert!(!config.auth.allow_github_token_env);
+    assert_eq!(
+        config.auth.gh_hostname.as_deref(),
+        Some("git.trusted.example")
+    );
+
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+}
+
 #[cfg(unix)]
 fn write_mock_gh(home: &Path, script_body: &str) -> String {
     use std::os::unix::fs::PermissionsExt;
@@ -1303,6 +1372,63 @@ fn test_github_token_passes_gh_hostname() {
 
     let token = Config::github_token();
     assert_eq!(token, Some("gh-host-token".to_string()));
+
+    let _ = fs::remove_dir_all(&temp_dir);
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
+    match orig_home {
+        Some(v) => unsafe { env::set_var("HOME", v) },
+        None => unsafe { env::remove_var("HOME") },
+    }
+    match orig_path {
+        Some(v) => unsafe { env::set_var("PATH", v) },
+        None => unsafe { env::remove_var("PATH") },
+    }
+    match orig_stax {
+        Some(v) => unsafe { env::set_var("STAX_GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
+    }
+    match orig_github {
+        Some(v) => unsafe { env::set_var("GITHUB_TOKEN", v) },
+        None => unsafe { env::remove_var("GITHUB_TOKEN") },
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn automatic_github_auth_rejects_configured_hostname_mismatch_before_gh_lookup() {
+    let _guard = env_lock();
+
+    let orig_home = env::var("HOME").ok();
+    let orig_path = env::var("PATH").ok();
+    let orig_stax = env::var("STAX_GITHUB_TOKEN").ok();
+    let orig_github = env::var("GITHUB_TOKEN").ok();
+    let temp_dir =
+        std::env::temp_dir().join(format!("stax-test-gh-host-mismatch-{}", std::process::id()));
+    fs::create_dir_all(&temp_dir).unwrap();
+    write_auth_config(&temp_dir, true, false, Some("github.corp.example"));
+    unsafe { env::set_var("HOME", &temp_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.join(".config").join("stax")) };
+    unsafe { env::remove_var("STAX_GITHUB_TOKEN") };
+    unsafe { env::remove_var("GITHUB_TOKEN") };
+
+    let marker = temp_dir.join("gh-was-called");
+    let mock_path = write_mock_gh(
+        &temp_dir,
+        &format!(
+            "#!/bin/sh\ntouch \"{}\"\necho \"must-not-be-read\"\n",
+            marker.display()
+        ),
+    );
+    unsafe { env::set_var("PATH", mock_path) };
+    let config = Config::load().unwrap();
+
+    let error = config
+        .github_token_with_source_for_host("github.other.example")
+        .unwrap_err();
+
+    assert!(error.to_string().contains("hostname"));
+    assert!(!marker.exists(), "gh token lookup must not run on mismatch");
+    assert!(!error.to_string().contains("must-not-be-read"));
 
     let _ = fs::remove_dir_all(&temp_dir);
     unsafe { env::remove_var("STAX_CONFIG_DIR") };

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -111,6 +111,19 @@ impl ForgeClient {
         }
     }
 
+    pub(crate) fn new_with_config(remote: &RemoteInfo, config: &Config) -> Result<Self> {
+        match remote.forge {
+            ForgeType::GitHub => Ok(Self::GitHub(GitHubClient::new_with_config(
+                remote.owner(),
+                &remote.repo,
+                remote.api_base_url.clone(),
+                config,
+            )?)),
+            ForgeType::GitLab => Ok(Self::GitLab(GitLabClient::new(remote)?)),
+            ForgeType::Gitea => Ok(Self::Gitea(GiteaClient::new(remote)?)),
+        }
+    }
+
     pub fn api_call_stats(&self) -> Option<crate::github::client::ApiCallStats> {
         match self {
             Self::GitHub(client) => Some(client.api_call_stats()),

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -14,7 +14,7 @@ use crate::github::client::{GitHubClient, OpenPrInfo};
 use crate::github::pr::{
     CiStatus, IssueComment, MergeMethod, PrComment, PrInfo, PrInfoWithHead, PrMergeStatus,
 };
-use crate::remote::{ForgeType, RemoteInfo};
+use crate::remote::{ForgeType, RemoteInfo, TrustedRemoteInfo};
 
 /// PR activity for standup reports.
 #[derive(Debug, Clone, Serialize)]
@@ -111,13 +111,18 @@ impl ForgeClient {
         }
     }
 
-    pub(crate) fn new_with_config(remote: &RemoteInfo, config: &Config) -> Result<Self> {
+    pub(crate) fn new_for_automatic(
+        trusted_remote: &TrustedRemoteInfo,
+        config: &Config,
+    ) -> Result<Self> {
+        let remote = trusted_remote.remote();
         match remote.forge {
-            ForgeType::GitHub => Ok(Self::GitHub(GitHubClient::new_with_config(
+            ForgeType::GitHub => Ok(Self::GitHub(GitHubClient::new_for_automatic(
                 remote.owner(),
                 &remote.repo,
                 remote.api_base_url.clone(),
                 config,
+                &remote.host,
             )?)),
             ForgeType::GitLab => Ok(Self::GitLab(GitLabClient::new(remote)?)),
             ForgeType::Gitea => Ok(Self::Gitea(GiteaClient::new(remote)?)),
@@ -452,6 +457,18 @@ fn base_headers(token: &str, auth_style: AuthStyle) -> Result<HeaderMap> {
 fn build_http_client(token: &str, auth_style: AuthStyle) -> Result<Client> {
     Client::builder()
         .default_headers(base_headers(token, auth_style)?)
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            let stays_on_origin = attempt.previous().first().is_some_and(|origin| {
+                attempt.url().scheme() == origin.scheme()
+                    && attempt.url().host_str() == origin.host_str()
+                    && attempt.url().port_or_known_default() == origin.port_or_known_default()
+            });
+            if stays_on_origin {
+                reqwest::redirect::Policy::limited(10).redirect(attempt)
+            } else {
+                attempt.stop()
+            }
+        }))
         .connect_timeout(Duration::from_secs(10))
         .read_timeout(Duration::from_secs(30))
         .timeout(Duration::from_secs(60))
@@ -568,6 +585,8 @@ mod tests {
     use std::env;
     use std::fs;
     use std::sync::{Mutex, OnceLock};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -621,6 +640,92 @@ mod tests {
         let statuses: [&str; 0] = [];
         let result = aggregate_ci_overall(statuses.iter().copied(), is_failure, is_pending);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn authenticated_forge_client_does_not_forward_headers_across_origins() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            for (auth_style, header_name) in [
+                (AuthStyle::AuthorizationToken, "authorization"),
+                (AuthStyle::PrivateToken, "private-token"),
+            ] {
+                let attacker = MockServer::start().await;
+                Mock::given(method("GET"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+                    .mount(&attacker)
+                    .await;
+
+                let trusted = MockServer::start().await;
+                Mock::given(method("GET"))
+                    .respond_with(ResponseTemplate::new(302).insert_header(
+                        "Location",
+                        format!(
+                            "{}/stolen",
+                            attacker.uri().replacen("127.0.0.1", "localhost", 1)
+                        ),
+                    ))
+                    .mount(&trusted)
+                    .await;
+
+                let client = build_http_client("redirect-secret", auth_style).unwrap();
+                let _ = client
+                    .get(format!("{}/checks", trusted.uri()))
+                    .send()
+                    .await
+                    .unwrap();
+                let trusted_requests = trusted.received_requests().await.unwrap_or_default();
+                let attacker_requests = attacker.received_requests().await.unwrap_or_default();
+
+                assert_eq!(trusted_requests.len(), 1);
+                assert!(
+                    trusted_requests[0].headers.contains_key(header_name),
+                    "trusted endpoint did not receive {header_name}"
+                );
+                assert!(
+                    attacker_requests
+                        .iter()
+                        .all(|request| !request.headers.contains_key(header_name)),
+                    "attacker endpoint received {header_name}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn authenticated_forge_client_preserves_same_origin_redirects() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/checks"))
+                .respond_with(ResponseTemplate::new(302).insert_header("Location", "/final"))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/final"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+                .mount(&server)
+                .await;
+
+            let client = build_http_client("redirect-secret", AuthStyle::PrivateToken).unwrap();
+            let response = client
+                .get(format!("{}/checks", server.uri()))
+                .send()
+                .await
+                .unwrap();
+            let requests = server.received_requests().await.unwrap_or_default();
+
+            assert!(response.status().is_success());
+            assert_eq!(requests.len(), 2);
+            assert!(
+                requests
+                    .iter()
+                    .all(|request| request.headers.contains_key("private-token"))
+            );
+        });
     }
 
     #[test]

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1910,9 +1910,14 @@ Use --auto-stash-pop or stash/commit changes first.",
         }
     }
 
-    /// Check if a branch has a remote tracking branch (origin/<branch>)
+    /// Check if a branch has an origin remote-tracking branch.
     pub fn has_remote(&self, branch: &str) -> bool {
-        let remote_name = format!("origin/{}", branch);
+        self.has_remote_named("origin", branch)
+    }
+
+    /// Check if a branch has a remote-tracking branch for the named remote.
+    pub fn has_remote_named(&self, remote: &str, branch: &str) -> bool {
+        let remote_name = format!("{remote}/{branch}");
         self.repo
             .find_branch(&remote_name, BranchType::Remote)
             .is_ok()
@@ -1937,10 +1942,16 @@ Use --auto-stash-pop or stash/commit changes first.",
         Ok(names)
     }
 
-    /// Get commits ahead/behind compared to remote tracking branch (origin/branch)
+    /// Get commits ahead/behind compared to the origin remote-tracking branch.
     /// Returns (unpushed, unpulled) or None if no remote tracking branch exists
     pub fn commits_vs_remote(&self, branch: &str) -> Option<(usize, usize)> {
-        let remote_name = format!("origin/{}", branch);
+        self.commits_vs_remote_named("origin", branch)
+    }
+
+    /// Get commits ahead/behind compared to a named remote-tracking branch.
+    /// Returns (unpushed, unpulled) or None if no remote tracking branch exists.
+    pub fn commits_vs_remote_named(&self, remote: &str, branch: &str) -> Option<(usize, usize)> {
+        let remote_name = format!("{remote}/{branch}");
         if self
             .repo
             .find_branch(&remote_name, BranchType::Remote)
@@ -2562,6 +2573,41 @@ mod tests {
                 .expect("canonical workdir"),
             std::fs::canonicalize(path).expect("canonical temp repo path")
         );
+    }
+
+    #[test]
+    fn configured_remote_helpers_use_the_named_tracking_ref() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test User"]);
+        fs::write(path.join("README.md"), "base\n").expect("write readme");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-m", "Initial commit"]);
+        run_git(path, &["switch", "-c", "feature"]);
+        fs::write(path.join("feature.txt"), "feature\n").expect("write feature");
+        run_git(path, &["add", "feature.txt"]);
+        run_git(path, &["commit", "-m", "Feature commit"]);
+        run_git(
+            path,
+            &["update-ref", "refs/remotes/upstream/feature", "main"],
+        );
+        run_git(
+            path,
+            &["update-ref", "refs/remotes/origin/feature", "feature"],
+        );
+        let repo = GitRepo::open_from_path(path).expect("open repo");
+
+        assert!(repo.has_remote_named("upstream", "feature"));
+        assert_eq!(
+            repo.commits_vs_remote_named("upstream", "feature"),
+            Some((1, 0))
+        );
+        assert!(!repo.has_remote_named("missing", "feature"));
+        assert_eq!(repo.commits_vs_remote_named("missing", "feature"), None);
+        assert!(repo.has_remote("feature"));
+        assert_eq!(repo.commits_vs_remote("feature"), Some((0, 0)));
     }
 
     #[test]

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -13,6 +13,14 @@ pub struct GitRepo {
     repo: Repository,
 }
 
+/// Immutable object IDs for one merge-base branch diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiffTarget {
+    pub(crate) parent_oid: String,
+    pub(crate) branch_oid: String,
+    pub(crate) merge_base_oid: String,
+}
+
 fn normalize_local_branch_name(branch: &str) -> &str {
     branch.strip_prefix("refs/heads/").unwrap_or(branch)
 }
@@ -1944,16 +1952,65 @@ Use --auto-stash-pop or stash/commit changes first.",
         }
     }
 
+    /// Resolve the refs for a diff once so subsequent work cannot observe ref movement.
+    pub(crate) fn resolve_diff_target(&self, branch: &str, parent: &str) -> Result<DiffTarget> {
+        let parent_oid = self.resolve_to_oid(parent).with_context(|| {
+            format!("Failed to resolve parent '{parent}' for branch '{branch}'")
+        })?;
+        let branch_oid = self
+            .resolve_to_oid(branch)
+            .with_context(|| format!("Failed to resolve branch '{branch}' against '{parent}'"))?;
+        let merge_base_oid = self
+            .repo
+            .merge_base(parent_oid, branch_oid)
+            .with_context(|| {
+                format!("Failed to find merge base for parent '{parent}' and branch '{branch}'")
+            })?;
+
+        Ok(DiffTarget {
+            parent_oid: parent_oid.to_string(),
+            branch_oid: branch_oid.to_string(),
+            merge_base_oid: merge_base_oid.to_string(),
+        })
+    }
+
     /// Get diff between a branch and its parent
     pub fn diff_against_parent(&self, branch: &str, parent: &str) -> Result<Vec<String>> {
-        // Use merge-base diff (A...B) to match PR semantics and avoid showing unrelated
-        // parent-side changes when the parent branch has advanced.
-        let range = format!("{}...{}", parent, branch);
-        let output = command::output(self.workdir()?, &["diff", "--color=never", &range])
-            .context("Failed to get diff")?;
+        let target = self.resolve_diff_target(branch, parent)?;
+        self.diff_against_target(branch, parent, &target)
+    }
+
+    /// Get a patch from a previously captured merge base and branch tip.
+    pub(crate) fn diff_against_target(
+        &self,
+        branch: &str,
+        parent: &str,
+        target: &DiffTarget,
+    ) -> Result<Vec<String>> {
+        let output = command::output(
+            self.workdir()?,
+            &[
+                "diff",
+                "--color=never",
+                &target.merge_base_oid,
+                &target.branch_oid,
+            ],
+        )
+        .context("Failed to get diff")?;
 
         if !output.status.success() {
-            return Ok(Vec::new());
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!(
+                "git diff patch for branch '{}' against parent '{}' failed with {}: {}",
+                branch,
+                parent,
+                output.status,
+                if stderr.is_empty() {
+                    "<no stderr>"
+                } else {
+                    &stderr
+                }
+            );
         }
 
         let diff = String::from_utf8_lossy(&output.stdout);
@@ -1962,12 +2019,41 @@ Use --auto-stash-pop or stash/commit changes first.",
 
     /// Get diff stat (numstat) between a branch and its parent
     pub fn diff_stat(&self, branch: &str, parent: &str) -> Result<Vec<(String, usize, usize)>> {
-        let range = format!("{}...{}", parent, branch);
-        let output = command::output(self.workdir()?, &["diff", "--numstat", &range])
-            .context("Failed to get diff stat")?;
+        let target = self.resolve_diff_target(branch, parent)?;
+        self.diff_stat_at_target(branch, parent, &target)
+    }
+
+    /// Get a diffstat from a previously captured merge base and branch tip.
+    pub(crate) fn diff_stat_at_target(
+        &self,
+        branch: &str,
+        parent: &str,
+        target: &DiffTarget,
+    ) -> Result<Vec<(String, usize, usize)>> {
+        let output = command::output(
+            self.workdir()?,
+            &[
+                "diff",
+                "--numstat",
+                &target.merge_base_oid,
+                &target.branch_oid,
+            ],
+        )
+        .context("Failed to get diff stat")?;
 
         if !output.status.success() {
-            return Ok(Vec::new());
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!(
+                "git diff --numstat for branch '{}' against parent '{}' failed with {}: {}",
+                branch,
+                parent,
+                output.status,
+                if stderr.is_empty() {
+                    "<no stderr>"
+                } else {
+                    &stderr
+                }
+            );
         }
 
         let stat = String::from_utf8_lossy(&output.stdout);
@@ -2476,6 +2562,46 @@ mod tests {
                 .expect("canonical workdir"),
             std::fs::canonicalize(path).expect("canonical temp repo path")
         );
+    }
+
+    #[test]
+    fn resolved_diff_target_remains_stable_after_branch_moves() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test User"]);
+        fs::write(path.join("README.md"), "base\n").expect("write readme");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-m", "Initial commit"]);
+        run_git(path, &["switch", "-c", "feature"]);
+        fs::write(path.join("captured.txt"), "captured\n").expect("write captured");
+        run_git(path, &["add", "captured.txt"]);
+        run_git(path, &["commit", "-m", "Captured feature"]);
+
+        let repo = GitRepo::open_from_path(path).expect("open repo");
+        let target = repo
+            .resolve_diff_target("feature", "main")
+            .expect("resolve immutable target");
+
+        fs::write(path.join("moved.txt"), "moved\n").expect("write moved");
+        run_git(path, &["add", "moved.txt"]);
+        run_git(path, &["commit", "-m", "Move feature"]);
+        assert_ne!(
+            target.branch_oid,
+            repo.rev_parse("feature").expect("moved feature oid")
+        );
+
+        let stat = repo
+            .diff_stat_at_target("feature", "main", &target)
+            .expect("diff stat at captured target");
+        assert_eq!(stat, vec![("captured.txt".to_string(), 1, 0)]);
+
+        let patch = repo
+            .diff_against_target("feature", "main", &target)
+            .expect("patch at captured target");
+        assert!(patch.iter().any(|line| line == "+captured"));
+        assert!(!patch.iter().any(|line| line == "+moved"));
     }
 
     #[test]

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -176,9 +176,31 @@ impl GitHubClient {
             "GitHub auth not configured. Use one of: `stax auth`, `stax auth --from-gh`, \
              `gh auth login`, or set `STAX_GITHUB_TOKEN`.",
         )?;
+        Self::new_with_auth(owner, repo, api_base_url, auth_source, token)
+    }
 
+    pub(crate) fn new_with_config(
+        owner: &str,
+        repo: &str,
+        api_base_url: Option<String>,
+        config: &Config,
+    ) -> Result<Self> {
+        let (auth_source, token) = config.github_token_with_source_for_config().context(
+            "GitHub auth not configured. Use one of: `stax auth`, `stax auth --from-gh`, \
+             `gh auth login`, or set `STAX_GITHUB_TOKEN`.",
+        )?;
+        Self::new_with_auth(owner, repo, api_base_url, auth_source, token)
+    }
+
+    fn new_with_auth(
+        owner: &str,
+        repo: &str,
+        api_base_url: Option<String>,
+        auth_source: GitHubAuthSource,
+        token: String,
+    ) -> Result<Self> {
         let mut builder = Octocrab::builder()
-            .personal_token(token.to_string())
+            .personal_token(token)
             .add_retry_config(RetryConfig::Simple(GITHUB_API_RETRY_COUNT))
             .set_connect_timeout(Some(GITHUB_API_CONNECT_TIMEOUT))
             .set_read_timeout(Some(GITHUB_API_READ_TIMEOUT))

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -179,16 +179,19 @@ impl GitHubClient {
         Self::new_with_auth(owner, repo, api_base_url, auth_source, token)
     }
 
-    pub(crate) fn new_with_config(
+    pub(crate) fn new_for_automatic(
         owner: &str,
         repo: &str,
         api_base_url: Option<String>,
         config: &Config,
+        validated_remote_host: &str,
     ) -> Result<Self> {
-        let (auth_source, token) = config.github_token_with_source_for_config().context(
-            "GitHub auth not configured. Use one of: `stax auth`, `stax auth --from-gh`, \
-             `gh auth login`, or set `STAX_GITHUB_TOKEN`.",
-        )?;
+        let (auth_source, token) = config
+            .github_token_with_source_for_host(validated_remote_host)?
+            .context(
+                "GitHub auth not configured. Use one of: `stax auth`, `stax auth --from-gh`, \
+                 `gh auth login`, or set `STAX_GITHUB_TOKEN`.",
+            )?;
         Self::new_with_auth(owner, repo, api_base_url, auth_source, token)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! The main binary is in main.rs.
 
 // Internal modules used by the CLI and tests
+pub mod application;
 mod cache;
 mod ci;
 pub mod cli;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! stax library interface
 //!
-//! This module exposes internal functionality for integration testing.
-//! The main binary is in main.rs.
+//! Shared functionality for the CLI, TUI, desktop application, and integration
+//! tests. The main CLI binary is in `main.rs`.
 
-// Internal modules used by the CLI and tests
+// Shared and internal modules used by the stax clients
 pub mod application;
 mod cache;
 mod ci;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -36,6 +36,25 @@ pub struct RemoteInfo {
     pub api_base_url: Option<String>,
 }
 
+/// A remote whose Git host, provider, and API destination were validated before
+/// automatic credential lookup.
+#[derive(Debug, Clone)]
+pub(crate) struct TrustedRemoteInfo {
+    remote: RemoteInfo,
+}
+
+impl TrustedRemoteInfo {
+    pub(crate) fn from_repo(repo: &GitRepo, global_config: &Config) -> Result<Self> {
+        let remote = RemoteInfo::from_repo(repo, global_config)?;
+        validate_automatic_network_remote(&remote, global_config)?;
+        Ok(Self { remote })
+    }
+
+    pub(crate) fn remote(&self) -> &RemoteInfo {
+        &self.remote
+    }
+}
+
 impl RemoteInfo {
     pub fn from_repo(repo: &GitRepo, config: &Config) -> Result<Self> {
         let name = config.remote_name().to_string();
@@ -54,7 +73,7 @@ impl RemoteInfo {
             || (configured_base == "https://gitlab.com" && host != "gitlab.com")
             || (configured_base == "https://gitea.com" && host != "gitea.com")
         {
-            format!("https://{}", host)
+            format!("https://{}", url_authority_host(&host))
         } else {
             configured_base.to_string()
         };
@@ -140,6 +159,106 @@ fn default_api_base_url(forge: ForgeType, base_url: &str) -> String {
         }
         ForgeType::GitLab => format!("{}/api/v4", base_url),
         ForgeType::Gitea => format!("{}/api/v1", base_url),
+    }
+}
+
+fn validate_automatic_network_remote(remote: &RemoteInfo, global_config: &Config) -> Result<()> {
+    let remote_host = remote.host.to_ascii_lowercase();
+    let base_host = network_url_host(&remote.base_url, "provider base URL")?;
+    if base_host != remote_host {
+        anyhow::bail!(
+            "Automatic CI hydration blocked a provider base URL that does not match the Git \
+             remote hostname; configure matching global remote.base_url settings"
+        );
+    }
+
+    let official_forge = official_forge_for_host(&remote_host);
+    if let Some(expected) = official_forge {
+        if remote.forge != expected {
+            anyhow::bail!(
+                "Automatic CI hydration blocked a provider mismatch for an official forge host; \
+                 remove or correct the global remote.forge override"
+            );
+        }
+    } else {
+        let configured_base_host =
+            network_url_host(&global_config.remote.base_url, "global provider base URL")?;
+        if configured_base_host != remote_host {
+            anyhow::bail!(
+                "Automatic CI hydration blocked an untrusted Git remote hostname; configure \
+                 matching global remote.base_url and remote.forge settings to trust this host"
+            );
+        }
+    }
+
+    let api_url = remote.api_base_url.as_deref().context(
+        "Automatic CI hydration requires a resolved provider API URL in global configuration",
+    )?;
+    let api_host = network_url_host(api_url, "provider API URL")?;
+    let built_in_relationship = matches!(
+        (remote.forge, remote_host.as_str(), api_host.as_str()),
+        (ForgeType::GitHub, "github.com", "api.github.com")
+            | (ForgeType::GitLab, "gitlab.com", "gitlab.com")
+            | (ForgeType::Gitea, "gitea.com", "gitea.com")
+    );
+    if api_host != remote_host
+        && !built_in_relationship
+        && global_config.remote.api_base_url.is_none()
+    {
+        anyhow::bail!(
+            "Automatic CI hydration blocked an untrusted provider API hostname; configure the \
+             remote/API relationship explicitly in global remote.api_base_url"
+        );
+    }
+
+    Ok(())
+}
+
+fn official_forge_for_host(host: &str) -> Option<ForgeType> {
+    match host {
+        "github.com" => Some(ForgeType::GitHub),
+        "gitlab.com" => Some(ForgeType::GitLab),
+        "gitea.com" => Some(ForgeType::Gitea),
+        _ => None,
+    }
+}
+
+fn network_url_host(url: &str, label: &str) -> Result<String> {
+    let parsed = reqwest::Url::parse(url)
+        .with_context(|| format!("Automatic CI hydration has an invalid {label}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        anyhow::bail!("Automatic CI hydration requires an HTTP(S) {label}");
+    }
+    parsed_url_host(&parsed)
+        .with_context(|| format!("Automatic CI hydration has an invalid {label} hostname"))
+}
+
+fn normalize_url_host(host: &str) -> String {
+    host.strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_ascii_lowercase()
+}
+
+fn parsed_url_host(parsed: &reqwest::Url) -> Result<String> {
+    let host = normalize_url_host(
+        parsed
+            .host_str()
+            .context("Remote URL does not contain a hostname")?,
+    );
+    if host.chars().any(|character| {
+        matches!(character, '@' | '%' | '/' | '\\' | '?' | '#') || character.is_whitespace()
+    }) {
+        anyhow::bail!("Remote URL contains an ambiguous hostname");
+    }
+    Ok(host)
+}
+
+fn url_authority_host(host: &str) -> String {
+    if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]")
+    } else {
+        host.to_string()
     }
 }
 
@@ -288,57 +407,67 @@ pub fn fetch_remote_refs(workdir: &Path, remote: &str, branches: &[String]) -> R
 }
 
 fn parse_remote_url(url: &str) -> Result<(String, String)> {
-    if let Some(stripped) = url.strip_prefix("git@") {
-        let mut parts = stripped.splitn(2, ':');
-        let host = parts.next().unwrap_or("").to_string();
-        let path = parts
-            .next()
-            .context("Invalid SSH remote URL")?
-            .trim_end_matches(".git")
-            .to_string();
-        return Ok((host, path));
+    if url.contains("://") {
+        let parsed = reqwest::Url::parse(url).context("Invalid remote URL")?;
+        if !matches!(parsed.scheme(), "ssh" | "http" | "https") {
+            anyhow::bail!("Unsupported remote URL scheme");
+        }
+        return remote_host_and_path(&parsed);
     }
 
-    if let Some(stripped) = url.strip_prefix("ssh://") {
-        let without_scheme = stripped;
-        let mut host_and_path = without_scheme.splitn(2, '/');
-        let host_part = host_and_path.next().unwrap_or("");
-        let path = host_and_path
-            .next()
-            .context("Invalid SSH remote URL")?
-            .trim_end_matches(".git")
-            .to_string();
-
-        let host_with_user = host_part.split('@').nth(1).unwrap_or(host_part);
-        // SSH listen port (e.g. :2222) is not the HTTPS/web port; omit it from host.
-        let host = host_with_user
-            .split(':')
-            .next()
-            .unwrap_or(host_with_user)
-            .to_string();
-        return Ok((host, path));
-    }
-
-    if let Some(stripped) = url.strip_prefix("https://") {
-        return parse_http_remote(stripped);
-    }
-
-    if let Some(stripped) = url.strip_prefix("http://") {
-        return parse_http_remote(stripped);
-    }
-
-    anyhow::bail!("Unsupported remote URL format: {}", url)
+    parse_scp_like_remote(url)
 }
 
-fn parse_http_remote(stripped: &str) -> Result<(String, String)> {
-    let mut parts = stripped.splitn(2, '/');
-    let host = parts.next().unwrap_or("").to_string();
-    let path = parts
-        .next()
-        .context("Invalid HTTP remote URL")?
+fn remote_host_and_path(parsed: &reqwest::Url) -> Result<(String, String)> {
+    let host = parsed_url_host(parsed)?;
+    let path = parsed
+        .path()
+        .trim_start_matches('/')
         .trim_end_matches(".git")
         .to_string();
+    if path.is_empty() {
+        anyhow::bail!("Invalid remote URL: missing repository path");
+    }
     Ok((host, path))
+}
+
+fn parse_scp_like_remote(url: &str) -> Result<(String, String)> {
+    let mut inside_ipv6_literal = false;
+    let mut separator = None;
+    for (index, character) in url.char_indices() {
+        match character {
+            '[' if !inside_ipv6_literal => inside_ipv6_literal = true,
+            ']' if inside_ipv6_literal => inside_ipv6_literal = false,
+            ':' if !inside_ipv6_literal => {
+                separator = Some(index);
+                break;
+            }
+            _ => {}
+        }
+    }
+    if inside_ipv6_literal {
+        anyhow::bail!("Invalid SCP-like remote URL: unterminated IPv6 hostname");
+    }
+
+    let separator = separator.context("Unsupported remote URL format")?;
+    let authority = &url[..separator];
+    let path = url[separator + 1..].trim_end_matches(".git");
+    if authority.is_empty() || path.is_empty() {
+        anyhow::bail!("Invalid SCP-like remote URL");
+    }
+    if authority.matches('@').count() > 1 {
+        anyhow::bail!("Invalid SCP-like remote URL: ambiguous user information");
+    }
+    if let Some((user, _)) = authority.split_once('@')
+        && user.is_empty()
+    {
+        anyhow::bail!("Invalid SCP-like remote URL: empty user information");
+    }
+
+    let authority_url = reqwest::Url::parse(&format!("ssh://{authority}/"))
+        .context("Invalid SCP-like remote URL authority")?;
+    let host = parsed_url_host(&authority_url)?;
+    Ok((host, path.to_string()))
 }
 
 fn split_namespace_repo(path: &str) -> Result<(String, String)> {
@@ -412,6 +541,72 @@ mod tests {
             parse_remote_url("ssh://git@gitlab.example.com:2222/org/project.git").unwrap();
         assert_eq!(host, "gitlab.example.com");
         assert_eq!(path, "org/project");
+    }
+
+    #[test]
+    fn test_parse_ssh_scheme_uses_the_actual_authority_host() {
+        let (host, path) =
+            parse_remote_url("ssh://git@github.com@attacker.example/org/project.git").unwrap();
+        assert_eq!(host, "attacker.example");
+        assert_eq!(path, "org/project");
+    }
+
+    #[test]
+    fn test_parse_ssh_scheme_ignores_userinfo_that_looks_like_a_host_and_port() {
+        let (host, path) =
+            parse_remote_url("ssh://github.com:22@attacker.example/org/project.git").unwrap();
+        assert_eq!(host, "attacker.example");
+        assert_eq!(path, "org/project");
+    }
+
+    #[test]
+    fn test_parse_ssh_scheme_rejects_an_encoded_authority_delimiter() {
+        assert!(
+            parse_remote_url("ssh://git@github.com%40attacker.example/org/project.git").is_err()
+        );
+    }
+
+    #[test]
+    fn test_parse_ssh_scheme_ipv6_host_and_port() {
+        let (host, path) =
+            parse_remote_url("ssh://git@[2001:db8::1]:2222/org/project.git").unwrap();
+        assert_eq!(host, "2001:db8::1");
+        assert_eq!(path, "org/project");
+    }
+
+    #[test]
+    fn test_parse_scp_like_ipv6_remote() {
+        let (host, path) = parse_remote_url("git@[2001:db8::1]:org/project.git").unwrap();
+        assert_eq!(host, "2001:db8::1");
+        assert_eq!(path, "org/project");
+    }
+
+    #[test]
+    fn test_parse_scp_like_remote_with_custom_user() {
+        let (host, path) = parse_remote_url("deploy@git.example.com:org/project.git").unwrap();
+        assert_eq!(host, "git.example.com");
+        assert_eq!(path, "org/project");
+    }
+
+    #[test]
+    fn test_parse_scp_like_remote_rejects_ambiguous_userinfo() {
+        let error =
+            parse_remote_url("git@github.com@attacker.example:org/project.git").unwrap_err();
+        assert!(error.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn automatic_network_remote_does_not_trust_a_hostname_hidden_in_ssh_userinfo() {
+        let (_dir, repo) =
+            repo_with_remote("ssh://git@github.com@attacker.example/owner/private-repo.git");
+
+        let error = TrustedRemoteInfo::from_repo(&repo, &Config::default()).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("untrusted"));
+        assert!(message.contains("global"));
+        assert!(!message.contains("private-repo"));
+        assert!(!message.contains("github.com@attacker.example"));
     }
 
     #[test]
@@ -664,6 +859,136 @@ mod tests {
         );
     }
 
+    fn repo_with_remote(url: &str) -> (TempDir, GitRepo) {
+        let dir = TempDir::new().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.remote("origin", url).unwrap();
+        drop(repo);
+        let repo = GitRepo::open_from_path(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    #[test]
+    fn automatic_network_remote_trusts_official_host_resolutions() {
+        let cases = [
+            (
+                "https://github.com/owner/repo.git",
+                "github.com",
+                ForgeType::GitHub,
+                "https://github.com",
+                "https://api.github.com",
+            ),
+            (
+                "https://gitlab.com/owner/repo.git",
+                "gitlab.com",
+                ForgeType::GitLab,
+                "https://gitlab.com",
+                "https://gitlab.com/api/v4",
+            ),
+            (
+                "https://gitea.com/owner/repo.git",
+                "gitea.com",
+                ForgeType::Gitea,
+                "https://gitea.com",
+                "https://gitea.com/api/v1",
+            ),
+        ];
+
+        for (url, host, forge, base_url, api_base_url) in cases {
+            let (_dir, repo) = repo_with_remote(url);
+            let trusted = TrustedRemoteInfo::from_repo(&repo, &Config::default()).unwrap();
+            let remote = trusted.remote();
+
+            assert_eq!(remote.host, host);
+            assert_eq!(remote.forge, forge);
+            assert_eq!(remote.base_url, base_url);
+            assert_eq!(remote.api_base_url.as_deref(), Some(api_base_url));
+        }
+    }
+
+    #[test]
+    fn automatic_network_remote_accepts_globally_configured_custom_relationship() {
+        let (_dir, repo) = repo_with_remote("git@git.corp.example:platform/service.git");
+        let mut config = Config::default();
+        config.remote.base_url = "https://git.corp.example".to_string();
+        config.remote.api_base_url = Some("https://api.corp.example/v3".to_string());
+        config.remote.forge = Some(ForgeType::GitHub);
+        config.auth.gh_hostname = Some("git.corp.example".to_string());
+
+        let trusted = TrustedRemoteInfo::from_repo(&repo, &config).unwrap();
+        let remote = trusted.remote();
+
+        assert_eq!(remote.host, "git.corp.example");
+        assert_eq!(remote.forge, ForgeType::GitHub);
+        assert_eq!(
+            remote.api_base_url.as_deref(),
+            Some("https://api.corp.example/v3")
+        );
+    }
+
+    #[test]
+    fn automatic_network_remote_accepts_a_globally_configured_ipv6_host() {
+        let (_dir, repo) = repo_with_remote("ssh://git@[2001:db8::1]:2222/platform/service.git");
+        let mut config = Config::default();
+        config.remote.base_url = "https://[2001:db8::1]".to_string();
+        config.remote.api_base_url = Some("https://[2001:db8::1]/api/v3".to_string());
+        config.remote.forge = Some(ForgeType::GitHub);
+
+        let trusted = TrustedRemoteInfo::from_repo(&repo, &config).unwrap();
+        let remote = trusted.remote();
+
+        assert_eq!(remote.host, "2001:db8::1");
+        assert_eq!(remote.base_url, "https://[2001:db8::1]");
+        assert_eq!(
+            remote.api_base_url.as_deref(),
+            Some("https://[2001:db8::1]/api/v3")
+        );
+    }
+
+    #[test]
+    fn automatic_network_remote_rejects_unconfigured_unknown_host() {
+        let (_dir, repo) = repo_with_remote("https://untrusted.example/owner/private-repo.git");
+
+        let error = TrustedRemoteInfo::from_repo(&repo, &Config::default()).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("untrusted"));
+        assert!(message.contains("global"));
+        assert!(!message.contains("private-repo"));
+    }
+
+    #[test]
+    fn automatic_network_remote_rejects_official_provider_mismatch() {
+        let (_dir, repo) = repo_with_remote("https://github.com/owner/repo.git");
+        let mut config = Config::default();
+        config.remote.forge = Some(ForgeType::GitLab);
+
+        let error = TrustedRemoteInfo::from_repo(&repo, &config).unwrap_err();
+
+        assert!(error.to_string().contains("provider"));
+    }
+
+    #[test]
+    fn automatic_network_remote_rejects_implicit_api_host_mismatch() {
+        let mut config = Config::default();
+        config.remote.base_url = "https://git.corp.example".to_string();
+        config.remote.forge = Some(ForgeType::GitHub);
+        let remote = RemoteInfo {
+            name: "origin".to_string(),
+            forge: ForgeType::GitHub,
+            host: "git.corp.example".to_string(),
+            namespace: "platform".to_string(),
+            repo: "service".to_string(),
+            base_url: "https://git.corp.example".to_string(),
+            api_base_url: Some("https://api.other.example/v3".to_string()),
+        };
+
+        let error = validate_automatic_network_remote(&remote, &config).unwrap_err();
+
+        assert!(error.to_string().contains("API hostname"));
+        assert!(error.to_string().contains("global"));
+    }
+
     #[test]
     fn test_detect_forge_prefers_host() {
         assert_eq!(
@@ -741,19 +1066,5 @@ mod tests {
             serde_json::from_str::<ForgeType>(r#""forgejo""#).unwrap(),
             ForgeType::Gitea
         );
-    }
-
-    #[test]
-    fn test_parse_http_remote_simple() {
-        let (host, path) = parse_http_remote("github.com/owner/repo").unwrap();
-        assert_eq!(host, "github.com");
-        assert_eq!(path, "owner/repo");
-    }
-
-    #[test]
-    fn test_parse_http_remote_with_git_extension() {
-        let (host, path) = parse_http_remote("github.com/owner/repo.git").unwrap();
-        assert_eq!(host, "github.com");
-        assert_eq!(path, "owner/repo");
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,7 @@
 use crate::application::{
     BranchDetails, BranchDiff, BranchSummary, CiSummary, DiffLine, DiffStatLine, RepositorySession,
 };
-use crate::cache::{CiCache, TuiPaneVisibilityState, TuiStateCache};
+use crate::cache::{TuiPaneVisibilityState, TuiStateCache};
 use crate::engine::{Stack, StackSnapshot, build_parent_candidates};
 use crate::git::GitRepo;
 use anyhow::Result;
@@ -306,10 +306,8 @@ pub struct PendingCommand {
 /// Main application state
 pub struct App {
     pub stack: Stack,
-    pub cache: CiCache,
     pub repo: GitRepo,
     session: RepositorySession,
-    git_dir: PathBuf,
     diff_cache_dir: PathBuf,
     pub current_branch: String,
     pub selected_index: usize,
@@ -361,14 +359,11 @@ impl App {
         let session = RepositorySession::open(repo.workdir()?)?;
         let repository_snapshot = session.snapshot()?;
         let snapshot = StackSnapshot::load(&repo)?;
-        let git_dir = repo.git_dir()?;
-        let cache = CiCache::load(git_dir);
         let diff_cache_dir = repo.common_git_dir()?;
         let pane_visibility = TuiStateCache::load(&diff_cache_dir)
             .panes
             .map(PaneVisibility::from_persisted)
             .unwrap_or_default();
-        let git_dir = git_dir.to_path_buf();
         let status_set_at = initial_status.as_ref().map(|_| Instant::now());
         let branches = repository_snapshot
             .branches
@@ -378,10 +373,8 @@ impl App {
 
         let mut app = Self {
             stack: snapshot.stack,
-            cache,
             repo,
             session,
-            git_dir,
             diff_cache_dir,
             current_branch: repository_snapshot.current_branch,
             selected_index: 0,
@@ -1077,8 +1070,6 @@ impl App {
                 {
                     branch_display.ci_state = ci_state.clone();
                 }
-                self.cache.update(&branch, ci_state, None);
-                let _ = self.cache.save(&self.git_dir);
             }
             CiUpdate::Unavailable { branch, message } => {
                 self.ci_states.insert(
@@ -1497,9 +1488,7 @@ mod tests {
     use crate::application::{
         BranchDetails, BranchSummary, CiSummary, DiffLineKind, RepositorySession,
     };
-    use crate::cache::{
-        CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiStateCache,
-    };
+    use crate::cache::{DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiStateCache};
     use crate::engine::{BranchMetadata, Stack};
     use crate::git::GitRepo;
     use std::process::Command;
@@ -1568,15 +1557,12 @@ mod tests {
     fn minimal_app(repo: GitRepo, branches: Vec<BranchDisplay>) -> App {
         let session = RepositorySession::open(repo.workdir().expect("workdir"))
             .expect("open repository session");
-        let git_dir = repo.git_dir().expect("git dir").to_path_buf();
         let diff_cache_dir = repo.common_git_dir().expect("common git dir");
         let stack = Stack::load(&repo).expect("load stack");
         App {
             stack,
-            cache: CiCache::load(&git_dir),
             repo,
             session,
-            git_dir,
             diff_cache_dir,
             current_branch: "main".to_string(),
             selected_index: 0,
@@ -1648,6 +1634,37 @@ mod tests {
         assert!(app.branches[0].details_loaded);
         assert!(app.branches[0].has_remote);
         assert_eq!(app.ci_queued_branch.as_deref(), Some("feature"));
+    }
+
+    #[test]
+    fn applying_ci_update_does_not_duplicate_the_session_cache_write() {
+        let (_tempdir, repo) = test_repo();
+        let cache_path = repo
+            .git_dir()
+            .expect("git dir")
+            .join("stax")
+            .join("ci-cache.json");
+        let mut app = minimal_app(repo, vec![skeleton_branch("feature", Some("main"), true)]);
+        let summary = CiSummary {
+            overall_status: Some("success".to_string()),
+            total: 1,
+            passed: 1,
+            failed: 0,
+            running: 0,
+            queued: 0,
+            skipped: 0,
+            started_at: None,
+            completed_at: None,
+            average_secs: None,
+        };
+
+        app.apply_ci_update(CiUpdate::Loaded {
+            branch: "feature".to_string(),
+            summary,
+        });
+
+        assert_eq!(app.branches[0].ci_state.as_deref(), Some("success"));
+        assert!(!cache_path.exists());
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1828,7 +1828,14 @@ fn spawn_diff_loader(
             }
         };
 
-        let stat = match repo.diff_stat(&request.branch, &request.parent) {
+        let target = match repo.resolve_diff_target(&request.branch, &request.parent) {
+            Ok(target) => target,
+            Err(_) => {
+                let _ = sender.send(DiffUpdate::Unavailable { request });
+                return;
+            }
+        };
+        let stat = match repo.diff_stat_at_target(&request.branch, &request.parent, &target) {
             Ok(stats) => stats
                 .into_iter()
                 .map(|(file, additions, deletions)| DiffStatLine {
@@ -1837,10 +1844,13 @@ fn spawn_diff_loader(
                     deletions,
                 })
                 .collect(),
-            Err(_) => Vec::new(),
+            Err(_) => {
+                let _ = sender.send(DiffUpdate::Unavailable { request });
+                return;
+            }
         };
 
-        let lines = match repo.diff_against_parent(&request.branch, &request.parent) {
+        let lines = match repo.diff_against_target(&request.branch, &request.parent, &target) {
             Ok(lines) => lines
                 .into_iter()
                 .map(|line| DiffLine {
@@ -1848,15 +1858,23 @@ fn spawn_diff_loader(
                     content: line,
                 })
                 .collect(),
-            Err(_) => Vec::new(),
+            Err(_) => {
+                let _ = sender.send(DiffUpdate::Unavailable { request });
+                return;
+            }
         };
 
         let diff = CachedDiff { stat, lines };
-        if let Some(key) = persistent_diff_cache_key(&repo, &request) {
-            let mut cache = TuiDiffCache::load(&diff_cache_dir);
-            cache.insert(key, cached_diff_to_disk(&diff));
-            let _ = cache.save(&diff_cache_dir);
-        }
+        let key = TuiDiffCache::key(
+            &request.parent,
+            &request.branch,
+            &target.parent_oid,
+            &target.branch_oid,
+            &target.merge_base_oid,
+        );
+        let mut cache = TuiDiffCache::load(&diff_cache_dir);
+        cache.insert(key, cached_diff_to_disk(&diff));
+        let _ = cache.save(&diff_cache_dir);
 
         let _ = sender.send(DiffUpdate::Loaded { request, diff });
     });
@@ -1955,6 +1973,7 @@ mod tests {
         Mode, PaneVisibility, TuiPane, TuiPaneVisibilityState, live_ci_summary_text,
         run_in_tokio_runtime, spawn_diff_loader, substring_filter_indices,
     };
+    use crate::application::RepositorySession;
     use crate::cache::{
         CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiStateCache,
     };
@@ -2318,6 +2337,50 @@ mod tests {
         let cached = cache.get(&key).expect("persisted diff");
         assert_eq!(cached.stat.len(), 1);
         assert!(cached.lines.iter().any(|line| line.content == "+feature"));
+    }
+
+    #[test]
+    fn diff_loader_does_not_cache_git_failures_as_empty_success() {
+        let (_tempdir, repo) = test_repo();
+        let workdir = repo.workdir().expect("workdir").to_path_buf();
+        run_git(&workdir, &["switch", "-c", "feature"]);
+        std::fs::write(workdir.join("README.md"), "hello\nfeature\n").expect("write README");
+        run_git(&workdir, &["add", "README.md"]);
+        run_git(&workdir, &["commit", "-m", "feature"]);
+
+        let parent_oid = repo.rev_parse("main").expect("main oid");
+        let branch_oid = repo.rev_parse("feature").expect("feature oid");
+        let merge_base_oid = repo.merge_base_refs("main", "feature").expect("merge base");
+        let blob_oid = repo
+            .rev_parse("feature:README.md")
+            .expect("feature README blob");
+        let repo_path = repo.git_dir().expect("git dir").to_path_buf();
+        let cache_dir = repo.common_git_dir().expect("common git dir");
+        let object_path = cache_dir
+            .join("objects")
+            .join(&blob_oid[..2])
+            .join(&blob_oid[2..]);
+        std::fs::remove_file(object_path).expect("remove feature blob");
+        let request = DiffRequest::new("feature".to_string(), "main".to_string());
+
+        let update = spawn_diff_loader(repo_path, cache_dir.clone(), request.clone())
+            .recv_timeout(Duration::from_secs(15))
+            .expect("diff update");
+
+        match update {
+            DiffUpdate::Unavailable { request: failed } => assert_eq!(failed, request),
+            DiffUpdate::Loaded { .. } => panic!("failed diff must remain unavailable"),
+        }
+        let key = TuiDiffCache::key("main", "feature", &parent_oid, &branch_oid, &merge_base_oid);
+        assert!(TuiDiffCache::load(&cache_dir).get(&key).is_none());
+        assert!(!cache_dir.join("stax").join("tui-diff-cache.json").exists());
+
+        let error = RepositorySession::open(&workdir)
+            .expect("open session")
+            .diff("feature", "main")
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("exit status"));
+        assert!(TuiDiffCache::load(&cache_dir).get(&key).is_none());
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,17 +1,12 @@
-use crate::cache::{
-    CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiPaneVisibilityState,
-    TuiStateCache,
+use crate::application::{
+    BranchDetails, BranchDiff, BranchSummary, CiSummary, DiffLine, DiffStatLine, RepositorySession,
 };
-use crate::ci::{CheckRunInfo, history};
-use crate::config::Config;
+use crate::cache::{CiCache, TuiPaneVisibilityState, TuiStateCache};
 use crate::engine::{Stack, StackSnapshot, build_parent_candidates};
-use crate::forge::ForgeClient;
 use crate::git::GitRepo;
-use crate::remote::RemoteInfo;
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use std::collections::HashMap;
-use std::future::Future;
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
@@ -20,36 +15,6 @@ use std::time::{Duration, Instant};
 const CI_ACTIVE_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const CI_IDLE_REFRESH_INTERVAL: Duration = Duration::from_secs(120);
 const CI_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(60);
-
-/// A line in a diff with its type
-#[derive(Debug, Clone)]
-pub struct DiffLine {
-    pub content: String,
-    pub line_type: DiffLineType,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum DiffLineType {
-    Header,
-    Addition,
-    Deletion,
-    Context,
-    Hunk,
-}
-
-/// A line in diff stat output
-#[derive(Debug, Clone)]
-pub struct DiffStatLine {
-    pub file: String,
-    pub additions: usize,
-    pub deletions: usize,
-}
-
-#[derive(Debug, Clone)]
-struct CachedDiff {
-    stat: Vec<DiffStatLine>,
-    lines: Vec<DiffLine>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DiffRequest {
@@ -73,27 +38,11 @@ impl DiffRequest {
 enum DiffUpdate {
     Loaded {
         request: DiffRequest,
-        diff: CachedDiff,
+        diff: BranchDiff,
     },
     Unavailable {
         request: DiffRequest,
     },
-}
-
-#[derive(Debug, Clone)]
-struct BranchDetails {
-    ahead: usize,
-    behind: usize,
-    has_remote: bool,
-    unpushed: usize,
-    unpulled: usize,
-    commits: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-struct BranchDetailsRequest {
-    name: String,
-    parent: Option<String>,
 }
 
 #[derive(Debug)]
@@ -104,141 +53,16 @@ enum BranchDetailsUpdate {
     },
     Unavailable {
         branch: String,
+        message: String,
     },
     Done,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BranchCiSummary {
-    pub overall_status: Option<String>,
-    pub total: usize,
-    pub passed: usize,
-    pub failed: usize,
-    pub running: usize,
-    pub queued: usize,
-    pub skipped: usize,
-    pub started_at: Option<DateTime<Utc>>,
-    pub completed_at: Option<DateTime<Utc>>,
-    pub average_secs: Option<u64>,
-}
-
-impl BranchCiSummary {
-    fn from_checks(
-        overall_status: Option<String>,
-        checks: &[CheckRunInfo],
-        average_secs: Option<u64>,
-    ) -> Self {
-        let mut passed = 0;
-        let mut failed = 0;
-        let mut running = 0;
-        let mut queued = 0;
-        let mut skipped = 0;
-
-        for check in checks {
-            match check.status.as_str() {
-                "completed" => match check.conclusion.as_deref() {
-                    Some("success") => passed += 1,
-                    Some("skipped") | Some("neutral") | Some("cancelled") => skipped += 1,
-                    _ => failed += 1,
-                },
-                "in_progress" => running += 1,
-                "queued" | "waiting" | "requested" | "pending" => queued += 1,
-                _ => queued += 1,
-            }
-        }
-
-        let started_at = checks
-            .iter()
-            .filter_map(|check| parse_ci_timestamp(check.started_at.as_deref()))
-            .min();
-        let completed_at = if checks.iter().all(|check| check.status == "completed") {
-            checks
-                .iter()
-                .filter_map(|check| parse_ci_timestamp(check.completed_at.as_deref()))
-                .max()
-        } else {
-            None
-        };
-
-        Self {
-            overall_status,
-            total: checks.len(),
-            passed,
-            failed,
-            running,
-            queued,
-            skipped,
-            started_at,
-            completed_at,
-            average_secs,
-        }
-    }
-
-    pub fn has_checks(&self) -> bool {
-        self.total > 0
-    }
-
-    pub fn is_active(&self) -> bool {
-        !self.is_complete() && (self.running > 0 || self.queued > 0)
-    }
-
-    pub fn is_complete(&self) -> bool {
-        self.total > 0 && self.completed_count() == self.total
-    }
-
-    pub fn completed_count(&self) -> usize {
-        self.passed + self.failed + self.skipped
-    }
-
-    pub fn elapsed_secs(&self, now: DateTime<Utc>) -> Option<u64> {
-        let started_at = self.started_at?;
-        let finished_at = if self.is_complete() {
-            self.completed_at.unwrap_or(now)
-        } else {
-            now
-        };
-        Some(
-            finished_at
-                .signed_duration_since(started_at)
-                .num_seconds()
-                .max(0) as u64,
-        )
-    }
-
-    pub fn progress_percent(&self, now: DateTime<Utc>) -> Option<u8> {
-        if self.is_complete() {
-            return Some(100);
-        }
-
-        let average_secs = self.average_secs?;
-        let elapsed_secs = self.elapsed_secs(now)?;
-        if average_secs == 0 {
-            return Some(99);
-        }
-
-        Some(if elapsed_secs >= average_secs {
-            99
-        } else {
-            ((elapsed_secs * 100) / average_secs).min(99) as u8
-        })
-    }
-
-    pub fn eta_secs(&self, now: DateTime<Utc>) -> Option<u64> {
-        if self.is_complete() {
-            return Some(0);
-        }
-
-        let average_secs = self.average_secs?;
-        let elapsed_secs = self.elapsed_secs(now)?;
-        Some(average_secs.saturating_sub(elapsed_secs))
-    }
 }
 
 #[derive(Debug, Clone)]
 pub enum BranchCiState {
     Loading,
     Ready {
-        summary: BranchCiSummary,
+        summary: CiSummary,
         fetched_at: Instant,
     },
     Unavailable {
@@ -249,14 +73,8 @@ pub enum BranchCiState {
 
 #[derive(Debug)]
 enum CiUpdate {
-    Loaded {
-        branch: String,
-        summary: BranchCiSummary,
-    },
-    Unavailable {
-        branch: String,
-        message: String,
-    },
+    Loaded { branch: String, summary: CiSummary },
+    Unavailable { branch: String, message: String },
 }
 
 /// Branch display information for the TUI
@@ -278,9 +96,46 @@ pub struct BranchDisplay {
     pub ci_state: Option<String>,
     pub commits: Vec<String>,
     pub details_loaded: bool,
+    pub details_error: Option<String>,
 }
 
 impl BranchDisplay {
+    fn from_summary(summary: BranchSummary) -> Self {
+        Self {
+            name: summary.name,
+            parent: summary.parent,
+            column: summary.column,
+            is_current: summary.is_current,
+            is_trunk: summary.is_trunk,
+            ahead: 0,
+            behind: 0,
+            needs_restack: summary.needs_restack,
+            has_remote: false,
+            unpushed: 0,
+            unpulled: 0,
+            pr_number: summary.pr_number,
+            pr_state: summary.pr_state,
+            ci_state: summary.ci_state,
+            commits: Vec::new(),
+            details_loaded: summary.is_trunk,
+            details_error: None,
+        }
+    }
+
+    fn summary(&self) -> BranchSummary {
+        BranchSummary {
+            name: self.name.clone(),
+            parent: self.parent.clone(),
+            column: self.column,
+            is_current: self.is_current,
+            is_trunk: self.is_trunk,
+            needs_restack: self.needs_restack,
+            pr_number: self.pr_number,
+            pr_state: self.pr_state.clone(),
+            ci_state: self.ci_state.clone(),
+        }
+    }
+
     fn apply_details(&mut self, details: BranchDetails) {
         self.ahead = details.ahead;
         self.behind = details.behind;
@@ -289,6 +144,7 @@ impl BranchDisplay {
         self.unpulled = details.unpulled;
         self.commits = details.commits;
         self.details_loaded = true;
+        self.details_error = None;
     }
 }
 
@@ -452,6 +308,7 @@ pub struct App {
     pub stack: Stack,
     pub cache: CiCache,
     pub repo: GitRepo,
+    session: RepositorySession,
     git_dir: PathBuf,
     diff_cache_dir: PathBuf,
     pub current_branch: String,
@@ -483,7 +340,7 @@ pub struct App {
     pub move_picker_query: String,
     /// Index into the filtered view (see `move_picker_filtered_indices`).
     pub move_picker_selected: usize,
-    diff_cache: HashMap<String, CachedDiff>,
+    diff_cache: HashMap<String, BranchDiff>,
     ci_states: HashMap<String, BranchCiState>,
     ci_loader: Option<Receiver<CiUpdate>>,
     ci_loading_branch: Option<String>,
@@ -501,6 +358,8 @@ impl App {
         preferred_selection: Option<String>,
     ) -> Result<Self> {
         let repo = GitRepo::open()?;
+        let session = RepositorySession::open(repo.workdir()?)?;
+        let repository_snapshot = session.snapshot()?;
         let snapshot = StackSnapshot::load(&repo)?;
         let git_dir = repo.git_dir()?;
         let cache = CiCache::load(git_dir);
@@ -511,16 +370,22 @@ impl App {
             .unwrap_or_default();
         let git_dir = git_dir.to_path_buf();
         let status_set_at = initial_status.as_ref().map(|_| Instant::now());
+        let branches = repository_snapshot
+            .branches
+            .into_iter()
+            .map(BranchDisplay::from_summary)
+            .collect();
 
         let mut app = Self {
             stack: snapshot.stack,
             cache,
             repo,
+            session,
             git_dir,
             diff_cache_dir,
-            current_branch: snapshot.current_branch,
+            current_branch: repository_snapshot.current_branch,
             selected_index: 0,
-            branches: Vec::new(),
+            branches,
             mode: Mode::Normal,
             search_query: String::new(),
             filtered_indices: Vec::new(),
@@ -553,7 +418,6 @@ impl App {
             diff_queued: None,
         };
 
-        app.branches = app.build_branch_list()?;
         app.needs_refresh = false;
         app.branch_details_queued = true;
         if let Some(branch) = preferred_selection {
@@ -570,138 +434,34 @@ impl App {
     /// Refresh the branch list from the repository
     pub fn refresh_branches(&mut self) -> Result<()> {
         let snapshot = StackSnapshot::load(&self.repo)?;
+        let repository_snapshot = self.session.snapshot()?;
+        let details_errors = self
+            .branches
+            .iter()
+            .filter_map(|branch| {
+                branch
+                    .details_error
+                    .as_ref()
+                    .map(|message| (branch.name.clone(), message.clone()))
+            })
+            .collect::<HashMap<_, _>>();
         self.stack = snapshot.stack;
-        self.current_branch = snapshot.current_branch;
-        self.branches = self.build_branch_list()?;
+        self.current_branch = repository_snapshot.current_branch;
+        self.branches = repository_snapshot
+            .branches
+            .into_iter()
+            .map(|summary| {
+                let mut branch = BranchDisplay::from_summary(summary);
+                branch.details_error = details_errors.get(&branch.name).cloned();
+                branch
+            })
+            .collect();
         self.diff_cache.clear();
         self.needs_refresh = false;
         self.branch_details_queued = true;
         self.queue_diff_refresh_for_selected();
         self.queue_ci_refresh_for_selected();
         Ok(())
-    }
-
-    /// Build the ordered list of branches for display
-    fn build_branch_list(&self) -> Result<Vec<BranchDisplay>> {
-        let mut branches = Vec::new();
-        let trunk = &self.stack.trunk;
-
-        // Get trunk children (each starts a chain)
-        let trunk_info = self.stack.branches.get(trunk);
-        let trunk_children: Vec<String> =
-            trunk_info.map(|b| b.children.clone()).unwrap_or_default();
-
-        if trunk_children.is_empty() {
-            // Only trunk exists
-            branches.push(self.create_branch_display(trunk, 0, true));
-            return Ok(branches);
-        }
-
-        let mut max_column = 0;
-        let mut sorted_trunk_children = trunk_children;
-        sorted_trunk_children.sort();
-
-        // Build each stack
-        for (i, root) in sorted_trunk_children.iter().enumerate() {
-            self.collect_branches(&mut branches, root, i, &mut max_column)?;
-        }
-
-        // Add trunk at the end
-        branches.push(self.create_branch_display(trunk, 0, true));
-
-        Ok(branches)
-    }
-
-    fn collect_branches(
-        &self,
-        result: &mut Vec<BranchDisplay>,
-        branch: &str,
-        base_column: usize,
-        max_column: &mut usize,
-    ) -> Result<()> {
-        #[derive(Clone)]
-        struct Frame {
-            branch: String,
-            column: usize,
-            expanded: bool,
-        }
-
-        let mut stack_frames = vec![Frame {
-            branch: branch.to_string(),
-            column: base_column,
-            expanded: false,
-        }];
-        let mut visiting = std::collections::HashSet::new();
-        let mut emitted = std::collections::HashSet::new();
-
-        while let Some(frame) = stack_frames.pop() {
-            if frame.expanded {
-                visiting.remove(&frame.branch);
-                if emitted.insert(frame.branch.clone()) {
-                    result.push(self.create_branch_display(&frame.branch, frame.column, false));
-                }
-                continue;
-            }
-
-            if emitted.contains(&frame.branch) || !visiting.insert(frame.branch.clone()) {
-                continue;
-            }
-
-            *max_column = (*max_column).max(frame.column);
-            stack_frames.push(Frame {
-                branch: frame.branch.clone(),
-                column: frame.column,
-                expanded: true,
-            });
-
-            if let Some(info) = self.stack.branches.get(&frame.branch) {
-                let mut children: Vec<&String> = info.children.iter().collect();
-                children.sort();
-
-                for (i, child) in children.into_iter().enumerate().rev() {
-                    if emitted.contains(child) || visiting.contains(child) {
-                        continue;
-                    }
-
-                    stack_frames.push(Frame {
-                        branch: child.clone(),
-                        column: frame.column + i,
-                        expanded: false,
-                    });
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn create_branch_display(&self, branch: &str, column: usize, is_trunk: bool) -> BranchDisplay {
-        let is_current = branch == self.current_branch;
-        let info = self.stack.branches.get(branch);
-        let needs_restack = info.map(|i| i.needs_restack).unwrap_or(false);
-        let pr_number = info.and_then(|i| i.pr_number);
-        let pr_state = info.and_then(|i| i.pr_state.clone());
-        let parent = info.and_then(|i| i.parent.clone());
-        let ci_state = self.cache.get_ci_state(branch);
-
-        BranchDisplay {
-            name: branch.to_string(),
-            parent,
-            column,
-            is_current,
-            is_trunk,
-            ahead: 0,
-            behind: 0,
-            needs_restack,
-            has_remote: false,
-            unpushed: 0,
-            unpulled: 0,
-            pr_number,
-            pr_state,
-            ci_state,
-            commits: Vec::new(),
-            details_loaded: is_trunk,
-        }
     }
 
     /// Select the current branch in the list
@@ -883,7 +643,7 @@ impl App {
             return;
         }
 
-        if let Some(cached) = self.load_persisted_diff(&request) {
+        if let Ok(Some(cached)) = self.session.cached_diff(&request.branch, &request.parent) {
             self.diff_cache.insert(request.key.clone(), cached.clone());
             self.diff_stat = cached.stat;
             self.selected_diff = cached.lines;
@@ -1035,6 +795,10 @@ impl App {
     }
 
     pub fn ci_summary_line(&self, branch: &BranchDisplay) -> (String, bool) {
+        if let Some(message) = branch.details_error.as_ref() {
+            return (format!("Live CI: {message}"), true);
+        }
+
         match self.ci_states.get(&branch.name) {
             Some(BranchCiState::Loading) => ("Live CI: fetching latest checks…".to_string(), false),
             Some(BranchCiState::Unavailable { message, .. }) => {
@@ -1065,6 +829,20 @@ impl App {
         };
 
         if !selected.details_loaded {
+            return;
+        }
+
+        if let Some(message) = selected.details_error.clone() {
+            if self.ci_queued_branch.as_deref() == Some(branch.as_str()) {
+                self.ci_queued_branch = None;
+            }
+            self.ci_states.insert(
+                branch,
+                BranchCiState::Unavailable {
+                    message,
+                    fetched_at: Instant::now(),
+                },
+            );
             return;
         }
 
@@ -1112,15 +890,12 @@ impl App {
             .branches
             .iter()
             .filter(|branch| !branch.is_trunk)
-            .map(|branch| BranchDetailsRequest {
-                name: branch.name.clone(),
-                parent: branch.parent.clone(),
-            })
+            .map(BranchDisplay::summary)
             .collect::<Vec<_>>();
 
         self.branch_details_queued = false;
         self.branch_details_loader = (!requests.is_empty())
-            .then(|| spawn_branch_details_loader(self.git_dir.clone(), requests));
+            .then(|| spawn_branch_details_loader(self.session.clone(), requests));
     }
 
     fn poll_branch_details_updates(&mut self) {
@@ -1147,17 +922,38 @@ impl App {
     fn apply_branch_details_update(&mut self, update: BranchDetailsUpdate) {
         match update {
             BranchDetailsUpdate::Loaded { branch, details } => {
+                let mut recovered_from_error = false;
                 if let Some(branch_display) =
                     self.branches.iter_mut().find(|item| item.name == branch)
                 {
+                    recovered_from_error = branch_display.details_error.is_some();
                     branch_display.apply_details(details);
                 }
+                if recovered_from_error
+                    && matches!(
+                        self.ci_states.get(&branch),
+                        Some(BranchCiState::Unavailable { .. })
+                    )
+                {
+                    self.ci_states.remove(&branch);
+                }
             }
-            BranchDetailsUpdate::Unavailable { branch } => {
+            BranchDetailsUpdate::Unavailable { branch, message } => {
                 if let Some(branch_display) =
                     self.branches.iter_mut().find(|item| item.name == branch)
                 {
                     branch_display.details_loaded = true;
+                    branch_display.details_error = Some(message.clone());
+                    self.ci_states.insert(
+                        branch.clone(),
+                        BranchCiState::Unavailable {
+                            message,
+                            fetched_at: Instant::now(),
+                        },
+                    );
+                    if self.ci_queued_branch.as_deref() == Some(branch.as_str()) {
+                        self.ci_queued_branch = None;
+                    }
                 }
             }
             BranchDetailsUpdate::Done => {
@@ -1198,17 +994,7 @@ impl App {
         };
 
         self.diff_loading = Some(request.clone());
-        self.diff_loader = Some(spawn_diff_loader(
-            self.git_dir.clone(),
-            self.diff_cache_dir.clone(),
-            request,
-        ));
-    }
-
-    fn load_persisted_diff(&self, request: &DiffRequest) -> Option<CachedDiff> {
-        let key = persistent_diff_cache_key(&self.repo, request)?;
-        let cache = TuiDiffCache::load(&self.diff_cache_dir);
-        cache.get(&key).map(cached_diff_from_disk)
+        self.diff_loader = Some(spawn_diff_loader(self.session.clone(), request));
     }
 
     fn apply_diff_update(&mut self, update: DiffUpdate) {
@@ -1265,7 +1051,7 @@ impl App {
         self.ci_states
             .insert(branch.clone(), BranchCiState::Loading);
         self.ci_loading_branch = Some(branch.clone());
-        self.ci_loader = Some(spawn_ci_loader(self.git_dir.clone(), branch));
+        self.ci_loader = Some(spawn_ci_loader(self.session.clone(), branch));
     }
 
     fn apply_ci_update(&mut self, update: CiUpdate) {
@@ -1577,11 +1363,7 @@ fn substring_filter_indices(candidates: &[String], query: &str) -> Vec<usize> {
         .collect()
 }
 
-fn parse_ci_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
-    value.and_then(|timestamp| timestamp.parse::<DateTime<Utc>>().ok())
-}
-
-fn live_ci_summary_text(summary: &BranchCiSummary) -> (String, bool) {
+fn live_ci_summary_text(summary: &CiSummary) -> (String, bool) {
     if !summary.has_checks() {
         return (
             "Live CI: no checks reported for the latest push".to_string(),
@@ -1649,161 +1431,23 @@ fn format_duration_compact(secs: u64) -> String {
     }
 }
 
-fn branch_average_secs(repo: &GitRepo, checks: &[CheckRunInfo]) -> Option<u64> {
-    history::estimate_run_average(repo, checks)
-        .or_else(|| checks.iter().filter_map(|check| check.average_secs).max())
-}
-
-fn diff_line_type(line: &str) -> DiffLineType {
-    if line.starts_with("+++") || line.starts_with("---") {
-        DiffLineType::Header
-    } else if line.starts_with('+') {
-        DiffLineType::Addition
-    } else if line.starts_with('-') {
-        DiffLineType::Deletion
-    } else if line.starts_with("@@") {
-        DiffLineType::Hunk
-    } else if line.starts_with("diff ") || line.starts_with("index ") {
-        DiffLineType::Header
-    } else {
-        DiffLineType::Context
-    }
-}
-
-fn diff_line_type_name(line_type: &DiffLineType) -> &'static str {
-    match line_type {
-        DiffLineType::Header => "header",
-        DiffLineType::Addition => "addition",
-        DiffLineType::Deletion => "deletion",
-        DiffLineType::Context => "context",
-        DiffLineType::Hunk => "hunk",
-    }
-}
-
-fn diff_line_type_from_name(name: &str, content: &str) -> DiffLineType {
-    match name {
-        "header" => DiffLineType::Header,
-        "addition" => DiffLineType::Addition,
-        "deletion" => DiffLineType::Deletion,
-        "context" => DiffLineType::Context,
-        "hunk" => DiffLineType::Hunk,
-        _ => diff_line_type(content),
-    }
-}
-
-fn cached_diff_to_disk(diff: &CachedDiff) -> DiskCachedDiff {
-    DiskCachedDiff {
-        stat: diff
-            .stat
-            .iter()
-            .map(|line| DiskDiffStat {
-                file: line.file.clone(),
-                additions: line.additions,
-                deletions: line.deletions,
-            })
-            .collect(),
-        lines: diff
-            .lines
-            .iter()
-            .map(|line| DiskDiffLine {
-                content: line.content.clone(),
-                line_type: diff_line_type_name(&line.line_type).to_string(),
-            })
-            .collect(),
-    }
-}
-
-fn cached_diff_from_disk(diff: &DiskCachedDiff) -> CachedDiff {
-    CachedDiff {
-        stat: diff
-            .stat
-            .iter()
-            .map(|line| DiffStatLine {
-                file: line.file.clone(),
-                additions: line.additions,
-                deletions: line.deletions,
-            })
-            .collect(),
-        lines: diff
-            .lines
-            .iter()
-            .map(|line| DiffLine {
-                content: line.content.clone(),
-                line_type: diff_line_type_from_name(&line.line_type, &line.content),
-            })
-            .collect(),
-    }
-}
-
-fn persistent_diff_cache_key(repo: &GitRepo, request: &DiffRequest) -> Option<String> {
-    let parent_oid = repo.rev_parse(&request.parent).ok()?;
-    let branch_oid = repo.rev_parse(&request.branch).ok()?;
-    let merge_base_oid = repo
-        .merge_base_refs(&request.parent, &request.branch)
-        .ok()?;
-
-    Some(TuiDiffCache::key(
-        &request.parent,
-        &request.branch,
-        &parent_oid,
-        &branch_oid,
-        &merge_base_oid,
-    ))
-}
-
-fn load_branch_details(repo: &GitRepo, request: &BranchDetailsRequest) -> BranchDetails {
-    let (ahead, behind) = request
-        .parent
-        .as_deref()
-        .and_then(|parent| repo.commits_ahead_behind(parent, &request.name).ok())
-        .unwrap_or((0, 0));
-    let has_remote = repo.has_remote(&request.name);
-    let (unpushed, unpulled) = repo.commits_vs_remote(&request.name).unwrap_or((0, 0));
-    let commits = request
-        .parent
-        .as_deref()
-        .and_then(|parent| repo.commits_between(parent, &request.name).ok())
-        .unwrap_or_default()
-        .into_iter()
-        .take(10)
-        .collect();
-
-    BranchDetails {
-        ahead,
-        behind,
-        has_remote,
-        unpushed,
-        unpulled,
-        commits,
-    }
-}
-
 fn spawn_branch_details_loader(
-    repo_path: PathBuf,
-    requests: Vec<BranchDetailsRequest>,
+    session: RepositorySession,
+    requests: Vec<BranchSummary>,
 ) -> Receiver<BranchDetailsUpdate> {
     let (sender, receiver) = mpsc::channel();
 
     thread::spawn(move || {
-        let repo = match GitRepo::open_from_path(&repo_path) {
-            Ok(repo) => repo,
-            Err(_) => {
-                for request in requests {
-                    let _ = sender.send(BranchDetailsUpdate::Unavailable {
-                        branch: request.name,
-                    });
-                }
-                let _ = sender.send(BranchDetailsUpdate::Done);
-                return;
-            }
-        };
-
         for request in requests {
-            let details = load_branch_details(&repo, &request);
-            let _ = sender.send(BranchDetailsUpdate::Loaded {
-                branch: request.name,
-                details,
-            });
+            let branch = request.name.clone();
+            let update = match session.branch_details(&request) {
+                Ok(details) => BranchDetailsUpdate::Loaded { branch, details },
+                Err(error) => BranchDetailsUpdate::Unavailable {
+                    branch,
+                    message: format!("{error:#}"),
+                },
+            };
+            let _ = sender.send(update);
         }
 
         let _ = sender.send(BranchDetailsUpdate::Done);
@@ -1812,155 +1456,32 @@ fn spawn_branch_details_loader(
     receiver
 }
 
-fn spawn_diff_loader(
-    repo_path: PathBuf,
-    diff_cache_dir: PathBuf,
-    request: DiffRequest,
-) -> Receiver<DiffUpdate> {
+fn spawn_diff_loader(session: RepositorySession, request: DiffRequest) -> Receiver<DiffUpdate> {
     let (sender, receiver) = mpsc::channel();
 
     thread::spawn(move || {
-        let repo = match GitRepo::open_from_path(&repo_path) {
-            Ok(repo) => repo,
-            Err(_) => {
-                let _ = sender.send(DiffUpdate::Unavailable { request });
-                return;
-            }
+        let update = match session.diff(&request.branch, &request.parent) {
+            Ok(diff) => DiffUpdate::Loaded { request, diff },
+            Err(_) => DiffUpdate::Unavailable { request },
         };
-
-        let target = match repo.resolve_diff_target(&request.branch, &request.parent) {
-            Ok(target) => target,
-            Err(_) => {
-                let _ = sender.send(DiffUpdate::Unavailable { request });
-                return;
-            }
-        };
-        let stat = match repo.diff_stat_at_target(&request.branch, &request.parent, &target) {
-            Ok(stats) => stats
-                .into_iter()
-                .map(|(file, additions, deletions)| DiffStatLine {
-                    file,
-                    additions,
-                    deletions,
-                })
-                .collect(),
-            Err(_) => {
-                let _ = sender.send(DiffUpdate::Unavailable { request });
-                return;
-            }
-        };
-
-        let lines = match repo.diff_against_target(&request.branch, &request.parent, &target) {
-            Ok(lines) => lines
-                .into_iter()
-                .map(|line| DiffLine {
-                    line_type: diff_line_type(&line),
-                    content: line,
-                })
-                .collect(),
-            Err(_) => {
-                let _ = sender.send(DiffUpdate::Unavailable { request });
-                return;
-            }
-        };
-
-        let diff = CachedDiff { stat, lines };
-        let key = TuiDiffCache::key(
-            &request.parent,
-            &request.branch,
-            &target.parent_oid,
-            &target.branch_oid,
-            &target.merge_base_oid,
-        );
-        let mut cache = TuiDiffCache::load(&diff_cache_dir);
-        cache.insert(key, cached_diff_to_disk(&diff));
-        let _ = cache.save(&diff_cache_dir);
-
-        let _ = sender.send(DiffUpdate::Loaded { request, diff });
+        let _ = sender.send(update);
     });
 
     receiver
 }
 
-fn run_in_tokio_runtime<T, F, Fut>(operation: F) -> Result<T>
-where
-    F: FnOnce() -> Result<Fut>,
-    Fut: Future<Output = Result<T>>,
-{
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async move {
-        let future = operation()?;
-        future.await
-    })
-}
-
-fn spawn_ci_loader(repo_path: PathBuf, branch: String) -> Receiver<CiUpdate> {
+fn spawn_ci_loader(session: RepositorySession, branch: String) -> Receiver<CiUpdate> {
     let (sender, receiver) = mpsc::channel();
 
     thread::spawn(move || {
-        let repo = match GitRepo::open_from_path(&repo_path) {
-            Ok(repo) => repo,
-            Err(_) => {
-                let _ = sender.send(CiUpdate::Unavailable {
-                    branch,
-                    message: "unable to open the repository".to_string(),
-                });
-                return;
-            }
+        let update = match session.load_ci(&branch) {
+            Ok(summary) => CiUpdate::Loaded { branch, summary },
+            Err(error) => CiUpdate::Unavailable {
+                branch,
+                message: format!("{error:#}"),
+            },
         };
-
-        let config = match Config::load() {
-            Ok(config) => config,
-            Err(_) => {
-                let _ = sender.send(CiUpdate::Unavailable {
-                    branch,
-                    message: "unable to load config".to_string(),
-                });
-                return;
-            }
-        };
-
-        let remote = match RemoteInfo::from_repo(&repo, &config) {
-            Ok(remote) => remote,
-            Err(_) => {
-                let _ = sender.send(CiUpdate::Unavailable {
-                    branch,
-                    message: "configure a git remote to fetch checks".to_string(),
-                });
-                return;
-            }
-        };
-
-        let sha = match repo.branch_commit(&branch) {
-            Ok(sha) => sha,
-            Err(_) => {
-                let _ = sender.send(CiUpdate::Unavailable {
-                    branch,
-                    message: "branch commit could not be resolved".to_string(),
-                });
-                return;
-            }
-        };
-
-        let repo_ref = &repo;
-        let sha_ref = sha.as_str();
-        let (overall_status, check_runs) = match run_in_tokio_runtime(|| {
-            let client = ForgeClient::new(&remote)?;
-            Ok(async move { client.fetch_checks(repo_ref, sha_ref).await })
-        }) {
-            Ok(result) => result,
-            Err(_) => {
-                let _ = sender.send(CiUpdate::Unavailable {
-                    branch: branch.clone(),
-                    message: "live CI is temporarily unavailable".to_string(),
-                });
-                return;
-            }
-        };
-
-        let average_secs = branch_average_secs(&repo, &check_runs);
-        let summary = BranchCiSummary::from_checks(overall_status, &check_runs, average_secs);
-        let _ = sender.send(CiUpdate::Loaded { branch, summary });
+        let _ = sender.send(update);
     });
 
     receiver
@@ -1969,25 +1490,20 @@ fn spawn_ci_loader(repo_path: PathBuf, branch: String) -> Receiver<CiUpdate> {
 #[cfg(test)]
 mod tests {
     use super::{
-        App, BranchCiSummary, BranchDisplay, DiffLineType, DiffRequest, DiffUpdate, FocusedPane,
-        Mode, PaneVisibility, TuiPane, TuiPaneVisibilityState, live_ci_summary_text,
-        run_in_tokio_runtime, spawn_diff_loader, substring_filter_indices,
+        App, BranchCiState, BranchDetailsUpdate, BranchDisplay, CiUpdate, DiffRequest, DiffUpdate,
+        FocusedPane, Mode, PaneVisibility, TuiPane, TuiPaneVisibilityState, live_ci_summary_text,
+        spawn_branch_details_loader, spawn_ci_loader, spawn_diff_loader, substring_filter_indices,
     };
-    use crate::application::RepositorySession;
+    use crate::application::{
+        BranchDetails, BranchSummary, CiSummary, DiffLineKind, RepositorySession,
+    };
     use crate::cache::{
         CiCache, DiskCachedDiff, DiskDiffLine, DiskDiffStat, TuiDiffCache, TuiStateCache,
     };
-    use crate::engine::Stack;
+    use crate::engine::{BranchMetadata, Stack};
     use crate::git::GitRepo;
-    use anyhow::{Result, anyhow};
-    use chrono::{TimeZone, Utc};
-    use std::future::Ready;
     use std::process::Command;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    };
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     fn names(values: &[&str]) -> Vec<String> {
@@ -2045,10 +1561,13 @@ mod tests {
             ci_state: None,
             commits: Vec::new(),
             details_loaded: parent.is_none(),
+            details_error: None,
         }
     }
 
     fn minimal_app(repo: GitRepo, branches: Vec<BranchDisplay>) -> App {
+        let session = RepositorySession::open(repo.workdir().expect("workdir"))
+            .expect("open repository session");
         let git_dir = repo.git_dir().expect("git dir").to_path_buf();
         let diff_cache_dir = repo.common_git_dir().expect("common git dir");
         let stack = Stack::load(&repo).expect("load stack");
@@ -2056,6 +1575,7 @@ mod tests {
             stack,
             cache: CiCache::load(&git_dir),
             repo,
+            session,
             git_dir,
             diff_cache_dir,
             current_branch: "main".to_string(),
@@ -2108,6 +1628,132 @@ mod tests {
     }
 
     #[test]
+    fn custom_remote_details_make_selected_branch_eligible_for_ci_queueing() {
+        let (_tempdir, repo) = test_repo();
+        let mut app = minimal_app(repo, vec![skeleton_branch("feature", Some("main"), true)]);
+
+        app.apply_branch_details_update(BranchDetailsUpdate::Loaded {
+            branch: "feature".to_string(),
+            details: BranchDetails {
+                ahead: 1,
+                behind: 0,
+                has_remote: true,
+                unpushed: 1,
+                unpulled: 0,
+                commits: vec!["feature commit".to_string()],
+            },
+        });
+        app.queue_ci_refresh_for_selected();
+
+        assert!(app.branches[0].details_loaded);
+        assert!(app.branches[0].has_remote);
+        assert_eq!(app.ci_queued_branch.as_deref(), Some("feature"));
+    }
+
+    #[test]
+    fn hydration_config_error_precedes_no_remote_ci_guidance_and_recovers() {
+        let (_tempdir, repo) = test_repo();
+        let workdir = repo.workdir().expect("workdir").to_path_buf();
+        run_git(&workdir, &["switch", "-c", "feature"]);
+        let main_oid = repo.rev_parse("main").expect("main oid");
+        BranchMetadata::new("main", &main_oid)
+            .write(repo.inner(), "feature")
+            .expect("write feature metadata");
+        std::fs::write(
+            workdir.join("stax.toml"),
+            "[remote\nname = \"origin\"\ntoken = \"super-secret-credential\"\n",
+        )
+        .expect("write malformed config");
+        let request = BranchSummary {
+            name: "feature".to_string(),
+            parent: Some("main".to_string()),
+            column: 0,
+            is_current: true,
+            is_trunk: false,
+            needs_restack: false,
+            pr_number: None,
+            pr_state: None,
+            ci_state: None,
+        };
+        let session = RepositorySession::open(&workdir).expect("open session");
+        let repository_root = session.repository_root().display().to_string();
+
+        let update = spawn_branch_details_loader(session, vec![request])
+            .recv_timeout(Duration::from_secs(15))
+            .expect("details update");
+        match &update {
+            BranchDetailsUpdate::Unavailable { branch, message } => {
+                assert_eq!(branch, "feature");
+                assert!(message.contains("Failed to load stax config"));
+                assert!(message.contains(&repository_root));
+                assert!(!message.contains("super-secret-credential"));
+            }
+            BranchDetailsUpdate::Loaded { .. } | BranchDetailsUpdate::Done => {
+                panic!("malformed config must make details unavailable")
+            }
+        }
+
+        let mut app = minimal_app(repo, vec![skeleton_branch("feature", Some("main"), true)]);
+        app.apply_branch_details_update(update);
+        app.queue_ci_refresh_for_selected();
+
+        assert!(app.branches[0].details_loaded);
+        assert!(app.branches[0].details_error.is_some());
+        assert!(app.ci_queued_branch.is_none());
+        match app.ci_states.get("feature") {
+            Some(BranchCiState::Unavailable { message, .. }) => {
+                assert!(message.contains("stax config"));
+                assert!(!message.contains("super-secret-credential"));
+            }
+            Some(BranchCiState::Loading | BranchCiState::Ready { .. }) | None => {
+                panic!("hydration failure must populate unavailable CI state")
+            }
+        }
+        let (summary, _) = app.ci_summary_line(&app.branches[0]);
+        assert!(summary.contains("stax config"));
+        assert!(!summary.contains("push branch"));
+        assert!(!summary.contains("super-secret-credential"));
+
+        std::fs::write(workdir.join("stax.toml"), "[remote]\nname = \"origin\"\n")
+            .expect("fix config");
+        app.refresh_branches().expect("refresh branches");
+        assert!(app.branch_details_queued);
+        let refreshing = app
+            .branches
+            .iter()
+            .find(|branch| branch.name == "feature")
+            .expect("refreshed feature");
+        assert!(!refreshing.details_loaded);
+        assert!(refreshing.details_error.is_some());
+
+        let started = Instant::now();
+        loop {
+            app.refresh_background();
+            let recovered = app
+                .branches
+                .iter()
+                .find(|branch| branch.name == "feature")
+                .is_some_and(|branch| branch.details_loaded && branch.details_error.is_none());
+            if recovered {
+                break;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(15),
+                "details refresh did not recover"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        app.select_branch("feature");
+        app.queue_ci_refresh_for_selected();
+
+        let recovered = app.selected_branch().expect("selected feature");
+        assert!(recovered.details_error.is_none());
+        let (summary, _) = app.ci_summary_line(recovered);
+        assert!(summary.contains("push branch"));
+        assert!(!summary.contains("stax config"));
+    }
+
+    #[test]
     fn selecting_next_branch_queues_diff_without_loading_patch_synchronously() {
         let (_tempdir, repo) = test_repo();
         let mut app = minimal_app(
@@ -2127,6 +1773,42 @@ mod tests {
         );
         assert!(app.selected_diff.is_empty());
         assert!(app.diff_stat.is_empty());
+    }
+
+    #[test]
+    fn selecting_branch_cache_miss_does_not_compute_patch_synchronously() {
+        let (_tempdir, repo) = test_repo();
+        let workdir = repo.workdir().expect("workdir").to_path_buf();
+        run_git(&workdir, &["switch", "-c", "feature"]);
+        std::fs::write(workdir.join("README.md"), "hello\nfeature\n").expect("write README");
+        run_git(&workdir, &["add", "README.md"]);
+        run_git(&workdir, &["commit", "-m", "feature"]);
+        let blob_oid = repo
+            .rev_parse("feature:README.md")
+            .expect("feature README blob");
+        let cache_dir = repo.common_git_dir().expect("common git dir");
+        let object_path = cache_dir
+            .join("objects")
+            .join(&blob_oid[..2])
+            .join(&blob_oid[2..]);
+        std::fs::remove_file(object_path).expect("remove feature blob");
+        let mut app = minimal_app(
+            repo,
+            vec![
+                skeleton_branch("main", None, false),
+                skeleton_branch("feature", Some("main"), true),
+            ],
+        );
+
+        app.select_next();
+
+        assert_eq!(
+            app.diff_queued,
+            Some(DiffRequest::new("feature".to_string(), "main".to_string()))
+        );
+        assert!(app.selected_diff.is_empty());
+        assert!(app.diff_stat.is_empty());
+        assert!(!cache_dir.join("stax").join("tui-diff-cache.json").exists());
     }
 
     #[test]
@@ -2241,7 +1923,7 @@ mod tests {
         assert_eq!(app.diff_queued, None);
         assert_eq!(app.selected_diff.len(), 1);
         assert_eq!(app.selected_diff[0].content, "cached diff line");
-        assert_eq!(app.selected_diff[0].line_type, DiffLineType::Context);
+        assert_eq!(app.selected_diff[0].kind, DiffLineKind::Context);
         assert_eq!(app.diff_stat.len(), 1);
         assert_eq!(app.diff_stat[0].file, "README.md");
     }
@@ -2314,10 +1996,10 @@ mod tests {
         run_git(&workdir, &["add", "README.md"]);
         run_git(&workdir, &["commit", "-m", "feature"]);
 
-        let repo_path = repo.git_dir().expect("git dir").to_path_buf();
         let cache_dir = repo.common_git_dir().expect("common git dir");
         let request = DiffRequest::new("feature".to_string(), "main".to_string());
-        let receiver = spawn_diff_loader(repo_path, cache_dir.clone(), request.clone());
+        let session = RepositorySession::open(&workdir).expect("open session");
+        let receiver = spawn_diff_loader(session, request.clone());
 
         match receiver
             .recv_timeout(Duration::from_secs(15))
@@ -2354,7 +2036,6 @@ mod tests {
         let blob_oid = repo
             .rev_parse("feature:README.md")
             .expect("feature README blob");
-        let repo_path = repo.git_dir().expect("git dir").to_path_buf();
         let cache_dir = repo.common_git_dir().expect("common git dir");
         let object_path = cache_dir
             .join("objects")
@@ -2362,8 +2043,9 @@ mod tests {
             .join(&blob_oid[2..]);
         std::fs::remove_file(object_path).expect("remove feature blob");
         let request = DiffRequest::new("feature".to_string(), "main".to_string());
+        let session = RepositorySession::open(&workdir).expect("open session");
 
-        let update = spawn_diff_loader(repo_path, cache_dir.clone(), request.clone())
+        let update = spawn_diff_loader(session, request.clone())
             .recv_timeout(Duration::from_secs(15))
             .expect("diff update");
 
@@ -2402,54 +2084,9 @@ mod tests {
         assert!(substring_filter_indices(&candidates, "xyz").is_empty());
     }
 
-    fn sample_summary() -> BranchCiSummary {
-        BranchCiSummary {
-            overall_status: Some("pending".to_string()),
-            total: 6,
-            passed: 2,
-            failed: 0,
-            running: 1,
-            queued: 3,
-            skipped: 0,
-            started_at: Some(Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap()),
-            completed_at: None,
-            average_secs: Some(900),
-        }
-    }
-
-    #[test]
-    fn ci_summary_tracks_completion_counts_and_eta() {
-        let summary = sample_summary();
-        let now = Utc.with_ymd_and_hms(2026, 4, 14, 10, 5, 0).unwrap();
-
-        assert_eq!(summary.completed_count(), 2);
-        assert_eq!(summary.elapsed_secs(now), Some(300));
-        assert_eq!(summary.progress_percent(now), Some(33));
-        assert_eq!(summary.eta_secs(now), Some(600));
-    }
-
-    #[test]
-    fn ci_summary_marks_completed_runs_as_done() {
-        let summary = BranchCiSummary {
-            overall_status: Some("success".to_string()),
-            total: 3,
-            passed: 2,
-            failed: 0,
-            running: 0,
-            queued: 0,
-            skipped: 1,
-            started_at: Some(Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap()),
-            completed_at: Some(Utc.with_ymd_and_hms(2026, 4, 14, 10, 6, 0).unwrap()),
-            average_secs: Some(600),
-        };
-
-        assert!(summary.is_complete());
-        assert_eq!(summary.progress_percent(Utc::now()), Some(100));
-    }
-
     #[test]
     fn live_ci_text_handles_missing_checks() {
-        let summary = BranchCiSummary {
+        let summary = CiSummary {
             overall_status: None,
             total: 0,
             passed: 0,
@@ -2468,48 +2105,21 @@ mod tests {
     }
 
     #[test]
-    fn run_in_tokio_runtime_provides_runtime_to_setup_and_future() {
-        let setup_has_runtime = Arc::new(AtomicBool::new(false));
-        let future_has_runtime = Arc::new(AtomicBool::new(false));
-        let setup_has_runtime_clone = Arc::clone(&setup_has_runtime);
-        let future_has_runtime_clone = Arc::clone(&future_has_runtime);
+    fn ci_loader_reports_actionable_session_errors() {
+        let (_tempdir, repo) = test_repo();
+        let session =
+            RepositorySession::open(repo.workdir().expect("workdir")).expect("open session");
 
-        let result = run_in_tokio_runtime(|| {
-            setup_has_runtime_clone.store(
-                tokio::runtime::Handle::try_current().is_ok(),
-                Ordering::SeqCst,
-            );
-            Ok(async move {
-                future_has_runtime_clone.store(
-                    tokio::runtime::Handle::try_current().is_ok(),
-                    Ordering::SeqCst,
-                );
-                Ok::<_, anyhow::Error>(42usize)
-            })
-        })
-        .unwrap();
+        let update = spawn_ci_loader(session, "main".to_string())
+            .recv_timeout(Duration::from_secs(15))
+            .expect("CI update");
 
-        assert_eq!(result, 42);
-        assert!(setup_has_runtime.load(Ordering::SeqCst));
-        assert!(future_has_runtime.load(Ordering::SeqCst));
-    }
-
-    #[test]
-    fn run_in_tokio_runtime_propagates_setup_errors() {
-        let err =
-            run_in_tokio_runtime::<(), _, Ready<Result<()>>>(|| -> Result<Ready<Result<()>>> {
-                Err(anyhow!("setup failed"))
-            })
-            .unwrap_err();
-
-        assert!(format!("{err:#}").contains("setup failed"));
-    }
-
-    #[test]
-    fn run_in_tokio_runtime_propagates_async_errors() {
-        let err = run_in_tokio_runtime(|| Ok(async { Err::<(), _>(anyhow!("fetch failed")) }))
-            .unwrap_err();
-
-        assert!(format!("{err:#}").contains("fetch failed"));
+        match update {
+            CiUpdate::Unavailable { branch, message } => {
+                assert_eq!(branch, "main");
+                assert!(message.contains("configure a git remote"));
+            }
+            CiUpdate::Loaded { .. } => panic!("CI should be unavailable without a remote"),
+        }
     }
 }

--- a/src/tui/widgets/details.rs
+++ b/src/tui/widgets/details.rs
@@ -347,6 +347,7 @@ mod tests {
             ci_state: None,
             commits: vec!["add thing".to_string()],
             details_loaded: true,
+            details_error: None,
         }
     }
 

--- a/src/tui/widgets/diff.rs
+++ b/src/tui/widgets/diff.rs
@@ -1,4 +1,5 @@
-use crate::tui::app::{App, BranchDisplay, DiffLineType, FocusedPane};
+use crate::application::{DiffLine, DiffLineKind};
+use crate::tui::app::{App, BranchDisplay, FocusedPane};
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -167,14 +168,14 @@ fn build_patch_lines(
 
     visible_diff_lines(&app.selected_diff, app.diff_scroll, visible_height)
         .map(|diff_line| {
-            let style = match diff_line.line_type {
-                DiffLineType::Addition => Style::default().fg(Color::Green),
-                DiffLineType::Deletion => Style::default().fg(Color::Red),
-                DiffLineType::Hunk => Style::default().fg(Color::Cyan),
-                DiffLineType::Header => Style::default()
+            let style = match diff_line.kind {
+                DiffLineKind::Addition => Style::default().fg(Color::Green),
+                DiffLineKind::Deletion => Style::default().fg(Color::Red),
+                DiffLineKind::Hunk => Style::default().fg(Color::Cyan),
+                DiffLineKind::Header => Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
-                DiffLineType::Context => Style::default().fg(Color::White),
+                DiffLineKind::Context => Style::default().fg(Color::White),
             };
 
             Line::from(Span::styled(diff_line.content.clone(), style))
@@ -183,22 +184,22 @@ fn build_patch_lines(
 }
 
 fn visible_diff_lines(
-    lines: &[crate::tui::app::DiffLine],
+    lines: &[DiffLine],
     scroll: usize,
     visible_height: usize,
-) -> impl Iterator<Item = &crate::tui::app::DiffLine> {
+) -> impl Iterator<Item = &DiffLine> {
     lines.iter().skip(scroll).take(visible_height.max(1))
 }
 
 #[cfg(test)]
 mod tests {
     use super::visible_diff_lines;
-    use crate::tui::app::{DiffLine, DiffLineType};
+    use crate::application::{DiffLine, DiffLineKind};
 
     fn line(content: &str) -> DiffLine {
         DiffLine {
             content: content.to_string(),
-            line_type: DiffLineType::Context,
+            kind: DiffLineKind::Context,
         }
     }
 

--- a/src/tui/widgets/stack_tree.rs
+++ b/src/tui/widgets/stack_tree.rs
@@ -335,6 +335,7 @@ mod tests {
             ci_state: None,
             commits: Vec::new(),
             details_loaded: true,
+            details_error: None,
         }
     }
 
@@ -356,6 +357,7 @@ mod tests {
             ci_state: None,
             commits: Vec::new(),
             details_loaded: true,
+            details_error: None,
         }
     }
 

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -18,6 +18,8 @@ mod abort_tests;
 mod absorb_tests;
 #[path = "additional_coverage_tests.rs"]
 mod additional_coverage_tests;
+#[path = "application_session_tests.rs"]
+mod application_session_tests;
 #[path = "auth_tests.rs"]
 mod auth_tests;
 #[path = "changelog_tests.rs"]

--- a/tests/application_session_tests.rs
+++ b/tests/application_session_tests.rs
@@ -1,5 +1,28 @@
 use crate::common::TestRepo;
 use stax::application::{BranchSummary, DiffLineKind, RepositorySession};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
+
+struct CurrentDirGuard(PathBuf);
+
+impl CurrentDirGuard {
+    fn change_to(path: &Path) -> Self {
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self(original)
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).unwrap();
+    }
+}
 
 fn branch(snapshot: &[BranchSummary], name: &str) -> BranchSummary {
     snapshot
@@ -236,6 +259,92 @@ fn branch_details_for_trunk_have_no_parent_commits() {
 }
 
 #[test]
+fn branch_details_use_configured_remote_outside_process_cwd() {
+    let _cwd_lock = cwd_lock();
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    std::fs::write(
+        repo.path().join("stax.toml"),
+        "[remote]\nname = \"upstream\"\n",
+    )
+    .unwrap();
+    let add_remote = repo.git(&["remote", "add", "upstream", repo.path().to_str().unwrap()]);
+    assert!(
+        add_remote.status.success(),
+        "add upstream failed: {}",
+        TestRepo::stderr(&add_remote)
+    );
+    let update_ref = repo.git(&["update-ref", "refs/remotes/upstream/feature", "main"]);
+    assert!(
+        update_ref.status.success(),
+        "create upstream tracking ref failed: {}",
+        TestRepo::stderr(&update_ref)
+    );
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let _cwd = CurrentDirGuard::change_to(elsewhere.path());
+
+    let details = session
+        .branch_details(&branch(&snapshot.branches, "feature"))
+        .unwrap();
+
+    assert!(details.has_remote);
+    assert_eq!(details.unpushed, 1);
+    assert_eq!(details.unpulled, 0);
+}
+
+#[test]
+fn branch_details_do_not_fall_back_to_origin_for_unknown_configured_remote() {
+    let _cwd_lock = cwd_lock();
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    std::fs::write(
+        repo.path().join("stax.toml"),
+        "[remote]\nname = \"missing\"\n",
+    )
+    .unwrap();
+    let origin_ref = repo.git(&["update-ref", "refs/remotes/origin/feature", "main"]);
+    assert!(
+        origin_ref.status.success(),
+        "create origin tracking ref failed: {}",
+        TestRepo::stderr(&origin_ref)
+    );
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let _cwd = CurrentDirGuard::change_to(elsewhere.path());
+
+    let details = session
+        .branch_details(&branch(&snapshot.branches, "feature"))
+        .unwrap();
+
+    assert!(!details.has_remote);
+    assert_eq!(details.unpushed, 0);
+    assert_eq!(details.unpulled, 0);
+}
+
+#[test]
+fn branch_details_report_repository_config_errors() {
+    let _cwd_lock = cwd_lock();
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    std::fs::write(repo.path().join("stax.toml"), "[remote\nname = broken\n").unwrap();
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let _cwd = CurrentDirGuard::change_to(elsewhere.path());
+
+    let error = session
+        .branch_details(&branch(&snapshot.branches, "feature"))
+        .unwrap_err();
+    let message = format!("{error:#}");
+
+    assert!(message.contains("Failed to load stax config"));
+    assert!(message.contains(&repo.path().display().to_string()));
+}
+
+#[test]
 fn diff_returns_typed_stat_and_addition_lines() {
     let repo = TestRepo::new();
     repo.create_stack(&["feature"]);
@@ -274,6 +383,46 @@ fn second_diff_round_trips_through_the_tui_cache() {
         .unwrap();
 
     assert_eq!(second, first);
+}
+
+#[test]
+fn cached_diff_returns_the_same_entry_without_recalculating() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let loaded = session.diff("feature", "main").unwrap();
+
+    let cached = RepositorySession::open(repo.path())
+        .unwrap()
+        .cached_diff("feature", "main")
+        .unwrap();
+
+    assert_eq!(cached, Some(loaded));
+}
+
+#[test]
+fn cached_diff_miss_does_not_calculate_a_patch() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let blob_oid = repo.get_commit_sha("feature:feature.txt");
+    let object_path = repo
+        .path()
+        .join(".git")
+        .join("objects")
+        .join(&blob_oid[..2])
+        .join(&blob_oid[2..]);
+    std::fs::remove_file(object_path).unwrap();
+    let cache_path = repo
+        .path()
+        .join(".git")
+        .join("stax")
+        .join("tui-diff-cache.json");
+    let session = RepositorySession::open(repo.path()).unwrap();
+
+    let cached = session.cached_diff("feature", "main").unwrap();
+
+    assert_eq!(cached, None);
+    assert!(!cache_path.exists());
 }
 
 #[test]

--- a/tests/application_session_tests.rs
+++ b/tests/application_session_tests.rs
@@ -401,6 +401,66 @@ fn cached_diff_returns_the_same_entry_without_recalculating() {
 }
 
 #[test]
+fn refresh_diff_bypasses_matching_stale_cache_and_replaces_it() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let actual = session.diff("feature", "main").unwrap();
+    let cache_path = repo
+        .path()
+        .join(".git")
+        .join("stax")
+        .join("tui-diff-cache.json");
+    let mut stored: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&cache_path).unwrap()).unwrap();
+    let entry = stored["entries"]
+        .as_object_mut()
+        .unwrap()
+        .values_mut()
+        .next()
+        .unwrap();
+    entry["diff"]["stat"] = serde_json::json!([]);
+    entry["diff"]["lines"] = serde_json::json!([
+        {"content": "deliberately incorrect cached patch", "line_type": "context"}
+    ]);
+    std::fs::write(&cache_path, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
+
+    let cached = session.cached_diff("feature", "main").unwrap().unwrap();
+    assert_eq!(
+        cached.lines[0].content,
+        "deliberately incorrect cached patch"
+    );
+
+    let refreshed = session.refresh_diff("feature", "main").unwrap();
+
+    assert_eq!(refreshed, actual);
+    assert_eq!(
+        session.cached_diff("feature", "main").unwrap(),
+        Some(actual)
+    );
+}
+
+#[test]
+fn refresh_diff_returns_live_result_without_clobbering_malformed_cache() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let expected = session.diff("feature", "main").unwrap();
+    let cache_path = repo
+        .path()
+        .join(".git")
+        .join("stax")
+        .join("tui-diff-cache.json");
+    let malformed = b"{\"entries\":";
+    std::fs::write(&cache_path, malformed).unwrap();
+
+    let refreshed = session.refresh_diff("feature", "main").unwrap();
+
+    assert_eq!(refreshed, expected);
+    assert_eq!(std::fs::read(cache_path).unwrap(), malformed);
+}
+
+#[test]
 fn cached_diff_miss_does_not_calculate_a_patch() {
     let repo = TestRepo::new();
     repo.create_stack(&["feature"]);

--- a/tests/application_session_tests.rs
+++ b/tests/application_session_tests.rs
@@ -1,0 +1,326 @@
+use crate::common::TestRepo;
+use stax::application::{BranchSummary, DiffLineKind, RepositorySession};
+
+fn branch(snapshot: &[BranchSummary], name: &str) -> BranchSummary {
+    snapshot
+        .iter()
+        .find(|branch| branch.name == name)
+        .unwrap_or_else(|| panic!("missing branch {name}"))
+        .clone()
+}
+
+fn write_stack_parent(repo: &TestRepo, branch: &str, parent: &str) {
+    let metadata_file = format!(".metadata-{branch}.json");
+    let metadata = format!(
+        r#"{{"parentBranchName":"{parent}","parentBranchRevision":"{}"}}"#,
+        repo.get_commit_sha(parent)
+    );
+    repo.create_file(&metadata_file, &metadata);
+    let hash = repo.git(&["hash-object", "-w", &metadata_file]);
+    assert!(
+        hash.status.success(),
+        "hash metadata failed: {}",
+        TestRepo::stderr(&hash)
+    );
+    let oid = TestRepo::stdout(&hash).trim().to_string();
+    let refname = format!("refs/branch-metadata/{branch}");
+    let update = repo.git(&["update-ref", &refname, &oid]);
+    assert!(
+        update.status.success(),
+        "update metadata failed: {}",
+        TestRepo::stderr(&update)
+    );
+    std::fs::remove_file(repo.path().join(metadata_file)).unwrap();
+}
+
+#[test]
+fn snapshot_orders_tracked_stacks_before_trunk() {
+    let repo = TestRepo::new();
+    let created = repo.create_stack(&["first", "second"]);
+    assert_eq!(created, vec!["first", "second"]);
+
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+
+    assert_eq!(
+        session.repository_root(),
+        std::fs::canonicalize(repo.path()).unwrap()
+    );
+    assert_eq!(snapshot.current_branch, "second");
+    assert_eq!(snapshot.trunk, "main");
+    assert_eq!(
+        snapshot
+            .branches
+            .iter()
+            .map(|branch| branch.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["second", "first", "main"],
+    );
+    assert_eq!(
+        snapshot
+            .branches
+            .iter()
+            .map(|branch| branch.column)
+            .collect::<Vec<_>>(),
+        vec![0, 0, 0],
+    );
+    assert!(snapshot.branches[0].is_current);
+    assert!(!snapshot.branches[0].is_trunk);
+    assert_eq!(snapshot.branches[0].parent.as_deref(), Some("first"));
+    assert!(!snapshot.branches[1].is_current);
+    assert_eq!(snapshot.branches[1].parent.as_deref(), Some("main"));
+    assert!(snapshot.branches[2].is_trunk);
+    assert_eq!(snapshot.branches[2].parent, None);
+}
+
+#[test]
+fn snapshot_includes_a_trunk_only_repository() {
+    let repo = TestRepo::new();
+
+    let snapshot = RepositorySession::open(repo.path())
+        .unwrap()
+        .snapshot()
+        .unwrap();
+
+    assert_eq!(snapshot.current_branch, "main");
+    assert_eq!(snapshot.trunk, "main");
+    assert_eq!(snapshot.branches.len(), 1);
+    assert_eq!(snapshot.branches[0].name, "main");
+    assert!(snapshot.branches[0].is_current);
+    assert!(snapshot.branches[0].is_trunk);
+}
+
+#[test]
+fn snapshot_sorts_forked_siblings_and_assigns_deterministic_columns() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["zeta"]);
+    let checkout = repo.run_stax(&["checkout", "main"]);
+    assert!(
+        checkout.status.success(),
+        "checkout main failed: {}",
+        TestRepo::stderr(&checkout)
+    );
+    repo.create_stack(&["alpha"]);
+
+    let snapshot = RepositorySession::open(repo.path())
+        .unwrap()
+        .snapshot()
+        .unwrap();
+
+    assert_eq!(
+        snapshot
+            .branches
+            .iter()
+            .map(|branch| (branch.name.as_str(), branch.column))
+            .collect::<Vec<_>>(),
+        vec![("alpha", 0), ("zeta", 1), ("main", 0)]
+    );
+}
+
+#[test]
+fn snapshot_rejects_unreachable_parent_cycles() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["first", "second"]);
+    write_stack_parent(&repo, "first", "second");
+    write_stack_parent(&repo, "second", "first");
+    let session = RepositorySession::open(repo.path()).unwrap();
+
+    let error = session.snapshot().unwrap_err().to_string();
+
+    assert!(error.contains("Invalid stack topology"));
+    assert!(error.contains("first"));
+    assert!(error.contains("second"));
+    assert!(error.contains("exactly once"));
+}
+
+#[test]
+fn opening_a_linked_worktree_uses_its_canonical_root_and_branch() {
+    let repo = TestRepo::new();
+    let create_branch = repo.git(&["branch", "linked"]);
+    assert!(
+        create_branch.status.success(),
+        "create linked branch failed: {}",
+        TestRepo::stderr(&create_branch)
+    );
+    let linked_parent = tempfile::tempdir().unwrap();
+    let linked_root = linked_parent.path().join("linked-worktree");
+    let linked_root_text = linked_root.to_string_lossy().into_owned();
+    let add_worktree = repo.git(&["worktree", "add", &linked_root_text, "linked"]);
+    assert!(
+        add_worktree.status.success(),
+        "add linked worktree failed: {}",
+        TestRepo::stderr(&add_worktree)
+    );
+
+    let session = RepositorySession::open(&linked_root).unwrap();
+    let snapshot = session.snapshot().unwrap();
+
+    assert_eq!(
+        session.repository_root(),
+        std::fs::canonicalize(&linked_root).unwrap()
+    );
+    assert_eq!(snapshot.repository_root, session.repository_root());
+    assert_eq!(snapshot.current_branch, "linked");
+}
+
+#[test]
+fn opening_a_non_repository_reports_the_path() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let error = RepositorySession::open(dir.path()).unwrap_err().to_string();
+
+    assert!(error.contains(&dir.path().display().to_string()));
+    assert!(error.contains("git repository"));
+}
+
+#[test]
+fn branch_details_report_ahead_count_and_commit_messages() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    repo.create_file("second.txt", "second feature change\n");
+    repo.commit("Second feature commit");
+
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+    let details = session
+        .branch_details(&branch(&snapshot.branches, "feature"))
+        .unwrap();
+
+    assert_eq!(details.ahead, 2);
+    assert_eq!(details.behind, 0);
+    assert!(!details.has_remote);
+    assert_eq!(details.unpushed, 0);
+    assert_eq!(details.unpulled, 0);
+    assert_eq!(
+        details.commits,
+        vec!["Second feature commit", "Commit for feature"]
+    );
+}
+
+#[test]
+fn branch_details_limit_commit_messages_to_ten() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    for revision in 1..12 {
+        repo.create_file("feature.txt", &format!("revision {revision}\n"));
+        repo.commit(&format!("Feature revision {revision}"));
+    }
+
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+    let details = session
+        .branch_details(&branch(&snapshot.branches, "feature"))
+        .unwrap();
+
+    assert_eq!(details.ahead, 12);
+    assert_eq!(details.commits.len(), 10);
+    assert_eq!(
+        details.commits.first().map(String::as_str),
+        Some("Feature revision 11")
+    );
+}
+
+#[test]
+fn branch_details_for_trunk_have_no_parent_commits() {
+    let repo = TestRepo::new();
+    let session = RepositorySession::open(repo.path()).unwrap();
+    let snapshot = session.snapshot().unwrap();
+
+    let details = session
+        .branch_details(&branch(&snapshot.branches, "main"))
+        .unwrap();
+
+    assert_eq!(details.ahead, 0);
+    assert_eq!(details.behind, 0);
+    assert!(details.commits.is_empty());
+}
+
+#[test]
+fn diff_returns_typed_stat_and_addition_lines() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+
+    let diff = session.diff("feature", "main").unwrap();
+
+    assert_eq!(diff.stat.len(), 1);
+    assert_eq!(diff.stat[0].file, "feature.txt");
+    assert_eq!(diff.stat[0].additions, 1);
+    assert_eq!(diff.stat[0].deletions, 0);
+    assert!(diff.lines.iter().any(|line| {
+        line.kind == DiffLineKind::Addition && line.content == "+content for feature"
+    }));
+}
+
+#[test]
+fn second_diff_round_trips_through_the_tui_cache() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let first = RepositorySession::open(repo.path())
+        .unwrap()
+        .diff("feature", "main")
+        .unwrap();
+
+    let cache_path = repo
+        .path()
+        .join(".git")
+        .join("stax")
+        .join("tui-diff-cache.json");
+    assert!(cache_path.is_file());
+
+    let second = RepositorySession::open(repo.path())
+        .unwrap()
+        .diff("feature", "main")
+        .unwrap();
+
+    assert_eq!(second, first);
+}
+
+#[test]
+fn diff_reports_bad_branch_and_parent_names() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+
+    for (branch, parent, missing) in [
+        ("missing-branch", "main", "missing-branch"),
+        ("feature", "missing-parent", "missing-parent"),
+    ] {
+        let error = session.diff(branch, parent).unwrap_err().to_string();
+        assert!(error.contains("diff"));
+        assert!(error.contains(branch));
+        assert!(error.contains(parent));
+        assert!(error.contains(missing));
+    }
+}
+
+#[test]
+fn diff_failure_after_ref_validation_is_not_cached_as_empty() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let blob_oid = repo.get_commit_sha("feature:feature.txt");
+    let object_path = repo
+        .path()
+        .join(".git")
+        .join("objects")
+        .join(&blob_oid[..2])
+        .join(&blob_oid[2..]);
+    std::fs::remove_file(&object_path).unwrap();
+    let cache_path = repo
+        .path()
+        .join(".git")
+        .join("stax")
+        .join("tui-diff-cache.json");
+    assert!(!cache_path.exists());
+    let session = RepositorySession::open(repo.path()).unwrap();
+
+    let error = session.diff("feature", "main").unwrap_err();
+    let message = format!("{error:#}");
+
+    assert!(message.contains("diff stat"));
+    assert!(message.contains("feature"));
+    assert!(message.contains("main"));
+    assert!(message.contains("exit status"));
+    assert!(message.contains("fatal:"));
+    assert!(!cache_path.exists());
+}


### PR DESCRIPTION
## Summary
- extract a typed `stax::application` read layer and migrate TUI detail, diff, and CI hydration onto it
- add the standalone GPUI workspace with recents, a virtualized three-pane cockpit, bounded async hydration, and accessible mouse/keyboard controls
- make shared CI/diff caches transactional and revision-aware while enforcing trusted automatic forge credential routing

## Test plan
- [x] `make test` — 1,938 tests passed
- [x] `make lint`
- [x] `cargo nextest run -p stax-gui --locked` — 94 tests passed
- [x] `cargo check -p stax-gui --locked`
- [x] CI-equivalent GUI Clippy with warnings denied

## Stack
- Stacked on #607, which remains design-only.

## Documentation
README and `skills.md` are unchanged because Phase 1 does not expose a released GUI command or installation path yet; the design and Phase 1 implementation plan document the internal behavior.

## Notes
GPUI 0.2.2 currently brings in `block` 0.1.6, which emits a non-blocking future-incompatibility warning and should be revisited with a future GPUI upgrade.

Made with [Cursor](https://cursor.com)