### PR TITLE
feat(cli): make `refresh` the primary name for `st update` (kept as alias) + clarify cascade help

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ st ls
 st ss
 
 # 4. After the bottom PR merges on GitHub…
-st update          # sync trunk, restack this stack, update PRs
+st refresh         # sync trunk, restack this stack, update PRs (`st update` is a back-compat alias)
 ```
 
 Picked the wrong trunk? Run `st trunk main` or `st init --trunk <branch>` to reconfigure.
@@ -355,11 +355,11 @@ st config --set-ai
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` removes merged branches (including tracked merged PRs) and upstream-gone branches with no unique work |
-| `st update` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs |
-| `st update --force --yes --no-prompt` | Run update without sync or submit prompts |
-| `st update --verbose` | Include detailed sync/restack/submit timing |
+| `st refresh` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs (`st update` is a back-compat alias) |
+| `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |
+| `st refresh --verbose` | Include detailed sync/restack/submit timing |
 | `st restack` | Rebase current stack onto parents locally |
-| `st cascade` | Restack + push + open/update PRs |
+| `st cascade` | Restack + push + open/update PRs (no trunk fetch; offline-friendly) |
 | `st split` | Split a branch into stacked branches (by commit or `--hunk`) |
 | `st lane <name> "<task>"` | Spawn an AI agent on a new lane |
 | `st wt` | Open the worktree dashboard |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -45,7 +45,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, merge that PR, and let GitHub mark lower PRs merged when possible (`--full` includes descendants; GitHub only) |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
-| `st cascade` | Restack, push, and create/update PRs in one shot |
+| `st cascade` | Restack, push, and create/update PRs in one shot (no trunk fetch; offline-friendly) |
 
 Scoped submit keeps local branch metadata unchanged when it prepares a temporary publish head. Plain `git commit` work on the branch is included; `st restack` remains the command that updates local branch tips and parent revisions.
 
@@ -59,9 +59,9 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 | `st rs --restack` | `rs` **plus** rebase the current stack onto updated trunk |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
-| `st update` | Sync trunk without merged-branch cleanup, restack, then push and update PRs |
-| `st update --force --yes --no-prompt` | Full update flow without sync or submit prompts |
-| `st update --verbose` | Same as `st update`, with detailed sync/restack/submit timing |
+| `st refresh` | Sync trunk without merged-branch cleanup, restack, then push and update PRs (`st update` is a back-compat alias) |
+| `st refresh --force --yes --no-prompt` | Full refresh flow without sync or submit prompts |
+| `st refresh --verbose` | Same as `st refresh`, with detailed sync/restack/submit timing |
 
 ## Branch housekeeping
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -33,11 +33,11 @@ st --trace status --json >/dev/null
 | `st sweep --delete --force` | | Skip confirmation prompt |
 | `st sweep --stale-days <N>` | | Override stale threshold in days (default: 30) |
 | `st sweep --json` | | Machine-readable branch classification (conflicts with `--delete`) |
-| `st update` | | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack |
-| `st update --force --yes --no-prompt` | | Run the full update flow without sync or submit prompts |
-| `st update --verbose` | | Same as `st update`, with detailed sync/restack/submit timing |
+| `st refresh` | | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack (`st update` is a back-compat alias) |
+| `st refresh --force --yes --no-prompt` | | Run the full refresh flow without sync or submit prompts |
+| `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
 | `st restack` | | Rebase current stack locally — auto-normalizes missing/merged parents; `--stop-here` limits scope |
-| `st cascade` | | Restack from bottom and submit updates |
+| `st cascade` | | Restack the stack and submit updates, without fetching trunk (offline-friendly) |
 | `st diff` | | Show per-branch diffs vs parent |
 | `st range-diff` | | Show range-diff for branches needing restack |
 | `st stack` | `s` | Stack command namespace for `submit` and `restack` (`st stack submit`, `st stack restack`) |
@@ -315,7 +315,7 @@ st completions elvish
 - Imported branches from `st get` are remote-delete exempt: once they are detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch.
 - The completion footer summarizes the trunk commit, file, and line delta together with non-zero merged-cleanup, imported-update, and restack counts. It reuses sync's existing results and does not perform extra network or Git work.
 - When sync itself leaves exceptional work behind, it reports skipped cleanup with its reason, trunk update failures, and cleanup-driven checkout changes. It prints one prioritized next command: a diverged trunk gets non-destructive guidance to inspect and reconcile it with its remote; other trunk failures suggest `st trunk`; blocked cleanup suggests `st sweep`. Routine restack health remains visible in `st ls` and the TUI instead of appearing after every sync.
-- When `--restack` is requested, sync fails closed if its fetch did not succeed or the local trunk did not reach the fetched remote-trunk commit. It restores any sync auto-stash and exits non-zero before imported-branch refresh, merged-branch cleanup, or restacking can rewrite feature refs. `st update` inherits this guard and exits before its submit phase, so it does not push or update PRs after either failure.
+- When `--restack` is requested, sync fails closed if its fetch did not succeed or the local trunk did not reach the fetched remote-trunk commit. It restores any sync auto-stash and exits non-zero before imported-branch refresh, merged-branch cleanup, or restacking can rewrite feature refs. `st refresh` (and `st update`) inherits this guard and exits before its submit phase, so it does not push or update PRs after either failure.
 
 ### `st restack`
 
@@ -334,6 +334,8 @@ If the excluded parent has local-only commits, scoped submit still refuses and a
 - `--agent codex --model gpt-5.3-codex --max-rounds 5`
 
 ### `st cascade`
+
+Restack the stack and submit updates, without fetching trunk (offline-friendly).
 
 - `--no-pr` / `--no-submit` / `--auto-stash-pop`
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -44,8 +44,8 @@ st ss
 
 # After the bottom PR merges on GitHub, catch up in one shot:
 st rs --restack    # pull trunk, clean merged, rebase the rest
-# or: st update     # sync + restack + push/update PRs in one command
-# scripts: st update --force --yes --no-prompt
+# or: st refresh    # sync + restack + push/update PRs in one command (`st update` is a back-compat alias)
+# scripts: st refresh --force --yes --no-prompt
 ```
 
 Picked the wrong trunk? `st trunk main` or `st init --trunk <branch>` reconfigures.

--- a/docs/reference/windows.md
+++ b/docs/reference/windows.md
@@ -13,7 +13,7 @@ If you install with `cargo install` or `cargo binstall`, update notifications an
 All core stax features work on Windows without modification:
 
 - Stacked branches: `st create`, `st ls`, `st ll`, `st restack`
-- PR workflows: `st ss`, `st merge`, `st cascade`, `st update`, `st pr`
+- PR workflows: `st ss`, `st merge`, `st cascade`, `st refresh` (`st update` alias), `st pr`
 - Sync and cleanup: `st rs`, `st sync`
 - Undo/redo: `st undo`, `st redo`
 - Interactive TUI: bare `st`

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -119,7 +119,7 @@ Flow: retarget all PRs to trunk → enqueue each → poll until merged (respects
 
 ## `st cascade`
 
-Restack + push + create/update PRs in a single flow.
+Restack + push + create/update PRs in a single flow, without fetching trunk (offline-friendly).
 
 | Command | Behavior |
 |---|---|
@@ -128,15 +128,15 @@ Restack + push + create/update PRs in a single flow.
 | `st cascade --no-submit` | restack only |
 | `st cascade --auto-stash-pop` | auto stash/pop dirty worktrees |
 
-## `st update`
+## `st refresh`
 
-The "bottom PR merged, catch me up" command. Prints the plan up front, then syncs trunk without merged-branch cleanup, restacks, and submits.
+The "bottom PR merged, catch me up" command. Prints the plan up front, then syncs trunk without merged-branch cleanup, restacks, and submits. `st update` remains a back-compat alias.
 
 | Command | Behavior |
 |---|---|
-| `st update` | sync trunk → restack → push → create/update PRs |
-| `st update --no-pr` | sync trunk → restack → push |
-| `st update --no-submit` | sync trunk → restack |
-| `st update --force` | force the sync step instead of prompting |
-| `st update --force --yes --no-prompt` | run the full trunk-sync/restack/submit flow without prompts |
-| `st update --verbose` | show detailed sync/restack/submit timing |
+| `st refresh` | sync trunk → restack → push → create/update PRs |
+| `st refresh --no-pr` | sync trunk → restack → push |
+| `st refresh --no-submit` | sync trunk → restack |
+| `st refresh --force` | force the sync step instead of prompting |
+| `st refresh --force --yes --no-prompt` | run the full trunk-sync/restack/submit flow without prompts |
+| `st refresh --verbose` | show detailed sync/restack/submit timing |

--- a/skills.md
+++ b/skills.md
@@ -31,7 +31,7 @@ stax merge                     # Merge PRs from stack bottom upward
 stax sync|rs                   # Sync trunk + clean merged branches
 stax sweep                     # Classify + optionally delete merged/gone/stale branches
 stax restack                   # Rebase branch/stack onto parents
-stax cascade                   # Restack bottom-up and submit updates
+stax cascade                   # Restack bottom-up and submit updates (no trunk fetch; offline-friendly)
 
 stax get [branch|PR]           # Sync current stack, or fetch/checkout a remote branch or PR stack
 stax checkout|co|bco           # Checkout branch (interactive by default)
@@ -325,13 +325,14 @@ stax sweep --delete --force        # Skip confirmation prompt
 stax sweep --stale-days 60         # Override stale threshold in days (default 30, or branch.stale_days config)
 stax sweep --json                  # Machine-readable branch classification (conflicts with --delete)
 
-stax update                        # Sync trunk, restack, then submit (no merged cleanup)
-stax update --no-pr                # Push only after trunk sync/restack
-stax update --no-submit            # Trunk sync/restack only
-stax update --force                # Force sync without prompts first
-stax update --force --yes --no-prompt # Full update without sync/submit prompts
-stax update --verbose              # Show detailed sync/restack/submit timings
-# update inherits sync's fetch/trunk guard and exits before its submit phase, so it does not push or update PRs after that failure.
+stax refresh                        # Sync trunk, restack, then submit (no merged cleanup)
+stax refresh --no-pr                # Push only after trunk sync/restack
+stax refresh --no-submit            # Trunk sync/restack only
+stax refresh --force                # Force sync without prompts first
+stax refresh --force --yes --no-prompt # Full refresh without sync/submit prompts
+stax refresh --verbose              # Show detailed sync/restack/submit timings
+# `stax update` remains a back-compat alias for `stax refresh`.
+# refresh inherits sync's fetch/trunk guard and exits before its submit phase, so it does not push or update PRs after that failure.
 
 stax restack                       # Restack current branch onto parent
 stax restack --all                 # Restack whole stack
@@ -341,7 +342,7 @@ stax restack --submit-after yes    # ask|yes|no
 stax restack --auto-stash-pop      # Stash/pop dirty target worktrees
 stax restack --quiet               # Also silences the preflight notice below
 
-stax cascade                       # Restack bottom-up then submit
+stax cascade                       # Restack bottom-up then submit (no trunk fetch; offline-friendly)
 stax cascade --no-pr               # Push only, skip PR updates
 stax cascade --no-submit           # Local restack only
 stax cascade --auto-stash-pop      # Stash/pop dirty target worktrees
@@ -567,7 +568,8 @@ stax merge --stack --when-ready    # GitHub stack fast-forward: selected tip CI 
 ### After Base PR Merges
 
 ```bash
-stax update
+stax refresh
+# `stax update` is a back-compat alias for `stax refresh`.
 ```
 
 ### Resolve Rebase Conflicts

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -500,7 +500,7 @@ pub(crate) enum Commands {
         submit_after: RestackSubmitAfter,
     },
 
-    /// Restack from the bottom and submit updates
+    /// Restack the stack and submit updates, without fetching trunk (offline-friendly)
     Cascade {
         /// Push branches to remote but skip PR creation/updates
         #[arg(long)]
@@ -514,8 +514,8 @@ pub(crate) enum Commands {
     },
 
     /// Sync trunk, restack current stack, then submit updates
-    #[command(alias = "refresh")]
-    Update {
+    #[command(visible_alias = "update")]
+    Refresh {
         /// Push branches to remote but skip PR creation/updates
         #[arg(long)]
         no_pr: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -375,7 +375,7 @@ pub fn run() -> Result<()> {
             no_submit,
             auto_stash_pop,
         } => commands::cascade::run(no_pr, no_submit, auto_stash_pop),
-        Commands::Update {
+        Commands::Refresh {
             no_pr,
             no_submit,
             force,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -181,7 +181,8 @@ fn test_help() {
     assert!(stdout.contains("Fast stacked Git branches and PRs"));
     assert!(stdout.contains("status"));
     assert!(stdout.contains("submit"));
-    assert!(stdout.contains("update"));
+    assert!(stdout.contains("refresh"));
+    assert!(stdout.contains("[aliases: update]"));
     assert!(stdout.contains("run"));
     assert!(stdout.contains("restack"));
     assert!(stdout.contains("resolve"));
@@ -233,7 +234,22 @@ fn test_sync_alias_rs() {
 }
 
 #[test]
-fn test_update_help() {
+fn test_refresh_help() {
+    let output = stax(&["refresh", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Sync trunk"));
+    assert!(stdout.contains("no-pr"));
+    assert!(stdout.contains("no-submit"));
+    assert!(stdout.contains("force"));
+    assert!(stdout.contains("safe"));
+    assert!(stdout.contains("verbose"));
+    assert!(stdout.contains("--yes"));
+    assert!(stdout.contains("--no-prompt"));
+}
+
+#[test]
+fn test_update_alias_still_works() {
     let output = stax(&["update", "--help"]);
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -248,12 +264,12 @@ fn test_update_help() {
 }
 
 #[test]
-fn test_refresh_alias_help() {
-    let output = stax(&["refresh", "--help"]);
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Sync trunk"));
-    assert!(stdout.contains("no-submit"));
+fn test_update_typo_exits_nonzero() {
+    let output = stax(&["updatee"]);
+    assert!(
+        !output.status.success(),
+        "near-miss subcommand should not match the update alias"
+    );
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2166,10 +2166,10 @@ fn test_refresh_no_submit_keeps_original_branch_and_restacks_stack() {
     repo.run_stax(&["checkout", &middle]);
     let original = repo.current_branch();
 
-    let output = repo.run_stax(&["update", "--no-submit", "--force"]);
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
     assert!(
         output.status.success(),
-        "update --no-submit failed\nstdout: {}\nstderr: {}",
+        "refresh --no-submit failed\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );
@@ -2256,11 +2256,11 @@ fn test_update_aborts_before_restack_when_trunk_diverges() {
     configure_submit_remote(&repo);
     repo.run_stax(&["checkout", &feature]);
 
-    let output = repo.run_stax(&["update", "--no-pr", "--force", "--yes", "--no-prompt"]);
+    let output = repo.run_stax(&["refresh", "--no-pr", "--force", "--yes", "--no-prompt"]);
 
     assert!(
         !output.status.success(),
-        "update must fail when trunk diverges\nstdout: {}\nstderr: {}",
+        "refresh must fail when trunk diverges\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output),
     );
@@ -2503,10 +2503,10 @@ fn test_update_no_submit_skips_merged_branch_cleanup() {
     assert!(push.status.success(), "failed to update remote main");
 
     repo.run_stax(&["checkout", &child]);
-    let output = repo.run_stax(&["update", "--no-submit", "--force"]);
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
     assert!(
         output.status.success(),
-        "update --no-submit failed\nstdout: {}\nstderr: {}",
+        "refresh --no-submit failed\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );
@@ -2563,13 +2563,13 @@ fn test_update_submit_does_not_refetch_trunk_after_sync() {
     let trace_dir = test_tempdir();
     let trace_file = trace_dir.path().join("git-trace.log");
     let output = repo.run_stax_with_env(
-        &["update", "--no-pr", "--force", "--yes", "--no-prompt"],
+        &["refresh", "--no-pr", "--force", "--yes", "--no-prompt"],
         &[("GIT_TRACE", trace_file.as_path())],
     );
 
     assert!(
         output.status.success(),
-        "update --no-pr failed\nstdout: {}\nstderr: {}",
+        "refresh --no-pr failed\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );
@@ -2604,13 +2604,13 @@ fn test_update_submit_fetches_once_with_unpublished_branch() {
     let trace_dir = test_tempdir();
     let trace_file = trace_dir.path().join("git-trace.log");
     let output = repo.run_stax_with_env(
-        &["update", "--no-pr", "--force", "--yes", "--no-prompt"],
+        &["refresh", "--no-pr", "--force", "--yes", "--no-prompt"],
         &[("GIT_TRACE", trace_file.as_path())],
     );
 
     assert!(
         output.status.success(),
-        "update --no-pr failed\nstdout: {}\nstderr: {}",
+        "refresh --no-pr failed\nstdout: {}\nstderr: {}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
     );

--- a/tests/refresh_visual_tests.rs
+++ b/tests/refresh_visual_tests.rs
@@ -1,4 +1,4 @@
-//! Visual-presentation checks for `st update`'s header.
+//! Visual-presentation checks for `st refresh`'s header.
 //!
 //! The header prints before sync/submit run, so we only assert on stdout
 //! content and tolerate non-zero exit codes for the paths that would try to
@@ -9,7 +9,7 @@ use crate::common::{OutputAssertions, TestRepo};
 #[test]
 fn update_header_no_submit_uses_skip_wording() {
     let repo = TestRepo::new_with_remote();
-    let output = repo.run_stax(&["update", "--no-submit", "--force"]);
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
     let stdout = TestRepo::stdout(&output);
 
     output.assert_success();
@@ -55,7 +55,7 @@ fn update_header_default_mentions_push_and_prs() {
 #[test]
 fn update_header_no_pr_mentions_push_without_prs() {
     let repo = TestRepo::new_with_remote();
-    let output = repo.run_stax(&["update", "--no-pr", "--force"]);
+    let output = repo.run_stax(&["refresh", "--no-pr", "--force"]);
     let stdout = TestRepo::stdout(&output);
 
     assert!(

--- a/tests/submit_pr_base_tests.rs
+++ b/tests/submit_pr_base_tests.rs
@@ -188,9 +188,9 @@ async fn submit_treats_native_stack_base_lock_as_non_fatal() {
     );
 }
 
-/// `stax update` (sync + restack + submit) reuses the exact same submit
+/// `stax refresh` (sync + restack + submit) reuses the exact same submit
 /// planning/PR-update logic as `stax submit`. Regression coverage for a real
-/// user report: `st update` was surfacing the raw GitHub "part of a stack"
+/// user report: `st refresh` (via the `update` alias) was surfacing the raw GitHub "part of a stack"
 /// error as a fatal failure instead of the soft note above, even though
 /// `stax submit` alone handled it gracefully — see
 /// `submit_treats_native_stack_base_lock_as_non_fatal`.


### PR DESCRIPTION
## Motivation

The `update` verb was vague and overlapped conceptually with `cascade` (restack + submit) and `sync` (trunk fetch). This makes `refresh` the primary command name while keeping `st update` as a visible back-compat alias.

## Description of changes / notes for reviewers

- Renamed clap command `Update` → `Refresh` with `visible_alias = "update"`; dispatch unchanged (`commands::refresh::run`)
- Sharpened `cascade` one-line help to clarify it restacks + submits **without** fetching trunk (help-only; no behavior change in `cascade.rs`)
- Updated docs: README.md, skills.md, and docs under `docs/commands/`, `docs/getting-started/`, `docs/workflows/`, `docs/reference/`
- Tests: strengthened `[aliases: update]` guard in `test_help`; alias parity + near-miss typo regression tests
- **Back-compat:** `st update` still works; `st --help` lists `refresh … [aliases: update]`
- **Historical note:** CHANGELOG previously recorded a rename in the opposite direction; this restores `refresh` as primary with the alias kept for migration. `docs/superpowers/{plans,specs}` archives were intentionally left unchanged.

## Verification

- `make test` (Docker fast path) — full suite green
- `make lint` — clean (fmt + clippy all targets)
- Live sanity: `st refresh --help` and `st update --help` render identical flag surface; `Usage: stax refresh` for both

## Residual risk

Low — CLI surface rename and help text only; no behavior changes in `src/commands/refresh.rs`. Scripts pinned to `st update` continue to work via the visible alias.