### PR TITLE
Fix worktree promotion for nested worktrees

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -580,6 +580,16 @@ impl GitRepo {
             &mut current_prunable_reason,
         );
 
+        // Worktrees can be nested beneath another worktree's path (for example,
+        // `<repo>/.worktrees/feature`). Choose the deepest matching root so only
+        // the actual current worktree is marked current.
+        let current_worktree_path = raw_entries
+            .iter()
+            .map(|(path, _, _, _, _, _)| path)
+            .filter(|path| cwd_normalized.starts_with(path))
+            .max_by_key(|path| path.components().count())
+            .cloned();
+
         let label_candidates = raw_entries
             .iter()
             .enumerate()
@@ -602,7 +612,7 @@ impl GitRepo {
             .map(
                 |(idx, (path, branch, is_locked, lock_reason, is_prunable, prunable_reason))| {
                     let is_main = idx == 0;
-                    let is_current = cwd_normalized.starts_with(&path);
+                    let is_current = current_worktree_path.as_ref() == Some(&path);
                     WorktreeInfo {
                         name: labels[idx].clone(),
                         path,

--- a/tests/worktree_promote_tests.rs
+++ b/tests/worktree_promote_tests.rs
@@ -161,6 +161,44 @@ fn wt_promote_works_from_nested_directory() {
 }
 
 #[test]
+fn wt_promote_works_when_linked_worktree_is_nested_under_main() {
+    let repo = TestRepo::new();
+    repo.create_file(".gitignore", ".worktrees/\n");
+    repo.commit("Ignore nested worktrees");
+
+    repo.run_stax(&["create", "promote-feature"])
+        .assert_success();
+    let branch = repo.current_branch();
+    repo.create_file("feature.txt", "promoted\n");
+    repo.commit("Add promoted feature");
+    repo.run_stax(&["checkout", "main"]).assert_success();
+
+    let linked = repo
+        .path()
+        .join(".worktrees")
+        .join("promote-feature-worktree");
+    fs::create_dir_all(linked.parent().expect("nested worktree parent"))
+        .expect("create nested worktree parent");
+    repo.git(&[
+        "worktree",
+        "add",
+        linked.to_str().expect("UTF-8 worktree path"),
+        &branch,
+    ])
+    .assert_success();
+
+    let output = repo.run_stax_in(&linked, &["wt", "promote"]);
+
+    output.assert_success();
+    assert_eq!(current_branch(&repo, &repo.path()), branch);
+    assert!(repo.path().join("feature.txt").exists());
+    assert!(
+        !linked.exists(),
+        "promoted nested worktree should be retired"
+    );
+}
+
+#[test]
 fn wt_promote_refuses_dirty_linked_worktree() {
     let (repo, branch, linked) = setup_promotable_worktree();
     fs::write(linked.join("dirty.txt"), "dirty\n").expect("write dirty source file");


### PR DESCRIPTION
## Motivation

Fix cases where `stax wt promote` could misidentify the current worktree when a linked worktree lives underneath another worktree path, causing the wrong entry to be treated as current.

## Description of changes / notes for reviewers

- Detect the deepest matching worktree path before marking the current worktree, so nested worktrees are handled correctly.
- Add a regression test covering promotion from a nested linked worktree under `.worktrees/`.