### PR TITLE
fix(worktree): handle external relative roots

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -79,6 +79,7 @@ Config is loaded as follows:
 
 [worktree]
 # root_dir = "" # default: ~/.stax/worktrees/<repo>
+# root_dir = ".." # optional: keep lanes beside a nested trunk clone
 # reuse_slots = true
 #   Warm-slot recycling. Removing a clean, merged-equivalent worktree parks it
 #   (reset --hard trunk + `git clean -fd`, keeping gitignored deps like

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -216,6 +216,7 @@ Override in `~/.config/stax/config.toml`, or set shared project overrides in rep
 [worktree]
 # root_dir = ""             # default external root
 # root_dir = ".worktrees"   # keep worktrees inside the repo
+# root_dir = ".."           # keep lanes beside the main checkout
 
 # Warm-slot recycling: a removed worktree is parked and reused by the next lane
 # instead of being deleted, keeping built gitignored deps on disk.
@@ -236,8 +237,23 @@ pre_remove  = ""   # blocking hook before removal
 post_remove = ""   # background hook after removal
 ```
 
-- Relative `root_dir` values resolve under the main repo root.
-- Repo-local roots like `.worktrees` are added to `.gitignore` automatically.
+- Relative `root_dir` values resolve from the main repo root. Configure them
+  globally in `~/.config/stax/config.toml` to reuse the same layout across repos.
+- To keep a trunk clone and its lanes as siblings, place the trunk clone one
+  level below a plain container directory and set `root_dir = ".."` globally:
+
+  ```text
+  my-repo/
+    development/  # trunk clone
+    feature-x/    # stax-managed lane
+    feature-y/    # stax-managed lane
+  ```
+
+- Roots inside the repository, such as `.worktrees`, are added to `.gitignore`
+  automatically. Roots outside the repository, including `..`, leave
+  `.gitignore` untouched.
+- `root_dir` cannot resolve to the main repo directory itself. Use a
+  subdirectory or an external directory.
 - Warm-slot recycling (default): removing a clean, merged-equivalent worktree **parks** it instead of deleting it — stax moves it off its lane branch, resets it hard to trunk, and runs `git clean -fd`. That never uses `-x`, so gitignored dependency directories (`node_modules`, `.venv`, `vendor`, …) survive on disk.
 - The next `create` / `lane` **adopts** an idle parked slot instead of a cold `git worktree add`: it switches the slot to the fresh lane branch, resets to the base, cleans untracked files, and runs the `reconcile` hook. Adopting reuses the same directory, so the built deps are already there.
 - `reconcile` re-syncs deps after adoption (e.g. `pnpm install`, `uv sync`). It is **non-fatal** — a missing or failing command only warns and never fails the create.

--- a/src/commands/worktree/ai.rs
+++ b/src/commands/worktree/ai.rs
@@ -135,7 +135,7 @@ fn run_named_lane(
     fs::create_dir_all(&worktrees_dir)?;
     ensure_managed_worktrees_root(repo, config, &worktrees_dir)?;
     let main_repo_workdir = repo.main_repo_workdir()?;
-    ensure_gitignore(&main_repo_workdir, &config.worktree.root_dir)?;
+    ensure_gitignore(&main_repo_workdir, &worktrees_dir)?;
     let outcome = adopt_or_create_worktree(
         repo,
         config,

--- a/src/commands/worktree/create.rs
+++ b/src/commands/worktree/create.rs
@@ -142,7 +142,7 @@ pub fn run(
     fs::create_dir_all(&worktrees_dir)?;
     ensure_managed_worktrees_root(&repo, &config, &worktrees_dir)?;
     let main_repo_workdir = repo.main_repo_workdir()?;
-    ensure_gitignore(&main_repo_workdir, &config.worktree.root_dir)?;
+    ensure_gitignore(&main_repo_workdir, &worktrees_dir)?;
 
     let outcome = adopt_or_create_worktree(
         &repo,

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -241,18 +241,39 @@ pub fn ensure_managed_worktrees_root(
     Ok(())
 }
 
-pub fn ensure_gitignore(repo_root: &Path, worktrees_dir: &str) -> Result<()> {
-    if worktrees_dir.trim().is_empty() {
-        return Ok(());
+pub fn ensure_gitignore(repo_root: &Path, worktrees_dir: &Path) -> Result<()> {
+    let repo_root = fs::canonicalize(repo_root).with_context(|| {
+        format!(
+            "Failed to resolve repository root '{}'",
+            repo_root.display()
+        )
+    })?;
+    let worktrees_dir = fs::canonicalize(worktrees_dir).with_context(|| {
+        format!(
+            "Failed to resolve configured worktree root '{}'",
+            worktrees_dir.display()
+        )
+    })?;
+
+    if worktrees_dir == repo_root {
+        bail!(
+            "Worktree root cannot be the main repository directory '{}'. \
+             Configure a subdirectory or an external directory instead.",
+            repo_root.display()
+        );
     }
 
-    let expanded = expand_home_path(worktrees_dir)?;
-    if expanded.is_absolute() {
+    let Ok(relative_dir) = worktrees_dir.strip_prefix(&repo_root) else {
         return Ok(());
-    }
+    };
 
     let gitignore = repo_root.join(".gitignore");
-    let entry = format!("{}/", worktrees_dir.trim_end_matches('/'));
+    let relative_dir = relative_dir
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    let entry = format!("{relative_dir}/");
 
     if gitignore.exists() {
         let content = fs::read_to_string(&gitignore)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -289,8 +289,8 @@ pub struct AuthConfig {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WorktreeConfig {
-    /// Directory for stax-managed worktrees. Empty means the default external root:
-    /// ~/.stax/worktrees/<repo>.
+    /// Directory for stax-managed worktrees. Relative paths resolve from the main
+    /// checkout. Empty means the default external root: ~/.stax/worktrees/<repo>.
     #[serde(default = "default_worktree_root_dir")]
     pub root_dir: String,
     /// Recycle removed worktrees as warm slots instead of deleting them, so a new

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -950,6 +950,82 @@ fn wt_create_respects_explicit_repo_local_root_dir() {
 }
 
 #[test]
+fn wt_create_respects_absolute_repo_local_root_dir() {
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    let worktree_root = repo.path().join(".absolute-worktrees");
+    write_worktree_config(&home, &worktree_root.to_string_lossy());
+
+    let out = repo.run_stax_with_env(
+        &["wt", "c", "absolute-local-root"],
+        &[("HOME", home.as_str())],
+    );
+    out.assert_success();
+
+    assert!(worktree_root.join("absolute-local-root").is_dir());
+    assert_eq!(
+        fs::read_to_string(repo.path().join(".gitignore")).expect("read .gitignore"),
+        ".absolute-worktrees/\n"
+    );
+}
+
+#[test]
+fn wt_create_with_external_relative_root_keeps_gitignore_clean() {
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    let external_root = tempfile::tempdir_in(
+        repo.path()
+            .parent()
+            .expect("test repository should have a parent"),
+    )
+    .expect("create sibling worktree root");
+    let relative_root = format!(
+        "../{}",
+        external_root
+            .path()
+            .file_name()
+            .expect("sibling worktree root name")
+            .to_string_lossy()
+    );
+    write_worktree_config(&home, &relative_root);
+    repo.create_file(".gitignore", "existing-entry\n");
+    repo.commit("Track gitignore");
+
+    let out = repo.run_stax_with_env(&["wt", "c", "sibling-root"], &[("HOME", home.as_str())]);
+    out.assert_success();
+
+    assert!(
+        external_root.path().join("sibling-root").is_dir(),
+        "expected lane next to the main checkout"
+    );
+    assert_eq!(
+        fs::read_to_string(repo.path().join(".gitignore")).expect("read tracked .gitignore"),
+        "existing-entry\n",
+        "an external worktree root must not modify .gitignore"
+    );
+    assert!(
+        TestRepo::stdout(&repo.git(&["status", "--porcelain"])).is_empty(),
+        "worktree creation should leave the main checkout clean"
+    );
+}
+
+#[test]
+fn wt_create_rejects_main_checkout_as_worktree_root() {
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    write_worktree_config(&home, ".");
+
+    let out = repo.run_stax_with_env(&["wt", "c", "unsafe-root"], &[("HOME", home.as_str())]);
+
+    out.assert_failure()
+        .assert_stderr_contains("Worktree root cannot be the main repository directory");
+    assert!(
+        !repo.path().join("unsafe-root").exists(),
+        "invalid worktree root must not create a lane"
+    );
+}
+
+#[test]
 fn wt_prune_cleans_stale_git_worktree_entries() {
     let repo = TestRepo::new();
     let home = repo.clean_home();


### PR DESCRIPTION
## Summary

- resolve configured worktree roots before deciding whether `.gitignore` needs an entry
- keep external relative roots such as `..` from dirtying tracked files
- document the global sibling-lane layout and cover internal, external, and root-equality cases

## Testing

- `make lint`
- `make test` (2,103 passed)

Fixes #654