### PR TITLE
Fix GUI screenshot link in docs

### DIFF
--- a/docs/interface/gui.md
+++ b/docs/interface/gui.md
@@ -49,7 +49,7 @@ The `-n` flag is part of the contract. Every `st gui [path]` invocation opens a 
 
 ## Workspace
 
-![Stax native macOS GUI showing a stacked branch graph, changes, and branch inspector](../../assets/gui.png)
+![Stax native macOS GUI showing a stacked branch graph, changes, and branch inspector](../assets/gui.png)
 
 The workspace shows the repository stack, the selected branch changes, and an inspector for branch actions and status. Background hydration refreshes CI, PR, and diff data without blocking normal browsing. Selecting a branch changes the visible details; it does not check out the branch until you explicitly run Checkout.
 


### PR DESCRIPTION
## Motivation

<!-- What feature does this add / what does it fix? -->

Fix the broken screenshot reference in the GUI documentation so the image renders correctly.

## Description of changes / notes for reviewers

- Updated the `gui.png` link in `docs/interface/gui.md` to use the correct relative path.
- Documentation-only change; no runtime behavior is affected.