### PR TITLE
fix: describe native stack commands in help

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -749,7 +749,7 @@ pub(crate) enum Commands {
     #[command(subcommand, visible_alias = "ds")]
     Downstack(DownstackCommands),
 
-    /// Stack commands (submit, restack)
+    /// Stack commands (submit, restack, native GitHub Stack link/unlink)
     #[command(subcommand, visible_alias = "s")]
     Stack(StackCommands),
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -507,6 +507,17 @@ fn test_downstack_commands() {
 }
 
 #[test]
+fn test_stack_help_describes_native_link_commands() {
+    let output = stax(&["stack", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("link"));
+    assert!(stdout.contains("unlink"));
+    assert!(stdout.contains("Stack commands (submit, restack, native GitHub Stack link/unlink)"));
+    assert!(!stdout.contains("Stack commands (submit, restack)"));
+}
+
+#[test]
 fn test_scoped_submit_subcommand_help_flags() {
     for args in [
         ["branch", "submit", "--help"],


### PR DESCRIPTION
## Summary
- refresh `st stack --help` so its namespace summary includes native GitHub Stack `link` and `unlink` commands
- add CLI help coverage that guards the complete summary and both native subcommands

## Verification
- `cargo +1.96.1-aarch64-unknown-linux-gnu nextest run cli_tests::test_stack_help_describes_native_link_commands --no-fail-fast`
- `target/debug/stax stack --help`
- `RUSTUP_TOOLCHAIN=1.96.1-aarch64-unknown-linux-gnu make lint-fast`
- `RUSTUP_TOOLCHAIN=1.96.1-aarch64-unknown-linux-gnu make test` (2068 passed)
- `RUSTUP_TOOLCHAIN=1.96.1-aarch64-unknown-linux-gnu make lint`

## Docs
No documentation files changed: this corrects the CLI namespace summary; the existing command docs already cover `st stack link` and `st stack unlink`.

Closes #602
