### PR TITLE
fix(restack): repair stale parent metadata after external rebase

### DIFF
--- a/src/engine/restack_preflight.rs
+++ b/src/engine/restack_preflight.rs
@@ -10,6 +10,13 @@
 //! boundary is clearly worse than the current merge-base. The correction is
 //! intentionally conservative and only affects the current rebase invocation;
 //! normal restack success still refreshes metadata to the parent tip.
+//!
+//! Besides the count-based heuristic, the module also detects a *structural*
+//! signal: when the branch has already been rebased externally so that the
+//! parent tip equals the merge-base but differs from the stored boundary, the
+//! stored boundary is stale and replaying from it would re-apply commits that
+//! are already merged. In that case restack rebases from the merge-base (a
+//! no-op) rather than the stale stored boundary.
 
 use crate::config::Config;
 use crate::git::GitRepo;
@@ -39,6 +46,10 @@ pub struct RestackPreflight {
     /// `stored_revision`.
     #[allow(dead_code)]
     pub merge_base: Option<String>,
+    /// Current tip of `parent` when available. Used to detect an external
+    /// rebase that left the stored boundary stale.
+    #[allow(dead_code)]
+    pub parent_tip: Option<String>,
     pub stored_to_branch: Option<usize>,
     pub merge_base_to_branch: Option<usize>,
 }
@@ -84,11 +95,14 @@ impl RestackPreflight {
             None => None,
         };
 
+        let parent_tip = repo.branch_commit(parent).ok();
+
         Ok(Self {
             branch: branch.to_string(),
             parent: parent.to_string(),
             stored_revision: stored_revision.to_string(),
             merge_base,
+            parent_tip,
             stored_to_branch,
             merge_base_to_branch,
         })
@@ -111,10 +125,28 @@ impl RestackPreflight {
         stored > mb.saturating_mul(RANGE_RATIO) + ABSOLUTE_HEADROOM
     }
 
+    /// Structural signal: the branch has already been rebased externally so
+    /// that the parent tip equals the merge-base, but the stored boundary still
+    /// points at an older revision. Replaying from the stored boundary would
+    /// re-apply commits that are already part of the parent; rebasing from the
+    /// merge-base is a no-op that preserves the branch and repairs metadata.
+    pub fn already_rebased_externally(&self) -> bool {
+        let Some(merge_base) = self.merge_base.as_deref() else {
+            return false;
+        };
+        let Some(parent_tip) = self.parent_tip.as_deref() else {
+            return false;
+        };
+        if self.stored_revision.trim().is_empty() {
+            return false;
+        }
+        merge_base == parent_tip && self.stored_revision != parent_tip
+    }
+
     /// Whether this report has a merge-base boundary that can be used instead
     /// of the stored boundary.
     pub fn corrected_upstream(&self) -> Option<&str> {
-        if !self.is_suspicious() {
+        if !self.is_suspicious() && !self.already_rebased_externally() {
             return None;
         }
         self.merge_base.as_deref()
@@ -146,10 +178,8 @@ pub fn choose_rebase_upstream(
     if let Ok(report) = RestackPreflight::analyze(repo, branch, parent, stored_revision)
         && let Some(upstream) = report.corrected_upstream()
     {
-        return RebaseBoundaryDecision {
-            upstream: upstream.to_string(),
-            adjusted: true,
-            reason: Some(format!(
+        let reason = if report.is_suspicious() {
+            format!(
                 "'{}' stored boundary from '{}' would replay {} commit(s); using merge-base boundary ({} commit(s))",
                 report.branch,
                 report.parent,
@@ -161,7 +191,17 @@ pub fn choose_rebase_upstream(
                     .merge_base_to_branch
                     .map(|count| count.to_string())
                     .unwrap_or_else(|| "?".into())
-            )),
+            )
+        } else {
+            format!(
+                "'{}' is already based on the current '{}' tip; repairing stale stored boundary",
+                report.branch, report.parent
+            )
+        };
+        return RebaseBoundaryDecision {
+            upstream: upstream.to_string(),
+            adjusted: true,
+            reason: Some(reason),
         };
     }
 
@@ -182,8 +222,26 @@ mod tests {
             parent: "main".into(),
             stored_revision: "abc".into(),
             merge_base: Some("def".into()),
+            parent_tip: None,
             stored_to_branch: stored,
             merge_base_to_branch: mb,
+        }
+    }
+
+    /// Build a report exercising the structural (external-rebase) signal.
+    fn structural_pf(
+        stored_revision: &str,
+        merge_base: Option<&str>,
+        parent_tip: Option<&str>,
+    ) -> RestackPreflight {
+        RestackPreflight {
+            branch: "feat".into(),
+            parent: "main".into(),
+            stored_revision: stored_revision.into(),
+            merge_base: merge_base.map(|s| s.into()),
+            parent_tip: parent_tip.map(|s| s.into()),
+            stored_to_branch: None,
+            merge_base_to_branch: None,
         }
     }
 
@@ -222,5 +280,36 @@ mod tests {
     fn boundary_uses_absolute_headroom() {
         assert!(!pf(Some(MIN_STORED_RANGE_FOR_WARNING), Some(5)).is_suspicious());
         assert!(pf(Some(60), Some(0)).is_suspicious());
+    }
+
+    #[test]
+    fn already_rebased_externally_true_when_parent_tip_matches_merge_base() {
+        // Parent tip == merge-base but stored boundary is a stale, older SHA.
+        assert!(structural_pf("stale", Some("tip"), Some("tip")).already_rebased_externally());
+    }
+
+    #[test]
+    fn already_rebased_externally_false_cases() {
+        // Stored boundary already equals the parent tip → nothing stale.
+        assert!(!structural_pf("tip", Some("tip"), Some("tip")).already_rebased_externally());
+        // Merge-base differs from parent tip → branch still diverges, not a no-op.
+        assert!(!structural_pf("stale", Some("base"), Some("tip")).already_rebased_externally());
+        // Missing merge-base or parent tip.
+        assert!(!structural_pf("stale", None, Some("tip")).already_rebased_externally());
+        assert!(!structural_pf("stale", Some("tip"), None).already_rebased_externally());
+        // Empty stored revision.
+        assert!(!structural_pf("", Some("tip"), Some("tip")).already_rebased_externally());
+    }
+
+    #[test]
+    fn structural_report_uses_merge_base_as_corrected_upstream() {
+        assert_eq!(
+            structural_pf("stale", Some("tip"), Some("tip")).corrected_upstream(),
+            Some("tip")
+        );
+        assert_eq!(
+            structural_pf("tip", Some("tip"), Some("tip")).corrected_upstream(),
+            None
+        );
     }
 }

--- a/tests/restack_provenance_tests.rs
+++ b/tests/restack_provenance_tests.rs
@@ -409,6 +409,69 @@ fn test_restack_with_non_ancestor_revision_preserves_only_feature_commits() {
 }
 
 // =============================================================================
+// Regression (#679): external rebase leaves stored boundary stale
+// =============================================================================
+
+/// Reproduces issue #679: the branch was rebased externally onto the advanced
+/// parent, so the parent tip already equals the branch merge-base, but the
+/// stored `parentBranchRevision` still points at the old parent tip. Restack
+/// must treat the stored boundary as stale, rebase from the merge-base (a
+/// no-op), leave the branch SHA untouched, and repair the metadata so no
+/// further restack is required.
+#[test]
+fn test_restack_after_external_rebase_is_noop_and_repairs_metadata() {
+    let repo = TestRepo::new();
+
+    // Feature with 2 commits.
+    repo.git(&["checkout", "-b", "count-feature"]);
+    repo.create_file("f1.txt", "file one");
+    repo.commit("Feature commit 1");
+    repo.create_file("f2.txt", "file two");
+    repo.commit("Feature commit 2");
+
+    // Advance main by one commit after capturing the old tip.
+    repo.git(&["checkout", "main"]);
+    let old_main = repo.get_commit_sha("HEAD");
+    repo.create_file("s.txt", "main advance");
+    repo.commit("Main advance commit");
+
+    // Externally rebase the feature onto the advanced main.
+    repo.git(&["checkout", "count-feature"]);
+    repo.git(&["rebase", "main"]);
+    let feature_before = repo.get_commit_sha("count-feature");
+
+    // Stored boundary is stale: still the old main tip.
+    write_branch_metadata_raw(&repo, "count-feature", "main", &old_main);
+    repo.set_trunk("main");
+
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_success();
+    assert!(!repo.has_rebase_in_progress());
+
+    // No replay: the branch SHA is unchanged.
+    assert_eq!(
+        repo.get_commit_sha("count-feature"),
+        feature_before,
+        "restack after an external rebase must be a no-op (no commit replay)"
+    );
+
+    // Exactly the two feature commits above main, and none behind.
+    assert_eq!(rev_list_count(&repo, "main..count-feature"), 2);
+    assert_eq!(rev_list_count(&repo, "count-feature..main"), 0);
+
+    // Metadata repaired: stored parentBranchRevision now equals current main tip.
+    let main_tip = repo.get_commit_sha("main");
+    let meta_out = repo.git(&["cat-file", "-p", "refs/branch-metadata/count-feature"]);
+    assert!(meta_out.status.success(), "failed to read branch metadata");
+    let meta = String::from_utf8_lossy(&meta_out.stdout).to_string();
+    assert!(
+        meta.contains(&format!("\"parentBranchRevision\":\"{main_tip}\"")),
+        "metadata should be repaired to the current main tip so no further restack is needed;\n\
+         expected parentBranchRevision={main_tip}\nmetadata=\n{meta}"
+    );
+}
+
+// =============================================================================
 // Monorepo-style trunk churn: stale stored parent tip + linear feature branch
 // =============================================================================
 


### PR DESCRIPTION
## Motivation

Fixes #679

`st restack` could replay an outdated commit range when a branch had already been rebased onto its parent externally (e.g. `git rebase main`), but stax metadata still recorded the previous parent revision. This could reintroduce commits already squash-merged into the parent, and repeated `st restack` invocations could repeat the same no-op-that-wasn't rebase.

## Description of changes / notes for reviewers

- The existing restack preflight only treated the stored parent revision as suspicious when the replay range exceeded a size/ratio heuristic (`is_suspicious()` in `src/engine/restack_preflight.rs`). It missed the stronger structural signal: when the parent's current tip equals the branch's merge-base but differs from the stored parent revision, the branch is already based on the current parent regardless of replay-range size.
- Added `RestackPreflight::already_rebased_externally()` to detect this case, and widened `corrected_upstream()` to use the merge-base as the boundary when either the size heuristic or the new structural signal fires. `choose_rebase_upstream()` now emits a distinct diagnostic reason for the structural case.
- Added a regression test (`tests/restack_provenance_tests.rs`) that reproduces the exact repro from the issue: create a feature branch, advance main, externally rebase the feature onto main, preserve the stale stax parent revision, then run `st restack` — asserts the branch SHA and its commits are unchanged and the metadata self-repairs so no further restack is reported as needed.

## Testing

- `cargo check && cargo clippy -- -D warnings`
- `cargo nextest run restack_preflight::` (9 passed)
- `cargo nextest run restack_provenance_tests::` (22 passed, including the new regression test)