### PR TITLE
fix: preserve st pr lookup errors

### DIFF
--- a/src/application/ci.rs
+++ b/src/application/ci.rs
@@ -224,7 +224,10 @@ mod tests {
         let expected = home.path().join(".config").join("stax");
         let _guard = HomeConfigGuard::set(home.path());
 
-        assert_eq!(env::var_os("STAX_CONFIG_DIR"), Some(expected.into_os_string()));
+        assert_eq!(
+            env::var_os("STAX_CONFIG_DIR"),
+            Some(expected.into_os_string())
+        );
     }
 
     fn commit_file(repo: &git2::Repository, contents: &str) -> String {

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -1,4 +1,7 @@
-use crate::application::{NoopOperationReporter, OperationOutcome, RepositorySession};
+use crate::application::{
+    NoopOperationReporter, OperationErrorDetails, OperationErrorKind, OperationOutcome,
+    RepositorySession,
+};
 use crate::commands::github_list::{
     CellTone, TableCell, TableColumn, TruncationMode, format_relative_time, print_table,
     split_flexible_width, terminal_width,
@@ -43,11 +46,17 @@ pub fn run_open() -> Result<()> {
         .resolve_pull_request_url(&current, &mut NoopOperationReporter)
     {
         Ok(receipt) => receipt,
-        Err(_) => anyhow::bail!(
-            "No PR found for branch '{}'. Use {} to create one.",
-            current,
-            "stax submit".cyan()
-        ),
+        Err(error)
+            if error.kind == OperationErrorKind::PreconditionFailed
+                && matches!(error.details, OperationErrorDetails::PullRequest { .. }) =>
+        {
+            anyhow::bail!(
+                "No PR found for branch '{}'. Use {} to create one.",
+                current,
+                "stax submit".cyan()
+            )
+        }
+        Err(error) => return Err(error.into()),
     };
     let pr_url = match receipt.outcome {
         OperationOutcome::PullRequestResolved { url, .. } => url,

--- a/tests/pr_open_tests.rs
+++ b/tests/pr_open_tests.rs
@@ -46,3 +46,47 @@ async fn pr_open_network_fallback_does_not_panic_without_a_reactor() {
         "expected a missing-PR error after the forge lookup, got:\n{stderr}"
     );
 }
+
+#[tokio::test]
+async fn pr_open_preserves_lookup_authentication_failure() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["feature-open"]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/test-owner/test-repo.git",
+    ])
+    .assert_success();
+
+    let server = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let env = IsolatedProcessEnv::with_config(&format!(
+        "[remote]\napi_base_url = \"{}\"\n",
+        server.uri()
+    ));
+    let output = env
+        .command(&repo.path())
+        .env("STAX_GITHUB_TOKEN", "test-token")
+        .arg("pr")
+        .output()
+        .expect("run stax pr");
+
+    assert!(
+        !output.status.success(),
+        "st pr should report the lookup failure"
+    );
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("Could not resolve the pull request"),
+        "expected the structured lookup failure, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("No PR found for branch"),
+        "lookup failure must not be reported as a missing PR:\n{stderr}"
+    );
+}

--- a/tests/tui_commands_tests.rs
+++ b/tests/tui_commands_tests.rs
@@ -178,23 +178,27 @@ fn test_tui_submit_no_prompt_does_not_hang() {
     // The important thing is it didn't hang waiting for interactive prompts
 }
 
-/// Test that `stax pr` works (TUI KeyAction::OpenPr)
-/// Note: This will fail if no PR exists, which is expected behavior
+/// Test that `stax pr` preserves a remote-configuration failure (TUI KeyAction::OpenPr).
 #[test]
-fn test_tui_pr_no_pr_exists() {
+fn test_tui_pr_preserves_remote_configuration_failure() {
     let repo = TestRepo::new();
 
-    // Create a tracked branch
+    // Create a tracked branch without configuring a trusted remote.
     repo.run_stax(&["create", "pr-test"]).assert_success();
 
     // TUI calls: run_external_command(app, &["pr"])
-    // Should fail gracefully since there's no PR
     let output = repo.run_stax(&["pr"]);
     output.assert_failure();
 
-    // Should mention that no PR exists
     let stderr = TestRepo::stderr(&output);
-    assert!(stderr.contains("No PR") || stderr.contains("submit"));
+    assert!(
+        stderr.contains("Repository network access is not trusted for this remote"),
+        "expected the structured remote-configuration failure, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("No PR found for branch"),
+        "remote-configuration failure must not be reported as a missing PR:\n{stderr}"
+    );
 }
 
 /// Test that branch creation with empty name fails gracefully


### PR DESCRIPTION
## Summary
- preserve structured `OperationError` values from `st pr` lookup failures
- retain missing-PR guidance only for the explicit missing-pull-request precondition
- cover authentication and untrusted-remote failure presentation

## Tests
- `cargo nextest run pr_open_tests:: --test all_tests --no-fail-fast`
- `cargo nextest run tui_commands_tests::test_tui_pr_preserves_remote_configuration_failure --test all_tests --no-fail-fast`
- `make test`

## Documentation
No documentation update: this corrects error reporting for an existing command; its flags and normal workflow are unchanged.

Closes #624