### PR TITLE
feat: add --stack to draft and undraft commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ st config --set-ai
 | `st freeze` / `st unfreeze` | Protect/unprotect a tracked branch from restacks, imported-branch refreshes, and squash-merge cleanup rebases |
 | `st completions <shell>` | Generate completions for Bash, Zsh, Fish, PowerShell, or Elvish |
 | `st doctor --fix` | Check repo/config health and apply safe local repairs after one confirmation |
-| `st draft [branch]` / `st undraft [branch]` | Toggle a PR between draft and ready-for-review |
+| `st draft [branch]` / `st draft --stack` / `st undraft [branch]` / `st undraft --stack` | Toggle one PR or every PR in the current stack between draft and ready-for-review |
 | `st pr` / `st pr body` / `st pr list` / `st pr list --ready` / `st issue list` | Open current PR · view/edit PR body · list PRs · PR readiness · list issues |
 
 Full reference: [docs/commands/core.md](docs/commands/core.md) · [docs/commands/reference.md](docs/commands/reference.md)

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -35,7 +35,9 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st branch submit` | Submit only the current branch; if its parent is already synced to the remote, Stax may publish a temporary rebased head without moving your local branch |
 | `st upstack submit` | Submit current branch and descendants; descendants are temporarily chained onto any temporary parent publish heads |
 | `st draft [branch]` | Convert the current (or named) branch's PR to draft |
+| `st draft --stack` | Convert every PR in the current stack to draft |
 | `st undraft [branch]` | Mark the current (or named) branch's PR as ready for review |
+| `st undraft --stack` | Mark every PR in the current stack as ready for review |
 | `st ready` | Open the interactive PR readiness dashboard for all tracked PRs: merge, ping, fix, wait, or draft |
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -146,7 +146,9 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st pr list --ready` | Open live PR readiness for all tracked branch PRs, newest changed PR first (`--current`/`--stack` limits to the current stack, `--plain` prints a table) |
 | `st ready` | Short alias for `st pr list --ready` (`--current`, `--stack`, `--all`, `--plain`, `--json`) |
 | `st draft [branch]` | Mark the current or named branch's PR as a draft |
+| `st draft --stack` | Mark every PR in the current stack as a draft |
 | `st undraft [branch]` | Mark the current or named branch's PR as ready for review |
+| `st undraft --stack` | Mark every PR in the current stack as ready for review |
 | `st issue list` | List open issues |
 | `st comments` / `st reviews` | Show current PR comments; `--stack` or `--all` creates a review inbox, GitHub review comments include inline file/line locations, and `--json` emits a versioned machine-readable view |
 | `st copy` · `st copy --pr` | Copy branch name · PR URL |

--- a/skills.md
+++ b/skills.md
@@ -67,6 +67,10 @@ stax ready --current           # Readiness dashboard for current stack only
 stax ready --stack             # Same as --current
 stax ready --plain             # Static readiness table for captured/non-interactive output
 stax pr list --ready           # Same readiness view under PR list
+stax draft [branch]            # Mark current or named branch PR as draft
+stax draft --stack             # Mark every PR in the current stack as draft
+stax undraft [branch]          # Mark current or named branch PR ready for review
+stax undraft --stack           # Mark every PR in the current stack ready for review
 stax ready --all               # Explicit all tracked branch PRs (default)
 stax issue list                # List open issues
 stax open                      # Open repo in browser

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -824,13 +824,21 @@ pub(crate) enum Commands {
     /// Mark the current (or named) branch's PR as a draft
     Draft {
         /// Branch to operate on (defaults to current)
+        #[arg(conflicts_with = "stack")]
         branch: Option<String>,
+        /// Apply to all PRs in the current stack
+        #[arg(long, conflicts_with = "branch")]
+        stack: bool,
     },
 
     /// Mark the current (or named) branch's PR as ready for review
     Undraft {
         /// Branch to operate on (defaults to current)
+        #[arg(conflicts_with = "stack")]
         branch: Option<String>,
+        /// Apply to all PRs in the current stack
+        #[arg(long, conflicts_with = "branch")]
+        stack: bool,
     },
 
     /// Show PR comments as a current-branch view or stack-wide review inbox

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -494,8 +494,8 @@ pub fn run() -> Result<()> {
             None => print_subcommand_help("issue"),
         },
         Commands::Open => commands::open::run(),
-        Commands::Draft { branch } => commands::draft::run(branch, true),
-        Commands::Undraft { branch } => commands::draft::run(branch, false),
+        Commands::Draft { branch, stack } => commands::draft::run(branch, stack, true),
+        Commands::Undraft { branch, stack } => commands::draft::run(branch, stack, false),
         Commands::Comments {
             plain,
             stack,

--- a/src/commands/draft.rs
+++ b/src/commands/draft.rs
@@ -7,29 +7,29 @@ use crate::remote::RemoteInfo;
 use anyhow::Result;
 use colored::Colorize;
 
-pub fn run(branch: Option<String>, is_draft: bool) -> Result<()> {
+pub fn run(branch: Option<String>, stack: bool, is_draft: bool) -> Result<()> {
     let repo = GitRepo::open()?;
-    let stack = Stack::load(&repo)?;
+    let stack_data = Stack::load(&repo)?;
     let config = Config::load()?;
+    let current = repo.current_branch()?;
 
-    let target = branch.unwrap_or_else(|| repo.current_branch().unwrap_or_default());
-
-    let branch_info = stack.branches.get(&target);
-    if branch_info.is_none() {
-        anyhow::bail!(
-            "Branch '{}' is not tracked. Use {} to track it first.",
-            target,
-            "stax branch track".cyan()
-        );
-    }
-
-    let pr_number = super::resolve_pr::resolve_pr_number(&repo, &stack, &target, &config)?;
-    let Some(pr_number) = pr_number else {
-        anyhow::bail!(
-            "No PR found for branch '{}'. Use {} to create one.",
-            target,
-            "stax submit".cyan()
-        );
+    let branches = if stack {
+        stack_data
+            .current_stack(&current)
+            .into_iter()
+            .filter(|name| name != &stack_data.trunk)
+            .collect::<Vec<_>>()
+    } else {
+        let target = branch.unwrap_or(current);
+        let branch_info = stack_data.branches.get(&target);
+        if branch_info.is_none() {
+            anyhow::bail!(
+                "Branch '{}' is not tracked. Use {} to track it first.",
+                target,
+                "stax branch track".cyan()
+            );
+        }
+        vec![target]
     };
 
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
@@ -37,35 +37,81 @@ pub fn run(branch: Option<String>, is_draft: bool) -> Result<()> {
     let _enter = rt.enter();
     let client = ForgeClient::new(&remote_info)?;
 
+    let mut skipped_without_pr = Vec::new();
+    let mut processed = 0usize;
+
+    for target in branches {
+        let Some(pr_number) =
+            super::resolve_pr::resolve_pr_number(&repo, &stack_data, &target, &config)?
+        else {
+            skipped_without_pr.push(target);
+            continue;
+        };
+
+        process_branch(&repo, &rt, &client, &target, pr_number, is_draft)?;
+        processed += 1;
+    }
+
+    if processed == 0 {
+        anyhow::bail!(
+            "No PRs found in {}. Use {} to create one.",
+            if stack {
+                "the current stack"
+            } else {
+                "this branch"
+            },
+            "stax submit".cyan()
+        );
+    }
+
+    if stack && !skipped_without_pr.is_empty() {
+        eprintln!(
+            "Skipped {} without a PR: {}",
+            skipped_without_pr.len(),
+            skipped_without_pr.join(", ").dimmed()
+        );
+    }
+
+    Ok(())
+}
+
+fn process_branch(
+    repo: &GitRepo,
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    branch: &str,
+    pr_number: u64,
+    is_draft: bool,
+) -> Result<()> {
     let remote_pr = rt.block_on(async { client.get_pr(pr_number).await })?;
 
     if remote_pr.is_draft == is_draft {
-        update_local_pr_metadata(&repo, &target, pr_number, is_draft);
+        update_local_pr_metadata(repo, branch, pr_number, is_draft);
         let state = if is_draft {
             "already a draft"
         } else {
             "already published"
         };
-        println!("PR #{} is {}.", pr_number, state);
+        println!("PR #{} on {} is {}.", pr_number, branch.cyan(), state);
         return Ok(());
     }
 
     rt.block_on(async { client.set_pr_draft(pr_number, is_draft).await })?;
 
-    update_local_pr_metadata(&repo, &target, pr_number, is_draft);
+    update_local_pr_metadata(repo, branch, pr_number, is_draft);
 
     if is_draft {
         println!(
             "PR #{} on {} marked as {}.",
             pr_number.to_string().cyan(),
-            target.cyan(),
+            branch.cyan(),
             "draft".yellow()
         );
     } else {
         println!(
             "PR #{} on {} marked as {}.",
             pr_number.to_string().cyan(),
-            target.cyan(),
+            branch.cyan(),
             "ready for review".green()
         );
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8258,6 +8258,197 @@ mod forge_mock_tests {
         );
     }
 
+    async fn setup_two_branch_stack_with_prs(
+        home: &Path,
+        mock_server: &MockServer,
+    ) -> (TestRepo, String, String) {
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home);
+
+        let output = run_stax_with_env(&repo, home, &["bc", "draft-stack-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home, &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home, &["bc", "draft-stack-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home, &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        write_branch_pr_metadata(&repo, &branch_a, "main", 701, Some(false));
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 702, Some(false));
+
+        mount_github_pr_draft_transition(mock_server, 701, &branch_a, false, true).await;
+        mount_github_pr_draft_transition(mock_server, 702, &branch_b, false, true).await;
+
+        (repo, branch_a, branch_b)
+    }
+
+    #[tokio::test]
+    async fn test_draft_stack_marks_all_stack_prs_as_draft() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let (repo, branch_a, branch_b) =
+            setup_two_branch_stack_with_prs(home.path(), &mock_server).await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["draft", "--stack"]);
+        assert!(
+            output.status.success(),
+            "draft --stack failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let stdout = TestRepo::stdout(&output);
+        assert!(
+            stdout.contains("PR #701"),
+            "expected parent PR output: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("PR #702"),
+            "expected child PR output: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("marked as draft"),
+            "expected draft output: {}",
+            stdout
+        );
+
+        for (branch, pr_number) in [(&branch_a, 701_u64), (&branch_b, 702_u64)] {
+            let metadata_ref = format!("refs/branch-metadata/{}", branch);
+            let metadata_output = repo.git(&["show", &metadata_ref]);
+            assert!(metadata_output.status.success());
+            let metadata: serde_json::Value =
+                serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+            assert_eq!(metadata["prInfo"]["isDraft"], true);
+            assert_eq!(metadata["prInfo"]["number"], pr_number);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_undraft_stack_marks_all_stack_prs_ready() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "undraft-stack-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "undraft-stack-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        write_branch_pr_metadata(&repo, &branch_a, "main", 711, Some(true));
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 712, Some(true));
+
+        mount_github_pr_draft_transition(&mock_server, 711, &branch_a, true, false).await;
+        mount_github_pr_draft_transition(&mock_server, 712, &branch_b, true, false).await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["undraft", "--stack"]);
+        assert!(
+            output.status.success(),
+            "undraft --stack failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let stdout = TestRepo::stdout(&output);
+        assert!(
+            stdout.contains("ready for review"),
+            "expected ready output: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("PR #711"),
+            "expected parent PR output: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains("PR #712"),
+            "expected child PR output: {}",
+            stdout
+        );
+
+        for branch in [&branch_a, &branch_b] {
+            let metadata_ref = format!("refs/branch-metadata/{}", branch);
+            let metadata_output = repo.git(&["show", &metadata_ref]);
+            assert!(metadata_output.status.success());
+            let metadata: serde_json::Value =
+                serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+            assert_eq!(metadata["prInfo"]["isDraft"], false);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_draft_stack_skips_branches_without_prs() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_github_remote(&repo, home.path());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "draft-stack-skip-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "draft-stack-skip-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 721, Some(false));
+        mount_github_pr_draft_transition(&mock_server, 721, &branch_b, false, true).await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["draft", "--stack"]);
+        assert!(
+            output.status.success(),
+            "draft --stack failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+
+        let stderr = TestRepo::stderr(&output);
+        assert!(
+            stderr.contains(&branch_a),
+            "expected skip notice for branch without PR, stderr: {}",
+            stderr
+        );
+        assert!(
+            TestRepo::stdout(&output).contains("PR #721"),
+            "expected child PR to be drafted"
+        );
+    }
+
     #[tokio::test]
     async fn test_submit_with_mock_pr_creation() {
         let (repo, mock_server) = setup_mock_github().await;


### PR DESCRIPTION
## Motivation

`st draft` and `st undraft` only operate on a single branch today. When working on a stack, toggling draft state across every PR means running the command once per branch. This adds a `--stack` flag so both commands can update every PR in the current stack in one shot.

## Description of changes / notes for reviewers

- Add `--stack` to `st draft` and `st undraft` (conflicts with the optional branch positional, same pattern as `st reviews --stack` and `st ci --stack`).
- In stack mode, walk the current stack base→tip, skip trunk, and process each branch that has a PR.
- Branches without a PR are skipped with a stderr notice rather than failing the whole command.
- Fail only when no PRs exist anywhere in the stack.
- Refactor `draft.rs` so single-branch and stack paths share the same remote/local metadata update logic.
- Add integration tests for stack draft, stack undraft, and skip-without-PR behavior.
- Update README, docs, and `skills.md`.

**Usage**

```bash
st draft --stack
st undraft --stack
```

## Test plan

- [x] `cargo nextest run test_draft_stack test_undraft_stack test_undraft_fetches_remote test_undraft_noops`
- [x] `make lint-fast`