### PR TITLE
fix: resolve all clippy warnings

### DIFF
--- a/src/application/operation.rs
+++ b/src/application/operation.rs
@@ -545,6 +545,7 @@ pub struct OperationError {
 
 impl OperationError {
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_source(
         request: OperationRequest,
         kind: OperationErrorKind,

--- a/src/application/pull_request.rs
+++ b/src/application/pull_request.rs
@@ -293,18 +293,9 @@ fn operation_error_from_source(
         || lowercase.contains("auth")
     {
         OperationErrorKind::Authentication
-    } else if lowercase.contains("timeout")
-        || lowercase.contains("connect")
-        || lowercase.contains("network")
-        || lowercase.contains("dns")
-        || lowercase.contains("request")
-        || lowercase.contains("500")
-        || lowercase.contains("502")
-        || lowercase.contains("503")
-        || lowercase.contains("504")
-    {
-        OperationErrorKind::Network
     } else {
+        // Anything else that fails while resolving a PR URL is treated as a
+        // network-class failure.
         OperationErrorKind::Network
     };
     OperationError::from_source(

--- a/src/application/restack.rs
+++ b/src/application/restack.rs
@@ -902,6 +902,7 @@ fn open_operation_repo(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn finish_transaction_error(
     request: &OperationRequest,
     repo: &GitRepo,
@@ -939,6 +940,7 @@ fn finish_transaction_error(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn finalize_restack_failure(
     request: &OperationRequest,
     state: RestackFailureState,

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -1339,6 +1339,7 @@ fn restore_after_failed_pre_branch_commit(
 /// exactly as git left them after the successful commit, so the user can retry
 /// without re-staging. With an active `--below` auto-stash, restore the original
 /// stash instead because the post-commit tree may be based on a different parent.
+#[allow(clippy::too_many_arguments)]
 fn rollback_after_commit(
     workdir: &Path,
     original_branch: &str,
@@ -1385,6 +1386,7 @@ fn rollback_after_commit(
 ///
 /// The caller owns whatever comes next — the trailing "No changes to commit"
 /// note, the stage/commit block, or the tips line.
+#[allow(clippy::too_many_arguments)]
 fn create_branch_with_banner(
     repo: &GitRepo,
     config: &Config,

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -217,11 +217,14 @@ fn load_commits(
     parse_commits(&stdout)
 }
 
+/// Normalized `(from, to, find)` triple produced by [`normalize_find_args`].
+type NormalizedFindArgs = (Option<String>, Option<String>, Option<Option<String>>);
+
 fn normalize_find_args(
     from: Option<String>,
     to: Option<String>,
     find: Option<Option<String>>,
-) -> Result<(Option<String>, Option<String>, Option<Option<String>>)> {
+) -> Result<NormalizedFindArgs> {
     if find.is_some() {
         return Ok((from, to, find));
     }

--- a/src/commands/ready.rs
+++ b/src/commands/ready.rs
@@ -113,7 +113,7 @@ impl CiSummary {
     fn failed(count: usize) -> Self {
         Self {
             status: CiStatus::Failure,
-            text: format!("{} {}", count, if count == 1 { "failed" } else { "failed" }),
+            text: format!("{count} failed"),
         }
     }
 
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn readiness_fetches_multiple_rows_per_batch() {
-        assert!(crate::parallel::IO_CONCURRENCY_LIMIT > 1);
+        const { assert!(crate::parallel::IO_CONCURRENCY_LIMIT > 1) };
     }
 
     fn run_git(path: &std::path::Path, args: &[&str]) {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1052,9 +1052,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 );
 
             // Check if PR base needs updating (not for empty branches)
-            let needs_pr_update = if is_empty {
-                false
-            } else if is_imported {
+            let needs_pr_update = if is_empty || is_imported {
                 false
             } else if let Some(pr) = &existing_pr {
                 pr.info.base != base || needs_push

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -266,8 +266,7 @@ mod tests {
 
     #[test]
     fn test_rand_suffix_produces_values() {
-        let suffix = rand_suffix();
-        // Just check it produces a non-zero value
-        assert!(suffix > 0 || suffix == 0); // Always true, just testing it runs
+        // Just check it runs and produces a value.
+        let _suffix = rand_suffix();
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7878,6 +7878,7 @@ mod forge_mock_tests {
             .await;
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn gitlab_mr_fixture(
         iid: u64,
         title: &str,
@@ -7918,6 +7919,7 @@ mod forge_mock_tests {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn gitea_pull_fixture(
         number: u64,
         title: &str,


### PR DESCRIPTION
Clears the `-D warnings` clippy backlog across the lib, unit tests, and the integration test binary. `cargo clippy --all-targets -- -D warnings` now exits 0; `make test` passes (2100/2100).

## Real simplifications (lints caught genuine redundancy)
- **`commands/ready.rs`** — `if count == 1 { "failed" } else { "failed" }` → `format!("{count} failed")`
- **`application/pull_request.rs`** — dropped a redundant network-keyword `else if` whose block was identical to the fallback `else` (both `Network`)
- **`commands/submit.rs`** — merged two identical `false` arms into `if is_empty || is_imported`
- **`ops/mod.rs`** — removed an always-true `suffix > 0 || suffix == 0` assert; test now just exercises `rand_suffix()`
- **`commands/changelog.rs`** — factored the complex return tuple into a `NormalizedFindArgs` type alias
- **`commands/ready.rs`** — promoted the compile-time `IO_CONCURRENCY_LIMIT` assert to a `const` block

## Suppressions (cohesive signatures)
`#[allow(clippy::too_many_arguments)]` on the builder-style helpers (`from_source`, `finish_transaction_error`, `finalize_restack_failure`, `rollback_after_commit`, `create_branch_with_banner`) and two test fixtures.

**Reviewers:** the `pull_request.rs` and `submit.rs` changes alter control flow — worth a look. Everything else is mechanical/no-behavior-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)