### PR TITLE
feat(resolve): retry AI conflict resolution with feedback on invalid output

### DIFF
--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -4,6 +4,7 @@ use crate::git::{GitRepo, RebaseResult};
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::IsTerminal;
@@ -18,6 +19,12 @@ struct FileResolution {
     path: String,
     content: String,
 }
+
+/// How many times to ask the agent for a schema-valid resolution within a
+/// single round before giving up. The first attempt uses the plain prompt;
+/// subsequent attempts feed the rejection reason and prior output back so the
+/// agent can self-correct malformed JSON or rule violations.
+const MAX_PARSE_ATTEMPTS: usize = 3;
 
 pub fn run(
     agent_flag: Option<String>,
@@ -59,10 +66,12 @@ Run `stax continue` or inspect `git status`."
 
         let baseline_changes: HashSet<String> = repo.changed_files()?.into_iter().collect();
         let conflicted_contents = read_conflicted_files(&repo, &conflicted_files)?;
-        let prompt = build_resolve_prompt(&conflicted_contents);
-        let raw_response = generate::invoke_ai_agent(&agent, model.as_deref(), &prompt)?;
-        let parsed = parse_agent_response(&raw_response)?;
-        let resolutions = validate_resolutions(&conflicted_files, parsed.resolutions)?;
+        let resolutions = obtain_resolutions(
+            &agent,
+            model.as_deref(),
+            &conflicted_files,
+            &conflicted_contents,
+        )?;
         apply_resolutions(&repo, &resolutions)?;
         enforce_conflicted_only_changes(&repo, &conflicted_files, &baseline_changes)?;
         repo.add_files(&conflicted_files)?;
@@ -171,6 +180,70 @@ fn build_resolve_prompt(conflicts: &[(String, String)]) -> String {
         }
         prompt.push_str("----- END CONTENT -----\n");
     }
+    prompt
+}
+
+/// Invoke the agent and coerce its output into a validated resolution map,
+/// retrying up to [`MAX_PARSE_ATTEMPTS`] times. Only schema/validation failures
+/// are retried (with the rejection reason fed back); a failed agent invocation
+/// aborts immediately, and success returns on the first valid response.
+fn obtain_resolutions(
+    agent: &str,
+    model: Option<&str>,
+    conflicted_files: &[String],
+    conflicted_contents: &[(String, String)],
+) -> Result<HashMap<String, String>> {
+    let base_prompt = build_resolve_prompt(conflicted_contents);
+    // Borrowed on the first attempt (the common path, no clone); each retry
+    // swaps in an owned repair prompt that feeds the rejection reason back.
+    let mut prompt: Cow<str> = Cow::Borrowed(&base_prompt);
+
+    for attempt in 1..MAX_PARSE_ATTEMPTS {
+        let raw_response = generate::invoke_ai_agent(agent, model, &prompt)?;
+        match parse_agent_response(&raw_response)
+            .and_then(|parsed| validate_resolutions(conflicted_files, parsed.resolutions))
+        {
+            Ok(resolved) => return Ok(resolved),
+            Err(err) => {
+                println!(
+                    "  {}",
+                    format!(
+                        "Attempt {}/{} produced an invalid response; asking the agent to fix it...",
+                        attempt, MAX_PARSE_ATTEMPTS
+                    )
+                    .yellow()
+                );
+                prompt = Cow::Owned(build_repair_prompt(
+                    &base_prompt,
+                    &raw_response,
+                    &format!("{err:#}"),
+                ));
+            }
+        }
+    }
+
+    // Final attempt: propagate the validation error instead of retrying.
+    let raw_response = generate::invoke_ai_agent(agent, model, &prompt)?;
+    parse_agent_response(&raw_response)
+        .and_then(|parsed| validate_resolutions(conflicted_files, parsed.resolutions))
+        .with_context(|| {
+            format!("AI agent failed to produce a valid resolution after {MAX_PARSE_ATTEMPTS} attempts")
+        })
+}
+
+/// Build a follow-up prompt that restates the schema, shows the agent its
+/// rejected output, and states exactly why it was rejected.
+fn build_repair_prompt(base_prompt: &str, previous_response: &str, error: &str) -> String {
+    let mut prompt = String::new();
+    prompt.push_str(base_prompt);
+    prompt.push_str("\nYour previous response was REJECTED. Return a corrected response.\n");
+    prompt.push_str(&format!("Rejection reason:\n{}\n\n", error.trim()));
+    prompt.push_str("Your previous response was:\n");
+    prompt.push_str("----- BEGIN PREVIOUS RESPONSE -----\n");
+    prompt.push_str(previous_response.trim());
+    prompt.push('\n');
+    prompt.push_str("----- END PREVIOUS RESPONSE -----\n\n");
+    prompt.push_str("Return only the corrected JSON object, with no markdown and no code fences.\n");
     prompt
 }
 

--- a/tests/resolve_tests.rs
+++ b/tests/resolve_tests.rs
@@ -194,6 +194,54 @@ printf '%s' '{"resolutions":[{"path":"conflict.txt","content":"resolved content\
 }
 
 #[test]
+fn test_resolve_retries_invalid_response_then_succeeds() {
+    let repo = TestRepo::new();
+    setup_single_conflict(&repo);
+
+    // First invocation emits invalid JSON; the marker flips the second
+    // invocation to a valid response, exercising the repair loop. The marker
+    // lives outside the repo working tree so the conflicted-only side-effect
+    // guard doesn't flag it.
+    let marker = std::env::temp_dir().join("stax-resolve-retry.marker");
+    let _ = fs::remove_file(&marker);
+    let marker_env = marker.display().to_string();
+
+    let (_bin_dir, path_env) = install_fake_codex(
+        &repo,
+        r#"#!/bin/sh
+cat >/dev/null
+if [ -f "$STAX_RETRY_MARKER" ]; then
+  printf '%s' '{"resolutions":[{"path":"conflict.txt","content":"resolved content\nline 2\nline 3\n"}]}'
+else
+  : > "$STAX_RETRY_MARKER"
+  printf '%s' 'not-json'
+fi
+"#,
+    );
+
+    let output = repo.run_stax_with_env(
+        &["resolve", "--agent", "codex", "--max-rounds", "3"],
+        &[
+            ("PATH", path_env.as_str()),
+            ("STAX_RETRY_MARKER", marker_env.as_str()),
+        ],
+    );
+    let _ = fs::remove_file(&marker);
+    output.assert_success();
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Rebase should complete after the agent repairs its response"
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("asking the agent to fix it"),
+        "Expected a repair-attempt notice, got: {}",
+        stdout
+    );
+}
+
+#[test]
 fn test_resolve_max_rounds_exhaustion() {
     let repo = TestRepo::new();
     setup_two_round_conflict(&repo);


### PR DESCRIPTION
## What

`stax resolve` invokes an external AI CLI agent to resolve rebase conflicts and expects JSON back. Previously **any** malformed JSON or schema-rule violation aborted the whole command. This wraps the invoke→parse→validate step in a bounded **repair loop** (`MAX_PARSE_ATTEMPTS = 3`): on a schema/validation failure it feeds the rejection reason and the agent's prior output back through a new repair prompt so the agent can self-correct.

## Scope for reviewers

- **`src/commands/resolve.rs`** — the whole change lives in the new `obtain_resolutions` + `build_repair_prompt`. Worth a close read:
  - Only **schema/validation** failures retry; a failed agent *invocation* still aborts immediately (via `?`).
  - The repair loop is orthogonal to the existing `--max-rounds` git-conflict loop — attempts live entirely inside one round.
  - Happy path borrows the base prompt via `Cow<str>` to avoid cloning the full conflicted-file payload.
- **`tests/resolve_tests.rs`** — `test_resolve_retries_invalid_response_then_succeeds` proves the loop: fake agent emits bad JSON first, valid JSON on retry.

## Not in scope (noted)

The pre-existing `strip_markdown_fences` (resolve) vs `generate::extract_ai_json_blob` duplication is the natural next generalization target (a shared `invoke_ai_agent_json::<T>()`), but it's outside this diff.

## Testing

- `cargo check` clean, no new clippy warnings in `resolve.rs`
- All 7 `resolve_tests::` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
