### PR TITLE
fix: abort restack when trunk diverges

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -312,6 +312,7 @@ st completions elvish
 - Imported branches from `st get` are remote-delete exempt: once they are detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch.
 - The completion footer summarizes the trunk commit, file, and line delta together with non-zero merged-cleanup, imported-update, and restack counts. It reuses sync's existing results and does not perform extra network or Git work.
 - When sync itself leaves exceptional work behind, it reports skipped cleanup with its reason, trunk update failures, and cleanup-driven checkout changes. It prints one prioritized next command: a diverged trunk gets non-destructive guidance to inspect and reconcile it with its remote; other trunk failures suggest `st trunk`; blocked cleanup suggests `st sweep`. Routine restack health remains visible in `st ls` and the TUI instead of appearing after every sync.
+- When `--restack` is requested, sync fails closed if its fetch did not succeed or the local trunk did not reach the fetched remote-trunk commit. It restores any sync auto-stash and exits non-zero before imported-branch refresh, merged-branch cleanup, or restacking can rewrite feature refs. `st update` inherits this guard and exits before its submit phase, so it does not push or update PRs after either failure.
 
 ### `st restack`
 

--- a/docs/superpowers/plans/2026-07-16-diverged-trunk-update-guard.md
+++ b/docs/superpowers/plans/2026-07-16-diverged-trunk-update-guard.md
@@ -1,0 +1,180 @@
+# Diverged Trunk Update Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `stax update` and `stax sync --restack` from rewriting feature branches when local trunk did not reach the fetched remote trunk.
+
+**Architecture:** Add fail-closed checks inside `commands::sync::run` after fetch, after trunk update but before feature-ref cleanup, and immediately before optional restack. Reuse a small trunk/ref comparison helper for the OID checks and final sync reporting; let the existing `?` in `commands::refresh::run` prevent submission after a guard fails.
+
+**Tech Stack:** Rust, real-Git integration fixtures, Cargo test suite.
+
+## Global Constraints
+
+- Plain `stax sync` without `--restack` retains its existing warning-only behavior.
+- Divergent local trunk commits are never reset, rebased, merged, or pushed automatically.
+- Any automatic stash is restored before the guard returns an error.
+- A failed fetch cannot be treated as fresh merely because cached remote-tracking refs match local trunk.
+- The first trunk OID guard runs before imported refresh and merged cleanup can mutate feature refs.
+- The fix covers both `stax update` and direct `stax sync --restack` through their shared sync path.
+- No unrelated sync, restack, submit, or reporting refactors.
+
+---
+
+### Task 1: Fail Closed Before Restack
+
+**Files:**
+- Modify: `tests/integration_tests.rs` in the Refresh Tests section
+- Modify: `src/commands/sync.rs` near the optional restack phase and final trunk reporting
+
+**Interfaces:**
+- Consumes: `resolve_ref_oid(workdir: &Path, reference: &str) -> Option<String>`, `remote_trunk_after_fetch: Option<String>`, `repo.stash_pop() -> Result<()>`
+- Produces: `trunk_reached_remote(workdir: &Path, trunk: &str, remote_oid: Option<&str>) -> bool`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add this test after `test_refresh_no_submit_keeps_original_branch_and_restacks_stack`:
+
+```rust
+#[test]
+fn test_update_aborts_before_restack_when_trunk_diverges() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "diverged-update"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature\n");
+    repo.commit("Feature commit");
+    let push = repo.git(&["push", "-u", "origin", &feature]);
+    assert!(push.status.success(), "failed to seed feature remote");
+
+    let feature_before = repo.get_commit_sha(&feature);
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let remote_ref = format!("refs/heads/{feature}");
+    let remote_before = TestRepo::stdout(&repo.git_in(
+        &remote_path,
+        &["rev-parse", &remote_ref],
+    ))
+    .trim()
+    .to_string();
+
+    repo.run_stax(&["checkout", "main"]);
+    repo.create_file("local-main.txt", "local main\n");
+    repo.commit("Local main commit");
+    let local_main_before = repo.get_commit_sha("main");
+    repo.simulate_remote_commit("remote-main.txt", "remote main\n", "Remote main commit");
+    configure_submit_remote(&repo);
+    repo.run_stax(&["checkout", &feature]);
+
+    let output = repo.run_stax(&[
+        "update",
+        "--no-pr",
+        "--force",
+        "--yes",
+        "--no-prompt",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "update must fail when trunk diverges\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output),
+    );
+    let diagnostic = format!(
+        "{}{}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output),
+    );
+    assert!(diagnostic.contains("Cannot restack because main did not reach origin/main"));
+    assert!(diagnostic.contains("Inspect and reconcile main with origin/main, then retry"));
+    assert_eq!(repo.get_commit_sha(&feature), feature_before);
+    assert_eq!(repo.get_commit_sha("main"), local_main_before);
+
+    let remote_after = TestRepo::stdout(&repo.git_in(
+        &remote_path,
+        &["rev-parse", &remote_ref],
+    ))
+    .trim()
+    .to_string();
+    assert_eq!(remote_after, remote_before);
+    assert!(!repo.path().join(".git/rebase-merge").exists());
+    assert!(!repo.path().join(".git/rebase-apply").exists());
+}
+```
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run the targeted regression with:
+
+```bash
+cargo nextest run test_update_aborts_before_restack_when_trunk_diverges
+```
+
+Expected: FAIL because current `stax update` succeeds, rebases the feature branch onto divergent local trunk, and submits the rewritten branch.
+
+- [ ] **Step 3: Add the shared trunk comparison helper**
+
+In `src/commands/sync.rs`, add:
+
+```rust
+fn trunk_reached_remote(workdir: &Path, trunk: &str, remote_oid: Option<&str>) -> bool {
+    remote_oid.is_some_and(|remote| {
+        resolve_ref_oid(workdir, trunk).as_deref() == Some(remote)
+    })
+}
+```
+
+- [ ] **Step 4: Guard every pre-restack mutation boundary**
+
+Capture whether fetch succeeded. For restack requests, restore any auto-stash and return an actionable error immediately after a failed fetch. After the trunk-update attempt, compare the local trunk with the fixed fetched remote OID and fail before imported refresh or merged cleanup when they differ. Retain the same OID check immediately before the restack loop as a second boundary. Reuse `trunk_reached_remote` for final reporting and a small stash-restoration helper for every error path.
+
+- [ ] **Step 5: Run the regression test and verify GREEN**
+
+Run:
+
+```bash
+cargo nextest run test_update_aborts_before_restack_when_trunk_diverges
+```
+
+Expected: PASS. The command exits non-zero before rebase or submit, and all recorded refs remain unchanged.
+
+- [ ] **Step 6: Run focused update and sync coverage**
+
+Run:
+
+```bash
+cargo nextest run refresh
+cargo nextest run commands::sync::tests
+```
+
+Expected: all matching tests pass.
+
+- [ ] **Step 7: Run repository verification**
+
+Run:
+
+```bash
+make lint
+make test
+git diff --check
+```
+
+Expected: lint and the full test suite pass.
+
+- [ ] **Step 8: Commit with Stax**
+
+Run:
+
+```bash
+stax modify -a -m "fix: abort restack when trunk diverges"
+```
+
+Expected: the tracked branch contains one focused commit with the design, plan, regression test, and fix.
+
+- [ ] **Step 9: Submit and create the PR with Stax**
+
+Run:
+
+```bash
+stax submit --publish --yes --no-prompt
+```
+
+Expected: Stax pushes `cesar/fix-update-diverged-trunk`, creates a PR targeting `main`, and reports its URL.

--- a/docs/superpowers/specs/2026-07-16-diverged-trunk-update-guard-design.md
+++ b/docs/superpowers/specs/2026-07-16-diverged-trunk-update-guard-design.md
@@ -1,0 +1,76 @@
+# Diverged Trunk Update Guard Design
+
+## Problem
+
+`stax update` promises to sync trunk before it restacks and submits the current stack. When the local trunk and its remote-tracking branch have diverged, sync correctly refuses to reset the local trunk, but the command currently continues into restack. The feature branch is then rebased onto a trunk that did not sync, and a later submit can publish that incorrect history.
+
+The same unsafe path is available through `stax sync --restack` because update delegates its sync and restack work to that command.
+
+## Desired Behavior
+
+- A command that requests restacking must fail closed when the local trunk does not reach the fetched remote trunk.
+- A failed fetch must also block restacking; cached remote-tracking refs are not proof that the remote state is fresh.
+- The failure must occur before imported-branch refresh, merged-branch cleanup, or restacking can rewrite or delete feature refs.
+- `stax update` must not enter its submit phase after the sync failure.
+- The error must name both trunk refs and tell the user to inspect and reconcile them before retrying.
+- Plain `stax sync` without `--restack` keeps its existing behavior: fetch what it can, preserve local trunk commits, finish without rewriting feature branches, and print the existing follow-up warning.
+- Stax must never reset or discard divergent local trunk commits automatically.
+
+## Design
+
+Keep the safety boundary in `commands::sync::run`, where it protects every caller that requests restacking. There are three checks:
+
+1. Immediately after fetch, a non-successful fetch blocks restacking before any ref-update phase. This check does not trust an existing remote-tracking ref because it may be stale.
+2. Immediately after the trunk-update attempt, compare the fixed fetched remote OID with the current local trunk OID. This runs before imported-branch refresh and merged-branch cleanup.
+3. Repeat the OID comparison immediately before the optional restack phase, in case an intervening cleanup path changed trunk state.
+
+The OID checks use:
+
+- the fetched remote trunk OID captured after fetch; and
+- the current local trunk OID resolved at each OID guard.
+
+When a guard fails, restore any automatic stash and return an error. Because `commands::refresh::run` already propagates sync errors with `?`, `stax update` will stop and will not call submit.
+
+The guard belongs in sync rather than only in update so direct `stax sync --restack` calls receive the same protection. Plain sync calls skip the guard because they did not request history rewriting.
+
+## Error Handling
+
+The failure should be explicit and actionable, for example:
+
+```text
+Cannot restack because main did not reach origin/main.
+Inspect and reconcile main with origin/main, then retry.
+```
+
+If sync stashed a dirty worktree, it must pop that stash before returning the error. A stash-pop failure remains an error and must not be hidden.
+
+## Regression Coverage
+
+Add an integration test that creates this history:
+
+1. local and remote trunk share a baseline;
+2. local trunk gains one local-only commit;
+3. remote trunk gains a different commit;
+4. a tracked feature branch remains based on the original baseline.
+
+Run `stax update` through a non-interactive local-remote fixture and assert:
+
+- the command exits unsuccessfully with the actionable divergence message;
+- the feature branch OID is unchanged;
+- the feature branch remote OID is unchanged;
+- no rebase remains in progress; and
+- local trunk retains its local-only commit.
+
+Existing update and sync tests must continue to pass for fast-forwardable and already-current trunks.
+
+Add two edge-case regressions:
+
+- a squash-merged parent with a surviving child under default cleanup, proving the child OID and parent ref remain untouched when trunk diverges; and
+- a failed fetch while cached `origin/main` still equals local `main`, proving stale cached state cannot authorize restacking and an auto-stash is restored.
+
+## Non-Goals
+
+- Automatically choosing between local and remote trunk history.
+- Resetting, rebasing, merging, or pushing the trunk on the user's behalf.
+- Changing cleanup behavior for plain `stax sync`.
+- Redesigning the sync command's reporting model.

--- a/skills.md
+++ b/skills.md
@@ -305,6 +305,7 @@ stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 # sync cleanup may delete merged/gone imported support branches locally, but never push-deletes their remotes.
 # The sync footer reports trunk commits/files/line changes plus non-zero cleanup/imported/restack counts.
 # Conditional attention lines name blocked cleanup, trunk failures, and checkout changes, followed by one prioritized next command. For a diverged trunk, inspect and reconcile it with its remote instead of treating `st trunk` as a repair; other trunk failures use `st trunk`. Routine restack health stays in stax ls and the TUI.
+# When --restack is requested, a failed fetch or trunk that did not reach the fetched remote commit stops sync before imported refresh, merged cleanup, or feature-branch rebases. Any sync auto-stash is restored first.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
 stax sweep --delete                # Delete merged/tracked-merged PRs + upstream-gone branches with no unique work after confirmation
@@ -319,6 +320,7 @@ stax update --no-submit            # Trunk sync/restack only
 stax update --force                # Force sync without prompts first
 stax update --force --yes --no-prompt # Full update without sync/submit prompts
 stax update --verbose              # Show detailed sync/restack/submit timings
+# update inherits sync's fetch/trunk guard and exits before its submit phase, so it does not push or update PRs after that failure.
 
 stax restack                       # Restack current branch onto parent
 stax restack --all                 # Restack whole stack

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -333,7 +333,8 @@ pub fn run(
 
     step_timings.push((format!("fetch {}", remote_name), fetch_started_at.elapsed()));
 
-    if output.status.success() {
+    let fetch_succeeded = output.status.success();
+    if fetch_succeeded {
         LiveTimer::maybe_finish_timed(fetch_timer);
         if !quiet && verbose {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -354,6 +355,16 @@ pub fn run(
                 }
             }
         }
+    }
+
+    if restack && !fetch_succeeded {
+        restore_stashed_changes(&repo, stashed, quiet)?;
+        anyhow::bail!(
+            "Cannot restack because fetching {} did not succeed.\n\
+             Restore access to {}, then retry.",
+            remote_name,
+            remote_name,
+        );
     }
 
     let local_trunk_before_sync = resolve_ref_oid(&workdir, &stack.trunk);
@@ -575,6 +586,22 @@ pub fn run(
         format!("update {}", stack.trunk),
         update_trunk_started_at.elapsed(),
     ));
+
+    // Restack is a history-rewriting operation, so fail closed before imported-branch
+    // refresh or merged-branch cleanup can move any feature refs. Keep the later check
+    // as a second boundary in case cleanup itself changes trunk state.
+    if restack && !trunk_reached_remote(&workdir, &stack.trunk, remote_trunk_after_fetch.as_deref())
+    {
+        restore_stashed_changes(&repo, stashed, quiet)?;
+        anyhow::bail!(
+            "Cannot restack because {} did not reach {}.\n\
+             Inspect and reconcile {} with {}, then retry.",
+            stack.trunk,
+            remote_trunk_ref,
+            stack.trunk,
+            remote_trunk_ref,
+        );
+    }
 
     let imported_update_started_at = Instant::now();
     let updated_imported_branches = refresh_imported_branches(
@@ -1406,6 +1433,20 @@ pub fn run(
     }
 
     // 4. Optionally restack
+    if restack && !trunk_reached_remote(&workdir, &stack.trunk, remote_trunk_after_fetch.as_deref())
+    {
+        restore_stashed_changes(&repo, stashed, quiet)?;
+
+        anyhow::bail!(
+            "Cannot restack because {} did not reach {}.\n\
+             Inspect and reconcile {} with {}, then retry.",
+            stack.trunk,
+            remote_trunk_ref,
+            stack.trunk,
+            remote_trunk_ref,
+        );
+    }
+
     if restack {
         let restack_started_at = Instant::now();
         if !quiet {
@@ -1691,9 +1732,8 @@ pub fn run(
     }
 
     let trunk_summary = wait_for_trunk_summary(trunk_stats_worker)?;
-    let trunk_reached_remote = remote_trunk_after_fetch
-        .as_deref()
-        .is_some_and(|remote| resolve_ref_oid(&workdir, &stack.trunk).as_deref() == Some(remote));
+    let trunk_reached_remote =
+        trunk_reached_remote(&workdir, &stack.trunk, remote_trunk_after_fetch.as_deref());
     stats.trunk = trunk_reached_remote.then_some(trunk_summary).flatten();
 
     if !trunk_reached_remote {
@@ -3072,6 +3112,20 @@ fn resolve_ref_oid(workdir: &Path, reference: &str) -> Option<String> {
     }
 
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn trunk_reached_remote(workdir: &Path, trunk: &str, remote_oid: Option<&str>) -> bool {
+    remote_oid.is_some_and(|remote| resolve_ref_oid(workdir, trunk).as_deref() == Some(remote))
+}
+
+fn restore_stashed_changes(repo: &GitRepo, stashed: bool, quiet: bool) -> Result<()> {
+    if stashed {
+        repo.stash_pop()?;
+        if !quiet {
+            println!("{}", "✓ Restored stashed changes.".green());
+        }
+    }
+    Ok(())
 }
 
 fn is_ancestor(workdir: &Path, ancestor: &str, descendant: &str) -> bool {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2234,6 +2234,252 @@ fn test_refresh_no_submit_keeps_original_branch_and_restacks_stack() {
 }
 
 #[test]
+fn test_update_aborts_before_restack_when_trunk_diverges() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "diverged-update"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature\n");
+    repo.commit("Feature commit");
+    let push = repo.git(&["push", "-u", "origin", &feature]);
+    assert!(push.status.success(), "failed to seed feature remote");
+
+    let feature_before = repo.get_commit_sha(&feature);
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let remote_ref = format!("refs/heads/{feature}");
+    let remote_before = TestRepo::stdout(&repo.git_in(&remote_path, &["rev-parse", &remote_ref]))
+        .trim()
+        .to_string();
+
+    repo.run_stax(&["checkout", "main"]);
+    repo.create_file("local-main.txt", "local main\n");
+    repo.commit("Local main commit");
+    let local_main_before = repo.get_commit_sha("main");
+    repo.simulate_remote_commit("remote-main.txt", "remote main\n", "Remote main commit");
+    configure_submit_remote(&repo);
+    repo.run_stax(&["checkout", &feature]);
+
+    let output = repo.run_stax(&["update", "--no-pr", "--force", "--yes", "--no-prompt"]);
+
+    assert!(
+        !output.status.success(),
+        "update must fail when trunk diverges\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output),
+    );
+    let diagnostic = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output),);
+    assert!(diagnostic.contains("Cannot restack because main did not reach origin/main"));
+    assert!(diagnostic.contains("Inspect and reconcile main with origin/main, then retry"));
+    assert_eq!(repo.get_commit_sha(&feature), feature_before);
+    assert_eq!(repo.get_commit_sha("main"), local_main_before);
+
+    let remote_after = TestRepo::stdout(&repo.git_in(&remote_path, &["rev-parse", &remote_ref]))
+        .trim()
+        .to_string();
+    assert_eq!(remote_after, remote_before);
+    assert!(!repo.path().join(".git/rebase-merge").exists());
+    assert!(!repo.path().join(".git/rebase-apply").exists());
+}
+
+#[test]
+fn test_sync_restack_aborts_and_restores_stash_when_trunk_diverges() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "diverged-sync"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature\n");
+    repo.commit("Feature commit");
+    let push = repo.git(&["push", "-u", "origin", &feature]);
+    assert!(push.status.success(), "failed to seed feature remote");
+
+    let feature_before = repo.get_commit_sha(&feature);
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let remote_ref = format!("refs/heads/{feature}");
+    let remote_before = TestRepo::stdout(&repo.git_in(&remote_path, &["rev-parse", &remote_ref]))
+        .trim()
+        .to_string();
+
+    repo.run_stax(&["checkout", "main"]);
+    repo.create_file("local-main.txt", "local main\n");
+    repo.commit("Local main commit");
+    let local_main_before = repo.get_commit_sha("main");
+    repo.simulate_remote_commit("remote-main.txt", "remote main\n", "Remote main commit");
+    repo.run_stax(&["checkout", &feature]);
+    repo.create_file("dirty.txt", "dirty worktree\n");
+
+    let output = repo.run_stax(&["sync", "--restack", "--force", "--no-delete"]);
+
+    assert!(
+        !output.status.success(),
+        "sync --restack must fail when trunk diverges\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output),
+    );
+    let diagnostic = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(diagnostic.contains("Cannot restack because main did not reach origin/main"));
+    assert!(diagnostic.contains("Inspect and reconcile main with origin/main, then retry"));
+    assert_eq!(
+        fs::read_to_string(repo.path().join("dirty.txt")).expect("read restored dirty file"),
+        "dirty worktree\n"
+    );
+
+    let stash_list = repo.git(&["stash", "list"]);
+    assert!(stash_list.status.success());
+    assert!(
+        TestRepo::stdout(&stash_list).trim().is_empty(),
+        "expected no leftover auto-stash entries, got:\n{}",
+        TestRepo::stdout(&stash_list)
+    );
+    assert_eq!(repo.get_commit_sha(&feature), feature_before);
+    assert_eq!(repo.get_commit_sha("main"), local_main_before);
+
+    let remote_after = TestRepo::stdout(&repo.git_in(&remote_path, &["rev-parse", &remote_ref]))
+        .trim()
+        .to_string();
+    assert_eq!(remote_after, remote_before);
+    assert!(!repo.path().join(".git/rebase-merge").exists());
+    assert!(!repo.path().join(".git/rebase-apply").exists());
+}
+
+#[test]
+fn test_sync_restack_aborts_before_squash_cleanup_when_trunk_diverges() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "diverged-cleanup-parent"]);
+    let parent = repo.current_branch();
+    repo.create_file("parent.txt", "parent change\n");
+    repo.commit("Parent commit");
+    assert!(
+        repo.git(&["push", "-u", "origin", &parent])
+            .status
+            .success()
+    );
+
+    repo.run_stax(&["bc", "diverged-cleanup-child"]);
+    let child = repo.current_branch();
+    repo.create_file("child.txt", "child change\n");
+    repo.commit("Child commit");
+    assert!(repo.git(&["push", "-u", "origin", &child]).status.success());
+    let child_before = repo.get_commit_sha(&child);
+
+    repo.run_stax(&["checkout", "main"]);
+    let local_squash = repo.git(&["merge", "--squash", &parent]);
+    assert!(
+        local_squash.status.success(),
+        "failed to squash parent locally\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&local_squash),
+        TestRepo::stderr(&local_squash)
+    );
+    repo.commit("Local squash merge parent");
+    repo.create_file("local-main.txt", "local main\n");
+    repo.commit("Local main commit");
+    let local_main_before = repo.get_commit_sha("main");
+
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let clone_dir = test_tempdir();
+    let run_remote_git = |args: &[&str]| {
+        let output = hermetic_git_command()
+            .args(args)
+            .current_dir(clone_dir.path())
+            .output()
+            .expect("Failed to run git in remote clone");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run_remote_git(&["clone", remote_path.to_str().unwrap(), "."]);
+    run_remote_git(&["checkout", "-B", "main", "origin/main"]);
+    run_remote_git(&["config", "user.email", "merger@test.com"]);
+    run_remote_git(&["config", "user.name", "Merger"]);
+    run_remote_git(&["fetch", "origin", &parent]);
+    run_remote_git(&["merge", "--squash", &format!("origin/{}", parent)]);
+    run_remote_git(&["commit", "-m", "Squash merge parent"]);
+    run_remote_git(&["push", "origin", "main"]);
+    run_remote_git(&["push", "origin", "--delete", &parent]);
+
+    repo.run_stax(&["checkout", &child]);
+    let output = repo.run_stax(&["sync", "--restack", "--force"]);
+
+    assert!(
+        !output.status.success(),
+        "sync --restack must fail when trunk diverges\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output),
+    );
+    let diagnostic = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(diagnostic.contains("Cannot restack because main did not reach origin/main"));
+    assert_eq!(repo.get_commit_sha(&child), child_before);
+    assert_eq!(repo.get_commit_sha("main"), local_main_before);
+    assert!(
+        repo.list_branches().iter().any(|branch| branch == &parent),
+        "cleanup must not delete the squash-merged parent before the guard"
+    );
+    assert!(!repo.path().join(".git/rebase-merge").exists());
+    assert!(!repo.path().join(".git/rebase-apply").exists());
+}
+
+#[test]
+fn test_sync_restack_aborts_and_restores_stash_when_fetch_fails() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "failed-fetch"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature\n");
+    repo.commit("Feature commit");
+    assert!(
+        repo.git(&["push", "-u", "origin", &feature])
+            .status
+            .success()
+    );
+    let feature_before = repo.get_commit_sha(&feature);
+    let local_main_before = repo.get_commit_sha("main");
+    assert_eq!(repo.get_commit_sha("origin/main"), local_main_before);
+
+    let missing_remote = repo.path().join("missing-origin.git");
+    assert!(
+        repo.git(&[
+            "remote",
+            "set-url",
+            "origin",
+            missing_remote.to_str().unwrap(),
+        ])
+        .status
+        .success()
+    );
+    repo.create_file("dirty.txt", "dirty worktree\n");
+
+    let output = repo.run_stax(&["sync", "--restack", "--force", "--no-delete"]);
+
+    assert!(
+        !output.status.success(),
+        "sync --restack must fail when fetch fails\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output),
+    );
+    let diagnostic = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(diagnostic.contains("Cannot restack because fetching origin did not succeed"));
+    assert_eq!(repo.get_commit_sha(&feature), feature_before);
+    assert_eq!(repo.get_commit_sha("main"), local_main_before);
+    assert_eq!(
+        fs::read_to_string(repo.path().join("dirty.txt")).expect("read restored dirty file"),
+        "dirty worktree\n"
+    );
+    let stash_list = repo.git(&["stash", "list"]);
+    assert!(stash_list.status.success());
+    assert!(
+        TestRepo::stdout(&stash_list).trim().is_empty(),
+        "expected no leftover auto-stash entries, got:\n{}",
+        TestRepo::stdout(&stash_list)
+    );
+    assert!(!repo.path().join(".git/rebase-merge").exists());
+    assert!(!repo.path().join(".git/rebase-apply").exists());
+}
+
+#[test]
 fn test_update_no_submit_skips_merged_branch_cleanup() {
     let repo = TestRepo::new_with_remote();
 
@@ -2256,6 +2502,8 @@ fn test_update_no_submit_skips_merged_branch_cleanup() {
         TestRepo::stdout(&merge),
         TestRepo::stderr(&merge)
     );
+    let push = repo.git(&["push", "origin", "main"]);
+    assert!(push.status.success(), "failed to update remote main");
 
     repo.run_stax(&["checkout", &child]);
     let output = repo.run_stax(&["update", "--no-submit", "--force"]);
@@ -3234,6 +3482,8 @@ fn test_sync_restack_only_targets_current_stack() {
     repo.run_stax(&["t"]);
     repo.create_file("main.txt", "main change");
     repo.commit("main commit");
+    let push = repo.git(&["push", "origin", "main"]);
+    assert!(push.status.success(), "failed to update remote main");
 
     // Run sync --restack from stack A tip; only stack A should be restacked.
     repo.run_stax(&["checkout", &a2]);


### PR DESCRIPTION
## Summary

- fail closed when a restack fetch fails or local trunk does not reach the fetched remote trunk
- stop before imported refresh, merged cleanup, feature rebases, or update submission, restoring any sync auto-stash first
- cover diverged cleanup and stale cached-ref fetch failures with end-to-end regressions

## Testing

- `make lint`
- `make test` — 2,066 passed, 0 failed, 0 skipped

## Documentation

- updated the sync command reference and `skills.md`
- README unchanged because the quick-start, command table, flags, and core command surface are unchanged