### PR TITLE
fix: handle append-only native stack updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ gh extension install github/gh-stack
 st doctor --fix
 ```
 
-That's it — no config needed. From then on, `st ss`/`st bs` auto-link multi-PR stacks under the hood, no extra command required. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top.
+That's it — no config needed. From then on, `st ss`/`st bs` auto-link multi-PR stacks under the hood, no extra command required. Existing stax PR body/comment stack links keep working; the native GitHub stack map is added on top. On gh-stack v0.0.8+, stax also prints the repository-scoped Stack number returned by GitHub.
 
 ```bash
 st ss                    # auto-links native stack when available
@@ -228,7 +228,7 @@ st stack link            # manually re-link the current stack
 st stack unlink 7        # unstack native Stack #7 remotely
 ```
 
-Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. `gh-stack` v0.0.8+ uses GitHub's public Stacks REST API and supports the normal GitHub CLI authentication sources, including `GH_TOKEN`/`GITHUB_TOKEN`. For older link-capable versions, stax strips those overrides before `gh stack` operations so the extension can fall back to an OAuth-authenticated `gh` login. `st doctor` always shows the installed version, marks anything below v0.0.8 as out of date, and can upgrade it with `st doctor --fix`. `st stack unlink <stack-number>` removes a native stack remotely without local gh-stack tracking; argument-free `st stack unlink` retains the active locally tracked behavior.
+Repos without the feature, users without the extension, and non-GitHub remotes keep the existing stax behavior — this is purely additive and never blocks a submit. `gh-stack` v0.0.8+ uses GitHub's public Stacks REST API and supports the normal GitHub CLI authentication sources, including `GH_TOKEN`/`GITHUB_TOKEN`. For older link-capable versions, stax strips those overrides before `gh stack` operations so the extension can fall back to an OAuth-authenticated `gh` login. `st doctor` always shows the installed version, marks anything below v0.0.8 as out of date, and can upgrade it with `st doctor --fix`. Native Stack updates are append-only; to remove or insert PRs, run `st stack unlink <stack-number>` and then link again. Argument-free `st stack unlink` retains the active locally tracked behavior.
 
 → [Native GitHub Stacks guide](docs/integrations/github-native-stacks.md)
 

--- a/docs/integrations/github-native-stacks.md
+++ b/docs/integrations/github-native-stacks.md
@@ -41,7 +41,7 @@ stax still owns local stack management: branch creation, parent metadata, restac
 gh stack link <pr> [<next-pr> ...] --base <trunk> --remote <remote>
 ```
 
-That registers one or more already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order and keeps its own body/comment stack links unless you opt out.
+That registers one or more already-submitted PRs as a native GitHub Stack. stax passes PR numbers in bottom-to-top order, keeps its own body/comment stack links unless you opt out, and shows the repository-scoped Stack number when gh-stack returns it.
 
 <a id="default-behavior"></a>
 ## Default behavior
@@ -83,6 +83,17 @@ Where a base change to trunk is a hard precondition — merging a single PR out 
 GitHub's native Stack feature can only represent a single straight line of PRs. If a branch in your local stack has two or more children (e.g. `test-3` has both `test-4` and `test-3-1` branching off it), stax detects that fork itself and skips native registration for that submit, printing a `note:` instead — it never hands `gh stack link` a branch set that doesn't form a real linear chain. This matters because gh-stack doesn't reliably reject forked input: it sometimes does (surfacing as a `409`/`422` from GitHub), but it can also silently accept it and linearize the PRs in whatever order it was given, which would misrepresent which branch each PR actually builds on.
 
 stax's own PR body/comment stack links (see [`stack_links`](../configuration/index.md)) have no such limitation and continue to render forked stacks correctly, with sibling branches indented at the same depth. Run `st stack unlink` on one side of the fork if you need that side registered as its own native stack.
+
+## Native Stack updates are append-only
+
+GitHub only lets `gh stack link` add new PRs at the top of an existing native Stack. An update that would remove a PR or insert one elsewhere is rejected. stax reports this separately from a forked-stack conflict and includes the recovery command:
+
+```bash
+st stack unlink <stack-number>
+st stack link
+```
+
+When gh-stack includes the Stack number in its output, stax prints that number and substitutes it into the unlink command. Automatic registration during `st submit` remains non-blocking: it prints the same recovery note, keeps the existing stax PR links, and completes the submit.
 
 ## Manual commands
 

--- a/skills.md
+++ b/skills.md
@@ -252,7 +252,11 @@ stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment l
 # CLI authentication, including GH_TOKEN/GITHUB_TOKEN. For known older versions,
 # stax strips those overrides before `gh stack` and falls back to a keyring OAuth
 # account. `stax doctor` always shows the installed version, marks anything below
-# v0.0.8 as out of date, and probes legacy OAuth only when token overrides exist.
+# v0.0.8 as out of date, can upgrade it with `stax doctor --fix`, and probes
+# legacy OAuth only when token overrides exist.
+# Native GitHub Stack updates are append-only. If relinking would remove or insert
+# a PR, run `stax stack unlink <stack-number>` and then `stax stack link` again.
+# stax prints the repository-scoped Stack number when gh-stack returns it.
 # Once linked, GitHub owns base-branch transitions for those PRs and rejects
 # any PATCH touching `base` ("...part of a stack"). stax treats this as
 # non-fatal in submit/merge cascade retargets (prints a note, continues);

--- a/src/commands/stack_cmd.rs
+++ b/src/commands/stack_cmd.rs
@@ -47,12 +47,20 @@ pub fn run_link() -> Result<()> {
     }
 
     match gh_stack::link_stack(&pr_numbers, &stack.trunk, &remote_info.name) {
-        LinkOutcome::Linked => {
+        LinkOutcome::Linked { stack_number } => {
             gh_stack::set_feature_enabled(repo.workdir()?, true)?;
+            let stack_label = stack_number
+                .map(|number| format!(" #{}", number))
+                .unwrap_or_default();
             println!(
                 "{} {}",
                 "✓".green(),
-                format!("Linked {} PRs as a native GitHub Stack", pr_numbers.len()).dimmed()
+                format!(
+                    "Linked {} PRs as a native GitHub Stack{}",
+                    pr_numbers.len(),
+                    stack_label
+                )
+                .dimmed()
             );
             Ok(())
         }
@@ -71,6 +79,19 @@ pub fn run_link() -> Result<()> {
         }
         LinkOutcome::SinglePrValidationRejected { message } => {
             anyhow::bail!("GitHub rejected the native Stack link: {message}");
+        }
+        LinkOutcome::NonAppendUpdate {
+            message,
+            stack_number,
+        } => {
+            let unlink_command = stack_number
+                .map(|number| format!("`st stack unlink {number}`"))
+                .unwrap_or_else(|| "`st stack unlink <stack-number>`".to_string());
+            anyhow::bail!(
+                "GitHub native Stack updates are append-only. Remove the remote Stack with \
+                 {unlink_command}, then run `st stack link` again.\n\n\
+                 gh-stack said: {message}"
+            );
         }
         LinkOutcome::Failed { message } => {
             if gh_stack::is_stack_fork_conflict(&message) {
@@ -101,7 +122,7 @@ pub fn run_unlink(stack_number: Option<u64>) -> Result<()> {
     ensure_gh_stack_extension()?;
 
     match gh_stack::unlink_stack(stack_number) {
-        LinkOutcome::Linked => {
+        LinkOutcome::Linked { .. } => {
             println!("{}", "✓ Native GitHub Stack removed".green());
             Ok(())
         }
@@ -119,6 +140,9 @@ pub fn run_unlink(stack_number: Option<u64>) -> Result<()> {
         }
         LinkOutcome::SinglePrValidationRejected { message } => {
             anyhow::bail!("GitHub rejected the native Stack unlink: {message}");
+        }
+        LinkOutcome::NonAppendUpdate { message, .. } => {
+            anyhow::bail!("Failed to remove native GitHub Stack: {message}");
         }
         LinkOutcome::Failed { message } => {
             // `gh stack unstack` operates on a locally-tracked stack, but stacks

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -2614,10 +2614,13 @@ fn maybe_link_native_stack(
     }
 
     match gh_stack::link_stack(&pr_numbers, trunk, &remote_info.name) {
-        LinkOutcome::Linked => {
+        LinkOutcome::Linked { stack_number } => {
             gh_stack::set_feature_enabled(workdir, true)?;
             if !quiet {
-                println!("{} {}", "✓".green(), "Native GitHub Stack linked".dimmed());
+                let message = stack_number
+                    .map(|number| format!("Native GitHub Stack #{number} linked"))
+                    .unwrap_or_else(|| "Native GitHub Stack linked".to_string());
+                println!("{} {}", "✓".green(), message.dimmed());
             }
             Ok(true)
         }
@@ -2642,6 +2645,22 @@ fn maybe_link_native_stack(
             Ok(false)
         }
         LinkOutcome::SinglePrValidationRejected { .. } => Ok(false),
+        LinkOutcome::NonAppendUpdate {
+            message,
+            stack_number,
+        } => {
+            if !quiet {
+                let unlink_command = stack_number
+                    .map(|number| format!("`st stack unlink {number}`"))
+                    .unwrap_or_else(|| "`st stack unlink <stack-number>`".to_string());
+                let note = format!(
+                    "native GitHub Stack link skipped: remote Stack updates are append-only. \
+                     Remove it with {unlink_command}, then retry. gh-stack said: {message}"
+                );
+                println!("  {} {}", "note:".dimmed(), note.dimmed());
+            }
+            Ok(false)
+        }
         LinkOutcome::Failed { message } => {
             if !quiet {
                 let note = if gh_stack::is_stack_fork_conflict(&message) {

--- a/src/github/gh_stack.rs
+++ b/src/github/gh_stack.rs
@@ -49,7 +49,9 @@ pub enum FeatureState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LinkOutcome {
-    Linked,
+    Linked {
+        stack_number: Option<u64>,
+    },
     FeatureDisabled {
         message: String,
     },
@@ -64,6 +66,12 @@ pub enum LinkOutcome {
     },
     SinglePrValidationRejected {
         message: String,
+    },
+    /// The remote stack exists, but gh-stack v0.0.8 only permits appending new
+    /// PRs at its top. Removing or inserting PRs requires unstacking it first.
+    NonAppendUpdate {
+        message: String,
+        stack_number: Option<u64>,
     },
     Failed {
         message: String,
@@ -266,7 +274,9 @@ pub fn link_stack_with_env(
     command.args(["--base", base, "--remote", remote]);
 
     match command.output() {
-        Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if output.status.success() => LinkOutcome::Linked {
+            stack_number: stack_number_from_message(&output_details(&output)),
+        },
         // Must be checked before `feature_disabled_output`: gh-stack's PAT
         // rejection message also contains "private preview", which would
         // otherwise be misclassified as the repo/org lacking the feature.
@@ -281,6 +291,10 @@ pub fn link_stack_with_env(
                 message: command_message(&output),
             }
         }
+        Ok(output) if non_append_update_output(&output) => LinkOutcome::NonAppendUpdate {
+            stack_number: stack_number_from_message(&output_details(&output)),
+            message: command_message(&output),
+        },
         Ok(output) => LinkOutcome::Failed {
             message: command_message(&output),
         },
@@ -309,7 +323,7 @@ pub fn unlink_stack_with_env(stack_number: Option<u64>, env: &[(&str, &str)]) ->
     }
 
     match command.output() {
-        Ok(output) if output.status.success() => LinkOutcome::Linked,
+        Ok(output) if output.status.success() => LinkOutcome::Linked { stack_number: None },
         Ok(output) if auth_token_unsupported_output(&output) => LinkOutcome::AuthTokenUnsupported {
             message: command_message(&output),
         },
@@ -410,19 +424,38 @@ fn auth_token_unsupported_output(output: &Output) -> bool {
 /// linear — a PR can only anchor one native-stack "tip" at a time — so this
 /// fires whenever a *local* stack forks (two branches created off the same
 /// ancestor branch each try to register their own native Stack). gh-stack
-/// surfaces this in a couple of different shapes depending on whether it
-/// detects the conflict up front or only after attempting a reorder:
-///   - `"Cannot update stack: this would remove #123 from the stack"`
-///   - `"Failed to update stack (HTTP 409): Stack contents have changed"`
-///     (seen alongside a `422 PullRequest.base is invalid` on the branch
-///     gh-stack tried to reparent to fit its assumed linear order)
-///
-/// Both are surfaced as the same plain-language note instead of the raw
-/// multi-line CLI dump.
+/// surfaces this as `"Stack contents have changed"` after attempting a
+/// reorder. Append-only update errors are classified separately because they
+/// can be recovered from by unstacking the known remote stack number.
 pub(crate) fn is_stack_fork_conflict(message: &str) -> bool {
-    let lower = message.to_lowercase();
+    message
+        .to_lowercase()
+        .contains("stack contents have changed")
+}
+
+fn non_append_update_output(output: &Output) -> bool {
+    let lower = command_message(output).to_lowercase();
     (lower.contains("would remove") && lower.contains("from the stack"))
-        || lower.contains("stack contents have changed")
+        || lower.contains("must be added to the top")
+}
+
+fn stack_number_from_message(message: &str) -> Option<u64> {
+    let lower = message.to_ascii_lowercase();
+    let mut remainder = lower.as_str();
+
+    while let Some(index) = remainder.find("stack #") {
+        let after_marker = &remainder[index + "stack #".len()..];
+        let digits: String = after_marker
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if let Ok(number) = digits.parse() {
+            return Some(number);
+        }
+        remainder = after_marker;
+    }
+
+    None
 }
 
 fn single_pr_validation_output(pr_numbers: &[u64], output: &Output) -> bool {

--- a/tests/gh_stack_tests.rs
+++ b/tests/gh_stack_tests.rs
@@ -622,7 +622,10 @@ exit 1
         ],
     );
 
-    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    assert_eq!(
+        outcome,
+        stax::github::gh_stack::LinkOutcome::Linked { stack_number: None }
+    );
     let dump = fs::read_to_string(env_dump_file).expect("env dump written");
     assert_eq!(dump, "GH_TOKEN=unset\nGITHUB_TOKEN=unset\n");
 }
@@ -659,7 +662,10 @@ exit 1
         ],
     );
 
-    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    assert_eq!(
+        outcome,
+        stax::github::gh_stack::LinkOutcome::Linked { stack_number: None }
+    );
     assert_eq!(
         fs::read_to_string(env_dump_file).unwrap(),
         "GH_TOKEN=ghp_current\nGITHUB_TOKEN=github_current\n"
@@ -693,7 +699,10 @@ exit 1
         ],
     );
 
-    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    assert_eq!(
+        outcome,
+        stax::github::gh_stack::LinkOutcome::Linked { stack_number: None }
+    );
     assert_eq!(
         fs::read_to_string(env_dump_file).unwrap(),
         "GH_TOKEN=unset\nGITHUB_TOKEN=unset\n"
@@ -787,7 +796,10 @@ exit 0
         ],
     );
 
-    assert_eq!(outcome, stax::github::gh_stack::LinkOutcome::Linked);
+    assert_eq!(
+        outcome,
+        stax::github::gh_stack::LinkOutcome::Linked { stack_number: None }
+    );
     let args = fs::read_to_string(args_file).expect("args written");
     assert_eq!(
         args,
@@ -1367,14 +1379,12 @@ exit 1
     );
 }
 
-/// The fake `gh stack link` response gh-stack gives when a local stack has
-/// forked: another branch sharing the same ancestor PRs already anchors a
-/// native GitHub Stack, and GitHub's native Stack feature only supports one
-/// linear chain at a time.
-const FORK_CONFLICT_GH_STACK_SCRIPT: &str = r#"#!/bin/sh
+/// gh-stack v0.0.8 only permits additive updates. Omitting an existing PR is
+/// a remote-stack divergence, not proof that the local stack has forked.
+const NON_APPEND_GH_STACK_SCRIPT: &str = r#"#!/bin/sh
 case "$1 $2" in
   "--version "*) echo "gh version 2.71.0"; exit 0 ;;
-  "extension list") echo "gh-stack github/gh-stack v0.0.7"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.8"; exit 0 ;;
   "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
   "stack link")
     {
@@ -1391,7 +1401,7 @@ exit 1
 "#;
 
 #[tokio::test]
-async fn submit_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump() {
+async fn submit_explains_append_only_native_stack_conflict() {
     let mock_server = MockServer::start().await;
 
     let repo = TestRepo::new_with_remote();
@@ -1407,7 +1417,7 @@ async fn submit_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_du
     mock_existing_pr(&mock_server, 10, &branches[0], "main").await;
     mock_existing_pr(&mock_server, 20, &branches[1], &branches[0]).await;
 
-    let fake = fake_gh_dir(FORK_CONFLICT_GH_STACK_SCRIPT);
+    let fake = fake_gh_dir(NON_APPEND_GH_STACK_SCRIPT);
     let path = path_with_fake_gh(fake.path());
 
     let output = repo.run_stax_with_env(
@@ -1422,12 +1432,12 @@ async fn submit_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_du
     output.assert_success();
     let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("this stack has forked"),
-        "expected a plain-language fork-conflict note, stdout was:\n{stdout}"
+        stdout.contains("append-only") && stdout.contains("st stack unlink <stack-number>"),
+        "expected append-only recovery guidance, stdout was:\n{stdout}"
     );
     assert!(
-        !stdout.contains("Include all existing PRs"),
-        "the raw multi-line gh-stack dump should not leak to the user, stdout was:\n{stdout}"
+        !stdout.contains("this stack has forked"),
+        "append-only divergence must not be mislabeled as a fork, stdout was:\n{stdout}"
     );
 
     // Non-fatal: the fork conflict must not have blocked native-stack
@@ -1436,13 +1446,13 @@ async fn submit_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_du
     let feature_cache = repo.git(&["config", "--get", "stax.nativeStack.enabled"]);
     assert!(
         !feature_cache.status.success(),
-        "a forked-stack conflict must not be cached as feature-disabled, but got: {}",
+        "append-only divergence must not be cached as feature-disabled, but got: {}",
         TestRepo::stdout(&feature_cache)
     );
 }
 
 #[test]
-fn stack_link_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump() {
+fn stack_link_explains_append_only_native_stack_conflict() {
     let repo = TestRepo::new_with_remote();
     let home = repo.clean_home();
     repo.configure_github_like_submit_remote();
@@ -1451,23 +1461,86 @@ fn stack_link_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump
     write_branch_pr_metadata(&repo, &branches[0], "main", 10);
     write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
 
-    let fake = fake_gh_dir(FORK_CONFLICT_GH_STACK_SCRIPT);
+    let fake = fake_gh_dir(NON_APPEND_GH_STACK_SCRIPT);
     let path = path_with_fake_gh(fake.path());
 
     let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
 
-    assert!(
-        !output.status.success(),
-        "linking a forked stack should fail"
-    );
+    assert!(!output.status.success(), "a non-append update should fail");
     let stderr = TestRepo::stderr(&output);
     assert!(
-        stderr.contains("shares ancestor PRs") && stderr.contains("stax stack unlink"),
-        "expected a plain-language fork-conflict explanation with unlink guidance, stderr was:\n{stderr}"
+        stderr.contains("append-only") && stderr.contains("st stack unlink <stack-number>"),
+        "expected append-only recovery guidance, stderr was:\n{stderr}"
     );
     assert!(
-        stderr.contains("would remove #999"),
-        "the underlying gh-stack detail should still be included for debugging, stderr was:\n{stderr}"
+        !stderr.contains("shares ancestor PRs"),
+        "append-only divergence must not be mislabeled as a fork, stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn stack_link_explains_append_to_top_requirement() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["append-top-link-a", "append-top-link-b"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.96.0"; exit 0 ;;
+  "extension list") echo "gh stack github/gh-stack v0.0.8"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link") echo "Cannot update stack: new PRs must be added to the top of the existing stack" >&2; exit 1 ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+
+    assert!(!output.status.success());
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("append-only") && stderr.contains("st stack unlink <stack-number>"),
+        "expected append-to-top recovery guidance, stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn stack_link_shows_stack_number_from_success_output() {
+    let repo = TestRepo::new_with_remote();
+    let home = repo.clean_home();
+    repo.configure_github_like_submit_remote();
+    repo.run_stax(&["init", "--trunk", "main"]).assert_success();
+    let branches = repo.create_stack(&["number-link-a", "number-link-b"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 20);
+
+    let fake = fake_gh_dir(
+        r#"#!/bin/sh
+case "$1 $2" in
+  "--version "*) echo "gh version 2.96.0"; exit 0 ;;
+  "extension list") echo "gh stack github/gh-stack v0.0.8"; exit 0 ;;
+  "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
+  "stack link") echo "Updated stack to 2 PRs (stack #7)"; exit 0 ;;
+esac
+exit 1
+"#,
+    );
+    let path = path_with_fake_gh(fake.path());
+
+    let output = repo.run_stax_with_env(&["stack", "link"], &[("HOME", &home), ("PATH", &path)]);
+
+    output.assert_success();
+    assert!(
+        TestRepo::stdout(&output).contains("Linked 2 PRs as a native GitHub Stack #7"),
+        "explicit link should show the stack number, stdout was:\n{}",
+        TestRepo::stdout(&output)
     );
 }
 
@@ -1475,7 +1548,7 @@ fn stack_link_explains_forked_native_stack_conflict_instead_of_raw_gh_stack_dump
 /// forked stack up front and instead attempts to reorder PRs to fit its
 /// assumed linear chain, which fails once it hits a branch it can't
 /// reparent — a real-world variant of the same forked-stack limitation as
-/// `FORK_CONFLICT_GH_STACK_SCRIPT` above, but with different wording.
+/// the former removal wording above, but this remains a distinct conflict.
 const FORK_CONFLICT_REORDER_GH_STACK_SCRIPT: &str = r#"#!/bin/sh
 case "$1 $2" in
   "--version "*) echo "gh version 2.71.0"; exit 0 ;;
@@ -1680,10 +1753,11 @@ async fn submit_auto_registers_native_stack_and_keeps_stax_links() {
         r#"#!/bin/sh
 case "$1 $2" in
   "--version "*) echo "gh version 2.71.0"; exit 0 ;;
-  "extension list") echo "gh-stack github/gh-stack v0.0.6"; exit 0 ;;
+  "extension list") echo "gh-stack github/gh-stack v0.0.8"; exit 0 ;;
   "stack --help") printf 'Remote operations:\n  link  Link PRs into a stack on GitHub\n'; exit 0 ;;
   "stack link")
     printf '%s\n' "$@" >> "$GH_ARGS_FILE"
+    echo "Created stack with 2 PRs (stack #7)"
     exit 0
     ;;
 esac
@@ -1704,6 +1778,11 @@ exit 1
     );
 
     output.assert_success();
+    assert!(
+        TestRepo::stdout(&output).contains("Native GitHub Stack #7 linked"),
+        "submit should show the native stack number, stdout was:\n{}",
+        TestRepo::stdout(&output)
+    );
     let args = fs::read_to_string(&args_file).expect("gh stack link args written");
     assert_eq!(
         args,


### PR DESCRIPTION
## Motivation

gh-stack v0.0.8 only permits updates that append PRs to the top of an existing native Stack. Stax previously mislabeled removal conflicts as forked stacks and discarded the repository-scoped Stack number returned on success.

## Description of changes / notes for reviewers

- Classify append-only update failures separately from genuine fork/reorder conflicts.
- Show `st stack unlink <stack-number>` recovery guidance without blocking normal submit behavior.
- Parse and display the Stack number returned by successful explicit and automatic links.
- Document the append-only model and cover removal, top-only, success-number, fallback, and real-fork cases.

## Verification

- `make lint`
- `make test` — 2,119 passed

## Stack

3 of 3. Depends on #668.
