### PR TITLE
ci: drop main-branch GUI packaging job

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -34,9 +34,6 @@ jobs:
               - 'src/**'
               - 'crates/stax-gui/**'
               - 'scripts/build-gui**'
-              - 'scripts/package-gui**'
-              - 'scripts/gui-app-tests.sh'
-              - 'scripts/gui-release-tests.sh'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/rust-tests.yml'
@@ -114,31 +111,6 @@ jobs:
             -A clippy::unnecessary_sort_by \
             -A clippy::useless_format \
             -A clippy::useless_vec
-
-  gui-packaging:
-    name: GPUI Packaging
-    needs: changes
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.gui == 'true'
-    runs-on: macos-latest
-    env:
-      RUSTFLAGS: ""
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.96.1
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: macos-latest-gui-packaging
-      - name: Test developer app bundle
-        run: make gui-app-test
-      - name: Build developer app bundle
-        run: make gui-app
-      - name: Test GUI release packaging
-        run: make gui-release-test
 
   unit-tests:
     name: Unit Tests

--- a/scripts/gui-release-workflow-tests.sh
+++ b/scripts/gui-release-workflow-tests.sh
@@ -48,14 +48,10 @@ do
 done
 
 require_literal "$test_workflow" "gui-quality:"
-require_literal "$test_workflow" "gui-packaging:"
 require_literal "$test_workflow" "dorny/paths-filter@v3"
-require_literal "$test_workflow" "scripts/gui-app-tests.sh"
-require_literal "$test_workflow" "scripts/gui-release-tests.sh"
-reject_literal "$test_workflow" "scripts/gui-**"
-require_literal "$test_workflow" "make gui-app-test"
-require_literal "$test_workflow" "make gui-app"
-require_literal "$test_workflow" "make gui-release-test"
-require_literal "$test_workflow" "github.ref == 'refs/heads/main'"
+reject_literal "$test_workflow" "gui-packaging:"
+reject_literal "$test_workflow" "make gui-app-test"
+reject_literal "$test_workflow" "make gui-app"
+reject_literal "$test_workflow" "make gui-release-test"
 
 echo "GUI release workflow contract is complete."


### PR DESCRIPTION
## Summary
- Remove the `GPUI Packaging` job from `rust-tests.yml` so merges to `main` no longer run ~15 min macOS release builds.
- Trim GUI path filters to code and build scripts only; packaging script edits no longer trigger macOS CI.
- Update the workflow contract test to assert packaging stays in `release.yml` only.

## Test plan
- [x] `bash scripts/gui-release-workflow-tests.sh`
- [ ] Confirm `main` pushes no longer spawn `GPUI Packaging`
- [ ] Confirm GUI/engine PRs still run `GPUI Compile and Clippy`

No README/docs updates: CI-only workflow change.

Made with [Cursor](https://cursor.com)