### PR TITLE
refactor(forge): introduce Forge trait seam and neutral model module

### DIFF
--- a/src/application/pull_request.rs
+++ b/src/application/pull_request.rs
@@ -9,29 +9,10 @@ use super::{
 use crate::application::repository::require_blocking_network_context;
 use crate::config::Config;
 use crate::engine::metadata::BranchMetadata;
-use crate::forge::ForgeClient;
-use crate::github::pr::PrInfoWithHead;
+use crate::forge::{Forge, ForgeClient};
 use crate::remote::TrustedRemoteInfo;
 use anyhow::Result;
 use git2::BranchType;
-use std::future::Future;
-use std::pin::Pin;
-
-trait PullRequestLookup {
-    fn find_open_by_head<'a>(
-        &'a self,
-        branch: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<PrInfoWithHead>>> + Send + 'a>>;
-}
-
-impl PullRequestLookup for ForgeClient {
-    fn find_open_by_head<'a>(
-        &'a self,
-        branch: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<PrInfoWithHead>>> + Send + 'a>> {
-        Box::pin(async move { self.find_open_pr_by_head(branch).await })
-    }
-}
 
 impl RepositorySession {
     pub fn resolve_pull_request_url(
@@ -115,7 +96,7 @@ fn resolve_with_lookup<F, L>(
 ) -> OperationResult
 where
     F: FnOnce(&TrustedRemoteInfo, &Config) -> Result<L>,
-    L: PullRequestLookup,
+    L: Forge,
 {
     if let Some(receipt) = resolve_metadata_only(session, request, branch, reporter)? {
         return Ok(receipt);
@@ -167,7 +148,7 @@ where
     let found = runtime
         .block_on(async {
             let lookup = create_lookup(&trusted_remote, &config)?;
-            lookup.find_open_by_head(branch).await
+            lookup.find_open_pr_by_head(branch).await
         })
         .map_err(|error| operation_error_from_source(request, &error))?;
     let pr = found.ok_or_else(|| {
@@ -366,31 +347,16 @@ fn operation_error(
 
 #[cfg(test)]
 mod tests {
-    use super::{PullRequestLookup, resolve_with_lookup};
+    use super::resolve_with_lookup;
     use crate::application::{
         NoopOperationReporter, OperationOutcome, OperationRequest, OperationSideEffects,
         RepositorySession,
     };
     use crate::engine::metadata::{BranchMetadata, PrInfo};
+    use crate::forge::FakeForge;
     use crate::git::GitRepo;
     use crate::github::pr::{PrInfo as ForgePrInfo, PrInfoWithHead};
-    use anyhow::Result;
-    use std::future::Future;
     use std::path::Path;
-    use std::pin::Pin;
-
-    struct FakePullRequestLookup {
-        result: Option<PrInfoWithHead>,
-    }
-
-    impl PullRequestLookup for FakePullRequestLookup {
-        fn find_open_by_head<'a>(
-            &'a self,
-            _branch: &'a str,
-        ) -> Pin<Box<dyn Future<Output = Result<Option<PrInfoWithHead>>> + Send + 'a>> {
-            Box::pin(async move { Ok(self.result.clone()) })
-        }
-    }
 
     fn git(cwd: &Path, args: &[&str]) {
         let output = std::process::Command::new("git")
@@ -496,7 +462,7 @@ mod tests {
             &session,
             &request("feature"),
             "feature",
-            |_, _| Ok(FakePullRequestLookup { result: None }),
+            |_, _| Ok(FakeForge::default()),
             &mut NoopOperationReporter,
         )
         .unwrap();
@@ -522,8 +488,8 @@ mod tests {
             &request("feature"),
             "feature",
             |_, _| {
-                Ok(FakePullRequestLookup {
-                    result: Some(fake_pr(42)),
+                Ok(FakeForge {
+                    open_pr_by_head: Some(fake_pr(42)),
                 })
             },
             &mut NoopOperationReporter,

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -10,59 +10,18 @@ use std::time::Duration;
 
 use crate::ci::CheckRunInfo;
 use crate::config::Config;
-use crate::github::client::{GitHubClient, OpenPrInfo};
-use crate::github::pr::{
-    CiStatus, IssueComment, MergeMethod, PrComment, PrInfo, PrInfoWithHead, PrMergeStatus,
-};
+use crate::github::client::GitHubClient;
 use crate::remote::{ForgeType, RemoteInfo, TrustedRemoteInfo};
-
-/// PR activity for standup reports.
-#[derive(Debug, Clone, Serialize)]
-pub struct PrActivity {
-    pub number: u64,
-    pub title: String,
-    pub timestamp: DateTime<Utc>,
-    pub url: String,
-}
-
-/// Review activity for standup reports.
-#[derive(Debug, Clone, Serialize)]
-pub struct ReviewActivity {
-    pub pr_number: u64,
-    pub pr_title: String,
-    pub reviewer: String,
-    pub state: String,
-    pub timestamp: DateTime<Utc>,
-    pub is_received: bool,
-}
-
-/// Open pull request info for repo-level listing commands.
-#[derive(Debug, Clone, Serialize)]
-pub struct RepoPrListItem {
-    pub number: u64,
-    pub title: String,
-    pub url: String,
-    pub author: String,
-    pub head_branch: String,
-    pub base_branch: String,
-    pub state: String,
-    pub is_draft: bool,
-    pub created_at: DateTime<Utc>,
-}
-
-/// Open issue info for repo-level listing commands.
-#[derive(Debug, Clone, Serialize)]
-pub struct RepoIssueListItem {
-    pub number: u64,
-    pub title: String,
-    pub url: String,
-    pub author: String,
-    pub labels: Vec<String>,
-    pub updated_at: DateTime<Utc>,
-}
 
 mod gitea;
 mod gitlab;
+mod model;
+mod traits;
+
+pub use model::*;
+pub use traits::Forge;
+#[cfg(test)]
+pub(crate) use traits::tests::FakeForge;
 
 use gitea::GiteaClient;
 use gitlab::GitLabClient;
@@ -80,13 +39,16 @@ pub enum AuthStyle {
     PrivateToken,
 }
 
-/// Dispatch an async method call uniformly across all forge variants.
+/// Dispatch an async trait method call uniformly across all forge variants.
+///
+/// Each arm forwards to the per-variant `Forge` implementation, which in turn
+/// resolves to the concrete inherent method (inherent-priority) — no recursion.
 macro_rules! dispatch {
     ($self:expr, $method:ident ( $($arg:expr),* $(,)? )) => {
         match $self {
-            Self::GitHub(c) => c.$method($($arg),*).await,
-            Self::GitLab(c) => c.$method($($arg),*).await,
-            Self::Gitea(c) => c.$method($($arg),*).await,
+            Self::GitHub(c) => Forge::$method(c, $($arg),*).await,
+            Self::GitLab(c) => Forge::$method(c, $($arg),*).await,
+            Self::Gitea(c) => Forge::$method(c, $($arg),*).await,
         }
     };
 }
@@ -141,11 +103,7 @@ impl ForgeClient {
     /// GitHub uses the stored owner for fork-aware lookup; other forges
     /// filter by source branch only.
     pub async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>> {
-        match self {
-            Self::GitHub(client) => client.find_open_pr_by_head(&client.owner, branch).await,
-            Self::GitLab(client) => client.find_open_pr_by_head(branch).await,
-            Self::Gitea(client) => client.find_open_pr_by_head(branch).await,
-        }
+        dispatch!(self, find_open_pr_by_head(branch))
     }
 
     pub async fn find_pr(&self, branch: &str) -> Result<Option<PrInfo>> {
@@ -195,27 +153,13 @@ impl ForgeClient {
 
     /// Enqueue a PR into the forge's merge queue (GitHub) or merge train (GitLab).
     /// Not supported on Gitea/Forgejo (no merge queue feature).
-    pub async fn enqueue_pr(&self, number: u64) -> Result<crate::github::pr::EnqueueResult> {
-        match self {
-            Self::GitHub(client) => client.enqueue_pr(number).await,
-            Self::GitLab(client) => client.add_to_merge_train(number).await,
-            Self::Gitea(_) => {
-                bail!(
-                    "`stax merge --queue` is not supported for Gitea/Forgejo — \
-                     Gitea does not have a merge queue feature"
-                )
-            }
-        }
+    pub async fn enqueue_pr(&self, number: u64) -> Result<EnqueueResult> {
+        dispatch!(self, enqueue_pr(number))
     }
 
     /// GitHub only: merge the PR base into the head branch remotely ("Update branch").
     pub async fn update_pr_branch(&self, number: u64) -> Result<()> {
-        match self {
-            Self::GitHub(client) => client.update_pr_branch(number).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                bail!("`stax merge --remote` is currently only supported for GitHub")
-            }
-        }
+        dispatch!(self, update_pr_branch(number))
     }
 
     pub async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
@@ -239,21 +183,11 @@ impl ForgeClient {
     }
 
     pub async fn create_issue_comment(&self, number: u64, body: &str) -> Result<()> {
-        match self {
-            Self::GitHub(client) => client.create_issue_comment(number, body).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                bail!("creating plain PR comments is currently only supported for GitHub")
-            }
-        }
+        dispatch!(self, create_issue_comment(number, body))
     }
 
     pub async fn close_pr(&self, number: u64) -> Result<()> {
-        match self {
-            Self::GitHub(client) => client.close_pr(number).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                bail!("closing PRs from stack merge is currently only supported for GitHub")
-            }
-        }
+        dispatch!(self, close_pr(number))
     }
 
     pub async fn delete_stack_comment(&self, number: u64) -> Result<()> {
@@ -271,21 +205,7 @@ impl ForgeClient {
         commit_title: Option<&str>,
         sha: Option<&str>,
     ) -> Result<()> {
-        match self {
-            Self::GitHub(client) => {
-                client
-                    .merge_pr(
-                        number,
-                        method,
-                        commit_title.map(str::to_string),
-                        None,
-                        sha.map(str::to_string),
-                    )
-                    .await
-            }
-            Self::GitLab(client) => client.merge_pr(number, method, commit_title, sha).await,
-            Self::Gitea(client) => client.merge_pr(number, method, commit_title, sha).await,
-        }
+        dispatch!(self, merge_pr(number, method, commit_title, sha))
     }
 
     pub async fn get_pr_merge_status(&self, number: u64) -> Result<PrMergeStatus> {
@@ -309,65 +229,23 @@ impl ForgeClient {
         repo: &crate::git::GitRepo,
         sha: &str,
     ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
-        match self {
-            Self::GitHub(client) => {
-                crate::commands::ci::fetch_github_checks(repo, client, sha).await
-            }
-            Self::GitLab(client) => client.fetch_checks(sha).await,
-            Self::Gitea(client) => client.fetch_checks(sha).await,
-        }
+        dispatch!(self, fetch_checks(repo, sha))
     }
 
     pub async fn request_reviewers(&self, number: u64, reviewers: &[String]) -> Result<()> {
-        match self {
-            Self::GitHub(client) => client.request_reviewers(number, reviewers).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                if !reviewers.is_empty() {
-                    eprintln!(
-                        "{} Requesting reviewers is not yet supported for this forge — skipping.",
-                        "warn:".yellow()
-                    );
-                }
-                Ok(())
-            }
-        }
+        dispatch!(self, request_reviewers(number, reviewers))
     }
 
     pub async fn get_requested_reviewers(&self, number: u64) -> Result<Vec<String>> {
-        match self {
-            Self::GitHub(client) => client.get_requested_reviewers(number).await,
-            Self::GitLab(_) | Self::Gitea(_) => Ok(Vec::new()),
-        }
+        dispatch!(self, get_requested_reviewers(number))
     }
 
     pub async fn add_labels(&self, number: u64, labels: &[String]) -> Result<()> {
-        match self {
-            Self::GitHub(client) => client.add_labels(number, labels).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                if !labels.is_empty() {
-                    eprintln!(
-                        "{} Adding labels is not yet supported for this forge — skipping.",
-                        "warn:".yellow()
-                    );
-                }
-                Ok(())
-            }
-        }
+        dispatch!(self, add_labels(number, labels))
     }
 
     pub async fn add_assignees(&self, number: u64, assignees: &[String]) -> Result<()> {
-        match self {
-            Self::GitHub(client) => client.add_assignees(number, assignees).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                if !assignees.is_empty() {
-                    eprintln!(
-                        "{} Adding assignees is not yet supported for this forge — skipping.",
-                        "warn:".yellow()
-                    );
-                }
-                Ok(())
-            }
-        }
+        dispatch!(self, add_assignees(number, assignees))
     }
 
     pub async fn get_current_user(&self) -> Result<String> {
@@ -408,6 +286,592 @@ impl ForgeClient {
         username: &str,
     ) -> Result<Vec<ReviewActivity>> {
         dispatch!(self, get_reviews_given(hours, username))
+    }
+}
+
+impl Forge for GitHubClient {
+    async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>> {
+        self.find_open_pr_by_head(&self.owner, branch).await
+    }
+    async fn find_pr(&self, branch: &str) -> Result<Option<PrInfo>> {
+        self.find_pr(branch).await
+    }
+    async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>> {
+        self.list_open_prs_by_head().await
+    }
+    async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        self.list_open_pull_requests(limit).await
+    }
+    async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        self.list_open_issues(limit).await
+    }
+    async fn create_pr(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+        is_draft: bool,
+    ) -> Result<PrInfo> {
+        self.create_pr(head, base, title, body, is_draft).await
+    }
+    async fn get_pr(&self, number: u64) -> Result<PrInfo> {
+        self.get_pr(number).await
+    }
+    async fn get_pr_with_head(&self, number: u64) -> Result<PrInfoWithHead> {
+        self.get_pr_with_head(number).await
+    }
+    async fn update_pr_base(&self, number: u64, new_base: &str) -> Result<()> {
+        self.update_pr_base(number, new_base).await
+    }
+    async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        self.set_pr_draft(number, is_draft).await
+    }
+    async fn enqueue_pr(&self, number: u64) -> Result<EnqueueResult> {
+        self.enqueue_pr(number).await
+    }
+    async fn update_pr_branch(&self, number: u64) -> Result<()> {
+        self.update_pr_branch(number).await
+    }
+    async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        self.update_pr_title(number, title).await
+    }
+    async fn update_pr_body(&self, number: u64, body: &str) -> Result<()> {
+        self.update_pr_body(number, body).await
+    }
+    async fn get_pr_body(&self, number: u64) -> Result<String> {
+        self.get_pr_body(number).await
+    }
+    async fn update_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.update_stack_comment(number, stack_comment).await
+    }
+    async fn create_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.create_stack_comment(number, stack_comment).await
+    }
+    async fn create_issue_comment(&self, number: u64, body: &str) -> Result<()> {
+        self.create_issue_comment(number, body).await
+    }
+    async fn close_pr(&self, number: u64) -> Result<()> {
+        self.close_pr(number).await
+    }
+    async fn delete_stack_comment(&self, number: u64) -> Result<()> {
+        self.delete_stack_comment(number).await
+    }
+    async fn list_all_comments(&self, number: u64) -> Result<Vec<PrComment>> {
+        self.list_all_comments(number).await
+    }
+    async fn merge_pr(
+        &self,
+        number: u64,
+        method: MergeMethod,
+        commit_title: Option<&str>,
+        sha: Option<&str>,
+    ) -> Result<()> {
+        self.merge_pr(
+            number,
+            method,
+            commit_title.map(str::to_string),
+            None,
+            sha.map(str::to_string),
+        )
+        .await
+    }
+    async fn get_pr_merge_status(&self, number: u64) -> Result<PrMergeStatus> {
+        self.get_pr_merge_status(number).await
+    }
+    async fn get_pr_review_decision(&self, number: u64) -> Result<Option<String>> {
+        self.get_pr_review_decision(number).await
+    }
+    async fn is_pr_merged(&self, number: u64) -> Result<bool> {
+        self.is_pr_merged(number).await
+    }
+    async fn get_pr_head_sha(&self, number: u64) -> Result<String> {
+        self.get_pr_head_sha(number).await
+    }
+    async fn fetch_checks(
+        &self,
+        repo: &crate::git::GitRepo,
+        sha: &str,
+    ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+        crate::commands::ci::fetch_github_checks(repo, self, sha).await
+    }
+    async fn request_reviewers(&self, number: u64, reviewers: &[String]) -> Result<()> {
+        self.request_reviewers(number, reviewers).await
+    }
+    async fn get_requested_reviewers(&self, number: u64) -> Result<Vec<String>> {
+        self.get_requested_reviewers(number).await
+    }
+    async fn add_labels(&self, number: u64, labels: &[String]) -> Result<()> {
+        self.add_labels(number, labels).await
+    }
+    async fn add_assignees(&self, number: u64, assignees: &[String]) -> Result<()> {
+        self.add_assignees(number, assignees).await
+    }
+    async fn get_current_user(&self) -> Result<String> {
+        self.get_current_user().await
+    }
+    async fn get_user_open_prs(&self, username: &str) -> Result<Vec<OpenPrInfo>> {
+        self.get_user_open_prs(username).await
+    }
+    async fn get_recent_merged_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_merged_prs(hours, username).await
+    }
+    async fn get_recent_opened_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_opened_prs(hours, username).await
+    }
+    async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_received(hours, username).await
+    }
+    async fn get_reviews_given(&self, hours: i64, username: &str) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_given(hours, username).await
+    }
+}
+
+impl Forge for GitLabClient {
+    async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>> {
+        self.find_open_pr_by_head(branch).await
+    }
+    async fn find_pr(&self, branch: &str) -> Result<Option<PrInfo>> {
+        self.find_pr(branch).await
+    }
+    async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>> {
+        self.list_open_prs_by_head().await
+    }
+    async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        self.list_open_pull_requests(limit).await
+    }
+    async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        self.list_open_issues(limit).await
+    }
+    async fn create_pr(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+        is_draft: bool,
+    ) -> Result<PrInfo> {
+        self.create_pr(head, base, title, body, is_draft).await
+    }
+    async fn get_pr(&self, number: u64) -> Result<PrInfo> {
+        self.get_pr(number).await
+    }
+    async fn get_pr_with_head(&self, number: u64) -> Result<PrInfoWithHead> {
+        self.get_pr_with_head(number).await
+    }
+    async fn update_pr_base(&self, number: u64, new_base: &str) -> Result<()> {
+        self.update_pr_base(number, new_base).await
+    }
+    async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        self.set_pr_draft(number, is_draft).await
+    }
+    async fn enqueue_pr(&self, number: u64) -> Result<EnqueueResult> {
+        self.add_to_merge_train(number).await
+    }
+    async fn update_pr_branch(&self, _number: u64) -> Result<()> {
+        bail!("`stax merge --remote` is currently only supported for GitHub")
+    }
+    async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        self.update_pr_title(number, title).await
+    }
+    async fn update_pr_body(&self, number: u64, body: &str) -> Result<()> {
+        self.update_pr_body(number, body).await
+    }
+    async fn get_pr_body(&self, number: u64) -> Result<String> {
+        self.get_pr_body(number).await
+    }
+    async fn update_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.update_stack_comment(number, stack_comment).await
+    }
+    async fn create_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.create_stack_comment(number, stack_comment).await
+    }
+    async fn create_issue_comment(&self, _number: u64, _body: &str) -> Result<()> {
+        bail!("creating plain PR comments is currently only supported for GitHub")
+    }
+    async fn close_pr(&self, _number: u64) -> Result<()> {
+        bail!("closing PRs from stack merge is currently only supported for GitHub")
+    }
+    async fn delete_stack_comment(&self, number: u64) -> Result<()> {
+        self.delete_stack_comment(number).await
+    }
+    async fn list_all_comments(&self, number: u64) -> Result<Vec<PrComment>> {
+        self.list_all_comments(number).await
+    }
+    async fn merge_pr(
+        &self,
+        number: u64,
+        method: MergeMethod,
+        commit_title: Option<&str>,
+        sha: Option<&str>,
+    ) -> Result<()> {
+        self.merge_pr(number, method, commit_title, sha).await
+    }
+    async fn get_pr_merge_status(&self, number: u64) -> Result<PrMergeStatus> {
+        self.get_pr_merge_status(number).await
+    }
+    async fn get_pr_review_decision(&self, number: u64) -> Result<Option<String>> {
+        self.get_pr_review_decision(number).await
+    }
+    async fn is_pr_merged(&self, number: u64) -> Result<bool> {
+        self.is_pr_merged(number).await
+    }
+    async fn get_pr_head_sha(&self, number: u64) -> Result<String> {
+        self.get_pr_head_sha(number).await
+    }
+    async fn fetch_checks(
+        &self,
+        _repo: &crate::git::GitRepo,
+        sha: &str,
+    ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+        self.fetch_checks(sha).await
+    }
+    async fn request_reviewers(&self, _number: u64, reviewers: &[String]) -> Result<()> {
+        if !reviewers.is_empty() {
+            eprintln!(
+                "{} Requesting reviewers is not yet supported for this forge — skipping.",
+                "warn:".yellow()
+            );
+        }
+        Ok(())
+    }
+    async fn get_requested_reviewers(&self, _number: u64) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+    async fn add_labels(&self, _number: u64, labels: &[String]) -> Result<()> {
+        if !labels.is_empty() {
+            eprintln!(
+                "{} Adding labels is not yet supported for this forge — skipping.",
+                "warn:".yellow()
+            );
+        }
+        Ok(())
+    }
+    async fn add_assignees(&self, _number: u64, assignees: &[String]) -> Result<()> {
+        if !assignees.is_empty() {
+            eprintln!(
+                "{} Adding assignees is not yet supported for this forge — skipping.",
+                "warn:".yellow()
+            );
+        }
+        Ok(())
+    }
+    async fn get_current_user(&self) -> Result<String> {
+        self.get_current_user().await
+    }
+    async fn get_user_open_prs(&self, username: &str) -> Result<Vec<OpenPrInfo>> {
+        self.get_user_open_prs(username).await
+    }
+    async fn get_recent_merged_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_merged_prs(hours, username).await
+    }
+    async fn get_recent_opened_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_opened_prs(hours, username).await
+    }
+    async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_received(hours, username).await
+    }
+    async fn get_reviews_given(&self, hours: i64, username: &str) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_given(hours, username).await
+    }
+}
+
+impl Forge for GiteaClient {
+    async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>> {
+        self.find_open_pr_by_head(branch).await
+    }
+    async fn find_pr(&self, branch: &str) -> Result<Option<PrInfo>> {
+        self.find_pr(branch).await
+    }
+    async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>> {
+        self.list_open_prs_by_head().await
+    }
+    async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        self.list_open_pull_requests(limit).await
+    }
+    async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        self.list_open_issues(limit).await
+    }
+    async fn create_pr(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+        is_draft: bool,
+    ) -> Result<PrInfo> {
+        self.create_pr(head, base, title, body, is_draft).await
+    }
+    async fn get_pr(&self, number: u64) -> Result<PrInfo> {
+        self.get_pr(number).await
+    }
+    async fn get_pr_with_head(&self, number: u64) -> Result<PrInfoWithHead> {
+        self.get_pr_with_head(number).await
+    }
+    async fn update_pr_base(&self, number: u64, new_base: &str) -> Result<()> {
+        self.update_pr_base(number, new_base).await
+    }
+    async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        self.set_pr_draft(number, is_draft).await
+    }
+    async fn enqueue_pr(&self, _number: u64) -> Result<EnqueueResult> {
+        bail!(
+            "`stax merge --queue` is not supported for Gitea/Forgejo — \
+             Gitea does not have a merge queue feature"
+        )
+    }
+    async fn update_pr_branch(&self, _number: u64) -> Result<()> {
+        bail!("`stax merge --remote` is currently only supported for GitHub")
+    }
+    async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        self.update_pr_title(number, title).await
+    }
+    async fn update_pr_body(&self, number: u64, body: &str) -> Result<()> {
+        self.update_pr_body(number, body).await
+    }
+    async fn get_pr_body(&self, number: u64) -> Result<String> {
+        self.get_pr_body(number).await
+    }
+    async fn update_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.update_stack_comment(number, stack_comment).await
+    }
+    async fn create_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.create_stack_comment(number, stack_comment).await
+    }
+    async fn create_issue_comment(&self, _number: u64, _body: &str) -> Result<()> {
+        bail!("creating plain PR comments is currently only supported for GitHub")
+    }
+    async fn close_pr(&self, _number: u64) -> Result<()> {
+        bail!("closing PRs from stack merge is currently only supported for GitHub")
+    }
+    async fn delete_stack_comment(&self, number: u64) -> Result<()> {
+        self.delete_stack_comment(number).await
+    }
+    async fn list_all_comments(&self, number: u64) -> Result<Vec<PrComment>> {
+        self.list_all_comments(number).await
+    }
+    async fn merge_pr(
+        &self,
+        number: u64,
+        method: MergeMethod,
+        commit_title: Option<&str>,
+        sha: Option<&str>,
+    ) -> Result<()> {
+        self.merge_pr(number, method, commit_title, sha).await
+    }
+    async fn get_pr_merge_status(&self, number: u64) -> Result<PrMergeStatus> {
+        self.get_pr_merge_status(number).await
+    }
+    async fn get_pr_review_decision(&self, number: u64) -> Result<Option<String>> {
+        self.get_pr_review_decision(number).await
+    }
+    async fn is_pr_merged(&self, number: u64) -> Result<bool> {
+        self.is_pr_merged(number).await
+    }
+    async fn get_pr_head_sha(&self, number: u64) -> Result<String> {
+        self.get_pr_head_sha(number).await
+    }
+    async fn fetch_checks(
+        &self,
+        _repo: &crate::git::GitRepo,
+        sha: &str,
+    ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+        self.fetch_checks(sha).await
+    }
+    async fn request_reviewers(&self, _number: u64, reviewers: &[String]) -> Result<()> {
+        if !reviewers.is_empty() {
+            eprintln!(
+                "{} Requesting reviewers is not yet supported for this forge — skipping.",
+                "warn:".yellow()
+            );
+        }
+        Ok(())
+    }
+    async fn get_requested_reviewers(&self, _number: u64) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+    async fn add_labels(&self, _number: u64, labels: &[String]) -> Result<()> {
+        if !labels.is_empty() {
+            eprintln!(
+                "{} Adding labels is not yet supported for this forge — skipping.",
+                "warn:".yellow()
+            );
+        }
+        Ok(())
+    }
+    async fn add_assignees(&self, _number: u64, assignees: &[String]) -> Result<()> {
+        if !assignees.is_empty() {
+            eprintln!(
+                "{} Adding assignees is not yet supported for this forge — skipping.",
+                "warn:".yellow()
+            );
+        }
+        Ok(())
+    }
+    async fn get_current_user(&self) -> Result<String> {
+        self.get_current_user().await
+    }
+    async fn get_user_open_prs(&self, username: &str) -> Result<Vec<OpenPrInfo>> {
+        self.get_user_open_prs(username).await
+    }
+    async fn get_recent_merged_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_merged_prs(hours, username).await
+    }
+    async fn get_recent_opened_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_opened_prs(hours, username).await
+    }
+    async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_received(hours, username).await
+    }
+    async fn get_reviews_given(&self, hours: i64, username: &str) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_given(hours, username).await
+    }
+}
+
+impl Forge for ForgeClient {
+    async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>> {
+        self.find_open_pr_by_head(branch).await
+    }
+    async fn find_pr(&self, branch: &str) -> Result<Option<PrInfo>> {
+        self.find_pr(branch).await
+    }
+    async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>> {
+        self.list_open_prs_by_head().await
+    }
+    async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>> {
+        self.list_open_pull_requests(limit).await
+    }
+    async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
+        self.list_open_issues(limit).await
+    }
+    async fn create_pr(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+        is_draft: bool,
+    ) -> Result<PrInfo> {
+        self.create_pr(head, base, title, body, is_draft).await
+    }
+    async fn get_pr(&self, number: u64) -> Result<PrInfo> {
+        self.get_pr(number).await
+    }
+    async fn get_pr_with_head(&self, number: u64) -> Result<PrInfoWithHead> {
+        self.get_pr_with_head(number).await
+    }
+    async fn update_pr_base(&self, number: u64, new_base: &str) -> Result<()> {
+        self.update_pr_base(number, new_base).await
+    }
+    async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()> {
+        self.set_pr_draft(number, is_draft).await
+    }
+    async fn enqueue_pr(&self, number: u64) -> Result<EnqueueResult> {
+        self.enqueue_pr(number).await
+    }
+    async fn update_pr_branch(&self, number: u64) -> Result<()> {
+        self.update_pr_branch(number).await
+    }
+    async fn update_pr_title(&self, number: u64, title: &str) -> Result<()> {
+        self.update_pr_title(number, title).await
+    }
+    async fn update_pr_body(&self, number: u64, body: &str) -> Result<()> {
+        self.update_pr_body(number, body).await
+    }
+    async fn get_pr_body(&self, number: u64) -> Result<String> {
+        self.get_pr_body(number).await
+    }
+    async fn update_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.update_stack_comment(number, stack_comment).await
+    }
+    async fn create_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()> {
+        self.create_stack_comment(number, stack_comment).await
+    }
+    async fn create_issue_comment(&self, number: u64, body: &str) -> Result<()> {
+        self.create_issue_comment(number, body).await
+    }
+    async fn close_pr(&self, number: u64) -> Result<()> {
+        self.close_pr(number).await
+    }
+    async fn delete_stack_comment(&self, number: u64) -> Result<()> {
+        self.delete_stack_comment(number).await
+    }
+    async fn list_all_comments(&self, number: u64) -> Result<Vec<PrComment>> {
+        self.list_all_comments(number).await
+    }
+    async fn merge_pr(
+        &self,
+        number: u64,
+        method: MergeMethod,
+        commit_title: Option<&str>,
+        sha: Option<&str>,
+    ) -> Result<()> {
+        self.merge_pr(number, method, commit_title, sha).await
+    }
+    async fn get_pr_merge_status(&self, number: u64) -> Result<PrMergeStatus> {
+        self.get_pr_merge_status(number).await
+    }
+    async fn get_pr_review_decision(&self, number: u64) -> Result<Option<String>> {
+        self.get_pr_review_decision(number).await
+    }
+    async fn is_pr_merged(&self, number: u64) -> Result<bool> {
+        self.is_pr_merged(number).await
+    }
+    async fn get_pr_head_sha(&self, number: u64) -> Result<String> {
+        self.get_pr_head_sha(number).await
+    }
+    async fn fetch_checks(
+        &self,
+        repo: &crate::git::GitRepo,
+        sha: &str,
+    ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+        self.fetch_checks(repo, sha).await
+    }
+    async fn request_reviewers(&self, number: u64, reviewers: &[String]) -> Result<()> {
+        self.request_reviewers(number, reviewers).await
+    }
+    async fn get_requested_reviewers(&self, number: u64) -> Result<Vec<String>> {
+        self.get_requested_reviewers(number).await
+    }
+    async fn add_labels(&self, number: u64, labels: &[String]) -> Result<()> {
+        self.add_labels(number, labels).await
+    }
+    async fn add_assignees(&self, number: u64, assignees: &[String]) -> Result<()> {
+        self.add_assignees(number, assignees).await
+    }
+    async fn get_current_user(&self) -> Result<String> {
+        self.get_current_user().await
+    }
+    async fn get_user_open_prs(&self, username: &str) -> Result<Vec<OpenPrInfo>> {
+        self.get_user_open_prs(username).await
+    }
+    async fn get_recent_merged_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_merged_prs(hours, username).await
+    }
+    async fn get_recent_opened_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>> {
+        self.get_recent_opened_prs(hours, username).await
+    }
+    async fn get_reviews_received(
+        &self,
+        hours: i64,
+        username: &str,
+    ) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_received(hours, username).await
+    }
+    async fn get_reviews_given(&self, hours: i64, username: &str) -> Result<Vec<ReviewActivity>> {
+        self.get_reviews_given(hours, username).await
     }
 }
 

--- a/src/forge/model.rs
+++ b/src/forge/model.rs
@@ -1,0 +1,292 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::str::FromStr;
+
+/// A comment on a PR issue thread (conversation comment)
+#[derive(Debug, Clone)]
+pub struct IssueComment {
+    #[allow(dead_code)]
+    pub id: u64,
+    pub body: String,
+    pub user: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A review comment on a PR (inline code comment)
+#[derive(Debug, Clone)]
+pub struct ReviewComment {
+    #[allow(dead_code)]
+    pub id: u64,
+    pub body: String,
+    pub user: String,
+    pub path: String,
+    pub line: Option<u32>,
+    pub start_line: Option<u32>,
+    pub created_at: DateTime<Utc>,
+    pub diff_hunk: Option<String>,
+}
+
+/// Combined comment for unified display
+#[derive(Debug, Clone)]
+pub enum PrComment {
+    Issue(IssueComment),
+    Review(ReviewComment),
+}
+
+impl PrComment {
+    pub fn created_at(&self) -> DateTime<Utc> {
+        match self {
+            PrComment::Issue(c) => c.created_at,
+            PrComment::Review(c) => c.created_at,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn user(&self) -> &str {
+        match self {
+            PrComment::Issue(c) => &c.user,
+            PrComment::Review(c) => &c.user,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn body(&self) -> &str {
+        match self {
+            PrComment::Issue(c) => &c.body,
+            PrComment::Review(c) => &c.body,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrInfo {
+    pub number: u64,
+    pub state: String,
+    pub is_draft: bool,
+    pub base: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrInfoWithHead {
+    pub info: PrInfo,
+    pub head: String,
+    pub head_label: Option<String>,
+    pub title: String,
+}
+
+/// Merge method for PRs
+#[derive(Debug, Clone, Copy, Default)]
+pub enum MergeMethod {
+    #[default]
+    Squash,
+    Merge,
+    Rebase,
+}
+
+impl MergeMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MergeMethod::Squash => "squash",
+            MergeMethod::Merge => "merge",
+            MergeMethod::Rebase => "rebase",
+        }
+    }
+}
+
+impl FromStr for MergeMethod {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "squash" => Ok(MergeMethod::Squash),
+            "merge" => Ok(MergeMethod::Merge),
+            "rebase" => Ok(MergeMethod::Rebase),
+            _ => anyhow::bail!("Invalid merge method: {}. Use: squash, merge, or rebase", s),
+        }
+    }
+}
+
+/// CI check status
+#[derive(Debug, Clone, PartialEq)]
+pub enum CiStatus {
+    Pending,
+    Success,
+    Failure,
+    /// No CI checks configured - treat as passing
+    NoCi,
+}
+
+impl CiStatus {
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "success" => CiStatus::Success,
+            "pending" => CiStatus::Pending,
+            "failure" | "error" => CiStatus::Failure,
+            // GitHub returns "neutral" for skipped/cancelled checks - treat as success
+            "neutral" | "skipped" | "cancelled" => CiStatus::Success,
+            // Empty or unknown typically means no CI configured
+            "" | "none" | "unknown" => CiStatus::NoCi,
+            // Default: no CI configured (don't block on unrecognized states)
+            _ => CiStatus::NoCi,
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        // NoCi is treated as success (nothing to wait for)
+        matches!(self, CiStatus::Success | CiStatus::NoCi)
+    }
+
+    pub fn is_pending(&self) -> bool {
+        matches!(self, CiStatus::Pending)
+    }
+
+    pub fn is_failure(&self) -> bool {
+        matches!(self, CiStatus::Failure)
+    }
+
+    #[allow(dead_code)]
+    pub fn display_text(&self) -> &'static str {
+        match self {
+            CiStatus::Success => "passed",
+            CiStatus::Pending => "running",
+            CiStatus::Failure => "failed",
+            CiStatus::NoCi => "no checks",
+        }
+    }
+}
+
+/// Detailed PR merge status
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct PrMergeStatus {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub updated_at: Option<String>,
+    pub is_draft: bool,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub ci_status: CiStatus,
+    pub review_decision: Option<String>,
+    pub approvals: usize,
+    pub changes_requested: bool,
+    pub head_sha: String,
+}
+
+impl PrMergeStatus {
+    /// Check if PR is ready to merge (approved + CI passed + mergeable)
+    pub fn is_ready(&self) -> bool {
+        self.ci_status.is_success()
+            && !self.is_draft
+            && self.mergeable.unwrap_or(false)
+            && !self.changes_requested
+            && self.state.to_lowercase() == "open"
+    }
+
+    /// Check if PR is waiting (CI pending or mergeable computing)
+    pub fn is_waiting(&self) -> bool {
+        self.ci_status.is_pending() || self.mergeable.is_none()
+    }
+
+    /// Check if PR has a blocking issue
+    pub fn is_blocked(&self) -> bool {
+        self.ci_status.is_failure()
+            || self.changes_requested
+            || self.is_draft
+            || self.mergeable == Some(false)
+    }
+
+    /// Get human-readable status
+    pub fn status_text(&self) -> &'static str {
+        if self.state.to_lowercase() != "open" {
+            return "Closed";
+        }
+        if self.is_draft {
+            return "Draft";
+        }
+        if self.changes_requested {
+            return "Changes requested";
+        }
+        if self.ci_status.is_failure() {
+            return "CI failed";
+        }
+        if self.mergeable == Some(false) {
+            return "Has conflicts";
+        }
+        if self.is_waiting() {
+            return "Waiting";
+        }
+        if self.is_ready() {
+            return "Ready";
+        }
+        "Ready" // Default to ready if nothing is blocking
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct EnqueueResult {
+    #[serde(rename = "mergeQueueEntry")]
+    pub merge_queue_entry: Option<MergeQueueEntry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct MergeQueueEntry {
+    pub position: Option<u32>,
+}
+
+/// Open PR info for tracking command
+#[derive(Debug, Clone)]
+pub struct OpenPrInfo {
+    pub number: u64,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub state: String,
+    pub is_draft: bool,
+}
+
+/// PR activity for standup reports.
+#[derive(Debug, Clone, Serialize)]
+pub struct PrActivity {
+    pub number: u64,
+    pub title: String,
+    pub timestamp: DateTime<Utc>,
+    pub url: String,
+}
+
+/// Review activity for standup reports.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewActivity {
+    pub pr_number: u64,
+    pub pr_title: String,
+    pub reviewer: String,
+    pub state: String,
+    pub timestamp: DateTime<Utc>,
+    pub is_received: bool,
+}
+
+/// Open pull request info for repo-level listing commands.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoPrListItem {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub author: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub state: String,
+    pub is_draft: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Open issue info for repo-level listing commands.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoIssueListItem {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub author: String,
+    pub labels: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -1,0 +1,247 @@
+use anyhow::Result;
+use std::collections::HashMap;
+
+use crate::ci::CheckRunInfo;
+use crate::forge::model::*;
+
+/// Forge-neutral seam over the concrete forge clients (GitHub, GitLab, Gitea).
+///
+/// Every method mirrors the existing inherent method on each concrete client
+/// so the trait can be introduced without changing behavior.
+#[allow(async_fn_in_trait)]
+pub trait Forge {
+    async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>>;
+    async fn find_pr(&self, branch: &str) -> Result<Option<PrInfo>>;
+    async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>>;
+    async fn list_open_pull_requests(&self, limit: u8) -> Result<Vec<RepoPrListItem>>;
+    async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>>;
+    async fn create_pr(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+        is_draft: bool,
+    ) -> Result<PrInfo>;
+    async fn get_pr(&self, number: u64) -> Result<PrInfo>;
+    async fn get_pr_with_head(&self, number: u64) -> Result<PrInfoWithHead>;
+    async fn update_pr_base(&self, number: u64, new_base: &str) -> Result<()>;
+    async fn set_pr_draft(&self, number: u64, is_draft: bool) -> Result<()>;
+    async fn enqueue_pr(&self, number: u64) -> Result<EnqueueResult>;
+    async fn update_pr_branch(&self, number: u64) -> Result<()>;
+    async fn update_pr_title(&self, number: u64, title: &str) -> Result<()>;
+    async fn update_pr_body(&self, number: u64, body: &str) -> Result<()>;
+    async fn get_pr_body(&self, number: u64) -> Result<String>;
+    async fn update_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()>;
+    async fn create_stack_comment(&self, number: u64, stack_comment: &str) -> Result<()>;
+    async fn create_issue_comment(&self, number: u64, body: &str) -> Result<()>;
+    async fn close_pr(&self, number: u64) -> Result<()>;
+    async fn delete_stack_comment(&self, number: u64) -> Result<()>;
+    async fn list_all_comments(&self, number: u64) -> Result<Vec<PrComment>>;
+    async fn merge_pr(
+        &self,
+        number: u64,
+        method: MergeMethod,
+        commit_title: Option<&str>,
+        sha: Option<&str>,
+    ) -> Result<()>;
+    async fn get_pr_merge_status(&self, number: u64) -> Result<PrMergeStatus>;
+    async fn get_pr_review_decision(&self, number: u64) -> Result<Option<String>>;
+    async fn is_pr_merged(&self, number: u64) -> Result<bool>;
+    async fn get_pr_head_sha(&self, number: u64) -> Result<String>;
+    async fn fetch_checks(
+        &self,
+        repo: &crate::git::GitRepo,
+        sha: &str,
+    ) -> Result<(Option<String>, Vec<CheckRunInfo>)>;
+    async fn request_reviewers(&self, number: u64, reviewers: &[String]) -> Result<()>;
+    async fn get_requested_reviewers(&self, number: u64) -> Result<Vec<String>>;
+    async fn add_labels(&self, number: u64, labels: &[String]) -> Result<()>;
+    async fn add_assignees(&self, number: u64, assignees: &[String]) -> Result<()>;
+    async fn get_current_user(&self) -> Result<String>;
+    async fn get_user_open_prs(&self, username: &str) -> Result<Vec<OpenPrInfo>>;
+    async fn get_recent_merged_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>>;
+    async fn get_recent_opened_prs(&self, hours: i64, username: &str) -> Result<Vec<PrActivity>>;
+    async fn get_reviews_received(&self, hours: i64, username: &str)
+    -> Result<Vec<ReviewActivity>>;
+    async fn get_reviews_given(&self, hours: i64, username: &str) -> Result<Vec<ReviewActivity>>;
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    pub(crate) struct FakeForge {
+        pub(crate) open_pr_by_head: Option<PrInfoWithHead>,
+    }
+
+    impl Forge for FakeForge {
+        async fn find_open_pr_by_head(&self, _branch: &str) -> Result<Option<PrInfoWithHead>> {
+            Ok(self.open_pr_by_head.clone())
+        }
+        async fn find_pr(&self, _branch: &str) -> Result<Option<PrInfo>> {
+            Ok(Some(PrInfo {
+                number: 7,
+                state: "OPEN".to_string(),
+                is_draft: false,
+                base: "main".to_string(),
+            }))
+        }
+        async fn list_open_prs_by_head(&self) -> Result<HashMap<String, PrInfoWithHead>> {
+            Ok(HashMap::new())
+        }
+        async fn list_open_pull_requests(&self, _limit: u8) -> Result<Vec<RepoPrListItem>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn list_open_issues(&self, _limit: u8) -> Result<Vec<RepoIssueListItem>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn create_pr(
+            &self,
+            _head: &str,
+            _base: &str,
+            _title: &str,
+            _body: &str,
+            _is_draft: bool,
+        ) -> Result<PrInfo> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_pr(&self, _number: u64) -> Result<PrInfo> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_pr_with_head(&self, _number: u64) -> Result<PrInfoWithHead> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn update_pr_base(&self, _number: u64, _new_base: &str) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn set_pr_draft(&self, _number: u64, _is_draft: bool) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn enqueue_pr(&self, _number: u64) -> Result<EnqueueResult> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn update_pr_branch(&self, _number: u64) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn update_pr_title(&self, _number: u64, _title: &str) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn update_pr_body(&self, _number: u64, _body: &str) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_pr_body(&self, _number: u64) -> Result<String> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn update_stack_comment(&self, _number: u64, _stack_comment: &str) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn create_stack_comment(&self, _number: u64, _stack_comment: &str) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn create_issue_comment(&self, _number: u64, _body: &str) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn close_pr(&self, _number: u64) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn delete_stack_comment(&self, _number: u64) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn list_all_comments(&self, _number: u64) -> Result<Vec<PrComment>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn merge_pr(
+            &self,
+            _number: u64,
+            _method: MergeMethod,
+            _commit_title: Option<&str>,
+            _sha: Option<&str>,
+        ) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_pr_merge_status(&self, _number: u64) -> Result<PrMergeStatus> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_pr_review_decision(&self, _number: u64) -> Result<Option<String>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn is_pr_merged(&self, _number: u64) -> Result<bool> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_pr_head_sha(&self, _number: u64) -> Result<String> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn fetch_checks(
+            &self,
+            _repo: &crate::git::GitRepo,
+            _sha: &str,
+        ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn request_reviewers(&self, _number: u64, _reviewers: &[String]) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_requested_reviewers(&self, _number: u64) -> Result<Vec<String>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn add_labels(&self, _number: u64, _labels: &[String]) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn add_assignees(&self, _number: u64, _assignees: &[String]) -> Result<()> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_current_user(&self) -> Result<String> {
+            Ok("fake-user".to_string())
+        }
+        async fn get_user_open_prs(&self, _username: &str) -> Result<Vec<OpenPrInfo>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_recent_merged_prs(
+            &self,
+            _hours: i64,
+            _username: &str,
+        ) -> Result<Vec<PrActivity>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_recent_opened_prs(
+            &self,
+            _hours: i64,
+            _username: &str,
+        ) -> Result<Vec<PrActivity>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_reviews_received(
+            &self,
+            _hours: i64,
+            _username: &str,
+        ) -> Result<Vec<ReviewActivity>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn get_reviews_given(
+            &self,
+            _hours: i64,
+            _username: &str,
+        ) -> Result<Vec<ReviewActivity>> {
+            anyhow::bail!("unused in fake")
+        }
+    }
+
+    async fn probe<F: Forge>(f: &F) -> Result<()> {
+        let user = f.get_current_user().await?;
+        assert_eq!(user, "fake-user");
+        let pr = f.find_pr("feature").await?;
+        assert_eq!(pr.map(|p| p.number), Some(7));
+        Ok(())
+    }
+
+    #[test]
+    fn fake_forge_satisfies_seam() {
+        let fake = FakeForge::default();
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(probe(&fake))
+            .unwrap();
+    }
+}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -91,15 +91,7 @@ struct CheckRun {
     conclusion: Option<String>,
 }
 
-/// Open PR info for tracking command
-#[derive(Debug, Clone)]
-pub struct OpenPrInfo {
-    pub number: u64,
-    pub head_branch: String,
-    pub base_branch: String,
-    pub state: String,
-    pub is_draft: bool,
-}
+pub use crate::forge::OpenPrInfo;
 
 #[derive(Debug, Deserialize)]
 struct ReviewUser {

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -35,36 +35,10 @@ pub(crate) fn is_native_stack_base_locked_error(err: &anyhow::Error) -> bool {
     })
 }
 
-/// A comment on a PR issue thread (conversation comment)
-#[derive(Debug, Clone)]
-pub struct IssueComment {
-    #[allow(dead_code)]
-    pub id: u64,
-    pub body: String,
-    pub user: String,
-    pub created_at: DateTime<Utc>,
-}
-
-/// A review comment on a PR (inline code comment)
-#[derive(Debug, Clone)]
-pub struct ReviewComment {
-    #[allow(dead_code)]
-    pub id: u64,
-    pub body: String,
-    pub user: String,
-    pub path: String,
-    pub line: Option<u32>,
-    pub start_line: Option<u32>,
-    pub created_at: DateTime<Utc>,
-    pub diff_hunk: Option<String>,
-}
-
-/// Combined comment for unified display
-#[derive(Debug, Clone)]
-pub enum PrComment {
-    Issue(IssueComment),
-    Review(ReviewComment),
-}
+pub use crate::forge::{
+    CiStatus, EnqueueResult, IssueComment, MergeMethod, MergeQueueEntry, PrComment, PrInfo,
+    PrInfoWithHead, PrMergeStatus, ReviewComment,
+};
 
 #[derive(Debug, Deserialize)]
 struct ApiUser {
@@ -77,47 +51,6 @@ struct ApiIssueComment {
     body: Option<String>,
     user: ApiUser,
     created_at: DateTime<Utc>,
-}
-
-impl PrComment {
-    pub fn created_at(&self) -> DateTime<Utc> {
-        match self {
-            PrComment::Issue(c) => c.created_at,
-            PrComment::Review(c) => c.created_at,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn user(&self) -> &str {
-        match self {
-            PrComment::Issue(c) => &c.user,
-            PrComment::Review(c) => &c.user,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn body(&self) -> &str {
-        match self {
-            PrComment::Issue(c) => &c.body,
-            PrComment::Review(c) => &c.body,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct PrInfo {
-    pub number: u64,
-    pub state: String,
-    pub is_draft: bool,
-    pub base: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct PrInfoWithHead {
-    pub info: PrInfo,
-    pub head: String,
-    pub head_label: Option<String>,
-    pub title: String,
 }
 
 fn octocrab_pr_number(pr: &PullRequest) -> Result<u64> {
@@ -167,156 +100,6 @@ fn octocrab_pr_info_with_head(pr: &PullRequest) -> Result<PrInfoWithHead> {
     })
 }
 
-/// Merge method for PRs
-#[derive(Debug, Clone, Copy, Default)]
-pub enum MergeMethod {
-    #[default]
-    Squash,
-    Merge,
-    Rebase,
-}
-
-impl MergeMethod {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            MergeMethod::Squash => "squash",
-            MergeMethod::Merge => "merge",
-            MergeMethod::Rebase => "rebase",
-        }
-    }
-}
-
-impl std::str::FromStr for MergeMethod {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s.to_lowercase().as_str() {
-            "squash" => Ok(MergeMethod::Squash),
-            "merge" => Ok(MergeMethod::Merge),
-            "rebase" => Ok(MergeMethod::Rebase),
-            _ => anyhow::bail!("Invalid merge method: {}. Use: squash, merge, or rebase", s),
-        }
-    }
-}
-
-/// CI check status
-#[derive(Debug, Clone, PartialEq)]
-pub enum CiStatus {
-    Pending,
-    Success,
-    Failure,
-    /// No CI checks configured - treat as passing
-    NoCi,
-}
-
-impl CiStatus {
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "success" => CiStatus::Success,
-            "pending" => CiStatus::Pending,
-            "failure" | "error" => CiStatus::Failure,
-            // GitHub returns "neutral" for skipped/cancelled checks - treat as success
-            "neutral" | "skipped" | "cancelled" => CiStatus::Success,
-            // Empty or unknown typically means no CI configured
-            "" | "none" | "unknown" => CiStatus::NoCi,
-            // Default: no CI configured (don't block on unrecognized states)
-            _ => CiStatus::NoCi,
-        }
-    }
-
-    pub fn is_success(&self) -> bool {
-        // NoCi is treated as success (nothing to wait for)
-        matches!(self, CiStatus::Success | CiStatus::NoCi)
-    }
-
-    pub fn is_pending(&self) -> bool {
-        matches!(self, CiStatus::Pending)
-    }
-
-    pub fn is_failure(&self) -> bool {
-        matches!(self, CiStatus::Failure)
-    }
-
-    #[allow(dead_code)]
-    pub fn display_text(&self) -> &'static str {
-        match self {
-            CiStatus::Success => "passed",
-            CiStatus::Pending => "running",
-            CiStatus::Failure => "failed",
-            CiStatus::NoCi => "no checks",
-        }
-    }
-}
-
-/// Detailed PR merge status
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct PrMergeStatus {
-    pub number: u64,
-    pub title: String,
-    pub state: String,
-    pub updated_at: Option<String>,
-    pub is_draft: bool,
-    pub mergeable: Option<bool>,
-    pub mergeable_state: String,
-    pub ci_status: CiStatus,
-    pub review_decision: Option<String>,
-    pub approvals: usize,
-    pub changes_requested: bool,
-    pub head_sha: String,
-}
-
-impl PrMergeStatus {
-    /// Check if PR is ready to merge (approved + CI passed + mergeable)
-    pub fn is_ready(&self) -> bool {
-        self.ci_status.is_success()
-            && !self.is_draft
-            && self.mergeable.unwrap_or(false)
-            && !self.changes_requested
-            && self.state.to_lowercase() == "open"
-    }
-
-    /// Check if PR is waiting (CI pending or mergeable computing)
-    pub fn is_waiting(&self) -> bool {
-        self.ci_status.is_pending() || self.mergeable.is_none()
-    }
-
-    /// Check if PR has a blocking issue
-    pub fn is_blocked(&self) -> bool {
-        self.ci_status.is_failure()
-            || self.changes_requested
-            || self.is_draft
-            || self.mergeable == Some(false)
-    }
-
-    /// Get human-readable status
-    pub fn status_text(&self) -> &'static str {
-        if self.state.to_lowercase() != "open" {
-            return "Closed";
-        }
-        if self.is_draft {
-            return "Draft";
-        }
-        if self.changes_requested {
-            return "Changes requested";
-        }
-        if self.ci_status.is_failure() {
-            return "CI failed";
-        }
-        if self.mergeable == Some(false) {
-            return "Has conflicts";
-        }
-        if self.is_waiting() {
-            return "Waiting";
-        }
-        if self.is_ready() {
-            return "Ready";
-        }
-        "Ready" // Default to ready if nothing is blocking
-    }
-}
-
 #[derive(Debug, Deserialize)]
 struct PrReviewData {
     repository: Option<RepositoryData>,
@@ -344,17 +127,6 @@ struct PrNodeId {
 struct EnqueueData {
     #[serde(rename = "enqueuePullRequest")]
     enqueue_pull_request: Option<EnqueueResult>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct EnqueueResult {
-    #[serde(rename = "mergeQueueEntry")]
-    pub merge_queue_entry: Option<MergeQueueEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct MergeQueueEntry {
-    pub position: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Motivation

Bottom of a 5-PR architecture-deepening stack (#642 → #646) from a codebase review. The forge abstraction was an `enum` + `dispatch!` macro rather than a real seam: there was no way to substitute a fake, so every forge test had to stand up a wiremock HTTP server. Worse, the *forge-neutral* domain types (`PrInfo`, `CiStatus`, `PrMergeStatus`, …) were defined inside the `github` module and imported by GitHub-named paths across ~15 files, and `ci.rs` reached past the seam into `client.octocrab`.

## Description of changes / notes for reviewers

- Add `trait Forge` (`src/forge/traits.rs`) with the 37 forge operations, implemented by `GitHubClient`, `GitLabClient`, `GiteaClient`, and `ForgeClient`.
- Move the forge-neutral model out of `src/github/` into `src/forge/model.rs`, with backward-compatible `pub use` re-exports that keep existing public and import paths working.
- Wire `application::pull_request::resolve_with_lookup` through `Forge`, removing the duplicate one-method `PullRequestLookup` seam.
- Add a configurable `FakeForge` test double and exercise the pull-request fallback path without a mock HTTP server.
- `ForgeClient` stays an enum but now delegates to the trait — lowest-churn shape.

**Not in scope (deliberate):** GitLab/Gitea stubs and the existing `fetch_checks` behavior are preserved verbatim (the CI layer inversion is fixed later in the stack, #644).

**Verification:** pure refactor, no user-visible behavior change. Full suite green under Docker (`make test`); `make lint` clean; forge and pull-request targeted tests pass.

**Risk:** low. Trait/inherent method resolution relies on inherent-method priority (no recursion); the fake-backed application test and existing wiremock HTTP tests exercise both injected and concrete paths.
