### PR TITLE
feat(agents): support pi as an AI agent and skills install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ AI and editor integration guides:
 - [Codex](docs/integrations/codex.md)
 - [Gemini CLI](docs/integrations/gemini-cli.md)
 - [OpenCode](docs/integrations/opencode.md)
+- [pi](docs/integrations/pi.md)
 - [PR templates + AI generation](docs/integrations/pr-templates-and-ai.md)
 
 Shared skill/instruction file used across agents: [skills.md](skills.md)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -58,7 +58,7 @@ Config is loaded as follows:
 # preflight_warn = true        # print a notice when that automatic repair happens
 
 [ai]
-# agent = "claude" # "codex" | "gemini" | "opencode" — global default
+# agent = "claude" # "codex" | "gemini" | "opencode" | "pi" — global default
 # model = "claude-opus-4-8"
 
 # Per-feature overrides — optional, fall back to [ai] above

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -24,5 +24,5 @@ When `claude` is selected, stax tries Anthropic's live Models API first (using `
 
 ## Related
 
-- [Codex](codex.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md)
+- [Codex](codex.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md) · [pi](pi.md)
 - [PR templates + AI](pr-templates-and-ai.md)

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -24,5 +24,5 @@ When `codex` is selected, stax tries OpenAI's live Models API first (using `OPEN
 
 ## Related
 
-- [Claude Code](claude-code.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md)
+- [Claude Code](claude-code.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md) · [pi](pi.md)
 - [PR templates + AI](pr-templates-and-ai.md)

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -31,5 +31,5 @@ st gen --commit-msg --agent gemini
 
 ## Related
 
-- [Claude Code](claude-code.md) · [Codex](codex.md) · [OpenCode](opencode.md)
+- [Claude Code](claude-code.md) · [Codex](codex.md) · [OpenCode](opencode.md) · [pi](pi.md)
 - [PR templates + AI](pr-templates-and-ai.md)

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -30,5 +30,5 @@ st gen --commit-msg --agent opencode
 
 ## Related
 
-- [Claude Code](claude-code.md) · [Codex](codex.md) · [Gemini CLI](gemini-cli.md)
+- [Claude Code](claude-code.md) · [Codex](codex.md) · [Gemini CLI](gemini-cli.md) · [pi](pi.md)
 - [PR templates + AI](pr-templates-and-ai.md)

--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -1,0 +1,49 @@
+# pi
+
+Install [pi](https://pi.dev) and add the stax skill so pi can drive stax workflows correctly.
+
+## 1. Install
+
+See [pi.dev](https://pi.dev) for installation.
+
+## 2. Add the stax skill
+
+The easiest path is to let stax manage it:
+
+```bash
+stax skills update
+```
+
+This writes the skill to `~/.pi/agent/skills/stax/SKILL.md` (alongside the other agents). To do it manually:
+
+```bash
+mkdir -p ~/.pi/agent/skills/stax
+curl -o ~/.pi/agent/skills/stax/SKILL.md https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md
+```
+
+pi loads skills from `~/.pi/agent/skills/<name>/SKILL.md`.
+
+## 3. Use pi with AI create/PR generation
+
+```bash
+st generate --pr-body --agent pi
+st generate --pr-body --agent pi --model anthropic/claude-opus-4-8
+st gen --pr-title --agent pi
+st gen --commit-msg --agent pi
+```
+
+## 4. AI worktree lanes
+
+```bash
+st lane deep-dive --agent pi
+st lane deep-dive --agent pi --model anthropic/claude-opus-4-8 "trace the flaky test"
+```
+
+`--yolo` is not supported for pi (permission bypass is provided by opt-in
+permission-mode extensions, not a stable core CLI flag). Pass a bypass flag
+manually with `--agent-arg` if your pi setup supports one.
+
+## Related
+
+- [Claude Code](claude-code.md) · [Codex](codex.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md)
+- [PR templates + AI](pr-templates-and-ai.md)

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -121,7 +121,7 @@ st generate --pr-body --no-prompt
 | `--template <name>` | Use a specific PR template |
 | `--no-template` | Skip PR template |
 
-Supported agents: `claude`, `codex`, `gemini`, `opencode`. When `codex` or `claude` is selected, stax tries the provider's live Models API first (using `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) before falling back to its local defaults.
+Supported agents: `claude`, `codex`, `gemini`, `opencode`, `pi`. When `codex` or `claude` is selected, stax tries the provider's live Models API first (using `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) before falling back to its local defaults.
 
 To forget the saved AI pairing and re-prompt:
 

--- a/docs/integrations/tmux.md
+++ b/docs/integrations/tmux.md
@@ -45,4 +45,4 @@ cesar/fix/refresh-pr-draft-on-sync [1/1] #394  running  15:12
 ## Related
 
 - [stax.tmux repository](https://github.com/cesarferreira/stax.tmux)
-- [Claude Code](claude-code.md) · [Codex](codex.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md)
+- [Claude Code](claude-code.md) · [Codex](codex.md) · [Gemini CLI](gemini-cli.md) · [OpenCode](opencode.md) · [pi](pi.md)

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -86,12 +86,13 @@ tmux attach -t <lane-name>
 
 ## Agent selection
 
-Supported `--agent` values: `claude`, `codex`, `gemini`, `opencode`.
+Supported `--agent` values: `claude`, `codex`, `gemini`, `opencode`, `pi`.
 
 ```bash
 st lane api-tests   --agent gemini
 st lane api-tests   --agent opencode --model opencode/gpt-5.5-fast
 st lane review-pass --agent codex "address the open PR comments"
+st lane deep-dive   --agent pi --model anthropic/claude-opus-4-8
 ```
 
 - `--model` requires `--agent`
@@ -108,6 +109,7 @@ For well-scoped work in an isolated lane, let the agent run autonomously:
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | `gemini` | `--yolo` |
 | `opencode` | *not supported — use `--agent-arg` instead* |
+| `pi` | *not supported (permission bypass is extension-provided) — use `--agent-arg` instead* |
 
 ```bash
 st lane fix-flaky --agent claude --yolo "stabilize the flaky test suite"

--- a/docs/workflows/reporting.md
+++ b/docs/workflows/reporting.md
@@ -86,13 +86,13 @@ Progress feedback is shown for the default card and Slack styles while context c
 
 ### Prerequisites
 
-- An AI agent installed on `PATH`: `claude`, `codex`, `gemini`, or `opencode`
+- An AI agent installed on `PATH`: `claude`, `codex`, `gemini`, `opencode`, or `pi`
 - For `--jit`: [`jit`](https://github.com/cesarferreira/jit) on `PATH`
 - Agent configured in `~/.config/stax/config.toml`:
 
 ```toml
 [ai]
-agent = "claude"   # or "codex", "gemini", "opencode"
+agent = "claude"   # or "codex", "gemini", "opencode", "pi"
 ```
 
 Or pass `--agent` directly.

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -99,7 +99,7 @@ st wt c review-pass --agent codex --tmux -- "address the open PR comments"
 st wt go review-pass --agent codex --tmux
 ```
 
-- `--agent` supports `claude`, `codex`, `gemini`, `opencode`
+- `--agent` supports `claude`, `codex`, `gemini`, `opencode`, `pi`
 - `--model` requires `--agent`
 - `--run` and `--agent` are mutually exclusive
 - anything after `--` is passed through to the agent/command

--- a/skills.md
+++ b/skills.md
@@ -1,7 +1,7 @@
 <!-- stax-skills-version: 0.99.0 -->
 # Stax Skills for AI Coding Agents
 
-This document teaches AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, OpenCode) how to use `stax` to manage stacked Git branches and PRs.
+This document teaches AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, pi) how to use `stax` to manage stacked Git branches and PRs.
 
 > Installing this skill: run `stax skills update` (or `st setup --install-skills`). Per-agent setup details live in `docs/integrations/`.
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -35,7 +35,7 @@ fn models_file() -> &'static ModelsFile {
     })
 }
 
-const SUPPORTED_AGENTS: &[&str] = &["claude", "codex", "gemini", "opencode"];
+const SUPPORTED_AGENTS: &[&str] = &["claude", "codex", "gemini", "opencode", "pi"];
 
 #[derive(Clone, Copy, Debug)]
 enum GenerateTarget {
@@ -697,6 +697,7 @@ fn auto_detect_agent(available: &[String]) -> Result<String> {
          - codex  (https://github.com/openai/codex)\n  \
          - gemini (https://github.com/google-gemini/gemini-cli)\n  \
          - opencode (https://opencode.ai)\n  \
+         - pi (https://pi.dev)\n  \
          Or set manually in ~/.config/stax/config.toml:\n    \
          [ai]\n    \
          agent = \"claude\"",
@@ -1342,6 +1343,12 @@ pub fn invoke_ai_agent(agent: &str, model: Option<&str>, prompt: &str) -> Result
             args.push(prompt.to_string());
             write_prompt_to_stdin = false;
         }
+        "pi" => {
+            args.push("-p".into());
+            if let Some(m) = model {
+                args.extend(["--model".into(), m.into()]);
+            }
+        }
         _ => bail!("Unsupported agent: {}", agent),
     }
 
@@ -1410,6 +1417,16 @@ mod tests {
     #[test]
     fn validate_agent_name_accepts_opencode() {
         assert!(validate_agent_name("opencode").is_ok());
+    }
+
+    #[test]
+    fn validate_agent_name_accepts_pi() {
+        assert!(validate_agent_name("pi").is_ok());
+    }
+
+    #[test]
+    fn validate_agent_name_rejects_unknown() {
+        assert!(validate_agent_name("nope").is_err());
     }
 
     #[test]

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -36,6 +36,11 @@ const SKILL_LOCATIONS: &[SkillLocation] = &[
         relative_path: ".cursor/skills/stax/SKILL.md",
         has_frontmatter: true,
     },
+    SkillLocation {
+        name: "pi",
+        relative_path: ".pi/agent/skills/stax/SKILL.md",
+        has_frontmatter: true,
+    },
 ];
 
 /// Parse `<!-- stax-skills-version: X.Y.Z -->` or `stax_version: "X.Y.Z"` from the
@@ -366,6 +371,16 @@ mod tests {
             Some(PKG_VERSION),
             "frontmatter PKG_VERSION should win over a stale body marker",
         );
+    }
+
+    #[test]
+    fn test_skill_locations_include_pi() {
+        let pi = SKILL_LOCATIONS
+            .iter()
+            .find(|loc| loc.name == "pi")
+            .expect("pi skill location should be registered");
+        assert_eq!(pi.relative_path, ".pi/agent/skills/stax/SKILL.md");
+        assert!(pi.has_frontmatter);
     }
 
     #[test]

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -885,13 +885,18 @@ pub fn build_launch_spec(
 /// `opencode run`, but stax launches the top-level `opencode` command. Until
 /// that invocation path is updated (or we confirm the flag is accepted on the
 /// top-level CLI), treat opencode yolo as unsupported.
+///
+/// Note on pi: permission bypass is provided by opt-in permission-mode
+/// extensions (configured via mode cycling / settings), not a stable core CLI
+/// flag, so there is no universal yolo flag to inject; treat pi yolo as
+/// unsupported and let users pass a flag manually via `--agent-arg`.
 pub fn yolo_flag_for_agent(agent: &str) -> Option<&'static str> {
     match agent {
         "claude" => Some("--dangerously-skip-permissions"),
         "codex" => Some("--dangerously-bypass-approvals-and-sandbox"),
         "gemini" => Some("--yolo"),
-        // "opencode" intentionally unsupported until the top-level CLI accepts
-        // the flag; see function-level docstring.
+        // "opencode" and "pi" intentionally unsupported; see function-level
+        // docstring.
         _ => None,
     }
 }
@@ -908,7 +913,7 @@ pub fn build_agent_launch_spec_with_options(
 
     let mut args = Vec::new();
     match agent {
-        "claude" | "codex" | "opencode" => {
+        "claude" | "codex" | "opencode" | "pi" => {
             if let Some(ref model) = model {
                 args.extend(["--model".to_string(), model.clone()]);
             }
@@ -1605,10 +1610,43 @@ mod tests {
             Some("--dangerously-bypass-approvals-and-sandbox")
         );
         assert_eq!(yolo_flag_for_agent("gemini"), Some("--yolo"));
-        // opencode is intentionally unsupported for --yolo right now
+        // opencode and pi are intentionally unsupported for --yolo right now
         // (see yolo_flag_for_agent docstring).
         assert_eq!(yolo_flag_for_agent("opencode"), None);
+        assert_eq!(yolo_flag_for_agent("pi"), None);
         assert_eq!(yolo_flag_for_agent("unknown"), None);
+    }
+
+    #[test]
+    fn build_agent_launch_spec_pi_uses_model_flag() {
+        let launch = build_agent_launch_spec_with_options(
+            "pi",
+            Some("anthropic/claude-opus-4-8".to_string()),
+            vec!["fix flaky tests".to_string()],
+            false,
+            &[],
+        )
+        .expect("agent launch");
+
+        match launch {
+            LaunchSpec::Process {
+                program,
+                args,
+                display,
+            } => {
+                assert_eq!(program, "pi");
+                assert_eq!(
+                    args,
+                    vec![
+                        "--model".to_string(),
+                        "anthropic/claude-opus-4-8".to_string(),
+                        "fix flaky tests".to_string(),
+                    ]
+                );
+                assert_eq!(display, "pi (anthropic/claude-opus-4-8)");
+            }
+            LaunchSpec::Shell { .. } => panic!("expected process launch"),
+        }
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -202,7 +202,7 @@ pub struct AiFeatureConfig {
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct AiConfig {
-    /// AI agent to use: "claude", "codex", "gemini", or "opencode" (default: auto-detect)
+    /// AI agent to use: "claude", "codex", "gemini", "opencode", or "pi" (default: auto-detect)
     #[serde(default)]
     pub agent: Option<String>,
     /// Model to use with the AI agent (default: agent's own default)


### PR DESCRIPTION
## Motivation

`pi` (https://pi.dev) is a first-class AI coding agent, but stax only recognized `claude`, `codex`, `gemini`, and `opencode`. This adds `pi` everywhere the other agents are supported so it works with lanes, AI generation, config, and skill installation.

## Description of changes / notes for reviewers

- **`generate.rs`** — added `pi` to `SUPPORTED_AGENTS` (the single gatekeeper used by `validate_agent_name`), the auto-detect install hint, and a `pi` arm in `invoke_ai_agent` (`pi -p [--model …]`, prompt piped via stdin — verified `pi -p` reads stdin and emits plain text).
- **`worktree/shared.rs`** (`st lane`) — `pi` joins the `--model` launch arm. `--yolo` is intentionally **not** supported for `pi`: its permission bypass is provided by opt-in permission-mode extensions, not a stable core CLI flag (mirrors how `opencode` is handled). Documented in the `yolo_flag_for_agent` docstring.
- **`skills.rs`** — new `SkillLocation` so `stax skills update` installs to `~/.pi/agent/skills/stax/SKILL.md` (frontmatter format, alongside Codex/OpenCode/Claude/Cursor).
- **`config/mod.rs`** — doc comment lists `pi` as a valid agent.
- **Docs** — new `docs/integrations/pi.md`; `pi` added to the agent lists in README, `skills.md`, config/reporting/worktrees/pr-templates/agent-worktrees pages, and all integration cross-links.

### Tests

4 new unit tests: `validate_agent_name` accepts `pi` (+ rejects unknown), lane spec builds `pi --model`, `yolo_flag_for_agent("pi")` → `None`, and the `pi` skill location is registered. All pass.

### Verification

- `make lint` — clean.
- Targeted unit tests — 11 pass (incl. the 4 new).
- `stax skills update` — confirmed it installs `~/.pi/agent/skills/stax/SKILL.md` with correct frontmatter.
- Not run: full `make test` Docker suite.
