### PR TITLE
feat: unstack native stacks by number

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ That's it — no config needed. From then on, `st ss`/`st bs` auto-link multi-PR
 ```bash
 st ss                    # auto-links native stack when available
 st stack link            # manually re-link the current stack
-st stack unlink          # unstack a locally tracked native GitHub Stack
+st stack unlink 7        # unstack native Stack #7 remotely
 ```
 
-Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. `gh-stack` v0.0.8+ uses GitHub's public Stacks REST API and supports the normal GitHub CLI authentication sources, including `GH_TOKEN`/`GITHUB_TOKEN`. For older link-capable versions, stax strips those overrides before `gh stack` operations so the extension can fall back to an OAuth-authenticated `gh` login. `st doctor` always shows the installed version, marks anything below v0.0.8 as out of date, and can upgrade it with `st doctor --fix`. `st stack unlink` delegates to `gh stack unstack`, so stacks that stax registered with `gh stack link` may need `gh stack checkout <pr>` first to create gh-stack's local tracking; otherwise remove the native stack in the GitHub UI.
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. `gh-stack` v0.0.8+ uses GitHub's public Stacks REST API and supports the normal GitHub CLI authentication sources, including `GH_TOKEN`/`GITHUB_TOKEN`. For older link-capable versions, stax strips those overrides before `gh stack` operations so the extension can fall back to an OAuth-authenticated `gh` login. `st doctor` always shows the installed version, marks anything below v0.0.8 as out of date, and can upgrade it with `st doctor --fix`. `st stack unlink <stack-number>` removes a native stack remotely without local gh-stack tracking; argument-free `st stack unlink` retains the active locally tracked behavior.
 
 → [Native GitHub Stacks guide](docs/integrations/github-native-stacks.md)
 

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -31,7 +31,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 |---|---|
 | `st ss` | Submit the whole stack — open or update linked PRs |
 | `st stack link` | Register the current PR stack as a native GitHub Stack when `gh-stack` is available |
-| `st stack unlink` | Unstack a locally tracked native GitHub Stack; stax-linked stacks may require `gh stack checkout <pr>` first |
+| `st stack unlink [<stack-number>]` | Unstack a remote native Stack by number, or the active locally tracked stack when omitted |
 | `st branch submit` | Submit only the current branch; if its parent is already synced to the remote, Stax may publish a temporary rebased head without moving your local branch |
 | `st upstack submit` | Submit current branch and descendants; descendants are temporarily chained onto any temporary parent publish heads |
 | `st draft [branch]` | Convert the current (or named) branch's PR to draft |
@@ -47,7 +47,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 
 Scoped submit keeps local branch metadata unchanged when it prepares a temporary publish head. Plain `git commit` work on the branch is included; `st restack` remains the command that updates local branch tips and parent revisions.
 
-On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change. `gh-stack` v0.0.8+ supports normal GitHub CLI authentication, including token environment variables; stax keeps its token-stripping OAuth fallback only for known older versions. `st doctor` always reports the installed version and marks versions below v0.0.8 as out of date. `st stack unlink` delegates to `gh stack unstack`, which only works for stacks gh-stack tracks locally; if stax registered the stack, run `gh stack checkout <pr>` first or remove the native stack in the GitHub UI. See [Native GitHub Stacked PRs](../integrations/github-native-stacks.md).
+On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register the submitted PRs with GitHub via `gh stack link` when the `github/gh-stack` extension is installed. Repos without access or users without the extension keep the normal stax stack links and see no behavior change. `gh-stack` v0.0.8+ supports normal GitHub CLI authentication, including token environment variables; stax keeps its token-stripping OAuth fallback only for known older versions. `st doctor` always reports the installed version and marks versions below v0.0.8 as out of date. `st stack unlink <stack-number>` delegates to v0.0.8's remote unstack operation without requiring local tracking; omit the number to target the active locally tracked stack. See [Native GitHub Stacked PRs](../integrations/github-native-stacks.md).
 
 ## Sync, restack, update
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -21,7 +21,7 @@ st --trace status --json >/dev/null
 | `st log` | `l` | Show stack with commits and PR info |
 | `st submit` | `ss` | Submit full current stack |
 | `st stack link` | | Register the current PR stack as a native GitHub Stack via `gh stack link` |
-| `st stack unlink` | | Unstack a locally tracked native GitHub Stack via `gh stack unstack`; stax-linked stacks may require `gh stack checkout <pr>` first |
+| `st stack unlink [<stack-number>]` | | Unstack a remote native Stack by number, or the active locally tracked stack when omitted |
 | `st merge` | | Cascade-merge from bottom to current (see flags below) |
 | `st merge-when-ready` | `mwr` | Backward-compatible alias for `st merge --when-ready` |
 | `st sync` | `rs` | Pull trunk, delete merged branches (incl. squash merges), reparent children |

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -88,12 +88,12 @@ stax's own PR body/comment stack links (see [`stack_links`](../configuration/ind
 
 ```bash
 st stack link
-st stack unlink
+st stack unlink [<stack-number>]
 ```
 
 Use `st stack link` to register the current stack manually (requires at least two PRs).
 
-`st stack unlink` calls `gh stack unstack`, which only operates on a stack that gh-stack tracks locally. Because stax registers stacks with `gh stack link` (which does **not** create local tracking), `st stack unlink` cannot remove a stax-registered stack directly — it reports that the current branch is not part of a tracked stack. To remove such a stack, run `gh stack checkout <pr>` to adopt it locally first, then `gh stack unstack`, or remove it from the GitHub PR UI.
+`st stack unlink <stack-number>` calls `gh stack unstack <stack-number>` and removes that native Stack remotely from anywhere in the repository, without requiring gh-stack local tracking. The number is the repository-scoped identifier shown in GitHub's Stack UI. With no number, `st stack unlink` keeps gh-stack's active-stack behavior and requires the current branch to belong to a locally tracked stack.
 
 ## Submit overrides
 

--- a/skills.md
+++ b/skills.md
@@ -26,7 +26,7 @@ stax gui [path]                # Launch fresh native macOS GUI preview for one r
 
 stax submit|ss                 # Submit full stack
 stax stack link                # Register current PR stack as native GitHub Stack (GitHub + gh-stack)
-stax stack unlink              # Unstack locally tracked native stack; stax-linked stacks may need gh stack checkout <pr>
+stax stack unlink <stack-number> # Unstack a native GitHub Stack remotely; omit number for active local tracking
 stax merge                     # Merge PRs from stack bottom upward
 stax sync|rs                   # Sync trunk + clean merged branches
 stax sweep                     # Classify + optionally delete merged/gone/stale branches

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1437,8 +1437,12 @@ pub(crate) enum StackCommands {
     /// Register the current stack as a native GitHub Stack via `gh stack`
     Link,
 
-    /// Unstack a locally tracked native GitHub Stack via `gh stack`
-    Unlink,
+    /// Unstack a native GitHub Stack via `gh stack`
+    Unlink {
+        /// Repository-scoped GitHub native stack number
+        #[arg(value_parser = clap::value_parser!(u64).range(1..))]
+        stack_number: Option<u64>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -741,7 +741,7 @@ pub fn run() -> Result<()> {
                 submit_after.into(),
             ),
             StackCommands::Link => commands::stack_cmd::run_link(),
-            StackCommands::Unlink => commands::stack_cmd::run_unlink(),
+            StackCommands::Unlink { stack_number } => commands::stack_cmd::run_unlink(stack_number),
         },
         // Hidden shortcuts
         Commands::Bc {

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -88,7 +88,7 @@ pub fn run_link() -> Result<()> {
     }
 }
 
-pub fn run_unlink() -> Result<()> {
+pub fn run_unlink(stack_number: Option<u64>) -> Result<()> {
     let repo = GitRepo::open()?;
     let config = Config::load()?;
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
@@ -100,7 +100,7 @@ pub fn run_unlink() -> Result<()> {
     }
     ensure_gh_stack_extension()?;
 
-    match gh_stack::unlink_stack() {
+    match gh_stack::unlink_stack(stack_number) {
         LinkOutcome::Linked => {
             println!("{}", "✓ Native GitHub Stack removed".green());
             Ok(())
@@ -128,9 +128,9 @@ pub fn run_unlink() -> Result<()> {
             if message.to_lowercase().contains("not part of a stack") {
                 anyhow::bail!(
                     "No locally-tracked native stack for the current branch. Native stacks that \
-                     stax registers via `gh stack link` are not tracked locally, so `gh stack \
-                     unstack` cannot remove them. Run `gh stack checkout <pr>` to adopt the stack \
-                     locally first, or remove the stack from the GitHub PR UI."
+                     stax registers via `gh stack link` are not tracked locally. Run `st stack \
+                     unlink <stack-number>` to remove one remotely, or remove it from the GitHub \
+                     PR UI."
                 );
             }
             anyhow::bail!("Failed to remove native GitHub Stack: {message}");

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -297,12 +297,18 @@ pub fn install_extension() -> Result<()> {
     install_extension_with_env(&[])
 }
 
-pub fn unlink_stack() -> LinkOutcome {
-    unlink_stack_with_env(&[])
+pub fn unlink_stack(stack_number: Option<u64>) -> LinkOutcome {
+    unlink_stack_with_env(stack_number, &[])
 }
 
-pub fn unlink_stack_with_env(env: &[(&str, &str)]) -> LinkOutcome {
-    match gh_stack_command(env).args(["stack", "unstack"]).output() {
+pub fn unlink_stack_with_env(stack_number: Option<u64>, env: &[(&str, &str)]) -> LinkOutcome {
+    let mut command = gh_stack_command(env);
+    command.args(["stack", "unstack"]);
+    if let Some(stack_number) = stack_number {
+        command.arg(stack_number.to_string());
+    }
+
+    match command.output() {
         Ok(output) if output.status.success() => LinkOutcome::Linked,
         Ok(output) if auth_token_unsupported_output(&output) => LinkOutcome::AuthTokenUnsupported {
             message: command_message(&output),

--- a/tests/command_coverage_tests.rs
+++ b/tests/command_coverage_tests.rs
@@ -201,7 +201,7 @@ fn documented_cli_commands_and_aliases_resolve_from_help() {
 }
 
 #[test]
-fn docs_clarify_stack_unlink_requires_gh_stack_local_tracking() {
+fn docs_cover_numbered_remote_and_active_local_stack_unlink() {
     let docs = [
         ("README.md", include_str!("../README.md")),
         (
@@ -217,14 +217,14 @@ fn docs_clarify_stack_unlink_requires_gh_stack_local_tracking() {
 
     for (path, content) in docs {
         assert!(
-            !content.contains("Remove native GitHub Stack object")
-                && !content.contains("remove the native GitHub Stack object")
-                && !content.contains("Remove the native GitHub Stack object"),
-            "{path} should not imply `st stack unlink` directly removes every native GitHub Stack object"
+            content.contains("stack unlink <stack-number>")
+                || content.contains("stack unlink [<stack-number>]")
+                || content.contains("stack unlink 7"),
+            "{path} should document numbered remote `st stack unlink`"
         );
         assert!(
-            content.contains("gh stack checkout <pr>") || content.contains("locally tracked"),
-            "{path} should mention gh-stack local tracking or `gh stack checkout <pr>` for `st stack unlink`"
+            content.contains("locally tracked") || content.contains("active local"),
+            "{path} should retain the argument-free active local behavior"
         );
     }
 }

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -683,12 +683,15 @@ exit 1
     let env_dump_file = fake.path().join("unlink-env.txt");
     let path = path_with_fake_gh(fake.path());
 
-    let outcome = stax::github::gh_stack::unlink_stack_with_env(&[
-        ("PATH", path.as_str()),
-        ("ENV_DUMP_FILE", env_dump_file.to_str().unwrap()),
-        ("GH_TOKEN", "ghp_should_be_stripped"),
-        ("GITHUB_TOKEN", "github_should_be_stripped"),
-    ]);
+    let outcome = stax::github::gh_stack::unlink_stack_with_env(
+        None,
+        &[
+            ("PATH", path.as_str()),
+            ("ENV_DUMP_FILE", env_dump_file.to_str().unwrap()),
+            ("GH_TOKEN", "ghp_should_be_stripped"),
+            ("GITHUB_TOKEN", "github_should_be_stripped"),
+        ],
+    );
 
     assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
     assert_eq!(
@@ -1097,6 +1100,90 @@ exit 1
     assert!(
         !stderr.contains("should not be called"),
         "must not shell out to gh-stack when the extension isn't installed, stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn stack_unlink_passes_stack_number_to_gh_stack() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.96.0"; exit 0 ;;
+  "extension list") echo "gh stack github/gh-stack v0.0.8"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack unstack") printf '%s\n' "$@" > "$GH_ARGS_FILE"; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("numbered-unlink-args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["stack", "unlink", "7"],
+        &[
+            ("HOME", &home),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    assert_eq!(
+        fs::read_to_string(args_file).unwrap(),
+        "stack\nunstack\n7\n"
+    );
+}
+
+#[test]
+fn stack_unlink_without_number_keeps_active_stack_behavior() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.96.0"; exit 0 ;;
+  "extension list") echo "gh stack github/gh-stack v0.0.8"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack unstack") printf '%s\n' "$@" > "$GH_ARGS_FILE"; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+    let args_file = fake.path().join("active-unlink-args.txt");
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(
+        &["stack", "unlink"],
+        &[
+            ("HOME", &home),
+            ("PATH", &path),
+            ("GH_ARGS_FILE", args_file.to_str().unwrap()),
+        ],
+    );
+
+    output.assert_success();
+    assert_eq!(fs::read_to_string(args_file).unwrap(), "stack\nunstack\n");
+}
+
+#[test]
+fn stack_unlink_rejects_zero_stack_number_before_calling_gh() {
+    let repo = TestRepo::new();
+    let output = repo.run_stax(&["stack", "unlink", "0"]);
+
+    assert!(!output.status.success());
+    assert!(
+        TestRepo::stderr(&output).contains("0"),
+        "expected invalid stack-number diagnostic, stderr was:\n{}",
+        TestRepo::stderr(&output)
     );
 }
 


### PR DESCRIPTION
## Motivation

gh-stack v0.0.8 adds `gh stack unstack <stack-number>`, allowing a native Stack to be removed remotely even when gh-stack has no active local tracking for it.

## Description of changes / notes for reviewers

- Accept an optional positive Stack number in `st stack unlink`.
- Forward numbered requests to `gh stack unstack <stack-number>` while preserving the existing argument-free active-stack behavior.
- Replace the local-tracking dead end with actionable numbered-unstack guidance.
- Update command documentation and cover numbered, argument-free, missing-extension, and invalid-zero paths.

## Verification

- `make lint`
- `make test` — 2,119 passed on the stack tip

## Stack

2 of 3. Depends on #667; followed by #669.
