### PR TITLE
fix: preserve promoted worktree after partial retirement

### DIFF
--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -174,8 +174,11 @@ lane according to the existing warm-slot configuration.
 Promotion preserves the branch, commits, upstream, PR linkage, and stax
 metadata. It does not merge, delete, untrack, or automatically stash anything.
 Both the current lane and main worktree must be clean, unlocked, and free of an
-in-progress merge, rebase, or conflicts. If switching or retirement fails,
-Stax restores the original checkouts and reports any rollback problem.
+in-progress merge, rebase, or conflicts. If switching fails, Stax restores the
+original checkouts and reports any rollback problem. Git may report a removal
+failure only after it has already unregistered the old lane; in that case Stax
+keeps the completed handoff in the main worktree, removes a dangling `.git` file
+when safe, and tells you to inspect any remaining files in the old lane path.
 
 With shell integration, the current shell moves to the main worktree only after
 the handoff succeeds. Without it, Stax prints the main worktree path and a

--- a/skills.md
+++ b/skills.md
@@ -693,5 +693,5 @@ Symbols:
 - Use `--json` on supported commands for machine-readable output.
 - Use `stax lane` with no arguments for an interactive picker over all stax-managed lanes — useful when you forget where a session lives.
 - Use `stax worktree go` (or `sw`) + shell integration to switch between stacks without `cd` gymnastics.
-- Use `stax worktree promote` when a lane should become the main-worktree checkout; it refuses dirty or conflicted checkouts instead of stashing automatically.
+- Use `stax worktree promote` when a lane should become the main-worktree checkout; it refuses dirty or conflicted checkouts instead of stashing automatically. If Git reports a removal failure after already retiring the lane, Stax keeps the completed promotion and warns you to inspect leftover files.
 - `stax worktree list` shows ALL worktrees including those created externally via `git worktree add`.

--- a/src/commands/worktree/promote.rs
+++ b/src/commands/worktree/promote.rs
@@ -9,7 +9,7 @@ use crate::git::GitRepo;
 use crate::git::repo::WorktreeInfo;
 use anyhow::{Context, Result, anyhow, bail};
 use colored::Colorize;
-use std::path::Path;
+use std::{fs, path::Path};
 
 pub fn run(shell_output: bool) -> Result<()> {
     let repo = GitRepo::open()?;
@@ -78,6 +78,26 @@ pub fn run(shell_output: bool) -> Result<()> {
         false,
         RemovalMode::AllowParking,
     ) {
+        if source_was_retired(&main, &source) {
+            let removed_dangling_git_file = remove_dangling_git_file(&source.path)?;
+            eprintln!(
+                "Warning: Git reported a removal failure after it had already retired the linked worktree. \
+                 Promotion completed in the main worktree.{} Inspect any leftover files at '{}'.",
+                if removed_dangling_git_file {
+                    " Removed its dangling .git file."
+                } else {
+                    ""
+                },
+                source.path.display()
+            );
+            spawn_background_hook(
+                config.worktree.hooks.post_remove.as_deref(),
+                &main.path,
+                "post_remove",
+            )?;
+            finish_success(shell_output, &main.path, &branch);
+            return Ok(());
+        }
         let main_rollback = restore_checkout(&repo, &main, &main_head).err();
         let source_rollback = repo.switch_branch_in(&source.path, &branch).err();
         return Err(transaction_error(
@@ -94,6 +114,43 @@ pub fn run(shell_output: bool) -> Result<()> {
     )?;
     finish_success(shell_output, &main.path, &branch);
     Ok(())
+}
+
+fn source_was_retired(main: &WorktreeInfo, source: &WorktreeInfo) -> bool {
+    GitRepo::list_worktrees_in(&main.path)
+        .map(|worktrees| {
+            worktrees
+                .iter()
+                .all(|worktree| worktree.path != source.path)
+        })
+        .unwrap_or(false)
+}
+
+fn remove_dangling_git_file(worktree_path: &Path) -> Result<bool> {
+    let git_file = worktree_path.join(".git");
+    let contents = match fs::read_to_string(&git_file) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed to inspect '{}'", git_file.display()));
+        }
+    };
+    let Some(gitdir) = contents.trim().strip_prefix("gitdir:") else {
+        return Ok(false);
+    };
+    let gitdir = Path::new(gitdir.trim());
+    let gitdir = if gitdir.is_absolute() {
+        gitdir.to_path_buf()
+    } else {
+        worktree_path.join(gitdir)
+    };
+    if gitdir.exists() {
+        return Ok(false);
+    }
+    fs::remove_file(&git_file)
+        .with_context(|| format!("Failed to remove dangling '{}'.", git_file.display()))?;
+    Ok(true)
 }
 
 fn ensure_clean_checkout(label: &str, details: &WorktreeDetails) -> Result<()> {

--- a/tests/worktree_promote_tests.rs
+++ b/tests/worktree_promote_tests.rs
@@ -78,6 +78,18 @@ if [ "$mode" = "remove" ] && [ "$cwd" = "$STAX_PROMOTE_MAIN" ] && \
   echo "synthetic worktree remove failure" >&2
   exit 42
 fi
+if [ "$mode" = "remove-after-retire" ] && [ "$cwd" = "$STAX_PROMOTE_MAIN" ] && \
+   [ "${1:-}" = "worktree" ] && [ "${2:-}" = "remove" ]; then
+  "$REAL_GIT" "$@"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    exit "$status"
+  fi
+  mkdir -p "$3"
+  printf 'gitdir: /missing/stax-worktree-admin\n' > "$3/.git"
+  echo "synthetic worktree remove failure after retirement" >&2
+  exit 43
+fi
 exec "$REAL_GIT" "$@"
 "#,
     )
@@ -313,4 +325,45 @@ fn wt_promote_rolls_back_when_retirement_fails() {
     assert_eq!(current_branch(&repo, &repo.path()), "main");
     assert_eq!(current_branch(&repo, &linked), branch);
     assert!(linked.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn wt_promote_keeps_main_promoted_when_removal_fails_after_retiring_source() {
+    let (repo, branch, linked) = setup_promotable_worktree();
+    let (_shim_dir, path) = failing_git_path();
+    let main = fs::canonicalize(repo.path())
+        .expect("canonical main path")
+        .to_string_lossy()
+        .into_owned();
+    let real_git = real_git_path();
+
+    let output = repo.run_stax_in_with_env(
+        &linked,
+        &["wt", "promote"],
+        &[
+            ("PATH", path.as_str()),
+            ("REAL_GIT", real_git.as_str()),
+            ("STAX_PROMOTE_FAIL_MODE", "remove-after-retire"),
+            ("STAX_PROMOTE_MAIN", main.as_str()),
+            ("STAX_PROMOTE_BRANCH", branch.as_str()),
+        ],
+    );
+
+    output
+        .assert_success()
+        .assert_stderr_contains("already retired the linked worktree");
+    assert_eq!(current_branch(&repo, &repo.path()), branch);
+    assert!(
+        linked.exists(),
+        "the simulated removal leaves directory residue"
+    );
+    assert!(
+        !linked.join(".git").exists(),
+        "a retired worktree must not retain a dangling .git file"
+    );
+    assert!(
+        !worktree_list(&repo).contains(linked.to_string_lossy().as_ref()),
+        "retired source must not remain registered"
+    );
 }


### PR DESCRIPTION
## Summary
- Detect when `git worktree remove` reports failure only after unregistering the promoted source worktree.
- Preserve the completed promotion in the main worktree rather than attempting an impossible rollback; safely remove only a dangling `.git` file and report any remaining residue.
- Add a deterministic post-side-effect Git-shim regression test and document the recovery behavior.

## Tests
- `cargo nextest run worktree_promote_tests::`
- `make lint && make test` (2051 passed)

## Documentation
Updated `docs/worktrees/index.md` and `skills.md` for the exceptional partial-retirement behavior. README is unchanged because the normal command surface and primary workflow are unchanged.

Closes #614
