### PR TITLE
fix: ignore empty config directory override

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -471,13 +471,20 @@ fn default_allow_github_token_env() -> bool {
     false
 }
 
+fn config_dir_override() -> Option<PathBuf> {
+    std::env::var("STAX_CONFIG_DIR")
+        .ok()
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+}
+
 impl Config {
     /// Get the config directory.
     /// Default: `~/.config/stax` (Unix) or `C:\Users\<you>\.config\stax` (Windows).
     /// Override with `STAX_CONFIG_DIR` env var for testing or custom locations.
     pub fn dir() -> Result<PathBuf> {
-        if let Ok(dir) = std::env::var("STAX_CONFIG_DIR") {
-            return Ok(PathBuf::from(dir));
+        if let Some(dir) = config_dir_override() {
+            return Ok(dir);
         }
         let home = std::env::var_os("HOME")
             .filter(|home| !home.is_empty())
@@ -522,7 +529,7 @@ impl Config {
     /// Load config from file
     pub fn load() -> Result<Self> {
         let path = Self::path()?;
-        if std::env::var("STAX_CONFIG_DIR").is_ok() {
+        if config_dir_override().is_some() {
             return Self::load_path_or_default(&path);
         }
 
@@ -541,7 +548,7 @@ impl Config {
     pub(crate) fn load_for_repo(root: &Path) -> Result<Self> {
         let path = Self::path()?;
         let config = Self::load_path_or_default(&path)?;
-        if std::env::var("STAX_CONFIG_DIR").is_ok() {
+        if config_dir_override().is_some() {
             return Ok(config);
         }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -610,6 +610,44 @@ fn config_path_env_override_wins_over_repo_local_config() {
 }
 
 #[test]
+fn config_load_ignores_empty_config_dir_override() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let original_dir = env::current_dir().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_dir = temp_dir.path().join("repo");
+    let home_dir = temp_dir.path().join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(global_config_dir.join("config.toml"), "[ui]\ntips = true\n").unwrap();
+    fs::write(repo_dir.join("config.toml"), "[ui]\ntips = false\n").unwrap();
+    fs::write(repo_dir.join("stax.toml"), "[ui]\ntips = false\n").unwrap();
+
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::set_var("STAX_CONFIG_DIR", "") };
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    env::set_current_dir(&repo_dir).unwrap();
+
+    assert_eq!(
+        Config::path().unwrap(),
+        global_config_dir.join("config.toml")
+    );
+    assert!(!Config::load().unwrap().ui.tips);
+
+    env::set_current_dir(original_dir).unwrap();
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+}
+
+#[test]
 fn config_load_ignores_old_repo_dot_config_path() {
     let _guard = env_lock();
 


### PR DESCRIPTION
## Summary
- ignore empty `STAX_CONFIG_DIR` values so configuration continues to resolve from the normal global directory
- preserve repository `stax.toml` overlays when the environment variable is empty
- add regression coverage for the conflicting current-directory `config.toml` case

## Tests
- `cargo +1.96.1-aarch64-unknown-linux-gnu nextest run config::tests::config_load_ignores_empty_config_dir_override`
- `RUSTUP_TOOLCHAIN=1.96.1-aarch64-unknown-linux-gnu make lint-fast`
- `RUSTUP_TOOLCHAIN=1.96.1-aarch64-unknown-linux-gnu make test`
- `RUSTUP_TOOLCHAIN=1.96.1-aarch64-unknown-linux-gnu make lint`

## Docs
No documentation changes: this restores the documented behavior of `STAX_CONFIG_DIR` as a config-directory override; an empty value is not a directory.

Closes #631