### PR TITLE
refactor(submit): unify branch-selection into one canonical function

### DIFF
--- a/src/application/submit.rs
+++ b/src/application/submit.rs
@@ -1029,7 +1029,7 @@ fn prepared_request_verify_hooks(prepared: &PreparedSubmit) -> bool {
     prepared.verify_hooks
 }
 
-fn branches_for_submit_scope(
+pub(crate) fn branches_for_submit_scope(
     stack: &Stack,
     current_branch: &str,
     scope: SubmitScope,
@@ -1307,5 +1307,133 @@ mod tests {
 
         assert!(cleanup_observed_while_locked.get());
         assert!(second.try_begin_mutation(&request).is_ok());
+    }
+
+    fn branch_scope_test_stack() -> crate::engine::Stack {
+        use crate::engine::stack::StackBranch;
+        use std::collections::HashMap;
+
+        // main (trunk)
+        //  ├── a
+        //  │   └── a1
+        //  │       └── a2
+        //  └── b
+        let mut branches = HashMap::new();
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                parent_revision: None,
+                children: vec!["a".to_string(), "b".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "a".to_string(),
+            StackBranch {
+                name: "a".to_string(),
+                parent: Some("main".to_string()),
+                parent_revision: Some("sha-main".to_string()),
+                children: vec!["a1".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "a1".to_string(),
+            StackBranch {
+                name: "a1".to_string(),
+                parent: Some("a".to_string()),
+                parent_revision: Some("sha-a".to_string()),
+                children: vec!["a2".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "a2".to_string(),
+            StackBranch {
+                name: "a2".to_string(),
+                parent: Some("a1".to_string()),
+                parent_revision: Some("sha-a1".to_string()),
+                children: vec![],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "b".to_string(),
+            StackBranch {
+                name: "b".to_string(),
+                parent: Some("main".to_string()),
+                parent_revision: Some("sha-main".to_string()),
+                children: vec![],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+
+        crate::engine::Stack {
+            branches,
+            trunk: "main".to_string(),
+        }
+    }
+
+    #[test]
+    fn branches_for_submit_scope_stack_from_middle() {
+        let stack = branch_scope_test_stack();
+        assert_eq!(
+            super::branches_for_submit_scope(&stack, "a", super::SubmitScope::Stack),
+            vec!["a", "a1", "a2"]
+        );
+    }
+
+    #[test]
+    fn branches_for_submit_scope_downstack_from_leaf() {
+        let stack = branch_scope_test_stack();
+        assert_eq!(
+            super::branches_for_submit_scope(&stack, "a2", super::SubmitScope::Downstack),
+            vec!["a", "a1", "a2"]
+        );
+    }
+
+    #[test]
+    fn branches_for_submit_scope_upstack_from_middle() {
+        let stack = branch_scope_test_stack();
+        assert_eq!(
+            super::branches_for_submit_scope(&stack, "a1", super::SubmitScope::Upstack),
+            vec!["a1", "a2"]
+        );
+    }
+
+    #[test]
+    fn branches_for_submit_scope_single() {
+        let stack = branch_scope_test_stack();
+        assert_eq!(
+            super::branches_for_submit_scope(&stack, "a1", super::SubmitScope::Branch),
+            vec!["a1"]
+        );
+    }
+
+    #[test]
+    fn branches_for_submit_scope_branch_on_trunk() {
+        let stack = branch_scope_test_stack();
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(
+            super::branches_for_submit_scope(&stack, "main", super::SubmitScope::Branch),
+            empty
+        );
     }
 }

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -2717,26 +2717,7 @@ pub(crate) fn resolve_branches_for_scope(
     current: &str,
     scope: SubmitScope,
 ) -> Vec<String> {
-    let branches = match scope {
-        SubmitScope::Stack => stack.current_stack(current),
-        SubmitScope::Downstack => {
-            let mut ancestors = stack.ancestors(current);
-            ancestors.reverse();
-            ancestors.push(current.to_string());
-            ancestors
-        }
-        SubmitScope::Upstack => {
-            let mut upstack = vec![current.to_string()];
-            upstack.extend(stack.descendants(current));
-            upstack
-        }
-        SubmitScope::Branch => vec![current.to_string()],
-    };
-
-    branches
-        .into_iter()
-        .filter(|branch| branch != &stack.trunk)
-        .collect()
+    crate::application::submit::branches_for_submit_scope(stack, current, scope)
 }
 
 /// Ref names to pass to `git fetch --no-tags <remote> ...` before submit (trunk, submitted branches,
@@ -3679,6 +3660,59 @@ mod tests {
             resolve_is_draft_without_prompt(false, false, false, true),
             Some(true)
         );
+    }
+
+    fn branch_scope_test_stack() -> Stack {
+        // main (trunk)
+        //  ├── a
+        //  │   └── a1
+        //  │       └── a2
+        //  └── b
+        let mut branches = HashMap::new();
+        let mut branch = |name: &str, parent: Option<&str>, children: &[&str]| {
+            branches.insert(
+                name.to_string(),
+                StackBranch {
+                    name: name.to_string(),
+                    parent: parent.map(str::to_string),
+                    parent_revision: parent.map(|p| format!("sha-{p}")),
+                    children: children.iter().map(|c| c.to_string()).collect(),
+                    needs_restack: false,
+                    pr_number: None,
+                    pr_state: None,
+                    pr_is_draft: None,
+                },
+            );
+        };
+        branch("main", None, &["a", "b"]);
+        branch("a", Some("main"), &["a1"]);
+        branch("a1", Some("a"), &["a2"]);
+        branch("a2", Some("a1"), &[]);
+        branch("b", Some("main"), &[]);
+        Stack {
+            branches,
+            trunk: "main".to_string(),
+        }
+    }
+
+    // Regression guard: `resolve_branches_for_scope` must keep delegating to the
+    // canonical `application::submit::branches_for_submit_scope`. Lives here (not in
+    // the application module) so it does not cross the application→command boundary.
+    #[test]
+    fn resolve_and_application_selection_match() {
+        let stack = branch_scope_test_stack();
+        for (current, scope) in [
+            ("a", SubmitScope::Stack),
+            ("a2", SubmitScope::Downstack),
+            ("a1", SubmitScope::Upstack),
+            ("a1", SubmitScope::Branch),
+        ] {
+            assert_eq!(
+                super::resolve_branches_for_scope(&stack, current, scope),
+                crate::application::submit::branches_for_submit_scope(&stack, current, scope),
+                "scope {scope:?} from {current}"
+            );
+        }
     }
 
     #[derive(Default)]


### PR DESCRIPTION
## Motivation

Part of the architecture-deepening stack (#642 → #646). Branch selection for `submit` was implemented twice — `commands/submit.rs::resolve_branches_for_scope` and `application/submit.rs::branches_for_submit_scope` — so the two could silently drift, and a scope bug could exist in one without the other's tests noticing.

## Description of changes / notes for reviewers

- Make `application/submit.rs::branches_for_submit_scope` the single canonical selector; `resolve_branches_for_scope` now delegates to it (identical signature, both callers untouched).
- Add 6 unit tests pinning selection for Branch / Downstack / Upstack / Stack scopes plus edge cases, including a regression test asserting the two entry points agree.

The two implementations were proven to produce **byte-identical output on every reachable input** before unifying (the application version's extra dedup/`retain` steps are provable no-ops given `Stack::ancestors/descendants/current_stack` semantics), so this changes nothing at runtime.

**Not in scope (deliberate):** the full `submit`/`sync` `plan()`/`apply()` split remains a larger follow-up — it's not a mechanical refactor and is tied to the strategic decision of whether to commit to (or delete) the half-migrated `application/` layer (worth an ADR).

**Verification:** pure refactor, no behavior change. Full suite green under Docker (2089 pass); the 6 new tests pass including the `resolve_and_application_selection_match` regression pin.

**Risk:** very low. Single delegation + additive tests; no signature or control-flow change.
