### PR TITLE
fix(create): honor -m message with explicit name; dedupe doubled user prefix

### DIFF
--- a/src/application/branch_name.rs
+++ b/src/application/branch_name.rs
@@ -93,18 +93,29 @@ fn apply_format_template(template: &str, message: &str, context: &BranchNameCont
             &context.date.format(&context.date_format).to_string(),
         );
     }
+    let user = context
+        .user
+        .as_deref()
+        .map(|user| sanitize_branch_segment(user, &context.replacement))
+        .unwrap_or_default();
     if result.contains("{user}") {
-        let user = context
-            .user
-            .as_deref()
-            .map(|user| sanitize_branch_segment(user, &context.replacement))
-            .unwrap_or_default();
         result = result.replace("{user}", &user);
     }
     while result.contains("//") {
         result = result.replace("//", "/");
     }
     result = result.trim_matches('/').to_string();
+    // Dedupe a duplicated leading user segment: when the message already begins
+    // with the user prefix (e.g. `{user}/{message}` + message "cesar/foo"), the
+    // substitution above yields "cesar/cesar/foo". Collapse the leading
+    // "<user>/<user>/" back to "<user>/" so the `{user}` template stays
+    // idempotent, matching how `apply_prefix` refuses to double an explicit
+    // prefix.
+    if !user.is_empty()
+        && let Some(rest) = result.strip_prefix(&format!("{user}/{user}/"))
+    {
+        result = format!("{user}/{rest}");
+    }
     apply_prefix(result, context.prefix.as_deref())
 }
 
@@ -191,6 +202,30 @@ mod tests {
                 normalized: "César-Ferreira/Fix-GUI".into(),
             }]
         );
+    }
+
+    #[test]
+    fn format_branch_name_dedupes_leading_user_segment() {
+        let context = BranchNameContext {
+            format: Some("{user}/{message}".into()),
+            prefix: None,
+            legacy_date: false,
+            date_format: "%Y-%m-%d".into(),
+            replacement: "-".into(),
+            user: Some("cesar".into()),
+            date: chrono::NaiveDate::from_ymd_opt(2026, 7, 12).unwrap(),
+        };
+        // Message already leads with the user prefix — must not double it.
+        let result = format_branch_name("cesar/fix-thing", &context).unwrap();
+        assert_eq!(result.name, "cesar/fix-thing");
+        assert!(result.warnings.is_empty());
+        // A bare message still gets the single user prefix.
+        let bare = format_branch_name("fix-thing", &context).unwrap();
+        assert_eq!(bare.name, "cesar/fix-thing");
+        // A message segment that merely starts with the user text (not the
+        // full `user/` segment) is left untouched.
+        let similar = format_branch_name("cesarine", &context).unwrap();
+        assert_eq!(similar.name, "cesar/cesarine");
     }
 
     #[test]

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -506,7 +506,7 @@ pub fn run(
     // skip the menu and force-stage.
     // When neither name nor message is provided, launch interactive wizard.
     let (input, commit_message, stage_mode, generated_branch_name) = if let Some(n) = &name {
-        let commit_message = ai_message;
+        let commit_message = message.clone().or(ai_message);
         let stage_mode = if commit_message.is_some() {
             if all {
                 StageMode::All

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -48,6 +48,8 @@ mod create_ai_tests;
 mod create_below_tests;
 #[path = "create_insert_tests.rs"]
 mod create_insert_tests;
+#[path = "create_message_tests.rs"]
+mod create_message_tests;
 #[path = "create_rollback_tests.rs"]
 mod create_rollback_tests;
 #[path = "demo_tests.rs"]

--- a/tests/create_message_tests.rs
+++ b/tests/create_message_tests.rs
@@ -1,0 +1,51 @@
+//! Tests for `st create <name> -m "message"`.
+//!
+//! Regression: when a positional branch name was supplied, the `-m` commit
+//! message was silently dropped (only staging happened), leaving an empty
+//! branch. The message must be committed while the branch keeps the explicit
+//! name.
+
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+
+#[test]
+fn test_create_with_name_and_message_commits_with_that_message() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let trunk_head = repo.get_commit_sha("HEAD");
+
+    repo.create_file("feature.txt", "feature work\n");
+
+    let output = repo.run_stax(&["create", "my-feature", "-a", "-m", "Add my feature"]);
+    output.assert_success();
+
+    // The branch keeps the explicit name, not the commit message.
+    let branch = repo.current_branch();
+    assert!(
+        branch.contains("my-feature"),
+        "Expected branch named after positional name, got: {}",
+        branch
+    );
+
+    // The message must actually be committed.
+    let subject = repo.git(&["log", "-1", "--pretty=%s"]);
+    assert!(subject.status.success(), "{}", TestRepo::stderr(&subject));
+    assert_eq!(TestRepo::stdout(&subject).trim(), "Add my feature");
+
+    // HEAD advanced past trunk (i.e. the branch is not empty).
+    let head = repo.get_commit_sha("HEAD");
+    assert_ne!(
+        head, trunk_head,
+        "create <name> -m should produce a new commit, not an empty branch"
+    );
+
+    // The committed file is present in the tree.
+    let show = repo.git(&["show", "HEAD:feature.txt"]);
+    assert!(
+        show.status.success(),
+        "committed change should be in HEAD tree: {}",
+        TestRepo::stderr(&show)
+    );
+}

--- a/tests/pr_template_tests.rs
+++ b/tests/pr_template_tests.rs
@@ -27,7 +27,7 @@ fn test_submit_with_single_template() {
     .unwrap();
 
     // Create a branch with stax
-    let output = repo.run_stax(&["create", "test-branch", "-m", "test commit"]);
+    let output = repo.run_stax(&["create", "test-branch"]);
     output.assert_success();
 
     // Verify branch was created
@@ -79,7 +79,7 @@ fn test_no_template_in_repo() {
     // No template created - use default repo
 
     // Create a branch with stax
-    let output = repo.run_stax(&["create", "test-branch", "-m", "test commit"]);
+    let output = repo.run_stax(&["create", "test-branch"]);
     output.assert_success();
 
     // Verify branch was created
@@ -261,7 +261,7 @@ fn test_templates_in_subdirectory() {
     fs::write(template_dir.join("default.md"), "# Default template\n").unwrap();
 
     // Create a branch
-    let output = repo.run_stax(&["create", "test-branch", "-m", "test commit"]);
+    let output = repo.run_stax(&["create", "test-branch"]);
     output.assert_success();
 
     // Verify template file exists
@@ -282,7 +282,7 @@ fn test_template_in_docs_directory() {
     .unwrap();
 
     // Create a branch
-    let output = repo.run_stax(&["create", "test-branch", "-m", "test commit"]);
+    let output = repo.run_stax(&["create", "test-branch"]);
     output.assert_success();
 
     // Verify template file exists


### PR DESCRIPTION
## Summary

Two independent `stax create` ergonomics bugs that showed up in real agent workflows:

### 1. `-m` message silently dropped when a branch name is given

`stax create <name> -m "msg"` was supposed to commit with that message, but the name-present code path hardcoded `commit_message = ai_message` (always `None` without `--ai`). The branch was created **empty** with changes only staged — exactly what happened when an agent ran `stax create cesar/foo -am "…"` and submit saw an empty branch.

**Fix:** use `message.clone().or(ai_message)`, matching the generated-branch arm and the flag's documented behavior.

### 2. `{user}/{message}` template doubles the user prefix

With `format = "{user}/{message}"` and `user = "cesar"`, passing a name that already starts with `cesar/` (e.g. `cesar/OBX-2978-foo`) produced `cesar/cesar/OBX-2978-foo`. The explicit `--prefix` path already dedupes; the `{user}` template did not.

**Fix:** collapse a doubled leading `<user>/<user>/` back to `<user>/`.

## Tests

- Unit: `format_branch_name_dedupes_leading_user_segment`
- Integration: `create_message_tests::test_create_with_name_and_message_commits_with_that_message`
- Fix: `pr_template_tests` — removed stray `-m` flags that were accidentally relying on bug #1

## Test plan

- [x] `cargo nextest run create_message_tests:: pr_template_tests:: application::branch_name::`
- [x] `make lint` (full)
- [ ] CI integration suite (re-running after test fix)