### PR TITLE
feat(generate): refresh Claude models, add live Anthropic Models API fetch

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -58,7 +58,7 @@ Config is loaded as follows:
 
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" — global default
-# model = "claude-sonnet-4-5-20250929"
+# model = "claude-opus-4-8"
 
 # Per-feature overrides — optional, fall back to [ai] above
 [ai.generate]   # st create --ai, st gen / st generate, st submit --ai

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -15,10 +15,12 @@ Enables workflow assistance for stacked branch creation, submit flows, and relat
 st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent claude
-st generate --pr-body --agent claude --model claude-opus-4-5
+st generate --pr-body --agent claude --model claude-opus-4-8
 st gen --pr-title --agent claude
 st gen --commit-msg --agent claude
 ```
+
+When `claude` is selected, stax tries Anthropic's live Models API first (using `ANTHROPIC_API_KEY`) before falling back to its local Claude defaults.
 
 ## Related
 

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -121,7 +121,7 @@ st generate --pr-body --no-prompt
 | `--template <name>` | Use a specific PR template |
 | `--no-template` | Skip PR template |
 
-Supported agents: `claude`, `codex`, `gemini`, `opencode`. When `codex` is selected, stax tries OpenAI's live Models API first (using `OPENAI_API_KEY`) before falling back to local Codex defaults.
+Supported agents: `claude`, `codex`, `gemini`, `opencode`. When `codex` or `claude` is selected, stax tries the provider's live Models API first (using `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) before falling back to its local defaults.
 
 To forget the saved AI pairing and re-prompt:
 
@@ -143,7 +143,7 @@ stack_links = "body"   # or "both"
 
 ```bash
 st generate --pr-body --agent codex --model gpt-5.3-codex
-st generate --pr-body --agent claude --model claude-haiku-4-5-20251001
+st generate --pr-body --agent claude --model claude-haiku-4-5
 st generate --pr-body --agent gemini --model gemini-2.5-flash
 st generate --pr-body --agent opencode
 st generate --pr-body --edit

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -991,13 +991,39 @@ struct ModelOption {
 }
 
 fn available_models_for(agent: &str) -> Vec<ModelOption> {
-    if agent == "codex"
-        && let Ok(models) = fetch_openai_codex_models()
-        && !models.is_empty()
-    {
-        return models;
+    let live = match agent {
+        "codex" => fetch_openai_codex_models().ok(),
+        "claude" => fetch_anthropic_models().ok(),
+        _ => None,
+    };
+    match live {
+        Some(models) if !models.is_empty() => models,
+        _ => known_models_for(agent),
     }
-    known_models_for(agent)
+}
+
+/// Fetch and deserialize a models listing, applying the shared timeouts.
+///
+/// `authorize` adds whatever auth/version headers the provider requires.
+fn fetch_models_json<T: serde::de::DeserializeOwned>(
+    url: &str,
+    authorize: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+) -> Result<T> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime
+        .block_on(async {
+            let client = reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(3))
+                .timeout(std::time::Duration::from_secs(5))
+                .build()?;
+            authorize(client.get(url))
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<T>()
+                .await
+        })
+        .map_err(Into::into)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1017,22 +1043,64 @@ fn fetch_openai_codex_models() -> Result<Vec<ModelOption>> {
         .unwrap_or_else(|_| "https://api.openai.com".to_string());
     let url = format!("{}/v1/models", base_url.trim_end_matches('/'));
 
-    let runtime = tokio::runtime::Runtime::new()?;
-    let response = runtime.block_on(async {
-        reqwest::Client::builder()
-            .connect_timeout(std::time::Duration::from_secs(3))
-            .timeout(std::time::Duration::from_secs(5))
-            .build()?
-            .get(&url)
-            .bearer_auth(api_key)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<OpenAiModelsResponse>()
-            .await
-    })?;
+    let response: OpenAiModelsResponse =
+        fetch_models_json(&url, |request| request.bearer_auth(api_key))?;
 
     Ok(filter_live_codex_models(response.data))
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModelsResponse {
+    data: Vec<AnthropicModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModel {
+    id: String,
+    display_name: Option<String>,
+    created_at: Option<String>,
+}
+
+fn fetch_anthropic_models() -> Result<Vec<ModelOption>> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .context("ANTHROPIC_API_KEY is not set; falling back to local claude model list")?;
+    let base_url = std::env::var("STAX_ANTHROPIC_API_BASE_URL")
+        .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
+    let url = format!("{}/v1/models?limit=100", base_url.trim_end_matches('/'));
+
+    let response: AnthropicModelsResponse = fetch_models_json(&url, |request| {
+        request
+            .header("x-api-key", api_key)
+            .header("anthropic-version", "2023-06-01")
+    })?;
+
+    Ok(filter_live_anthropic_models(response.data))
+}
+
+/// Keep Claude models only, newest first. The API paginates newest-last, and
+/// `created_at` is ISO-8601 so it sorts lexicographically.
+fn filter_live_anthropic_models(models: Vec<AnthropicModel>) -> Vec<ModelOption> {
+    let mut models: Vec<AnthropicModel> = models
+        .into_iter()
+        .filter(|model| model.id.starts_with("claude-"))
+        .collect();
+
+    models.sort_by(|a, b| {
+        b.created_at
+            .cmp(&a.created_at)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    models
+        .into_iter()
+        .map(|model| ModelOption {
+            description: match model.display_name {
+                Some(name) => format!("{} · live via Anthropic Models API", name),
+                None => "live via Anthropic Models API".to_string(),
+            },
+            id: model.id,
+        })
+        .collect()
 }
 
 fn filter_live_codex_models(models: Vec<OpenAiModel>) -> Vec<ModelOption> {
@@ -1364,6 +1432,42 @@ mod tests {
         let models = known_models_for("codex");
         assert!(models.iter().any(|m| m.id == "gpt-5.5"));
         assert!(models.iter().any(|m| m.id == "gpt-5.5-fast"));
+    }
+
+    #[test]
+    fn known_models_include_current_claude_defaults() {
+        let models = known_models_for("claude");
+        assert!(models.iter().any(|m| m.id == "claude-opus-4-8"));
+        assert!(models.iter().any(|m| m.id == "claude-sonnet-5"));
+        assert!(models.iter().any(|m| m.id == "claude-haiku-4-5"));
+    }
+
+    #[test]
+    fn live_anthropic_model_filter_sorts_newest_first() {
+        let filtered = filter_live_anthropic_models(vec![
+            AnthropicModel {
+                id: "claude-sonnet-4-6".to_string(),
+                display_name: Some("Claude Sonnet 4.6".to_string()),
+                created_at: Some("2025-11-14T00:00:00Z".to_string()),
+            },
+            AnthropicModel {
+                id: "some-other-model".to_string(),
+                display_name: None,
+                created_at: Some("2026-06-24T00:00:00Z".to_string()),
+            },
+            AnthropicModel {
+                id: "claude-opus-4-8".to_string(),
+                display_name: Some("Claude Opus 4.8".to_string()),
+                created_at: Some("2026-04-01T00:00:00Z".to_string()),
+            },
+        ]);
+
+        let ids: Vec<&str> = filtered.iter().map(|model| model.id.as_str()).collect();
+        assert_eq!(ids, vec!["claude-opus-4-8", "claude-sonnet-4-6"]);
+        assert_eq!(
+            filtered[0].description,
+            "Claude Opus 4.8 · live via Anthropic Models API"
+        );
     }
 
     #[test]

--- a/src/commands/models.json
+++ b/src/commands/models.json
@@ -1,9 +1,11 @@
 {
   "claude": [
-    { "id": "claude-sonnet-4-6",          "description": "Sonnet 4.6 · balanced · recommended" },
-    { "id": "claude-haiku-4-5-20251001",   "description": "Haiku 4.5 · fastest · cheapest" },
-    { "id": "claude-opus-4-6",             "description": "Opus 4.6 · most capable · slower" },
-    { "id": "claude-sonnet-4-5-20250929",  "description": "Sonnet 4.5 · previous gen" }
+    { "id": "claude-opus-4-8",   "description": "Opus 4.8 · most capable · recommended" },
+    { "id": "claude-sonnet-5",   "description": "Sonnet 5 · balanced · fast" },
+    { "id": "claude-haiku-4-5",  "description": "Haiku 4.5 · fastest · cheapest" },
+    { "id": "claude-fable-5",    "description": "Fable 5 · deepest reasoning · premium" },
+    { "id": "claude-opus-4-7",   "description": "Opus 4.7 · previous gen" },
+    { "id": "claude-sonnet-4-6", "description": "Sonnet 4.6 · previous gen" }
   ],
   "codex": [
     { "id": "gpt-5.5",       "description": "GPT-5.5 · latest · balanced" },


### PR DESCRIPTION
## What

Refreshes the stale Claude model list and adds a live model-listing path for the `claude` agent, mirroring the existing OpenAI/codex behavior.

## Changes

- **`src/commands/models.json`** — the `claude` list topped out at Opus/Sonnet 4.6. Updated to the current lineup (Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5) plus previous-gen Opus 4.7 / Sonnet 4.6. Switched the Haiku entry to the `claude-haiku-4-5` alias for consistency with the other entries.
- **`src/commands/generate.rs`** — added `fetch_anthropic_models()`: `GET /v1/models` with `x-api-key` + `anthropic-version`, gated on `ANTHROPIC_API_KEY`, overridable via `STAX_ANTHROPIC_API_BASE_URL`, falling back to `models.json` on any error. Filters to `claude-*` and sorts newest-first by `created_at`.
- Factored the shared runtime/timeout/JSON plumbing out of `fetch_openai_codex_models` into `fetch_models_json()` — only the auth headers differ between providers.
- Docs updated to reflect the new default model and the live-fetch note.

## Reviewer notes

- **`generate.rs`** is the substance — start at `available_models_for`, `fetch_models_json`, and `filter_live_anthropic_models`.
- The `models.json` diff is a mechanical data refresh.
- Docs changes are cosmetic string updates.

## Testing

- `cargo check --all-targets` clean
- `make test` — 2094 passed, 0 failed
- New unit tests: `known_models_include_current_claude_defaults`, `live_anthropic_model_filter_sorts_newest_first`

Note: `cargo clippy -- -D warnings` fails, but identically on a clean tree (13 pre-existing errors in `submit.rs`/`ready.rs`/`ops/mod.rs`) — none in `generate.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)