### PR TITLE
test: cover parallel untracked worktree recovery

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -373,7 +373,7 @@ The GUI can search branches; check out, create, rename, delete, move, and reorde
 - `--jobs <N>` sets the positive concurrency cap (default 8) and requires `--parallel`.
 - Each parallel command receives `STAX_RUN_BRANCH` with the original logical branch name; Git itself remains on a detached HEAD inside the temporary worktree.
 - Output is captured concurrently and printed in deterministic branch order.
-- Clean temporary worktrees are removed after success or failure. If a command leaves tracked changes, that worktree is preserved and its recovery path is printed; the branch is counted as failed.
+- Clean temporary worktrees are removed after success or failure. If a command leaves uncommitted tracked or untracked changes, that worktree is preserved and its recovery path is printed; the branch is counted as failed. Ignored artifacts do not prevent cleanup.
 - `--parallel` conflicts with `--fail-fast`, because commands may already be running concurrently.
 
 ### `st ci`

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -718,7 +718,7 @@ fn run_test_parallel(repo: &GitRepo, branches: &[String], cmd: &str, jobs: usize
         print_captured(&result.stderr);
         if result.dirty {
             println!(
-                "  {} Command left tracked changes; preserved for recovery at {}",
+                "  {} Command left uncommitted changes; preserved for recovery at {}",
                 "WARNING".yellow(),
                 result.path.display()
             );

--- a/tests/stack_test_tests.rs
+++ b/tests/stack_test_tests.rs
@@ -329,6 +329,115 @@ fn test_stack_run_parallel_propagates_failures_and_cleans_worktrees() {
 }
 
 #[test]
+fn test_stack_run_parallel_preserves_untracked_changes_for_recovery() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["parallel-untracked-a", "parallel-untracked-b"]);
+
+    let output = repo.run_stax(&[
+        "run",
+        "--parallel",
+        "--jobs",
+        "2",
+        "printf report > untracked-report",
+    ]);
+
+    output.assert_failure();
+    output.assert_stdout_contains("Command left uncommitted changes; preserved for recovery at");
+
+    let worktrees = TestRepo::stdout(&repo.git(&["worktree", "list", "--porcelain"]));
+    let preserved_paths: Vec<_> = worktrees
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .filter(|path| *path != repo.path().to_string_lossy())
+        .collect();
+    assert_eq!(
+        preserved_paths.len(),
+        2,
+        "Expected both dirty worktrees to be preserved"
+    );
+    assert!(
+        preserved_paths
+            .iter()
+            .all(|path| path.contains("stax-run-")),
+        "Expected preserved worktrees to use stax-run recovery paths: {worktrees}"
+    );
+    let recovery_root = std::path::Path::new(preserved_paths[0])
+        .parent()
+        .expect("Preserved worktree should have a recovery root")
+        .to_path_buf();
+
+    for path in preserved_paths {
+        repo.git(&["worktree", "remove", "--force", path])
+            .assert_success();
+    }
+    std::fs::remove_dir_all(&recovery_root).expect("Failed to remove recovery root");
+    let remaining = TestRepo::stdout(&repo.git(&["worktree", "list", "--porcelain"]));
+    assert_eq!(remaining.matches("worktree ").count(), 1);
+}
+
+#[test]
+fn test_stack_run_parallel_preserves_tracked_changes_for_recovery() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["parallel-tracked-a", "parallel-tracked-b"]);
+
+    let output = repo.run_stax(&[
+        "run",
+        "--parallel",
+        "--jobs",
+        "2",
+        "printf report > tracked-report && git add tracked-report",
+    ]);
+
+    output.assert_failure();
+    output.assert_stdout_contains("Command left uncommitted changes; preserved for recovery at");
+
+    let worktrees = TestRepo::stdout(&repo.git(&["worktree", "list", "--porcelain"]));
+    let preserved_paths: Vec<_> = worktrees
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .filter(|path| *path != repo.path().to_string_lossy())
+        .collect();
+    assert_eq!(
+        preserved_paths.len(),
+        2,
+        "Expected both dirty worktrees to be preserved"
+    );
+    let recovery_root = std::path::Path::new(preserved_paths[0])
+        .parent()
+        .expect("Preserved worktree should have a recovery root")
+        .to_path_buf();
+
+    for path in preserved_paths {
+        repo.git(&["worktree", "remove", "--force", path])
+            .assert_success();
+    }
+    std::fs::remove_dir_all(&recovery_root).expect("Failed to remove recovery root");
+    let remaining = TestRepo::stdout(&repo.git(&["worktree", "list", "--porcelain"]));
+    assert_eq!(remaining.matches("worktree ").count(), 1);
+}
+
+#[test]
+fn test_stack_run_parallel_cleans_ignored_artifacts() {
+    let repo = TestRepo::new();
+    repo.create_file(".gitignore", "ignored-report\n");
+    repo.commit("Add ignored parallel-run artifact");
+    repo.create_stack(&["parallel-ignored-a", "parallel-ignored-b"]);
+
+    let output = repo.run_stax(&[
+        "run",
+        "--parallel",
+        "--jobs",
+        "2",
+        "printf report > ignored-report",
+    ]);
+
+    output.assert_success();
+    output.assert_stdout_not_contains("preserved for recovery");
+    let worktrees = TestRepo::stdout(&repo.git(&["worktree", "list", "--porcelain"]));
+    assert_eq!(worktrees.matches("worktree ").count(), 1);
+}
+
+#[test]
 fn test_stack_run_parallel_rejects_zero_jobs() {
     let repo = TestRepo::new();
     repo.create_stack(&["parallel-jobs"]);


### PR DESCRIPTION
## Summary
- document that `st run --parallel` preserves worktrees for any uncommitted tracked or untracked content
- clarify ignored artifacts do not block cleanup
- add integration coverage for tracked, untracked, and ignored parallel-run artifacts

Closes #603

## Validation
- `make test` — 2,093 passed
- `make lint` — passed

The initial focused `cargo nextest run stack_test_tests::` build exceeded the 600-second foreground limit; the required full suite subsequently completed successfully.