### PR TITLE
Add `st --default-config` flag to print default config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ stax is wire-compatible with Freephite/Graphite for common stacked-branch workfl
 st config                  # open the config editor
 st config --set-ai         # pick AI agent + model
 st config --reset-ai       # clear saved AI pairing and re-prompt
+st --default-config       # print the default config.toml to stdout
 ```
 
 Config lives at `~/.config/stax/config.toml`. When `STAX_CONFIG_DIR` is unset,

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -168,6 +168,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st config` | Show current configuration |
 | `st config --set-ai` | Interactively set AI agent/model (global or per-feature) |
 | `st config --reset-ai` | Clear saved AI defaults and re-prompt (`--no-prompt` to clear only) |
+| `st --default-config` | Print the default config.toml to stdout |
 | `st init` | Initialize stax or reconfigure trunk (`--trunk <branch>`) |
 | `st cli upgrade` | Detect install method and run the matching upgrade |
 | `st doctor` | Check repo health |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -5,6 +5,7 @@ st config                     # show current configuration
 st config --set-ai            # interactively pick AI agent/model
 st config --reset-ai          # clear saved AI defaults and re-prompt
 st config --reset-ai --no-prompt
+st --default-config          # print the default config.toml to stdout
 ```
 
 Config is loaded as follows:

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -21,6 +21,10 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub(crate) trace: bool,
 
+    /// Print the default config.toml to stdout and exit
+    #[arg(long = "default-config")]
+    pub(crate) default_config: bool,
+
     #[command(subcommand)]
     pub(crate) command: Option<Commands>,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,6 +30,11 @@ pub fn run() -> Result<()> {
 
     let cli = Cli::parse();
 
+    if cli.default_config {
+        print!("{}", Config::default_toml()?);
+        return Ok(());
+    }
+
     if matches!(&cli.command, Some(Commands::UpdateCheck)) {
         update::run_background_check();
         return Ok(());

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -25,6 +25,16 @@ fn parse_cli(args: &[&str]) -> Cli {
 }
 
 #[test]
+fn parses_default_config_flag() {
+    let cli = parse_cli(&["stax", "--default-config"]);
+    assert!(cli.default_config);
+    assert!(cli.command.is_none());
+
+    let bare = parse_cli(&["stax"]);
+    assert!(!bare.default_config);
+}
+
+#[test]
 fn interactive_terminal_requires_both_stdio_streams() {
     assert!(has_interactive_terminal(true, true));
     assert!(!has_interactive_terminal(true, false));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -636,6 +636,11 @@ impl Config {
         Ok(base.try_into()?)
     }
 
+    /// Serialize the default config to its TOML representation (same serializer as `save()`).
+    pub fn default_toml() -> Result<String> {
+        Ok(toml::to_string_pretty(&Config::default())?)
+    }
+
     /// Save config to file
     pub fn save(&self) -> Result<()> {
         let path = Self::path()?;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -748,6 +748,16 @@ fn test_default_config() {
 }
 
 #[test]
+fn test_default_toml_serializes() {
+    let s = Config::default_toml().unwrap();
+    assert!(!s.is_empty());
+    assert!(s.contains("[branch]"));
+    assert!(s.contains("[remote]"));
+    assert!(s.contains("[submit]"));
+    let _: Config = toml::from_str(&s).unwrap();
+}
+
+#[test]
 fn test_ci_alert_config_round_trip() {
     let config: Config = toml::from_str(
         r#"


### PR DESCRIPTION
## Summary
- Adds a top-level `st --default-config` flag that prints the default `config.toml` contents to stdout, so users can consult the defaults without generating `~/.config/stax/config.toml` or being inside a Git repo.
- Reuses the existing `Config` TOML serializer (`Config::default_toml()` wraps the same `toml::to_string_pretty` call `save()` uses) so the printed output always matches the file stax would actually write.
- The flag is handled as an early exit in `cli::run()`, before `Config::ensure_exists()`, the update check, and `ensure_initialized()` — it neither writes a config file nor requires a repo.
- Documented in `README.md`, `docs/configuration/index.md`, and `docs/commands/reference.md`.

## Test plan
- [x] `cargo nextest run config::tests::test_default_toml_serializes cli::tests::parses_default_config_flag` — new tests pass
- [x] `cargo nextest run config::tests:: cli::tests::` — 119 tests pass (0 failed)
- [x] `cargo check && cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual smoke check: `cargo run -- --default-config` in an isolated, non-git scratch dir with isolated `HOME`/`STAX_CONFIG_DIR` — prints valid TOML, exits 0, creates no files