### PR TITLE
feat(gui): persist window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The native GUI opens a repository-scoped workspace with searchable Stack, Change
 
 When the app starts without an explicit path, it reopens the most recently used project. Use the project dropdown in the toolbar to switch between recent projects or choose **Add Project…** to open another repository. An explicit `st gui <path>` launch still opens that repository.
 
-Use `/` to search, `1`/`2`/`3` to toggle panes, and drag dividers to resize them; visibility and widths persist per canonical repository. Native menus and keyboard shortcuts dispatch the same typed actions as the buttons. Submit is always confirmed first, pushes the current stack as Draft, and does not show CLI prompts or auto-open PR pages. `st gui [path]` only launches the app.
+Use `/` to search, `1`/`2`/`3` to toggle panes, and drag dividers to resize them; visibility and widths persist per canonical repository. The app also restores its last window size and reduces it to fit the current display after a monitor change. Native menus and keyboard shortcuts dispatch the same typed actions as the buttons. Submit is always confirmed first, pushes the current stack as Draft, and does not show CLI prompts or auto-open PR pages. `st gui [path]` only launches the app.
 
 → [GUI guide](docs/interface/gui.md)
 

--- a/crates/stax-gui/src/preferences.rs
+++ b/crates/stax-gui/src/preferences.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, ensure};
 use fs4::FileExt;
+use gpui::{Pixels, px};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
@@ -10,6 +11,89 @@ use std::sync::Mutex;
 use tempfile::NamedTempFile;
 
 const MAX_RECENT_REPOSITORIES: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct WindowSize {
+    pub width: Pixels,
+    pub height: Pixels,
+}
+
+impl WindowSize {
+    pub fn normalized(self) -> Option<Self> {
+        (self.width >= px(1.0) && self.height >= px(1.0)).then_some(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WindowSizePreferencesFile {
+    path: PathBuf,
+}
+
+impl WindowSizePreferencesFile {
+    pub fn at(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn default_path() -> PathBuf {
+        dirs::data_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("stax/gui/window-size.json")
+    }
+
+    pub fn load(&self) -> Option<WindowSize> {
+        fs::read(&self.path)
+            .ok()
+            .and_then(|contents| serde_json::from_slice(&contents).ok())
+            .and_then(WindowSize::normalized)
+    }
+
+    pub fn save(&self, size: WindowSize) -> Result<()> {
+        let Some(size) = size.normalized() else {
+            return Ok(());
+        };
+        let parent = self
+            .path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create window preferences directory {}",
+                parent.display()
+            )
+        })?;
+        restrict_directory_permissions(parent)?;
+        let mut temporary = NamedTempFile::new_in(parent).with_context(|| {
+            format!(
+                "failed to create temporary window preferences in {}",
+                parent.display()
+            )
+        })?;
+        restrict_file_permissions(temporary.as_file(), temporary.path())?;
+        serde_json::to_writer_pretty(temporary.as_file_mut(), &size)
+            .context("failed to serialize window preferences")?;
+        temporary.as_file_mut().write_all(b"\n")?;
+        temporary.as_file_mut().flush()?;
+        temporary.as_file().sync_all()?;
+        temporary
+            .persist(&self.path)
+            .map_err(|error| error.error)
+            .with_context(|| {
+                format!(
+                    "failed to atomically replace window preferences {}",
+                    self.path.display()
+                )
+            })?;
+        sync_parent_directory(parent)?;
+        Ok(())
+    }
+}
+
+impl Default for WindowSizePreferencesFile {
+    fn default() -> Self {
+        Self::at(Self::default_path())
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct RecentRepositories {
@@ -524,9 +608,10 @@ fn sync_parent_directory(parent: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        PaneVisibility, PaneWidths, RecentRepositories, WorkspacePreferences,
-        WorkspacePreferencesFile,
+        PaneVisibility, PaneWidths, RecentRepositories, WindowSize, WindowSizePreferencesFile,
+        WorkspacePreferences, WorkspacePreferencesFile,
     };
+    use gpui::px;
     use std::collections::HashSet;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -538,6 +623,25 @@ mod tests {
     const WRITER_STORE_ENV: &str = "STAX_TEST_RECENT_WRITER_STORE";
     const WRITER_REPOSITORY_ENV: &str = "STAX_TEST_RECENT_WRITER_REPOSITORY";
     const WRITER_READY_ENV: &str = "STAX_TEST_RECENT_WRITER_READY";
+
+    #[test]
+    fn window_size_round_trips_and_rejects_invalid_saved_values() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("preferences/window-size.json");
+        let store = WindowSizePreferencesFile::at(&path);
+        let size = WindowSize {
+            width: px(1440.0),
+            height: px(900.0),
+        };
+
+        store.save(size).unwrap();
+
+        assert_eq!(store.load(), Some(size));
+        fs::write(&path, br#"{"width":0.0,"height":900.0}"#).unwrap();
+        assert_eq!(store.load(), None);
+        fs::write(&path, b"not json").unwrap();
+        assert_eq!(store.load(), None);
+    }
 
     #[test]
     fn workspace_preferences_round_trip_independently_per_repository() {

--- a/crates/stax-gui/src/views/mod.rs
+++ b/crates/stax-gui/src/views/mod.rs
@@ -15,9 +15,10 @@ mod operation_tests;
 mod tests;
 
 use anyhow::Context as _;
-use gpui::{App, AppContext as _, Bounds, WindowBounds, WindowOptions, px, size};
+use gpui::{App, AppContext as _, Bounds, Pixels, WindowBounds, WindowOptions, px, size};
 use std::path::PathBuf;
 
+use crate::preferences::{WindowSize, WindowSizePreferencesFile};
 use app::AppServices;
 pub use app::{AppView, ControlKind, activate_control, control_button, control_focus_style, init};
 pub(crate) use app::{
@@ -43,15 +44,88 @@ fn open_window_with_services(
     services: AppServices,
     cx: &mut App,
 ) -> anyhow::Result<()> {
-    let bounds = Bounds::centered(None, size(px(1100.0), px(720.0)), cx);
+    let saved_size = WindowSizePreferencesFile::default().load();
+    let display_size = cx.primary_display().map(|display| display.bounds().size);
+    let window_size = window_size_for_display(saved_size, display_size);
+    let bounds = Bounds::centered(None, size(window_size.width, window_size.height), cx);
+    let window_size_preferences = WindowSizePreferencesFile::default();
     cx.open_window(
         WindowOptions {
             window_bounds: Some(WindowBounds::Windowed(bounds)),
             window_min_size: Some(size(px(820.0), px(520.0))),
             ..Default::default()
         },
-        move |window, cx| cx.new(|cx| AppView::new(repository, services, window, cx)),
+        move |window, cx| {
+            let window_size_preferences = window_size_preferences.clone();
+            window.on_window_should_close(cx, move |window, _| {
+                if let Err(error) = window_size_preferences.save(WindowSize {
+                    width: window.bounds().size.width,
+                    height: window.bounds().size.height,
+                }) {
+                    eprintln!("stax-gui failed to save window size: {error:#}");
+                }
+                true
+            });
+            cx.new(|cx| AppView::new(repository, services, window, cx))
+        },
     )
     .context("failed to open the Stax window")?;
     Ok(())
+}
+
+const DEFAULT_WINDOW_SIZE: WindowSize = WindowSize {
+    width: px(1100.0),
+    height: px(720.0),
+};
+
+fn window_size_for_display(
+    saved: Option<WindowSize>,
+    display_size: Option<gpui::Size<Pixels>>,
+) -> WindowSize {
+    let size = saved.unwrap_or(DEFAULT_WINDOW_SIZE);
+    let Some(display_size) = display_size else {
+        return size;
+    };
+    WindowSize {
+        width: clamp_to_display(size.width, display_size.width),
+        height: clamp_to_display(size.height, display_size.height),
+    }
+}
+
+fn clamp_to_display(size: Pixels, display_size: Pixels) -> Pixels {
+    if size > display_size {
+        display_size
+    } else {
+        size
+    }
+}
+
+#[cfg(test)]
+mod window_size_tests {
+    use super::{DEFAULT_WINDOW_SIZE, WindowSize, window_size_for_display};
+    use gpui::{px, size};
+
+    #[test]
+    fn restored_size_is_clamped_to_the_current_display() {
+        let restored = window_size_for_display(
+            Some(WindowSize {
+                width: px(1800.0),
+                height: px(1200.0),
+            }),
+            Some(size(px(1440.0), px(900.0))),
+        );
+
+        assert_eq!(
+            restored,
+            WindowSize {
+                width: px(1440.0),
+                height: px(900.0),
+            }
+        );
+    }
+
+    #[test]
+    fn default_size_is_used_when_no_window_size_has_been_saved() {
+        assert_eq!(window_size_for_display(None, None), DEFAULT_WINDOW_SIZE);
+    }
 }

--- a/docs/interface/gui.md
+++ b/docs/interface/gui.md
@@ -49,6 +49,8 @@ The `-n` flag is part of the contract. Every `st gui [path]` invocation opens a 
 
 Launching Stax directly from Finder or the Dock supplies no repository path. In that case, and when macOS reopens the app after its last window closed, Stax automatically opens the most recently used valid repository. An explicit path always takes precedence. If the saved repository can no longer be opened, Stax shows the normal actionable repository error and keeps the folder picker available.
 
+Stax remembers the last window size across launches. If that size is larger than the display available at the next launch—for example after disconnecting an external monitor—the app reduces it to fit the current display.
+
 ## Workspace
 
 ![Stax native macOS GUI showing a stacked branch graph, changes, and branch inspector](../assets/gui.png)

--- a/skills.md
+++ b/skills.md
@@ -159,7 +159,7 @@ stax gui                         # Launch GUI for the current directory
 stax gui /path/to/repo           # Launch GUI for an explicit repository
 ```
 
-Public GitHub Releases include `Stax-aarch64-apple-darwin.zip` and `Stax-x86_64-apple-darwin.zip`; extract the matching archive and move `Stax.app` to `/Applications`. The app is a separate artifact, not a new package, so it does not enlarge the CLI binaries. Ad-hoc-signed builds must be opened once to trigger Gatekeeper, then approved with **Privacy & Security → Open Anyway**; never disable Gatekeeper globally. The final bundle id is `com.cesarferreira.stax`.
+Public GitHub Releases include `Stax-aarch64-apple-darwin.zip` and `Stax-x86_64-apple-darwin.zip`; extract the matching archive and move `Stax.app` to `/Applications`. The app is a separate artifact, not a new package, so it does not enlarge the CLI binaries. Ad-hoc-signed builds must be opened once to trigger Gatekeeper, then approved with **Privacy & Security → Open Anyway**; never disable Gatekeeper globally. The final bundle id is `com.cesarferreira.stax`. The GUI restores its most recent window size and clamps it to the active display after monitor changes.
 
 `stax gui [path]` is macOS-only. It canonicalizes the supplied path, defaults to the current directory, and launches exactly `open -n -b com.cesarferreira.stax --args <canonical-path>`. The `-n` fresh-instance behavior is intentional: every invocation opens a new app process/window for one repository.
 


### PR DESCRIPTION
## Summary
- persist the native GUI window dimensions when a window closes
- restore the saved size on launch and clamp it to the current primary display
- document the behavior in README, GUI docs, and agent skills

Closes #635

## Verification
- `cargo nextest run -p stax-gui window_size`
- `make lint`
- `make test` (2,107 passed)