### PR TITLE
fix: preserve auth for gh-stack probes

### DIFF
--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -90,12 +90,11 @@ fn extension_status_with_env(env: &[(&str, &str)]) -> ExtensionStatus {
     match extensions {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if stdout.lines().any(|line| line.contains("github/gh-stack")) {
-                if link_command_supported(env) {
-                    ExtensionStatus::Installed
-                } else {
-                    ExtensionStatus::Outdated
-                }
+            let extension_listed = stdout.lines().any(|line| line.contains("github/gh-stack"));
+            if link_command_supported(env) {
+                ExtensionStatus::Installed
+            } else if extension_listed {
+                ExtensionStatus::Outdated
             } else {
                 ExtensionStatus::NoExtension
             }
@@ -233,7 +232,7 @@ pub fn link_stack_with_env(
     remote: &str,
     env: &[(&str, &str)],
 ) -> LinkOutcome {
-    let mut command = gh_command(env);
+    let mut command = gh_stack_command(env);
     command.args(["stack", "link"]);
     for number in pr_numbers {
         command.arg(number.to_string());
@@ -277,7 +276,7 @@ pub fn unlink_stack() -> LinkOutcome {
 }
 
 pub fn unlink_stack_with_env(env: &[(&str, &str)]) -> LinkOutcome {
-    match gh_command(env).args(["stack", "unstack"]).output() {
+    match gh_stack_command(env).args(["stack", "unstack"]).output() {
         Ok(output) if output.status.success() => LinkOutcome::Linked,
         Ok(output) if auth_token_unsupported_output(&output) => LinkOutcome::AuthTokenUnsupported {
             message: command_message(&output),
@@ -333,11 +332,6 @@ pub fn upgrade_extension_with_env(env: &[(&str, &str)]) -> Result<()> {
     Ok(())
 }
 
-/// `gh` env vars that override the CLI's stored (OAuth) credentials.
-/// GitHub's native Stacked PRs API is in private preview and rejects
-/// Personal Access Tokens, so stax strips these before shelling out to
-/// `gh stack`, letting `gh` fall back to a keyring-stored OAuth account
-/// even when a PAT is exported for other tooling (CI scripts, other CLIs).
 const AUTH_OVERRIDE_ENV_VARS: &[&str] = &["GH_TOKEN", "GITHUB_TOKEN"];
 
 fn gh_command(env: &[(&str, &str)]) -> Command {
@@ -345,6 +339,13 @@ fn gh_command(env: &[(&str, &str)]) -> Command {
     for (key, value) in env {
         command.env(key, value);
     }
+    command
+}
+
+/// GitHub's native Stacked PRs API rejects Personal Access Tokens, so remote
+/// stack operations must fall back to a keyring-stored OAuth account.
+fn gh_stack_command(env: &[(&str, &str)]) -> Command {
+    let mut command = gh_command(env);
     for var in AUTH_OVERRIDE_ENV_VARS {
         command.env_remove(var);
     }

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -187,6 +187,82 @@ exit 1
 }
 
 #[test]
+fn doctor_detects_installed_gh_stack_with_env_only_auth() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.96.0"; exit 0 ;;
+  "extension list")
+    if [ "${GH_TOKEN:-}" != "ghp_env_only" ] || [ "${GITHUB_TOKEN:-}" != "github_env_only" ]; then
+      echo "not authenticated" >&2
+      exit 4
+    fi
+    echo "gh stack github/gh-stack v0.0.8"
+    exit 0
+    ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let output = repo.run_stax_with_env(
+        &["doctor"],
+        &[
+            ("PATH", &path_with_fake_gh(fake.path())),
+            ("GH_TOKEN", "ghp_env_only"),
+            ("GITHUB_TOKEN", "github_env_only"),
+        ],
+    );
+
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("gh-stack extension installed"),
+        "doctor should detect the installed extension, stdout was:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("gh-stack extension missing"),
+        "doctor must not misreport an auth failure as a missing extension, stdout was:\n{stdout}"
+    );
+}
+
+#[test]
+fn doctor_detects_gh_stack_by_capability_when_extension_metadata_is_missing() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.96.0"; exit 0 ;;
+  "extension list") printf 'gh stack\t\t\n'; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+
+    let output = repo.run_stax_with_env(&["doctor"], &[("PATH", &path_with_fake_gh(fake.path()))]);
+
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("gh-stack extension installed"),
+        "doctor should trust the installed command's capabilities, stdout was:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("gh-stack extension missing"),
+        "missing extension metadata must not override a working command, stdout was:\n{stdout}"
+    );
+}
+
+#[test]
 fn extension_status_reports_no_gh_when_gh_binary_is_missing() {
     // An empty PATH (no `gh` anywhere) must be classified as `NoGh`, not
     // silently treated as `NoExtension` or crash/hang the caller.


### PR DESCRIPTION
## Summary

- preserve `GH_TOKEN`/`GITHUB_TOKEN` for local `gh-stack` discovery, install, and upgrade probes
- strip PAT overrides only from native stack API operations that require keyring OAuth
- detect Nix-managed `gh-stack` installs by their `gh stack link` capability when `gh extension list` cannot report repository metadata
- add regressions for env-only auth and metadata-free extension installs

Closes #647.

## Testing

- `cargo nextest run gh_stack_tests::` (37 passed)
- `make lint-fast`
- full Docker suite delegated to CI after local Docker DNS failures while building the test image

## Documentation

Not updated: this fixes extension/auth detection and restores the already documented native-stack behavior; it does not change the CLI or configuration contract.
