### PR TITLE
test: validate documented CLI aliases and subcommands

### DIFF
--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -4,6 +4,7 @@
 use crate::common;
 
 use common::{OutputAssertions, TestRepo};
+use regex::Regex;
 
 // =============================================================================
 // Checkout Command Tests
@@ -158,6 +159,44 @@ fn test_full_command_reference_mentions_visible_top_level_commands() {
         missing.is_empty(),
         "docs/commands/reference.md is missing visible top-level commands: {}",
         missing.join(", ")
+    );
+}
+
+#[test]
+fn documented_cli_commands_and_aliases_resolve_from_help() {
+    let repo = TestRepo::new();
+    let command_references =
+        Regex::new(r"`(?:st|stax) ([a-z][a-z-]*)(?: ([a-z][a-z-]*))?").unwrap();
+    let docs = [
+        ("README.md", include_str!("../README.md")),
+        (
+            "docs/commands/reference.md",
+            include_str!("../docs/commands/reference.md"),
+        ),
+        ("skills.md", include_str!("../skills.md")),
+    ];
+    let mut invalid = Vec::new();
+
+    for (path, content) in docs {
+        for captures in command_references.captures_iter(content) {
+            let command = captures.get(1).unwrap().as_str();
+            let mut args = vec![command];
+            if let Some(subcommand) = captures.get(2).map(|capture| capture.as_str()) {
+                args.push(subcommand);
+            }
+            args.push("--help");
+
+            let output = repo.run_stax(&args);
+            if !output.status.success() {
+                invalid.push(format!("{path}: st {}", args[..args.len() - 1].join(" ")));
+            }
+        }
+    }
+
+    assert!(
+        invalid.is_empty(),
+        "documented CLI commands or aliases not accepted by help: {}",
+        invalid.join(", ")
     );
 }
 


### PR DESCRIPTION
## Summary
- validate backticked `st`/`stax` command references in README, command reference, and skills documentation
- exercise documented top-level aliases and one-level nested subcommands through `--help`

Closes #583

## Verification
- `cargo nextest run command_coverage_tests::documented_cli_commands_and_aliases_resolve_from_help`
- `make lint-fast`
- `make lint`
- `make test` (2,095 passed)