### PR TITLE
perf(gui): reuse cached branch diffs instantly

### DIFF
--- a/crates/stax-gui/src/hydration.rs
+++ b/crates/stax-gui/src/hydration.rs
@@ -257,17 +257,20 @@ mod tests {
 
         let session = RepositorySession::open(temp.path()).unwrap();
         let actual = session.diff("feature", "main").unwrap();
-        let cache_path = temp.path().join(".git/stax/tui-diff-cache.json");
+        let cache_dir = temp.path().join(".git/stax/diff-cache/v1");
+        let mut cache_entries = fs::read_dir(&cache_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.extension().and_then(|extension| extension.to_str()) == Some("json")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(cache_entries.len(), 1);
+        let cache_path = cache_entries.pop().unwrap();
         let mut stored: serde_json::Value =
             serde_json::from_slice(&fs::read(&cache_path).unwrap()).unwrap();
-        let entry = stored["entries"]
-            .as_object_mut()
-            .unwrap()
-            .values_mut()
-            .next()
-            .unwrap();
-        entry["diff"]["stat"] = serde_json::json!([]);
-        entry["diff"]["lines"] = serde_json::json!([
+        stored["stat"] = serde_json::json!([]);
+        stored["lines"] = serde_json::json!([
             {"content": "incorrect cached patch", "line_type": "context"}
         ]);
         fs::write(&cache_path, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();

--- a/crates/stax-gui/src/state.rs
+++ b/crates/stax-gui/src/state.rs
@@ -3,7 +3,50 @@ use stax::application::{
     OperationEvent, OperationOutcome, OperationProgress, OperationReceipt, OperationRequest,
     OperationResult, RepositorySnapshot,
 };
-use std::path::PathBuf;
+use std::{
+    collections::{HashMap, VecDeque},
+    path::PathBuf,
+};
+
+type SessionDiffKey = (String, Option<String>);
+const SESSION_DIFF_CACHE_CAPACITY: usize = 32;
+
+#[derive(Debug, Clone, Default)]
+struct SessionDiffCache {
+    entries: HashMap<SessionDiffKey, BranchDiff>,
+    recency: VecDeque<SessionDiffKey>,
+}
+
+impl SessionDiffCache {
+    fn get(&mut self, key: &SessionDiffKey) -> Option<BranchDiff> {
+        let diff = self.entries.get(key)?.clone();
+        self.touch(key);
+        Some(diff)
+    }
+
+    fn insert(&mut self, key: SessionDiffKey, diff: BranchDiff) {
+        self.entries.insert(key.clone(), diff);
+        self.touch(&key);
+        while self.entries.len() > SESSION_DIFF_CACHE_CAPACITY {
+            let Some(evicted) = self.recency.pop_front() else {
+                break;
+            };
+            self.entries.remove(&evicted);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.recency.clear();
+    }
+
+    fn touch(&mut self, key: &SessionDiffKey) {
+        if let Some(index) = self.recency.iter().position(|candidate| candidate == key) {
+            self.recency.remove(index);
+        }
+        self.recency.push_back(key.clone());
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LoadState<T> {
@@ -44,6 +87,7 @@ pub struct WorkspaceState {
     details: LoadState<BranchDetails>,
     diff: LoadState<BranchDiff>,
     diff_refreshing: bool,
+    diff_cache: SessionDiffCache,
     ci: LoadState<CiSummary>,
     generation: u64,
     operation_sequence: u64,
@@ -137,6 +181,7 @@ impl WorkspaceState {
             details: LoadState::Idle,
             diff: LoadState::Idle,
             diff_refreshing: false,
+            diff_cache: SessionDiffCache::default(),
             ci: LoadState::Idle,
             generation: 0,
             operation_sequence: 0,
@@ -513,11 +558,13 @@ impl WorkspaceState {
         }
 
         let same_branch = self.selected_branch.as_deref() == Some(name);
+        let cache_key = self.diff_cache_key(name);
+        let cached_diff = cache_key.as_ref().and_then(|key| self.diff_cache.get(key));
         self.selected_branch = Some(name.to_owned());
         self.advance_generation();
         self.details = LoadState::Idle;
         if !same_branch || !matches!(self.diff, LoadState::Ready(_)) {
-            self.diff = LoadState::Idle;
+            self.diff = cached_diff.map_or(LoadState::Idle, LoadState::Ready);
         }
         self.diff_refreshing = false;
         self.ci = LoadState::Idle;
@@ -553,6 +600,7 @@ impl WorkspaceState {
             LoadState::Ready(diff) => Some(diff.clone()),
             LoadState::Idle | LoadState::Loading | LoadState::Failed(_) => None,
         };
+        self.diff_cache.clear();
         let same_repository = previous_repository == snapshot.repository_root;
         if !same_repository {
             self.operation_error = None;
@@ -746,6 +794,9 @@ impl WorkspaceState {
         {
             return false;
         }
+        if let Some(key) = self.diff_cache_key(&token.branch) {
+            self.diff_cache.insert(key, diff.clone());
+        }
         self.diff = LoadState::Ready(diff);
         true
     }
@@ -757,6 +808,11 @@ impl WorkspaceState {
     ) -> bool {
         if !self.matches(&token) {
             return false;
+        }
+        if let Ok(diff) = &result
+            && let Some(key) = self.diff_cache_key(&token.branch)
+        {
+            self.diff_cache.insert(key, diff.clone());
         }
         self.diff = result.map_or_else(LoadState::Failed, LoadState::Ready);
         self.diff_refreshing = false;
@@ -816,6 +872,14 @@ impl WorkspaceState {
             branch,
             self.generation,
         )
+    }
+
+    fn diff_cache_key(&self, branch: &str) -> Option<SessionDiffKey> {
+        self.snapshot
+            .branches
+            .iter()
+            .find(|summary| summary.name == branch)
+            .map(|summary| (summary.name.clone(), summary.parent.clone()))
     }
 
     fn selected_branch_summary(&self) -> Option<&BranchSummary> {
@@ -1430,20 +1494,21 @@ mod tests {
     }
 
     #[test]
-    fn selecting_a_different_branch_never_retains_the_prior_patch() {
+    fn returning_to_a_visited_branch_restores_its_ready_patch() {
         let mut state = WorkspaceState::new(snapshot(
             "/repo",
             "feature-a",
             &[("feature-a", true), ("feature-b", false)],
         ));
-        let (first, _) = state.begin_hydration().unwrap();
-        assert!(state.apply_diff(first, Ok(diff("feature-a patch"))));
+        let (a, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(a, Ok(diff("a"))));
 
         state.select_branch("feature-b").unwrap();
-        let (_, _) = state.begin_hydration().unwrap();
+        let (b, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(b, Ok(diff("b"))));
+        state.select_branch("feature-a").unwrap();
 
-        assert_eq!(state.diff(), &LoadState::Loading);
-        assert!(state.diff_is_refreshing());
+        assert_eq!(state.diff().ready(), Some(&diff("a")));
     }
 
     #[test]
@@ -1467,6 +1532,70 @@ mod tests {
         assert_eq!(state.selected_branch(), Some("feature-b"));
         assert_eq!(state.diff().ready(), Some(&diff("feature-b patch")));
         assert!(state.diff_is_refreshing());
+    }
+
+    #[test]
+    fn snapshot_refresh_invalidates_other_branch_session_patches() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        let (a, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(a, Ok(diff("old a"))));
+        state.select_branch("feature-b").unwrap();
+        let (b, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(b, Ok(diff("old b"))));
+
+        state.replace_snapshot(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-b", false), ("feature-a", true)],
+        ));
+        let (_, _) = state.begin_hydration().unwrap();
+
+        assert_eq!(state.diff().ready(), Some(&diff("old b")));
+        assert!(state.diff_is_refreshing());
+        state.select_branch("feature-a").unwrap();
+        assert_eq!(state.diff(), &LoadState::Idle);
+    }
+
+    #[test]
+    fn session_diff_cache_evicts_the_least_recently_used_entry_after_32_patches() {
+        let branches = (0..33)
+            .map(|index| {
+                tracked_branch(
+                    &format!("branch-{index:02}"),
+                    Some("main"),
+                    index == 0,
+                    false,
+                )
+            })
+            .collect();
+        let mut state = WorkspaceState::new(RepositorySnapshot {
+            repository_root: PathBuf::from("/repo"),
+            current_branch: "branch-00".into(),
+            trunk: "main".into(),
+            branches,
+        });
+
+        for index in 0..32 {
+            let branch = format!("branch-{index:02}");
+            state.select_branch(&branch).unwrap();
+            let (token, _) = state.begin_hydration().unwrap();
+            assert!(state.apply_diff(token, Ok(diff(&format!("patch-{index:02}")))));
+        }
+
+        state.select_branch("branch-00").unwrap();
+        assert_eq!(state.diff().ready(), Some(&diff("patch-00")));
+        state.select_branch("branch-32").unwrap();
+        let (token, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(token, Ok(diff("patch-32"))));
+
+        state.select_branch("branch-01").unwrap();
+        assert_eq!(state.diff(), &LoadState::Idle);
+        state.select_branch("branch-00").unwrap();
+        assert_eq!(state.diff().ready(), Some(&diff("patch-00")));
     }
 
     #[test]

--- a/crates/stax-gui/src/state.rs
+++ b/crates/stax-gui/src/state.rs
@@ -859,6 +859,7 @@ impl WorkspaceState {
         {
             self.selected_branch = Some(preferred.to_string());
         }
+        self.diff_cache.clear();
         self.advance_generation();
         self.details = LoadState::Idle;
         self.diff = LoadState::Idle;
@@ -1577,6 +1578,25 @@ mod tests {
         assert_eq!(state.diff().ready(), Some(&diff("old b")));
         assert!(state.diff_is_refreshing());
         state.select_branch("feature-a").unwrap();
+        assert_eq!(state.diff(), &LoadState::Idle);
+    }
+
+    #[test]
+    fn repository_change_invalidates_session_patches_before_snapshot_refresh() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        let (a, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(a, Ok(diff("old a"))));
+        state.select_branch("feature-b").unwrap();
+        let (b, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(b, Ok(diff("old b"))));
+
+        present_receipt(&mut state, history_receipt(false));
+        state.select_branch("feature-a").unwrap();
+
         assert_eq!(state.diff(), &LoadState::Idle);
     }
 

--- a/crates/stax-gui/src/state.rs
+++ b/crates/stax-gui/src/state.rs
@@ -1494,6 +1494,26 @@ mod tests {
     }
 
     #[test]
+    fn returning_to_a_branch_restores_its_accepted_cached_patch() {
+        let mut state = WorkspaceState::new(snapshot(
+            "/repo",
+            "feature-a",
+            &[("feature-a", true), ("feature-b", false)],
+        ));
+        let (a, _) = state.begin_hydration().unwrap();
+        assert_eq!(state.diff(), &LoadState::Loading);
+        assert!(state.apply_cached_diff(a, diff("cached a")));
+
+        state.select_branch("feature-b").unwrap();
+        let (b, _) = state.begin_hydration().unwrap();
+        assert!(state.apply_diff(b, Ok(diff("b"))));
+        state.select_branch("feature-a").unwrap();
+
+        assert_eq!(state.diff().ready(), Some(&diff("cached a")));
+        assert!(!state.diff_is_refreshing());
+    }
+
+    #[test]
     fn returning_to_a_visited_branch_restores_its_ready_patch() {
         let mut state = WorkspaceState::new(snapshot(
             "/repo",

--- a/docs/superpowers/plans/2026-07-13-diff-cache.md
+++ b/docs/superpowers/plans/2026-07-13-diff-cache.md
@@ -1,0 +1,184 @@
+# Responsive Diff Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make repeated GUI branch selection instant and replace the monolithic diff cache with bounded revision-keyed JSON files.
+
+**Architecture:** `TuiDiffCache` keeps its caller-facing revision-key API but persists each `DiskCachedDiff` independently. `WorkspaceState` adds a small snapshot-scoped LRU that restores a previously displayed branch patch synchronously before background hydration.
+
+**Tech Stack:** Rust, serde_json, fs2 file locks, GPUI state tests, cargo-nextest, Docker-backed `make test`.
+
+## Global Constraints
+
+- Add no runtime dependency.
+- Persist entries under `.git/stax/diff-cache/v1` using parent, branch, and merge-base object IDs.
+- Cap persistent storage at 128 entries and 100 MiB; cap GUI memory at 32 entries.
+- Cache failures degrade to misses and must not replace a successfully calculated diff.
+- Full-suite validation must use `make test`.
+
+---
+
+### Task 1: Per-revision persistent files
+
+**Files:**
+- Modify: `src/cache.rs`
+- Test: `src/cache.rs`
+- Test: `tests/application_session_tests.rs`
+
+**Interfaces:**
+- Consumes: `TuiDiffCache::key`, `DiskCachedDiff`, `persist_json_atomic`, and `acquire_cache_lock`.
+- Produces: unchanged `read_persisted(git_dir, key)` and `insert_persisted(git_dir, key, diff)` APIs backed by independent files.
+
+- [ ] **Step 1: Write failing persistence tests**
+
+Add tests that insert two keys and assert independent JSON paths, place malformed JSON beside a valid requested entry and assert the valid entry still loads, overwrite a malformed requested entry, and invoke a parameterized cleanup helper to verify count and byte limits while ignoring unrelated files.
+
+```rust
+#[test]
+fn requested_diff_does_not_parse_unrelated_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    TuiDiffCache::insert_persisted(dir.path(), "v1:a:b:c".into(), disk_diff("kept"))
+        .unwrap();
+    fs::write(TuiDiffCache::entries_dir(dir.path()).join("broken.json"), b"{").unwrap();
+    assert_eq!(
+        TuiDiffCache::read_persisted(dir.path(), "v1:a:b:c").unwrap(),
+        Some(disk_diff("kept"))
+    );
+}
+```
+
+- [ ] **Step 2: Verify the new tests fail for the aggregate cache**
+
+Run: `cargo nextest run --lib cache::tests::requested_diff_does_not_parse_unrelated_entries`
+
+Expected: FAIL because `entries_dir` and independent entry files do not exist.
+
+- [ ] **Step 3: Implement independent entry paths and bounded cleanup**
+
+Keep revision keys stable for callers and map their colon-separated components to a portable hyphen-separated filename. Read and lock one entry; write one entry atomically; best-effort touch hits, delete malformed requested entries, remove the legacy aggregate file after a successful write, and clean oldest entry files after writes.
+
+```rust
+fn entry_path(git_dir: &Path, key: &str) -> PathBuf {
+    Self::entries_dir(git_dir).join(format!("{}.json", key.replace(':', "-")))
+}
+
+pub(crate) fn read_persisted(git_dir: &Path, key: &str) -> Result<Option<DiskCachedDiff>> {
+    let path = Self::entry_path(git_dir, key);
+    let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
+    match load_json_unlocked(&path) {
+        Ok(diff) => Ok(diff),
+        Err(error) => {
+            let _ = fs::remove_file(&path);
+            Err(error)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run focused cache and application-session tests**
+
+Run: `cargo nextest run --lib cache::tests::`
+
+Run: `cargo nextest run application_session_tests::cached_diff`
+
+Expected: PASS.
+
+---
+
+### Task 2: Snapshot-scoped GUI memory cache
+
+**Files:**
+- Modify: `crates/stax-gui/src/state.rs`
+- Test: `crates/stax-gui/src/state.rs`
+- Test: `crates/stax-gui/src/views/hydration_tests.rs`
+
+**Interfaces:**
+- Consumes: `WorkspaceState::select_branch`, `apply_cached_diff`, `apply_diff`, and snapshot refresh transitions.
+- Produces: synchronous A → B → A patch restoration with existing generation rejection unchanged.
+
+- [ ] **Step 1: Write failing state tests**
+
+Replace the prior assertion that a different branch always discards the patch with explicit A → B → A reuse, invalidation after snapshot replacement, and 32-entry LRU eviction tests.
+
+```rust
+#[test]
+fn returning_to_a_visited_branch_restores_its_ready_patch() {
+    let mut state = WorkspaceState::new(snapshot(
+        "/repo",
+        "feature-a",
+        &[("feature-a", true), ("feature-b", false)],
+    ));
+    let (a, _) = state.begin_hydration().unwrap();
+    assert!(state.apply_diff(a, Ok(diff("a"))));
+    state.select_branch("feature-b").unwrap();
+    let (b, _) = state.begin_hydration().unwrap();
+    assert!(state.apply_diff(b, Ok(diff("b"))));
+    state.select_branch("feature-a").unwrap();
+    assert_eq!(state.diff().ready(), Some(&diff("a")));
+}
+```
+
+- [ ] **Step 2: Verify the reuse test fails**
+
+Run: `cargo nextest run -p stax-gui state::tests::returning_to_a_visited_branch_restores_its_ready_patch`
+
+Expected: FAIL because selecting B currently discards A permanently.
+
+- [ ] **Step 3: Implement the bounded memory LRU**
+
+Add a private cache keyed by branch and parent names. Record accepted cached and fresh results, restore an entry during valid selection, update recency on access, evict past 32, and clear entries when a refreshed snapshot is applied.
+
+```rust
+#[derive(Debug, Clone, Default)]
+struct SessionDiffCache {
+    entries: HashMap<(String, Option<String>), BranchDiff>,
+    recency: VecDeque<(String, Option<String>)>,
+}
+```
+
+- [ ] **Step 4: Run focused GUI tests**
+
+Run: `cargo nextest run -p stax-gui state::tests::`
+
+Run: `cargo nextest run -p stax-gui hydration_tests::`
+
+Expected: PASS with stale-generation behavior unchanged.
+
+---
+
+### Task 3: Verification and publication
+
+**Files:**
+- Modify if required: `docs/superpowers/specs/2026-07-13-diff-cache-design.md`
+- No user-facing command documentation changes are expected.
+
+**Interfaces:**
+- Consumes: completed persistent and memory cache behavior.
+- Produces: formatted, linted, fully tested stacked PR.
+
+- [ ] **Step 1: Format and run targeted verification**
+
+Run: `cargo fmt --all -- --check`
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the repository-required full suite**
+
+Run: `make test`
+
+Expected: PASS through the Docker test path.
+
+- [ ] **Step 3: Commit and submit**
+
+```bash
+git add src/cache.rs crates/stax-gui/src/state.rs tests/application_session_tests.rs \
+  docs/superpowers/plans/2026-07-13-diff-cache.md
+git commit -m "perf(gui): reuse revision-keyed branch diffs"
+stax submit
+```
+
+- [ ] **Step 4: Set a complete PR body**
+
+Include the measured 20.3 MB aggregate-cache cause, per-entry persistence, in-memory A → B → A behavior, corruption/cleanup handling, exact tests run, and a one-line documentation-impact note.

--- a/docs/superpowers/plans/2026-07-13-diff-cache.md
+++ b/docs/superpowers/plans/2026-07-13-diff-cache.md
@@ -6,7 +6,7 @@
 
 **Architecture:** `TuiDiffCache` keeps its caller-facing revision-key API but persists each `DiskCachedDiff` independently. `WorkspaceState` adds a small snapshot-scoped LRU that restores a previously displayed branch patch synchronously before background hydration.
 
-**Tech Stack:** Rust, serde_json, fs2 file locks, GPUI state tests, cargo-nextest, Docker-backed `make test`.
+**Tech Stack:** Rust, serde_json, fs4 file locks, GPUI state tests, cargo-nextest, Docker-backed `make test`.
 
 ## Global Constraints
 

--- a/docs/superpowers/specs/2026-07-13-diff-cache-design.md
+++ b/docs/superpowers/specs/2026-07-13-diff-cache-design.md
@@ -94,9 +94,11 @@ modification time, and removes the oldest entries until both limits hold:
 - no more than 100 MiB in total serialized size.
 
 Cleanup failures do not fail diff calculation or overwrite the successfully
-written entry. Temporary files, lock files, directories, and unrelated files
-are ignored. A cache hit updates the entry's modification time best-effort so
-the cleanup policy approximates persistent LRU behavior.
+written entry. Lock files are excluded from count and byte accounting, while
+orphan cache-owned entry locks are reaped. Temporary files, directories,
+symlinks, and unrelated files are ignored. A cache hit updates the entry's
+modification time best-effort so the cleanup policy approximates persistent LRU
+behavior.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-07-13-diff-cache-design.md
+++ b/docs/superpowers/specs/2026-07-13-diff-cache-design.md
@@ -1,0 +1,133 @@
+# Revision-Keyed Diff Cache Design
+
+## Status
+
+Approved direction for implementation on `cesar/gpui-gui-diff-cache`, stacked
+on `cesar/gpui-gui-phase-4`.
+
+## Problem
+
+The shared diff cache currently serializes every cached patch into one
+`.git/stax/tui-diff-cache.json` file. Looking up one branch reads and parses the
+entire file. Updating one branch reads and rewrites the entire file. The GUI
+also retains only the selected patch, so selecting a previously visited branch
+shows a loading state while the same aggregate file is parsed again.
+
+In the repository used to reproduce the issue, the aggregate file was 20.3 MB
+with 27 entries and 166,175 patch lines. A single command-line JSON parse took
+about 260 ms, which is enough to make every branch selection feel uncached.
+
+## Goals
+
+- Show patches for branches visited during the current GUI session without a
+  loading-state round trip.
+- Read and deserialize only the requested persistent cache entry.
+- Preserve revision-safe reuse across the CLI, TUI, and GUI.
+- Keep the implementation dependency-free and easy to inspect.
+- Bound cache growth without putting cleanup work on the selection path.
+
+## Non-goals
+
+- A general-purpose database or query layer.
+- Persisting rendered GPUI elements or scroll state.
+- Guaranteeing that cache data survives corruption or format changes; cache
+  contents are disposable.
+- Migrating the aggregate cache in place.
+
+## Architecture
+
+### Session memory cache
+
+`WorkspaceState` will retain a bounded set of ready branch diffs for the
+current repository snapshot. Entries are keyed by branch and parent names,
+because the presentation snapshot does not expose object IDs. Applying either
+a persistent-cache result or a freshly calculated result records the patch.
+
+Selecting a branch already present in this session cache immediately restores
+its ready patch before hydration begins. Hydration may continue in the
+background, but the changes pane remains populated and presents only its
+existing subtle refreshing indicator.
+
+The memory cache is cleared when a refreshed repository snapshot is applied or
+after an operation changes repository state. The currently displayed patch may
+remain visible under the existing stale-while-refreshing behavior. This avoids
+serving a name-keyed patch after an external ref update while still making
+ordinary A → B → A navigation synchronous.
+
+The cache is capped at 32 entries with least-recently-used eviction. This is
+large enough for normal stacks while preventing large patches from remaining
+resident without bound.
+
+### Persistent per-entry cache
+
+The shared persistent cache will store one JSON document per immutable diff
+revision under:
+
+```text
+.git/stax/diff-cache/v1/
+└── <parent-oid>-<branch-oid>-<merge-base-oid>.json
+```
+
+The three object IDs are required because a branch diff is not identified by
+the branch commit alone. Branch and parent names are intentionally excluded:
+renames may reuse identical content, and object IDs produce portable filenames
+without escaping user input.
+
+Each document contains the existing `DiskCachedDiff` payload. Reads acquire a
+shared lock for that entry only, deserialize that entry only, and clone no
+unrelated patches. Writes acquire an exclusive entry lock and use the existing
+temporary-file plus atomic-rename helper. Concurrent writers may calculate the
+same deterministic patch; the last complete atomic write wins.
+
+The old `tui-diff-cache.json` file is not read or migrated. It is disposable
+cache data and will be removed best-effort during the first successful cleanup.
+The first lookup after upgrading may therefore be cold once.
+
+### Cleanup
+
+Cleanup runs opportunistically after a successful cache write, never during a
+read. It scans only `.git/stax/diff-cache/v1`, orders regular JSON entries by
+modification time, and removes the oldest entries until both limits hold:
+
+- no more than 128 entries;
+- no more than 100 MiB in total serialized size.
+
+Cleanup failures do not fail diff calculation or overwrite the successfully
+written entry. Temporary files, lock files, directories, and unrelated files
+are ignored. A cache hit updates the entry's modification time best-effort so
+the cleanup policy approximates persistent LRU behavior.
+
+## Error handling
+
+- A missing entry is a normal cache miss.
+- An unreadable or malformed entry is treated as a miss by the high-level diff
+  path and removed best-effort so it does not fail repeatedly.
+- Persistent-cache read, write, touch, and cleanup failures never replace a
+  successfully calculated diff with an error.
+- Revision resolution and actual Git diff failures keep their existing error
+  behavior because they are not cache failures.
+
+## Testing
+
+Tests will be written before production changes and will cover:
+
+- one entry can be read without parsing a malformed unrelated entry;
+- different revision keys create independent files;
+- malformed selected entries degrade to misses and can be replaced;
+- cleanup enforces entry-count and total-size limits while ignoring unrelated
+  files;
+- concurrent writes produce a complete readable entry;
+- selecting A → B → A restores A synchronously from session memory;
+- session memory is invalidated when repository state is refreshed;
+- stale asynchronous results still cannot overwrite the current selection.
+
+Targeted cache, application-session, and GPUI state tests will provide the
+tight feedback loop. Final validation will use the repository-required
+`make test` Docker path.
+
+## Documentation impact
+
+The behavior is internal performance work and adds no command or flag. The GUI
+guide and `skills.md` need no workflow changes. The pull request description
+will explicitly note that user-facing documentation is unchanged because the
+existing cached-diff promise is being made responsive rather than redefined.

--- a/docs/superpowers/specs/2026-07-13-diff-cache-design.md
+++ b/docs/superpowers/specs/2026-07-13-diff-cache-design.md
@@ -73,11 +73,12 @@ the branch commit alone. Branch and parent names are intentionally excluded:
 renames may reuse identical content, and object IDs produce portable filenames
 without escaping user input.
 
-Each document contains the existing `DiskCachedDiff` payload. Reads acquire a
-shared lock for that entry only, deserialize that entry only, and clone no
-unrelated patches. Writes acquire an exclusive entry lock and use the existing
-temporary-file plus atomic-rename helper. Concurrent writers may calculate the
-same deterministic patch; the last complete atomic write wins.
+Each document contains the existing `DiskCachedDiff` payload. Reads deliberately
+acquire an exclusive lock for that entry so deserialization and the best-effort
+modification-time touch happen atomically, and clone no unrelated patches.
+Writes acquire an exclusive entry lock and use the existing temporary-file plus
+atomic-rename helper. Concurrent writers may calculate the same deterministic
+patch; the last complete atomic write wins.
 
 The old `tui-diff-cache.json` file is not read or migrated. It is disposable
 cache data and will be removed best-effort during the first successful cleanup.

--- a/src/application/repository.rs
+++ b/src/application/repository.rs
@@ -248,8 +248,10 @@ impl RepositorySession {
             &target.branch_oid,
             &target.merge_base_oid,
         );
-        TuiDiffCache::read_persisted(&self.common_git_dir, &key)
-            .map(|diff| diff.as_ref().map(branch_diff_from_disk))
+        let cached = TuiDiffCache::read_persisted(&self.common_git_dir, &key)
+            .ok()
+            .flatten();
+        Ok(cached.as_ref().map(branch_diff_from_disk))
     }
 
     pub(super) fn open_repo(&self) -> Result<GitRepo> {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -620,18 +620,28 @@ impl TuiDiffCache {
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(error) => return Err(error).context("failed to inspect diff cache entry"),
             };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("failed to inspect diff cache entry type"),
+            };
+            if !file_type.is_file() {
+                continue;
+            }
             let path = entry.path();
             let Some(lock_name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };
-            let Some(payload_name) = lock_name.strip_suffix(".lock") else {
+            let Some(payload_name) = lock_name
+                .strip_prefix('.')
+                .and_then(|name| name.strip_suffix(".lock"))
+            else {
                 continue;
             };
             if !payload_name.ends_with(".json") {
                 continue;
             }
-            let payload_path =
-                entries_dir.join(payload_name.strip_prefix('.').unwrap_or(payload_name));
+            let payload_path = entries_dir.join(payload_name);
             match fs::metadata(&payload_path) {
                 Ok(metadata) if metadata.is_file() => continue,
                 Ok(_) => {}
@@ -996,6 +1006,68 @@ mod tests {
 
         assert!(live_payload.exists());
         assert!(live_lock.exists());
+    }
+
+    #[test]
+    fn diff_cache_cleanup_ignores_non_hidden_lock_like_file_and_enforces_count_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries_dir = TuiDiffCache::entries_dir(dir.path());
+        fs::create_dir_all(&entries_dir).unwrap();
+        let first = entries_dir.join("first.json");
+        let second = entries_dir.join("second.json");
+        let unrelated = entries_dir.join("notes.json.lock");
+        fs::write(&first, vec![b'a'; 10]).unwrap();
+        fs::write(&second, vec![b'b'; 10]).unwrap();
+        fs::write(&unrelated, b"keep me").unwrap();
+        File::open(&first)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_modified(UNIX_EPOCH + std::time::Duration::from_secs(1)),
+            )
+            .unwrap();
+        File::open(&second)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_modified(UNIX_EPOCH + std::time::Duration::from_secs(2)),
+            )
+            .unwrap();
+
+        TuiDiffCache::cleanup_entries(&entries_dir, 1, u64::MAX).unwrap();
+
+        assert_eq!(fs::read(&unrelated).unwrap(), b"keep me");
+        assert!(!first.exists());
+        assert!(second.exists());
+    }
+
+    #[test]
+    fn diff_cache_cleanup_ignores_lock_like_directory_and_enforces_byte_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries_dir = TuiDiffCache::entries_dir(dir.path());
+        fs::create_dir_all(&entries_dir).unwrap();
+        let first = entries_dir.join("first.json");
+        let second = entries_dir.join("second.json");
+        let unrelated = entries_dir.join(".notes.json.lock");
+        fs::write(&first, vec![b'a'; 10]).unwrap();
+        fs::write(&second, vec![b'b'; 20]).unwrap();
+        fs::create_dir(&unrelated).unwrap();
+        File::open(&first)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_modified(UNIX_EPOCH + std::time::Duration::from_secs(1)),
+            )
+            .unwrap();
+        File::open(&second)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_modified(UNIX_EPOCH + std::time::Duration::from_secs(2)),
+            )
+            .unwrap();
+
+        TuiDiffCache::cleanup_entries(&entries_dir, usize::MAX, 20).unwrap();
+
+        assert!(unrelated.is_dir());
+        assert!(!first.exists());
+        assert!(second.exists());
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -425,26 +425,33 @@ impl TuiDiffCache {
     ) -> Result<Option<DiskCachedDiff>> {
         let path = Self::entry_path(git_dir, key);
         let entries_dir = Self::entries_dir(git_dir);
-        let _directory_lock =
-            acquire_cache_lock(&Self::coordination_path(&entries_dir), LockMode::Shared)?;
-        if !path.exists() {
-            return Ok(None);
-        }
-        let _entry_lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
-        match load_json_unlocked::<Option<DiskCachedDiff>>(&path) {
-            Ok(diff) => {
-                if diff.is_some()
-                    && let Ok(file) = OpenOptions::new().read(true).write(true).open(&path)
-                {
-                    let _ = file.set_times(fs::FileTimes::new().set_modified(SystemTime::now()));
+        let result = (|| {
+            let _directory_lock =
+                acquire_cache_lock(&Self::coordination_path(&entries_dir), LockMode::Shared)?;
+            if !path.exists() {
+                return Ok(None);
+            }
+            let _entry_lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
+            match load_json_unlocked::<Option<DiskCachedDiff>>(&path) {
+                Ok(diff) => {
+                    if diff.is_some()
+                        && let Ok(file) = OpenOptions::new().read(true).write(true).open(&path)
+                    {
+                        let _ =
+                            file.set_times(fs::FileTimes::new().set_modified(SystemTime::now()));
+                    }
+                    Ok(diff)
                 }
-                Ok(diff)
+                Err(error) => {
+                    let _ = fs::remove_file(&path);
+                    Err(error)
+                }
             }
-            Err(error) => {
-                let _ = fs::remove_file(&path);
-                Err(error)
-            }
+        })();
+        if result.is_err() {
+            let _ = Self::cleanup_orphaned_entry_lock(&entries_dir, &path);
         }
+        result
     }
 
     /// Atomically insert one diff while preserving all other cached entries.
@@ -471,15 +478,48 @@ impl TuiDiffCache {
     ) -> Result<()> {
         let path = Self::entry_path(git_dir, &key);
         let entries_dir = Self::entries_dir(git_dir);
-        {
+        let write_result = (|| {
             let _directory_lock =
                 acquire_cache_lock(&Self::coordination_path(&entries_dir), LockMode::Shared)?;
             let _entry_lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
             persist_json_atomic(&path, &diff)?;
             let _ = fs::remove_file(Self::cache_path(git_dir));
+            Ok(())
+        })();
+        if let Err(error) = write_result {
+            let _ = Self::cleanup_orphaned_entry_lock(&entries_dir, &path);
+            return Err(error);
         }
         let _ = Self::cleanup_entries(&entries_dir, max_entries, max_bytes);
         Ok(())
+    }
+
+    fn cleanup_orphaned_entry_lock(entries_dir: &Path, entry_path: &Path) -> Result<()> {
+        let _directory_lock =
+            acquire_cache_lock(&Self::coordination_path(entries_dir), LockMode::Exclusive)?;
+        match fs::metadata(entry_path) {
+            Ok(metadata) if metadata.is_file() => return Ok(()),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to inspect diff cache entry {}",
+                        entry_path.display()
+                    )
+                });
+            }
+        }
+        match fs::remove_file(cache_lock_path(entry_path)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error).with_context(|| {
+                format!(
+                    "failed to remove orphaned diff cache entry lock {}",
+                    entry_path.display()
+                )
+            }),
+        }
     }
 
     fn cleanup_entries(entries_dir: &Path, max_entries: usize, max_bytes: u64) -> Result<()> {
@@ -801,12 +841,27 @@ mod tests {
 
         assert!(TuiDiffCache::read_persisted(dir.path(), key).is_err());
         assert!(!path.exists());
+        assert!(!cache_lock_path(&path).exists());
 
         TuiDiffCache::insert_persisted(dir.path(), key.into(), disk_diff("replacement")).unwrap();
         assert_eq!(
             TuiDiffCache::read_persisted(dir.path(), key).unwrap(),
             Some(disk_diff("replacement"))
         );
+    }
+
+    #[test]
+    fn failed_diff_write_without_an_entry_removes_its_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "v1:a:b:c";
+        let path = TuiDiffCache::entry_path(dir.path(), key);
+        fs::create_dir_all(&path).unwrap();
+
+        assert!(
+            TuiDiffCache::insert_persisted(dir.path(), key.into(), disk_diff("unwritten")).is_err()
+        );
+
+        assert!(!cache_lock_path(&path).exists());
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,6 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::NamedTempFile;
 
 const MAX_TUI_DIFF_CACHE_ENTRIES: usize = 128;
+const MAX_TUI_DIFF_CACHE_BYTES: u64 = 100 * 1024 * 1024;
 
 enum LockMode {
     Shared,
@@ -334,6 +335,14 @@ impl TuiDiffCache {
         git_dir.join("stax").join("tui-diff-cache.json")
     }
 
+    fn entries_dir(git_dir: &Path) -> PathBuf {
+        git_dir.join("stax").join("diff-cache").join("v1")
+    }
+
+    fn entry_path(git_dir: &Path, key: &str) -> PathBuf {
+        Self::entries_dir(git_dir).join(format!("{}.json", key.replace(':', "-")))
+    }
+
     pub fn key(
         _parent: &str,
         _branch: &str,
@@ -349,30 +358,72 @@ impl TuiDiffCache {
         Self::load_strict(git_dir).unwrap_or_default()
     }
 
+    #[cfg(test)]
     pub(crate) fn load_strict(git_dir: &std::path::Path) -> Result<Self> {
-        let path = Self::cache_path(git_dir);
-        let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
-        load_json_unlocked(&path)
+        let mut cache = Self::default();
+        let entries = match fs::read_dir(Self::entries_dir(git_dir)) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(cache),
+            Err(error) => return Err(error).context("failed to read diff cache directory"),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if !entry.file_type()?.is_file()
+                || path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
+            let Some(diff) = load_json_unlocked::<Option<DiskCachedDiff>>(&path)? else {
+                continue;
+            };
+            let updated_at = entry
+                .metadata()?
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs())
+                .unwrap_or_default();
+            cache.entries.insert(
+                stem.replace('-', ":"),
+                TuiDiffCacheEntry { diff, updated_at },
+            );
+        }
+        Ok(cache)
     }
 
     #[cfg(test)]
     pub fn save(&self, git_dir: &std::path::Path) -> Result<()> {
-        let path = Self::cache_path(git_dir);
-        let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
-        let mut stored = load_json_unlocked::<Self>(&path)?;
         for (key, entry) in &self.entries {
-            stored.entries.insert(key.clone(), entry.clone());
+            Self::insert_persisted(git_dir, key.clone(), entry.diff.clone())?;
         }
-        stored.prune_old_entries();
-        persist_json_atomic(&path, &stored)
+        Ok(())
     }
 
     pub(crate) fn read_persisted(
         git_dir: &std::path::Path,
         key: &str,
     ) -> Result<Option<DiskCachedDiff>> {
-        let cache = Self::load_strict(git_dir)?;
-        Ok(cache.get(key).cloned())
+        let path = Self::entry_path(git_dir, key);
+        let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
+        match load_json_unlocked::<Option<DiskCachedDiff>>(&path) {
+            Ok(diff) => {
+                if diff.is_some()
+                    && let Ok(file) = OpenOptions::new().read(true).write(true).open(&path)
+                {
+                    let _ = file.set_times(fs::FileTimes::new().set_modified(SystemTime::now()));
+                }
+                Ok(diff)
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&path);
+                Err(error)
+            }
+        }
     }
 
     /// Atomically insert one diff while preserving all other cached entries.
@@ -381,17 +432,67 @@ impl TuiDiffCache {
         key: String,
         diff: DiskCachedDiff,
     ) -> Result<()> {
-        let path = Self::cache_path(git_dir);
+        let path = Self::entry_path(git_dir, &key);
         let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
-        let mut stored = load_json_unlocked::<Self>(&path)?;
-        stored.insert(key, diff);
-        persist_json_atomic(&path, &stored)
+        persist_json_atomic(&path, &diff)?;
+        let _ = fs::remove_file(Self::cache_path(git_dir));
+        let _ = Self::cleanup_entries(
+            &Self::entries_dir(git_dir),
+            MAX_TUI_DIFF_CACHE_ENTRIES,
+            MAX_TUI_DIFF_CACHE_BYTES,
+        );
+        Ok(())
     }
 
+    fn cleanup_entries(entries_dir: &Path, max_entries: usize, max_bytes: u64) -> Result<()> {
+        let entries = match fs::read_dir(entries_dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to read diff cache directory {}",
+                        entries_dir.display()
+                    )
+                });
+            }
+        };
+        let mut cached = Vec::new();
+        let mut total_bytes = 0_u64;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if !entry.file_type()?.is_file()
+                || path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            {
+                continue;
+            }
+            let metadata = entry.metadata()?;
+            let bytes = metadata.len();
+            total_bytes = total_bytes.saturating_add(bytes);
+            cached.push((metadata.modified().unwrap_or(UNIX_EPOCH), path, bytes));
+        }
+        cached.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+        let mut remove_count = cached.len().saturating_sub(max_entries);
+        for (_, path, bytes) in cached {
+            if remove_count == 0 && total_bytes <= max_bytes {
+                break;
+            }
+            fs::remove_file(&path)
+                .with_context(|| format!("failed to remove diff cache entry {}", path.display()))?;
+            total_bytes = total_bytes.saturating_sub(bytes);
+            remove_count = remove_count.saturating_sub(1);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub fn get(&self, key: &str) -> Option<&DiskCachedDiff> {
         self.entries.get(key).map(|entry| &entry.diff)
     }
 
+    #[cfg(test)]
     pub fn insert(&mut self, key: String, diff: DiskCachedDiff) {
         self.entries.insert(
             key,
@@ -403,6 +504,7 @@ impl TuiDiffCache {
         self.prune_old_entries();
     }
 
+    #[cfg(test)]
     fn prune_old_entries(&mut self) {
         if self.entries.len() <= MAX_TUI_DIFF_CACHE_ENTRIES {
             return;
@@ -511,6 +613,7 @@ impl AheadBehindCache {
     }
 }
 
+#[cfg(test)]
 fn current_unix_time() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -533,6 +636,147 @@ mod tests {
                 line_type: "context".to_string(),
             }],
         }
+    }
+
+    fn assert_cleanup_limits(
+        max_entries: usize,
+        max_bytes: u64,
+        entries: &[(&str, usize)],
+        expected: &[&str],
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let entries_dir = TuiDiffCache::entries_dir(dir.path());
+        fs::create_dir_all(&entries_dir).unwrap();
+        for (name, size) in entries {
+            fs::write(entries_dir.join(format!("{name}.json")), vec![b'x'; *size]).unwrap();
+        }
+        fs::write(entries_dir.join("keep.txt"), b"unrelated").unwrap();
+
+        TuiDiffCache::cleanup_entries(&entries_dir, max_entries, max_bytes).unwrap();
+
+        let mut remaining = fs::read_dir(&entries_dir)
+            .unwrap()
+            .filter_map(|entry| {
+                let name = entry.unwrap().file_name().into_string().unwrap();
+                name.ends_with(".json").then_some(name)
+            })
+            .collect::<Vec<_>>();
+        remaining.sort();
+        assert_eq!(remaining, expected);
+        assert_eq!(
+            fs::read(entries_dir.join("keep.txt")).unwrap(),
+            b"unrelated"
+        );
+    }
+
+    #[test]
+    fn persisted_diffs_use_independent_portable_json_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_key = "v1:aaa:bbb:ccc";
+        let second_key = "v1:ddd:eee:fff";
+
+        TuiDiffCache::insert_persisted(dir.path(), first_key.into(), disk_diff("first")).unwrap();
+        fs::write(TuiDiffCache::cache_path(dir.path()), b"legacy aggregate").unwrap();
+        TuiDiffCache::insert_persisted(dir.path(), second_key.into(), disk_diff("second")).unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<DiskCachedDiff>(
+                &fs::read(TuiDiffCache::entry_path(dir.path(), first_key)).unwrap()
+            )
+            .unwrap(),
+            disk_diff("first")
+        );
+        assert_eq!(
+            serde_json::from_slice::<DiskCachedDiff>(
+                &fs::read(TuiDiffCache::entry_path(dir.path(), second_key)).unwrap()
+            )
+            .unwrap(),
+            disk_diff("second")
+        );
+        assert_eq!(
+            TuiDiffCache::entry_path(dir.path(), first_key)
+                .file_name()
+                .unwrap(),
+            "v1-aaa-bbb-ccc.json"
+        );
+        assert!(!TuiDiffCache::cache_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn requested_diff_does_not_parse_unrelated_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        TuiDiffCache::insert_persisted(dir.path(), "v1:a:b:c".into(), disk_diff("kept")).unwrap();
+        fs::write(
+            TuiDiffCache::entries_dir(dir.path()).join("broken.json"),
+            b"{",
+        )
+        .unwrap();
+
+        assert_eq!(
+            TuiDiffCache::read_persisted(dir.path(), "v1:a:b:c").unwrap(),
+            Some(disk_diff("kept"))
+        );
+    }
+
+    #[test]
+    fn malformed_requested_diff_is_removed_and_can_be_overwritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "v1:a:b:c";
+        let path = TuiDiffCache::entry_path(dir.path(), key);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"{").unwrap();
+
+        assert!(TuiDiffCache::read_persisted(dir.path(), key).is_err());
+        assert!(!path.exists());
+
+        TuiDiffCache::insert_persisted(dir.path(), key.into(), disk_diff("replacement")).unwrap();
+        assert_eq!(
+            TuiDiffCache::read_persisted(dir.path(), key).unwrap(),
+            Some(disk_diff("replacement"))
+        );
+    }
+
+    #[test]
+    fn reading_a_diff_touches_it_for_oldest_first_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_key = "v1:a:b:c";
+        let second_key = "v1:d:e:f";
+        TuiDiffCache::insert_persisted(dir.path(), first_key.into(), disk_diff("first")).unwrap();
+        TuiDiffCache::insert_persisted(dir.path(), second_key.into(), disk_diff("second")).unwrap();
+        let first_path = TuiDiffCache::entry_path(dir.path(), first_key);
+        let second_path = TuiDiffCache::entry_path(dir.path(), second_key);
+        File::open(&first_path)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_modified(UNIX_EPOCH + std::time::Duration::from_secs(1)),
+            )
+            .unwrap();
+        File::open(&second_path)
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new().set_modified(UNIX_EPOCH + std::time::Duration::from_secs(2)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            TuiDiffCache::read_persisted(dir.path(), first_key).unwrap(),
+            Some(disk_diff("first"))
+        );
+        TuiDiffCache::cleanup_entries(&TuiDiffCache::entries_dir(dir.path()), 1, u64::MAX).unwrap();
+
+        assert!(first_path.exists());
+        assert!(!second_path.exists());
+    }
+
+    #[test]
+    fn diff_cache_cleanup_enforces_count_and_byte_limits() {
+        assert_cleanup_limits(
+            2,
+            100,
+            &[("a", 10), ("b", 10), ("c", 10)],
+            &["b.json", "c.json"],
+        );
+        assert_cleanup_limits(10, 45, &[("a", 10), ("b", 20), ("c", 30)], &["c.json"]);
     }
 
     #[test]
@@ -958,9 +1202,14 @@ mod tests {
             writer.join().unwrap();
         }
 
-        let cache = TuiDiffCache::load_strict(&root).unwrap();
-        assert_eq!(cache.get("key-a"), Some(&disk_diff("patch-a")));
-        assert_eq!(cache.get("key-b"), Some(&disk_diff("patch-b")));
+        assert_eq!(
+            TuiDiffCache::read_persisted(&root, "key-a").unwrap(),
+            Some(disk_diff("patch-a"))
+        );
+        assert_eq!(
+            TuiDiffCache::read_persisted(&root, "key-b").unwrap(),
+            Some(disk_diff("patch-b"))
+        );
     }
 
     #[test]
@@ -980,18 +1229,20 @@ mod tests {
     }
 
     #[test]
-    fn malformed_diff_cache_is_not_clobbered_by_transaction() {
+    fn legacy_malformed_diff_cache_does_not_block_per_entry_write() {
         let temp = TempDir::new().unwrap();
         let path = TuiDiffCache::cache_path(temp.path());
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         let malformed = b"{\"entries\":";
         fs::write(&path, malformed).unwrap();
 
-        let error = TuiDiffCache::insert_persisted(temp.path(), "key".into(), disk_diff("patch"))
-            .unwrap_err();
+        TuiDiffCache::insert_persisted(temp.path(), "key".into(), disk_diff("patch")).unwrap();
 
-        assert!(error.to_string().contains("parse"));
-        assert_eq!(fs::read(path).unwrap(), malformed);
+        assert!(!path.exists());
+        assert_eq!(
+            TuiDiffCache::read_persisted(temp.path(), "key").unwrap(),
+            Some(disk_diff("patch"))
+        );
     }
 
     #[test]
@@ -1051,8 +1302,10 @@ mod tests {
 
         barrier.wait();
         for _ in 0..100 {
-            let cache = TuiDiffCache::load_strict(&root).unwrap();
-            assert_eq!(cache.get("seed"), Some(&disk_diff("seed")));
+            assert_eq!(
+                TuiDiffCache::read_persisted(&root, "seed").unwrap(),
+                Some(disk_diff("seed"))
+            );
         }
         writer.join().unwrap();
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -33,11 +33,7 @@ fn acquire_cache_lock(cache_path: &Path, mode: LockMode) -> Result<CacheLock> {
         .unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(parent)
         .with_context(|| format!("failed to create cache directory {}", parent.display()))?;
-    let file_name = cache_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("cache");
-    let lock_path = parent.join(format!(".{file_name}.lock"));
+    let lock_path = cache_lock_path(cache_path);
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -51,6 +47,18 @@ fn acquire_cache_lock(cache_path: &Path, mode: LockMode) -> Result<CacheLock> {
     }
     .with_context(|| format!("failed to lock cache {}", cache_path.display()))?;
     Ok(CacheLock { file })
+}
+
+fn cache_lock_path(cache_path: &Path) -> PathBuf {
+    let parent = cache_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = cache_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("cache");
+    parent.join(format!(".{file_name}.lock"))
 }
 
 fn load_json_unlocked<T>(path: &Path) -> Result<T>
@@ -343,6 +351,10 @@ impl TuiDiffCache {
         Self::entries_dir(git_dir).join(format!("{}.json", key.replace(':', "-")))
     }
 
+    fn coordination_path(entries_dir: &Path) -> PathBuf {
+        entries_dir.join("directory")
+    }
+
     pub fn key(
         _parent: &str,
         _branch: &str,
@@ -361,7 +373,10 @@ impl TuiDiffCache {
     #[cfg(test)]
     pub(crate) fn load_strict(git_dir: &std::path::Path) -> Result<Self> {
         let mut cache = Self::default();
-        let entries = match fs::read_dir(Self::entries_dir(git_dir)) {
+        let entries_dir = Self::entries_dir(git_dir);
+        let _directory_lock =
+            acquire_cache_lock(&Self::coordination_path(&entries_dir), LockMode::Shared)?;
+        let entries = match fs::read_dir(&entries_dir) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(cache),
             Err(error) => return Err(error).context("failed to read diff cache directory"),
@@ -409,7 +424,13 @@ impl TuiDiffCache {
         key: &str,
     ) -> Result<Option<DiskCachedDiff>> {
         let path = Self::entry_path(git_dir, key);
-        let _lock = acquire_cache_lock(&path, LockMode::Shared)?;
+        let entries_dir = Self::entries_dir(git_dir);
+        let _directory_lock =
+            acquire_cache_lock(&Self::coordination_path(&entries_dir), LockMode::Shared)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        let _entry_lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
         match load_json_unlocked::<Option<DiskCachedDiff>>(&path) {
             Ok(diff) => {
                 if diff.is_some()
@@ -432,19 +453,38 @@ impl TuiDiffCache {
         key: String,
         diff: DiskCachedDiff,
     ) -> Result<()> {
-        let path = Self::entry_path(git_dir, &key);
-        let _lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
-        persist_json_atomic(&path, &diff)?;
-        let _ = fs::remove_file(Self::cache_path(git_dir));
-        let _ = Self::cleanup_entries(
-            &Self::entries_dir(git_dir),
+        Self::insert_persisted_with_limits(
+            git_dir,
+            key,
+            diff,
             MAX_TUI_DIFF_CACHE_ENTRIES,
             MAX_TUI_DIFF_CACHE_BYTES,
-        );
+        )
+    }
+
+    fn insert_persisted_with_limits(
+        git_dir: &Path,
+        key: String,
+        diff: DiskCachedDiff,
+        max_entries: usize,
+        max_bytes: u64,
+    ) -> Result<()> {
+        let path = Self::entry_path(git_dir, &key);
+        let entries_dir = Self::entries_dir(git_dir);
+        {
+            let _directory_lock =
+                acquire_cache_lock(&Self::coordination_path(&entries_dir), LockMode::Shared)?;
+            let _entry_lock = acquire_cache_lock(&path, LockMode::Exclusive)?;
+            persist_json_atomic(&path, &diff)?;
+            let _ = fs::remove_file(Self::cache_path(git_dir));
+        }
+        let _ = Self::cleanup_entries(&entries_dir, max_entries, max_bytes);
         Ok(())
     }
 
     fn cleanup_entries(entries_dir: &Path, max_entries: usize, max_bytes: u64) -> Result<()> {
+        let _directory_lock =
+            acquire_cache_lock(&Self::coordination_path(entries_dir), LockMode::Exclusive)?;
         let entries = match fs::read_dir(entries_dir) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -460,14 +500,31 @@ impl TuiDiffCache {
         let mut cached = Vec::new();
         let mut total_bytes = 0_u64;
         for entry in entries {
-            let entry = entry?;
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("failed to inspect diff cache entry"),
+            };
             let path = entry.path();
-            if !entry.file_type()?.is_file()
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("failed to inspect diff cache entry type"),
+            };
+            if !file_type.is_file()
                 || path.extension().and_then(|extension| extension.to_str()) != Some("json")
             {
                 continue;
             }
-            let metadata = entry.metadata()?;
+            let metadata = match entry.metadata() {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to inspect diff cache entry {}", path.display())
+                    });
+                }
+            };
             let bytes = metadata.len();
             total_bytes = total_bytes.saturating_add(bytes);
             cached.push((metadata.modified().unwrap_or(UNIX_EPOCH), path, bytes));
@@ -479,8 +536,24 @@ impl TuiDiffCache {
             if remove_count == 0 && total_bytes <= max_bytes {
                 break;
             }
-            fs::remove_file(&path)
-                .with_context(|| format!("failed to remove diff cache entry {}", path.display()))?;
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to remove diff cache entry {}", path.display())
+                    });
+                }
+            }
+            match fs::remove_file(cache_lock_path(&path)) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to remove diff cache entry lock {}", path.display())
+                    });
+                }
+            }
             total_bytes = total_bytes.saturating_sub(bytes);
             remove_count = remove_count.saturating_sub(1);
         }
@@ -777,6 +850,49 @@ mod tests {
             &["b.json", "c.json"],
         );
         assert_cleanup_limits(10, 45, &[("a", 10), ("b", 20), ("c", 30)], &["c.json"]);
+    }
+
+    #[test]
+    fn concurrent_diff_writers_enforce_cleanup_limit_and_remove_evicted_locks() {
+        let temp = TempDir::new().unwrap();
+        let root = Arc::new(temp.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(25));
+        let writers = (0..24)
+            .map(|index| {
+                let root = Arc::clone(&root);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    TuiDiffCache::insert_persisted_with_limits(
+                        &root,
+                        format!("key-{index}"),
+                        disk_diff(&format!("patch-{index}")),
+                        4,
+                        u64::MAX,
+                    )
+                    .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+
+        let entries_dir = TuiDiffCache::entries_dir(&root);
+        let names = fs::read_dir(entries_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+            .collect::<Vec<_>>();
+        let entry_count = names.iter().filter(|name| name.ends_with(".json")).count();
+        let entry_lock_count = names
+            .iter()
+            .filter(|name| name.ends_with(".json.lock"))
+            .count();
+
+        assert!(entry_count <= 4, "found {entry_count} persisted entries");
+        assert_eq!(entry_lock_count, entry_count);
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -525,6 +525,7 @@ impl TuiDiffCache {
     fn cleanup_entries(entries_dir: &Path, max_entries: usize, max_bytes: u64) -> Result<()> {
         let _directory_lock =
             acquire_cache_lock(&Self::coordination_path(entries_dir), LockMode::Exclusive)?;
+        Self::cleanup_orphaned_entry_locks(entries_dir)?;
         let entries = match fs::read_dir(entries_dir) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -596,6 +597,66 @@ impl TuiDiffCache {
             }
             total_bytes = total_bytes.saturating_sub(bytes);
             remove_count = remove_count.saturating_sub(1);
+        }
+        Ok(())
+    }
+
+    fn cleanup_orphaned_entry_locks(entries_dir: &Path) -> Result<()> {
+        let entries = match fs::read_dir(entries_dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to read diff cache directory {}",
+                        entries_dir.display()
+                    )
+                });
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("failed to inspect diff cache entry"),
+            };
+            let path = entry.path();
+            let Some(lock_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(payload_name) = lock_name.strip_suffix(".lock") else {
+                continue;
+            };
+            if !payload_name.ends_with(".json") {
+                continue;
+            }
+            let payload_path =
+                entries_dir.join(payload_name.strip_prefix('.').unwrap_or(payload_name));
+            match fs::metadata(&payload_path) {
+                Ok(metadata) if metadata.is_file() => continue,
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to inspect diff cache entry {}",
+                            payload_path.display()
+                        )
+                    });
+                }
+            }
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to remove orphaned diff cache entry lock {}",
+                            path.display()
+                        )
+                    });
+                }
+            }
         }
         Ok(())
     }
@@ -905,6 +966,36 @@ mod tests {
             &["b.json", "c.json"],
         );
         assert_cleanup_limits(10, 45, &[("a", 10), ("b", 20), ("c", 30)], &["c.json"]);
+    }
+
+    #[test]
+    fn diff_cache_cleanup_removes_seeded_orphan_entry_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries_dir = TuiDiffCache::entries_dir(dir.path());
+        fs::create_dir_all(&entries_dir).unwrap();
+        let orphan_payload = entries_dir.join("orphan.json");
+        let orphan_lock = cache_lock_path(&orphan_payload);
+        fs::write(&orphan_lock, b"").unwrap();
+
+        TuiDiffCache::cleanup_entries(&entries_dir, usize::MAX, u64::MAX).unwrap();
+
+        assert!(!orphan_lock.exists());
+    }
+
+    #[test]
+    fn diff_cache_cleanup_retains_entry_lock_for_live_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries_dir = TuiDiffCache::entries_dir(dir.path());
+        fs::create_dir_all(&entries_dir).unwrap();
+        let live_payload = entries_dir.join("live.json");
+        let live_lock = cache_lock_path(&live_payload);
+        fs::write(&live_payload, b"{}").unwrap();
+        fs::write(&live_lock, b"").unwrap();
+
+        TuiDiffCache::cleanup_entries(&entries_dir, usize::MAX, u64::MAX).unwrap();
+
+        assert!(live_payload.exists());
+        assert!(live_lock.exists());
     }
 
     #[test]

--- a/tests/application_session_tests.rs
+++ b/tests/application_session_tests.rs
@@ -424,6 +424,32 @@ fn cached_diff_returns_the_same_entry_without_recalculating() {
 }
 
 #[test]
+fn cached_diff_treats_a_malformed_persisted_entry_as_a_miss() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+    session.diff("feature", "main").unwrap();
+    std::fs::write(only_diff_cache_entry(&repo), b"{").unwrap();
+
+    let cached = session.cached_diff("feature", "main").unwrap();
+
+    assert_eq!(cached, None);
+}
+
+#[test]
+fn cached_diff_still_reports_revision_resolution_errors() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature"]);
+    let session = RepositorySession::open(repo.path()).unwrap();
+
+    let error = session.cached_diff("missing", "main").unwrap_err();
+
+    let message = format!("{error:#}");
+    assert!(message.contains("cached diff lookup"));
+    assert!(message.contains("missing"));
+}
+
+#[test]
 fn refresh_diff_bypasses_matching_stale_cache_and_replaces_it() {
     let repo = TestRepo::new();
     repo.create_stack(&["feature"]);

--- a/tests/application_session_tests.rs
+++ b/tests/application_session_tests.rs
@@ -56,6 +56,34 @@ fn write_stack_parent(repo: &TestRepo, branch: &str, parent: &str) {
     std::fs::remove_file(repo.path().join(metadata_file)).unwrap();
 }
 
+fn diff_cache_entries(repo: &TestRepo) -> Vec<PathBuf> {
+    let dir = repo
+        .path()
+        .join(".git")
+        .join("stax")
+        .join("diff-cache")
+        .join("v1");
+    let mut entries = std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .filter_map(|entry| {
+                    let path = entry.ok()?.path();
+                    (path.extension().and_then(|extension| extension.to_str()) == Some("json"))
+                        .then_some(path)
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    entries.sort();
+    entries
+}
+
+fn only_diff_cache_entry(repo: &TestRepo) -> PathBuf {
+    let entries = diff_cache_entries(repo);
+    assert_eq!(entries.len(), 1, "expected one persisted diff entry");
+    entries.into_iter().next().unwrap()
+}
+
 #[test]
 fn snapshot_orders_tracked_stacks_before_trunk() {
     let repo = TestRepo::new();
@@ -370,12 +398,7 @@ fn second_diff_round_trips_through_the_tui_cache() {
         .diff("feature", "main")
         .unwrap();
 
-    let cache_path = repo
-        .path()
-        .join(".git")
-        .join("stax")
-        .join("tui-diff-cache.json");
-    assert!(cache_path.is_file());
+    assert!(only_diff_cache_entry(&repo).is_file());
 
     let second = RepositorySession::open(repo.path())
         .unwrap()
@@ -406,21 +429,11 @@ fn refresh_diff_bypasses_matching_stale_cache_and_replaces_it() {
     repo.create_stack(&["feature"]);
     let session = RepositorySession::open(repo.path()).unwrap();
     let actual = session.diff("feature", "main").unwrap();
-    let cache_path = repo
-        .path()
-        .join(".git")
-        .join("stax")
-        .join("tui-diff-cache.json");
+    let cache_path = only_diff_cache_entry(&repo);
     let mut stored: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&cache_path).unwrap()).unwrap();
-    let entry = stored["entries"]
-        .as_object_mut()
-        .unwrap()
-        .values_mut()
-        .next()
-        .unwrap();
-    entry["diff"]["stat"] = serde_json::json!([]);
-    entry["diff"]["lines"] = serde_json::json!([
+    stored["stat"] = serde_json::json!([]);
+    stored["lines"] = serde_json::json!([
         {"content": "deliberately incorrect cached patch", "line_type": "context"}
     ]);
     std::fs::write(&cache_path, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
@@ -441,23 +454,23 @@ fn refresh_diff_bypasses_matching_stale_cache_and_replaces_it() {
 }
 
 #[test]
-fn refresh_diff_returns_live_result_without_clobbering_malformed_cache() {
+fn refresh_diff_returns_live_result_and_replaces_malformed_cache() {
     let repo = TestRepo::new();
     repo.create_stack(&["feature"]);
     let session = RepositorySession::open(repo.path()).unwrap();
     let expected = session.diff("feature", "main").unwrap();
-    let cache_path = repo
-        .path()
-        .join(".git")
-        .join("stax")
-        .join("tui-diff-cache.json");
-    let malformed = b"{\"entries\":";
+    let cache_path = only_diff_cache_entry(&repo);
+    let malformed = b"{";
     std::fs::write(&cache_path, malformed).unwrap();
 
     let refreshed = session.refresh_diff("feature", "main").unwrap();
 
     assert_eq!(refreshed, expected);
-    assert_eq!(std::fs::read(cache_path).unwrap(), malformed);
+    assert_eq!(
+        session.cached_diff("feature", "main").unwrap(),
+        Some(expected)
+    );
+    assert_ne!(std::fs::read(cache_path).unwrap(), malformed);
 }
 
 #[test]
@@ -472,17 +485,12 @@ fn cached_diff_miss_does_not_calculate_a_patch() {
         .join(&blob_oid[..2])
         .join(&blob_oid[2..]);
     std::fs::remove_file(object_path).unwrap();
-    let cache_path = repo
-        .path()
-        .join(".git")
-        .join("stax")
-        .join("tui-diff-cache.json");
     let session = RepositorySession::open(repo.path()).unwrap();
 
     let cached = session.cached_diff("feature", "main").unwrap();
 
     assert_eq!(cached, None);
-    assert!(!cache_path.exists());
+    assert!(diff_cache_entries(&repo).is_empty());
 }
 
 #[test]
@@ -515,12 +523,7 @@ fn diff_failure_after_ref_validation_is_not_cached_as_empty() {
         .join(&blob_oid[..2])
         .join(&blob_oid[2..]);
     std::fs::remove_file(&object_path).unwrap();
-    let cache_path = repo
-        .path()
-        .join(".git")
-        .join("stax")
-        .join("tui-diff-cache.json");
-    assert!(!cache_path.exists());
+    assert!(diff_cache_entries(&repo).is_empty());
     let session = RepositorySession::open(repo.path()).unwrap();
 
     let error = session.diff("feature", "main").unwrap_err();
@@ -531,5 +534,5 @@ fn diff_failure_after_ref_validation_is_not_cached_as_empty() {
     assert!(message.contains("main"));
     assert!(message.contains("exit status"));
     assert!(message.contains("fatal:"));
-    assert!(!cache_path.exists());
+    assert!(diff_cache_entries(&repo).is_empty());
 }


### PR DESCRIPTION
## Summary

- keep the 32 most recently viewed branch diffs in GUI session memory so revisiting a branch renders synchronously;
- replace the aggregate diff-cache JSON with one revision-keyed JSON file per diff under `.git/stax/diff-cache/v1`;
- bound persistent storage to 128 entries and 100 MiB with concurrency-safe cleanup and orphan-lock reaping.

## Why

The previous cache stored every patch in one JSON document. In the repository used to reproduce the issue, that file was 20.3 MB with 27 entries and 166,175 patch lines. Selecting any branch had to read and deserialize the entire file before showing one cached patch, taking roughly 260 ms in a command-line parse and making repeated branch selection feel uncached.

## Implementation

- Persistent entries are keyed by the parent, branch, and merge-base object IDs, so unchanged revisions remain safe to reuse across branch renames and app launches.
- Each entry is read, locked, and written independently using the existing atomic persistence and `fs4` locking primitives; no database or new dependency is introduced.
- Cleanup coordinates across processes, ignores foreign files, removes cache-owned orphan locks, and safely degrades malformed or unavailable cache entries to misses without hiding Git errors.
- The GUI uses a snapshot-scoped 32-entry LRU keyed by branch and parent, clears it after repository mutations or snapshot replacement, and retains stale-generation rejection.
- The legacy aggregate file is disposable cache data: it is not migrated, and is removed best-effort after a successful new-format write. The first lookup after upgrading may therefore be cold once.

## Verification

- `cargo fmt --all -- --check`
- `make lint`
- `make test` — 2,050/2,050 passed through the required Docker path
- `cargo nextest run -p stax-gui` — 178/178 passed
- `cargo nextest run --lib cache::tests::` — 34/34 passed
- final whole-branch review — no remaining findings

## Documentation impact

No README, command documentation, or `skills.md` update is needed. This changes internal cache performance and makes the existing cached-diff behavior responsive; it does not add or change a command, flag, or workflow.
