### PR TITLE
perf: streamline Clippy workflow

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -64,9 +64,9 @@ jobs:
         run: cargo nextest run -p stax-gui --locked
       - name: Lint GPUI package
         # Clippy also lints the local stax path dependency. Mirror the reviewed
-        # legacy allowances from scripts/lint.sh while keeping other warnings fatal.
+        # legacy allowances from scripts/clippy-lint.sh while keeping other warnings fatal.
         run: |
-          cargo clippy -p stax-gui --all-targets --locked -- \
+          cargo clippy -p stax-gui --all-targets --locked --no-deps -- \
             -D warnings \
             -A clippy::assertions_on_constants \
             -A clippy::bool_assert_comparison \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@
 - This suite is process/filesystem heavy (`git` + `stax` subprocesses), and Linux Docker is dramatically faster and more stable than native macOS for full runs.
 - Native macOS performance remains sensitive to endpoint-security tooling; do not assume a warm native timing will match Docker.
 
+## Lint Command Policy
+
+- During implementation, use `make lint-fast` for formatting plus Clippy on library and binary targets.
+- Before completion or submission, run `make lint` once to cover all targets and features.
+- Use these Make targets instead of ad hoc `cargo clippy` commands so local and CI lint flags stay aligned.
+
 ## Documentation Policy
 
 When a change touches user-visible behaviour — new commands, changed flags, renamed concepts, removed features, or updated defaults — the following must also be updated in the same PR:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@ Thanks for your interest in contributing! Here's how to get started.
 
 ## Prerequisites
 
-- **Rust** via [rustup](https://rustup.rs/) (the repository pins the supported
-  toolchain in `rust-toolchain.toml`)
+- **Rust** via [rustup](https://rustup.rs/) or your system package manager. Local
+  commands use the Rust toolchain installed on your machine; it must satisfy the
+  `rust-version` declared in `Cargo.toml`.
 - **cargo-nextest** for running tests: `cargo install cargo-nextest`
 - **Docker** (optional, recommended on macOS for faster full test suite)
 
@@ -66,6 +67,12 @@ cargo nextest run --tests
 
 ## Code Quality
 
+Use the focused lint target while iterating:
+
+```bash
+make lint-fast
+```
+
 Before submitting a PR, make sure these pass:
 
 ```bash
@@ -79,9 +86,9 @@ make lint
 cargo check
 ```
 
-CI enforces `make lint` on every PR. This checks formatting and treats new
-Clippy diagnostics as errors while the explicit legacy-lint allowlist in
-`scripts/lint.sh` is paid down.
+CI enforces `make lint` on every PR. This checks all targets and features,
+validates formatting, and treats new Clippy diagnostics as errors while the
+explicit legacy-lint allowlist in `scripts/clippy-lint.sh` is paid down.
 
 ## Submitting Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-release release ensure-git-cliff install clean gui-icon gui-app gui-app-test gui-release gui-release-test install-gui-app test test-native test-native-script test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint benchmark-status all
+.PHONY: build build-release release ensure-git-cliff install clean gui-icon gui-app gui-app-test gui-release gui-release-test install-gui-app test test-native test-native-script test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint lint-fast benchmark-status all
 
 RAMDISK_NAME ?= STAXRAM
 RAMDISK_SIZE_MB ?= 2048
@@ -191,7 +191,7 @@ test-integration:
 # Run clippy and check
 check:
 	cargo check --all-targets --all-features
-	./scripts/lint.sh
+	./scripts/lint.sh full
 
 # Format code
 fmt:
@@ -200,7 +200,12 @@ fmt:
 # Lint (check formatting)
 lint:
 	cargo fmt -- --check
-	./scripts/lint.sh
+	./scripts/lint.sh full
+
+# Fast lint for local iteration (library and binary targets only)
+lint-fast:
+	cargo fmt -- --check
+	./scripts/clippy-lint.sh fast
 
 # Benchmark cold JSON status across deterministic stack sizes.
 benchmark-status:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.96.1"
-components = ["clippy", "rustfmt"]
-profile = "minimal"

--- a/scripts/clippy-lint-tests.sh
+++ b/scripts/clippy-lint-tests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fake_cargo="${tmp_dir}/cargo"
+calls_file="${tmp_dir}/calls"
+
+cat >"${fake_cargo}" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CLIPPY_LINT_TEST_CALLS}"
+EOF
+chmod +x "${fake_cargo}"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "expected command to contain: ${needle}" >&2
+    echo "actual command: ${haystack}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    echo "expected command not to contain: ${needle}" >&2
+    echo "actual command: ${haystack}" >&2
+    exit 1
+  fi
+}
+
+run_lint() {
+  local mode="$1"
+  : >"${calls_file}"
+  CLIPPY_LINT_CARGO="${fake_cargo}" \
+    CLIPPY_LINT_TEST_CALLS="${calls_file}" \
+    bash "${repo_root}/scripts/clippy-lint.sh" "${mode}"
+  cat "${calls_file}"
+}
+
+fast_call="$(run_lint fast)"
+assert_contains "${fast_call}" "clippy --lib --bins --no-deps --"
+assert_not_contains "${fast_call}" "--all-targets"
+assert_not_contains "${fast_call}" "--all-features"
+
+full_call="$(run_lint full)"
+assert_contains "${full_call}" "clippy --all-targets --all-features --no-deps --"
+assert_not_contains "${full_call}" "--lib"
+assert_not_contains "${full_call}" "--bins"
+
+: >"${calls_file}"
+if CLIPPY_LINT_CARGO="${fake_cargo}" \
+  CLIPPY_LINT_TEST_CALLS="${calls_file}" \
+  bash "${repo_root}/scripts/clippy-lint.sh" unexpected >"${tmp_dir}/stdout" 2>"${tmp_dir}/stderr"; then
+  echo "expected an invalid lint mode to fail" >&2
+  exit 1
+fi
+
+if [[ -s "${calls_file}" ]]; then
+  echo "invalid lint mode must not invoke cargo" >&2
+  exit 1
+fi
+
+assert_contains "$(cat "${tmp_dir}/stderr")" "expected 'fast' or 'full'"
+
+echo "clippy lint mode tests passed"

--- a/scripts/clippy-lint.sh
+++ b/scripts/clippy-lint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-full}"
+cargo_bin="${CLIPPY_LINT_CARGO:-cargo}"
+
+case "${mode}" in
+  fast)
+    targets=(--lib --bins)
+    ;;
+  full)
+    targets=(--all-targets --all-features)
+    ;;
+  *)
+    echo "invalid lint mode '${mode}'; expected 'fast' or 'full'" >&2
+    exit 2
+    ;;
+esac
+
+# Keep new Clippy warnings fatal while the explicitly listed legacy lint debt is
+# paid down. Removing an allowance is always safe; adding one requires review.
+"${cargo_bin}" clippy "${targets[@]}" --no-deps -- \
+  -D warnings \
+  -A clippy::assertions_on_constants \
+  -A clippy::bool_assert_comparison \
+  -A clippy::clone_on_copy \
+  -A clippy::collapsible_if \
+  -A clippy::collapsible_match \
+  -A clippy::double_comparisons \
+  -A clippy::if_same_then_else \
+  -A clippy::items_after_test_module \
+  -A clippy::len_zero \
+  -A clippy::let_and_return \
+  -A clippy::manual_checked_ops \
+  -A clippy::needless_borrow \
+  -A clippy::needless_lifetimes \
+  -A clippy::too_many_arguments \
+  -A clippy::to_string_in_format_args \
+  -A clippy::type_complexity \
+  -A clippy::unnecessary_map_or \
+  -A clippy::unnecessary_sort_by \
+  -A clippy::useless_format \
+  -A clippy::useless_vec

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+mode="${1:-full}"
+case "${mode}" in
+  fast|full) ;;
+  *)
+    echo "invalid lint mode '${mode}'; expected 'fast' or 'full'" >&2
+    exit 2
+    ;;
+esac
+
 if ! command -v rg >/dev/null 2>&1; then
   echo "lint requires ripgrep (rg) to check test environment mutations" >&2
   exit 1
@@ -15,28 +24,5 @@ fi
 
 bash scripts/application-boundary-lint-tests.sh
 bash scripts/application-boundary-lint.sh
-
-# Keep new Clippy warnings fatal while the explicitly listed legacy lint debt is
-# paid down. Removing an allowance is always safe; adding one requires review.
-cargo clippy --all-targets --all-features --no-deps -- \
-  -D warnings \
-  -A clippy::assertions_on_constants \
-  -A clippy::bool_assert_comparison \
-  -A clippy::clone_on_copy \
-  -A clippy::collapsible_if \
-  -A clippy::collapsible_match \
-  -A clippy::double_comparisons \
-  -A clippy::if_same_then_else \
-  -A clippy::items_after_test_module \
-  -A clippy::len_zero \
-  -A clippy::let_and_return \
-  -A clippy::manual_checked_ops \
-  -A clippy::needless_borrow \
-  -A clippy::needless_lifetimes \
-  -A clippy::too_many_arguments \
-  -A clippy::to_string_in_format_args \
-  -A clippy::type_complexity \
-  -A clippy::unnecessary_map_or \
-  -A clippy::unnecessary_sort_by \
-  -A clippy::useless_format \
-  -A clippy::useless_vec
+bash scripts/clippy-lint-tests.sh
+bash scripts/clippy-lint.sh "${mode}"

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -174,7 +174,7 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
             "{} {} {}",
             format!("[{}/{}]", i + 1, commits.len()).dimmed(),
             commit.short_sha().yellow(),
-            &commit.message
+            commit.message
         );
         println!("{}", prompt);
 
@@ -228,7 +228,7 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
             i + 1,
             action_str,
             commit.short_sha().yellow(),
-            &commit.message
+            commit.message
         );
     }
     if has_reword {

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -167,7 +167,7 @@ pub fn run(
 
         let pr_state = info
             .and_then(|b| b.pr_state.clone())
-            .and_then(|s| if s.trim().is_empty() { None } else { Some(s) });
+            .filter(|s| !s.trim().is_empty());
 
         let pr_number = info.and_then(|b| b.pr_number);
         let pr_url = pr_number.and_then(|n| remote_info.as_ref().map(|r| r.pr_url(n)));

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -222,7 +222,7 @@ pub fn run(
 
         let pr_state = info
             .and_then(|b| b.pr_state.clone())
-            .and_then(|s| if s.trim().is_empty() { None } else { Some(s) });
+            .filter(|s| !s.trim().is_empty());
 
         let pr_number = info.and_then(|b| b.pr_number);
         let pr_url = pr_number.and_then(|n| remote_info.as_ref().map(|r| r.pr_url(n)));


### PR DESCRIPTION
## Summary

- remove the repository-local Rust toolchain pin so local builds use the installed toolchain, subject to the Cargo rust-version requirement
- add a fast formatting and Clippy path for iteration while retaining all-target and all-feature coverage in the full lint gate
- avoid dependency linting in the GUI Clippy job and fix diagnostics reported by the current local Clippy
- document the fast/full lint workflow for contributors and coding agents

## Verification

- make lint (Rust 1.97.0 / Clippy 0.1.97)
- make test (2,062 passed)
- bash scripts/clippy-lint-tests.sh
- bash syntax, executable-bit, and whitespace checks

## Documentation

Updated CONTRIBUTING.md and AGENTS.md. README, docs, and skills.md are unchanged because this only changes developer tooling; no end-user command or behavior changed.