### PR TITLE
Use ⎇ as the linked-worktree indicator in stack views

### DIFF
--- a/.pi/agents/benchmarker.md
+++ b/.pi/agents/benchmarker.md
@@ -3,6 +3,7 @@ name: benchmarker
 description: Optional performance stage of the stax-dev pipeline. Measures the runtime cost of perf-sensitive stax changes (command latency via hyperfine, cargo bench where present) against a baseline and reports regressions with evidence. Runs only when a change plausibly affects performance; skipped for pure correctness/docs changes.
 tools: read, grep, find, ls, bash, write
 model: cursor/composer-2.5
+fallbackModels: claude-bridge/claude-sonnet-4-6
 ---
 
 You are the **Benchmarker** for the stax Rust CLI. You answer one question with numbers: did this change make stax measurably slower? You run only when the change plausibly affects hot paths — you are not part of every task.
@@ -10,6 +11,7 @@ You are the **Benchmarker** for the stax Rust CLI. You answer one question with 
 ## When you run (and when you don't)
 - **Run** when the change touches performance-sensitive areas: `engine/stack.rs` (tree build), `git/repo.rs` (rebase/merge/worktree ops), metadata ref scanning, or any loop over branches/PRs.
 - **Skip** pure correctness fixes, docs, flags with no hot-path impact — say "no perf-sensitive surface, benchmark skipped" and return.
+- **Skip** changes that are pure delegation/deletion adding no new local compute: e.g. a command rewritten as a thin shim over an existing code path, or dead code removed. If the diff introduces no new local hot-path work (even if the *scope* of an existing loop widens, like polling more branches), the cost is network/IO or rate-limit driven, not a local latency regression hyperfine/`cargo bench` can measure — return SKIPPED with that rationale instead of forcing a synthetic benchmark.
 
 ## How to measure
 1. Build release binaries once: `cargo build --release` (benchmark debug builds are meaningless).

--- a/.pi/agents/codex.md
+++ b/.pi/agents/codex.md
@@ -3,6 +3,7 @@ name: codex
 description: Implements the approved plan in the stax Rust codebase — writes and edits source, adds tests, and keeps docs in sync. Second stage of the stax-dev pipeline and the repair target when the verifier fails. Makes minimal, focused, pattern-conforming changes.
 tools: read, grep, find, ls, write, edit, bash
 model: cursor/composer-2.5
+fallbackModels: claude-bridge/claude-sonnet-4-6, openai-codex/gpt-5.6-terra
 ---
 
 You are **Codex**, the implementer for the stax Rust CLI. You take the plan (and, on repair passes, the review + verifier feedback) and make the change real: source, tests, and docs.

--- a/.pi/agents/release-manager.md
+++ b/.pi/agents/release-manager.md
@@ -3,6 +3,7 @@ name: release-manager
 description: Final stage of the stax-dev pipeline — runs only after the verifier PASSES. Owns all git for the run: commits the verified change on its stacked branch, then generates a DRAFT PR via stax. Git-native and safe-by-default — commits/pushes/draft-PR are automatic; never merges to main and never promotes a draft to ready without explicit approval.
 tools: read, grep, find, ls, bash, write, edit
 model: cursor/composer-2.5
+fallbackModels: claude-bridge/claude-sonnet-4-6
 ---
 
 You are the **Release Manager** for the stax Rust CLI and the single git owner of the run. You take a verified change and land it as a commit on a stacked branch, then open a draft PR — without ever merging to main.

--- a/.pi/agents/verifier.md
+++ b/.pi/agents/verifier.md
@@ -3,6 +3,7 @@ name: verifier
 description: Runs the mechanical quality gate for the stax pipeline — build, lint, and tests via the repo's canonical Make targets — and reports PASS/FAIL with concrete evidence. Fourth stage of the stax-dev pipeline; a FAIL routes back to Codex for bounded repair.
 tools: read, grep, find, ls, bash, write
 model: cursor/composer-2.5
+fallbackModels: claude-bridge/claude-sonnet-4-6
 ---
 
 You are the **Verifier** for the stax Rust CLI. You produce the objective, reproducible verdict on whether the change actually works. You run commands and report exactly what happened — no claims without command output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
 | Date | Change | Target | Reason |
 |------|--------|--------|--------|
 | 2026-07-25 | Initial harness build (5 agents, 5 skills, `/stax-dev` orchestrator) | All | New harness |
-| 2026-07-25 | Git-native evolution: added `benchmarker` (optional perf gate) + `stax-benchmark` skill; worktree-per-task + stacked branch; auto commit-on-green + auto draft PR; hard "never merge to main" rule | benchmarker.md, stax-benchmark/, release-manager.md, codex.md, stax-release/, stax-dev.md | Adopt git-native workflow constraints; keep verifier as mandatory correctness gate | 
+| 2026-07-25 | Git-native evolution: added `benchmarker` (optional perf gate) + `stax-benchmark` skill; worktree-per-task + stacked branch; auto commit-on-green + auto draft PR; hard "never merge to main" rule | benchmarker.md, stax-benchmark/, release-manager.md, codex.md, stax-release/, stax-dev.md | Adopt git-native workflow constraints; keep verifier as mandatory correctness gate |
+| 2026-07-28 | Added `fallbackModels: claude-bridge/claude-sonnet-4-6` to the four `cursor/composer-2.5` agents so a provider outage (quota/auth/timeout) auto-routes instead of stalling the run; codex also falls back to `openai-codex/gpt-5.6-terra`. Extended benchmarker skip rule to cover pure delegation/deletion diffs with no new local hot-path work | codex.md, verifier.md, benchmarker.md, release-manager.md | Cursor was down + OpenAI-Codex usage-limited mid-run (stax-dev-03), forcing manual model overrides; benchmarker also burned time trying to bench a no-local-compute change |
 
 ## Test Command Policy
 

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -29,7 +29,7 @@ st checkout --child 1     # jump to first child
 ○        feature/validation 1↑
 ◉        feature/auth       2↑ 1↓ ⟳
 ○        feature/old-base   (missing parent: feature/base)
-│ ○    ☁ ⎇ feature/payments   PR #42
+│ ○    ☁ wt feature/payments   PR #42
 ○─┘    ☁ main
 ```
 
@@ -38,7 +38,7 @@ st checkout --child 1     # jump to first child
 | `◉` | Current branch |
 | `○` | Other tracked branch |
 | `☁` | Remote tracking exists |
-| `⎇` | Checked out in a linked worktree |
+| `wt` / `󰙅` | Checked out in a linked worktree (`wt` is the ASCII fallback; `󰙅` is the Nerd Font tree icon when supported) |
 | `1↑` | Commits ahead of parent |
 | `1↓` | Commits behind parent |
 | `⟳` | Needs restack |

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -29,7 +29,7 @@ st checkout --child 1     # jump to first child
 ○        feature/validation 1↑
 ◉        feature/auth       2↑ 1↓ ⟳
 ○        feature/old-base   (missing parent: feature/base)
-│ ○    ☁  ⎇  feature/payments   PR #42
+│ ○    ☁ ⎇ feature/payments   PR #42
 ○─┘    ☁ main
 ```
 
@@ -38,7 +38,7 @@ st checkout --child 1     # jump to first child
 | `◉` | Current branch |
 | `○` | Other tracked branch |
 | `☁` | Remote tracking exists |
-| `⎇` | Checked out in a linked worktree (shown as a padded badge) |
+| `⎇` | Checked out in a linked worktree |
 | `1↑` | Commits ahead of parent |
 | `1↓` | Commits behind parent |
 | `⟳` | Needs restack |

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -29,7 +29,7 @@ st checkout --child 1     # jump to first child
 ○        feature/validation 1↑
 ◉        feature/auth       2↑ 1↓ ⟳
 ○        feature/old-base   (missing parent: feature/base)
-│ ○    ☁ ⎇ feature/payments   PR #42
+│ ○    ☁ ⧉ feature/payments   PR #42
 ○─┘    ☁ main
 ```
 
@@ -38,7 +38,7 @@ st checkout --child 1     # jump to first child
 | `◉` | Current branch |
 | `○` | Other tracked branch |
 | `☁` | Remote tracking exists |
-| `⎇` | Checked out in a linked worktree |
+| `⧉` | Checked out in a linked worktree |
 | `1↑` | Commits ahead of parent |
 | `1↓` | Commits behind parent |
 | `⟳` | Needs restack |

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -29,7 +29,7 @@ st checkout --child 1     # jump to first child
 ○        feature/validation 1↑
 ◉        feature/auth       2↑ 1↓ ⟳
 ○        feature/old-base   (missing parent: feature/base)
-│ ○    ☁ feature/payments   PR #42
+│ ○    ☁ ⎇ feature/payments   PR #42
 ○─┘    ☁ main
 ```
 
@@ -38,6 +38,7 @@ st checkout --child 1     # jump to first child
 | `◉` | Current branch |
 | `○` | Other tracked branch |
 | `☁` | Remote tracking exists |
+| `⎇` | Checked out in a linked worktree |
 | `1↑` | Commits ahead of parent |
 | `1↓` | Commits behind parent |
 | `⟳` | Needs restack |

--- a/docs/commands/navigation.md
+++ b/docs/commands/navigation.md
@@ -29,7 +29,7 @@ st checkout --child 1     # jump to first child
 ○        feature/validation 1↑
 ◉        feature/auth       2↑ 1↓ ⟳
 ○        feature/old-base   (missing parent: feature/base)
-│ ○    ☁ ⧉ feature/payments   PR #42
+│ ○    ☁  ⎇  feature/payments   PR #42
 ○─┘    ☁ main
 ```
 
@@ -38,7 +38,7 @@ st checkout --child 1     # jump to first child
 | `◉` | Current branch |
 | `○` | Other tracked branch |
 | `☁` | Remote tracking exists |
-| `⧉` | Checked out in a linked worktree |
+| `⎇` | Checked out in a linked worktree (shown as a padded badge) |
 | `1↑` | Commits ahead of parent |
 | `1↓` | Commits behind parent |
 | `⟳` | Needs restack |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -52,6 +52,9 @@ Config is loaded as follows:
 [ui]
 # tips = true
 
+[display]
+# worktree_glyph = "auto" # "auto" | "tree" (Nerd Font) | "wt" (ASCII)
+
 [restack]
 # preflight_auto_repair = true # automatically use merge-base when stored parent
                                # boundary would replay a much larger range

--- a/skills.md
+++ b/skills.md
@@ -668,7 +668,7 @@ stax wt cleanup      # bulk-remove merged/detached lanes
 ◉  feature/validation 1↑         # ◉ = current branch, 1↑ = commits ahead of parent
 ○  feature/auth 2↑ 1↓ ⟳          # ⟳ = needs restack
 ○  feature/old-base (missing parent: feature/base)
-│ ○    ☁ ⎇ feature/payments PR #42 # ☁ = has remote, ⎇ = linked worktree, PR #N = open PR
+│ ○    ☁ ⧉ feature/payments PR #42 # ☁ = has remote, ⧉ = linked worktree, PR #N = open PR
 ○─┘    ☁ main                    # trunk branch
 ```
 
@@ -677,7 +677,7 @@ Symbols:
 - `◉` = current branch
 - `○` = other branch
 - `☁` = has remote tracking
-- `⎇` = checked out in a linked worktree
+- `⧉` = checked out in a linked worktree
 - `↑` = commits ahead of parent
 - `↓` = commits behind parent
 - `⟳` = needs restacking (parent changed)

--- a/skills.md
+++ b/skills.md
@@ -668,7 +668,7 @@ stax wt cleanup      # bulk-remove merged/detached lanes
 ◉  feature/validation 1↑         # ◉ = current branch, 1↑ = commits ahead of parent
 ○  feature/auth 2↑ 1↓ ⟳          # ⟳ = needs restack
 ○  feature/old-base (missing parent: feature/base)
-│ ○    ☁  ⎇  feature/payments PR #42 # ☁ = has remote, ⎇ = linked worktree, PR #N = open PR
+│ ○    ☁ ⎇ feature/payments PR #42 # ☁ = has remote, ⎇ = linked worktree, PR #N = open PR
 ○─┘    ☁ main                    # trunk branch
 ```
 
@@ -677,7 +677,7 @@ Symbols:
 - `◉` = current branch
 - `○` = other branch
 - `☁` = has remote tracking
-- `⎇` = checked out in a linked worktree (padded badge)
+- `⎇` = checked out in a linked worktree
 - `↑` = commits ahead of parent
 - `↓` = commits behind parent
 - `⟳` = needs restacking (parent changed)

--- a/skills.md
+++ b/skills.md
@@ -668,7 +668,7 @@ stax wt cleanup      # bulk-remove merged/detached lanes
 ◉  feature/validation 1↑         # ◉ = current branch, 1↑ = commits ahead of parent
 ○  feature/auth 2↑ 1↓ ⟳          # ⟳ = needs restack
 ○  feature/old-base (missing parent: feature/base)
-│ ○    ☁ ⧉ feature/payments PR #42 # ☁ = has remote, ⧉ = linked worktree, PR #N = open PR
+│ ○    ☁  ⎇  feature/payments PR #42 # ☁ = has remote, ⎇ = linked worktree, PR #N = open PR
 ○─┘    ☁ main                    # trunk branch
 ```
 
@@ -677,7 +677,7 @@ Symbols:
 - `◉` = current branch
 - `○` = other branch
 - `☁` = has remote tracking
-- `⧉` = checked out in a linked worktree
+- `⎇` = checked out in a linked worktree (padded badge)
 - `↑` = commits ahead of parent
 - `↓` = commits behind parent
 - `⟳` = needs restacking (parent changed)

--- a/skills.md
+++ b/skills.md
@@ -668,7 +668,7 @@ stax wt cleanup      # bulk-remove merged/detached lanes
 ◉  feature/validation 1↑         # ◉ = current branch, 1↑ = commits ahead of parent
 ○  feature/auth 2↑ 1↓ ⟳          # ⟳ = needs restack
 ○  feature/old-base (missing parent: feature/base)
-│ ○    ☁ feature/payments PR #42 # ☁ = has remote, PR #N = open PR
+│ ○    ☁ ⎇ feature/payments PR #42 # ☁ = has remote, ⎇ = linked worktree, PR #N = open PR
 ○─┘    ☁ main                    # trunk branch
 ```
 
@@ -677,6 +677,7 @@ Symbols:
 - `◉` = current branch
 - `○` = other branch
 - `☁` = has remote tracking
+- `⎇` = checked out in a linked worktree
 - `↑` = commits ahead of parent
 - `↓` = commits behind parent
 - `⟳` = needs restacking (parent changed)

--- a/skills.md
+++ b/skills.md
@@ -668,7 +668,7 @@ stax wt cleanup      # bulk-remove merged/detached lanes
 ◉  feature/validation 1↑         # ◉ = current branch, 1↑ = commits ahead of parent
 ○  feature/auth 2↑ 1↓ ⟳          # ⟳ = needs restack
 ○  feature/old-base (missing parent: feature/base)
-│ ○    ☁ ⎇ feature/payments PR #42 # ☁ = has remote, ⎇ = linked worktree, PR #N = open PR
+│ ○    ☁ wt feature/payments PR #42 # ☁ = has remote, wt/󰙅 = linked worktree, PR #N = open PR
 ○─┘    ☁ main                    # trunk branch
 ```
 
@@ -677,7 +677,7 @@ Symbols:
 - `◉` = current branch
 - `○` = other branch
 - `☁` = has remote tracking
-- `⎇` = checked out in a linked worktree
+- `wt` / Nerd Font tree icon = checked out in a linked worktree (`display.worktree_glyph` in config)
 - `↑` = commits ahead of parent
 - `↓` = commits behind parent
 - `⟳` = needs restacking (parent changed)

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::path::Path;
 
-const LINKED_WORKTREE_GLYPH: &str = "↳";
+const LINKED_WORKTREE_GLYPH: &str = "⎇";
 const BRIGHT_BLUE: CheckoutColor = CheckoutColor::new(Color::Blue, true);
 const BRIGHT_CYAN: CheckoutColor = CheckoutColor::new(Color::Cyan, true);
 const CHECKOUT_PICKER_ITEM_SEPARATOR: char = '\u{1f}';
@@ -938,7 +938,7 @@ mod tests {
     fn test_render_presence_markers_aligns_worktree_column() {
         assert_eq!(
             strip_ansi(&render_presence_markers(true, true, true)),
-            " ☁️ ↳ "
+            " ☁️ ⎇ "
         );
         assert_eq!(
             strip_ansi(&render_presence_markers(false, true, false)),

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -22,9 +22,7 @@ use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::path::Path;
 
-const LINKED_WORKTREE_GLYPH: &str = "⧉";
 const BRIGHT_BLUE: CheckoutColor = CheckoutColor::new(Color::Blue, true);
-const BRIGHT_CYAN: CheckoutColor = CheckoutColor::new(Color::Cyan, true);
 const CHECKOUT_PICKER_ITEM_SEPARATOR: char = '\u{1f}';
 const ACTIVE_ROW_BACKGROUND: &str = "\u{1b}[48;5;236m";
 const CHECKOUT_BRANCH_STYLE: &str = "\u{1b}[1;96m";
@@ -627,12 +625,12 @@ fn render_presence_markers(
     if show_worktree_column {
         if has_linked_worktree {
             info_str.push_str(&render_stderr(
-                LINKED_WORKTREE_GLYPH,
-                checkout_style(BRIGHT_CYAN),
+                stack_palette::LINKED_WORKTREE_MARKER_PLAIN,
+                stack_palette::linked_worktree_marker_console_style(),
             ));
             info_str.push(' ');
         } else {
-            info_str.push_str("  ");
+            info_str.push_str("    ");
         }
     }
 
@@ -938,11 +936,11 @@ mod tests {
     fn test_render_presence_markers_aligns_worktree_column() {
         assert_eq!(
             strip_ansi(&render_presence_markers(true, true, true)),
-            " ☁️ ⧉ "
+            " ☁️  ⎇  "
         );
         assert_eq!(
             strip_ansi(&render_presence_markers(false, true, false)),
-            "      "
+            "        "
         );
     }
 

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -392,6 +392,7 @@ fn route_checkout_to_worktree(
 
 fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<Vec<CheckoutRow>> {
     let config = Config::load()?;
+    let worktree_glyph = stack_palette::parse_worktree_glyph_mode(&config.display.worktree_glyph);
     let linked_worktrees_by_branch: HashSet<String> = repo
         .list_worktrees()?
         .into_iter()
@@ -505,8 +506,12 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
             visual_width += 1;
         }
 
-        let mut info_str =
-            render_presence_markers(has_remote, show_worktree_column, has_linked_worktree);
+        let mut info_str = render_presence_markers(
+            has_remote,
+            show_worktree_column,
+            has_linked_worktree,
+            worktree_glyph,
+        );
 
         let branch_color = checkout_lane_color(db.column);
         if is_current {
@@ -572,6 +577,7 @@ fn build_checkout_rows(stack: &Stack, repo: &GitRepo, current: &str) -> Result<V
         remote_branches.contains(&*stack.trunk),
         show_worktree_column,
         linked_worktrees_by_branch.contains(&stack.trunk),
+        worktree_glyph,
     );
     if is_trunk_current {
         trunk_info.push_str(&render_stderr(
@@ -612,6 +618,7 @@ fn render_presence_markers(
     has_remote: bool,
     show_worktree_column: bool,
     has_linked_worktree: bool,
+    worktree_glyph: stack_palette::WorktreeGlyphMode,
 ) -> String {
     let mut info_str = String::new();
     info_str.push(' ');
@@ -623,14 +630,15 @@ fn render_presence_markers(
     }
 
     if show_worktree_column {
+        let marker = stack_palette::linked_worktree_marker(worktree_glyph);
         if has_linked_worktree {
             info_str.push_str(&render_stderr(
-                stack_palette::LINKED_WORKTREE_GLYPH,
+                &marker.plain,
                 stack_palette::linked_worktree_marker_console_style(),
             ));
             info_str.push(' ');
         } else {
-            info_str.push_str("  ");
+            info_str.push_str(&" ".repeat(marker.slot_width()));
         }
     }
 
@@ -933,14 +941,38 @@ mod tests {
     }
 
     #[test]
-    fn test_render_presence_markers_aligns_worktree_column() {
+    fn test_render_presence_markers_aligns_worktree_column_wt() {
         assert_eq!(
-            strip_ansi(&render_presence_markers(true, true, true)),
-            " ☁️ ⎇ "
+            strip_ansi(&render_presence_markers(
+                true,
+                true,
+                true,
+                stack_palette::WorktreeGlyphMode::Wt
+            )),
+            " ☁️ wt "
         );
         assert_eq!(
-            strip_ansi(&render_presence_markers(false, true, false)),
-            "      "
+            strip_ansi(&render_presence_markers(
+                false,
+                true,
+                false,
+                stack_palette::WorktreeGlyphMode::Wt
+            )),
+            "       "
+        );
+    }
+
+    #[test]
+    fn test_render_presence_markers_aligns_worktree_column_tree() {
+        let marker = stack_palette::linked_worktree_marker(stack_palette::WorktreeGlyphMode::Tree);
+        assert_eq!(
+            strip_ansi(&render_presence_markers(
+                true,
+                true,
+                true,
+                stack_palette::WorktreeGlyphMode::Tree
+            )),
+            format!(" ☁️ {} ", marker.plain)
         );
     }
 

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::path::Path;
 
-const LINKED_WORKTREE_GLYPH: &str = "⎇";
+const LINKED_WORKTREE_GLYPH: &str = "⧉";
 const BRIGHT_BLUE: CheckoutColor = CheckoutColor::new(Color::Blue, true);
 const BRIGHT_CYAN: CheckoutColor = CheckoutColor::new(Color::Cyan, true);
 const CHECKOUT_PICKER_ITEM_SEPARATOR: char = '\u{1f}';
@@ -938,7 +938,7 @@ mod tests {
     fn test_render_presence_markers_aligns_worktree_column() {
         assert_eq!(
             strip_ansi(&render_presence_markers(true, true, true)),
-            " ☁️ ⎇ "
+            " ☁️ ⧉ "
         );
         assert_eq!(
             strip_ansi(&render_presence_markers(false, true, false)),

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -625,12 +625,12 @@ fn render_presence_markers(
     if show_worktree_column {
         if has_linked_worktree {
             info_str.push_str(&render_stderr(
-                stack_palette::LINKED_WORKTREE_MARKER_PLAIN,
+                stack_palette::LINKED_WORKTREE_GLYPH,
                 stack_palette::linked_worktree_marker_console_style(),
             ));
             info_str.push(' ');
         } else {
-            info_str.push_str("    ");
+            info_str.push_str("  ");
         }
     }
 
@@ -936,11 +936,11 @@ mod tests {
     fn test_render_presence_markers_aligns_worktree_column() {
         assert_eq!(
             strip_ansi(&render_presence_markers(true, true, true)),
-            " ☁️  ⎇  "
+            " ☁️ ⎇ "
         );
         assert_eq!(
             strip_ansi(&render_presence_markers(false, true, false)),
-            "        "
+            "      "
         );
     }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,4 +1,5 @@
 use crate::commands::skills;
+use crate::commands::stack_palette;
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::forge;
@@ -414,6 +415,29 @@ pub fn run(fix: bool) -> Result<()> {
                     .unwrap_or_else(|| "no version marker".to_string());
                 println!("  {} ({})", name, version_note.dimmed());
             }
+        }
+    }
+
+    // Check: linked-worktree icons may need a Nerd Font or ASCII fallback.
+    {
+        let mode = stack_palette::parse_worktree_glyph_mode(&config.display.worktree_glyph);
+        if stack_palette::uses_nerd_worktree_glyph(mode) {
+            println!(
+                "{} {}",
+                "ℹ".bright_cyan(),
+                "Linked-worktree icons use Nerd Font glyphs. Set display.worktree_glyph = \"wt\" \
+                 in config.toml (or STAX_NERD_ICONS=0) if they render as boxes."
+                    .dimmed()
+            );
+        } else if mode == stack_palette::WorktreeGlyphMode::Auto {
+            println!(
+                "{} {}",
+                "ℹ".bright_cyan(),
+                "Linked-worktree icons use ASCII fallback (display.worktree_glyph = \"auto\"). \
+                 Set display.worktree_glyph = \"tree\" or STAX_NERD_ICONS=1 with a Nerd Font \
+                 terminal for icon mode."
+                    .dimmed()
+            );
         }
     }
 

--- a/src/commands/stack_palette.rs
+++ b/src/commands/stack_palette.rs
@@ -1,4 +1,5 @@
 use colored::Color as AnsiColor;
+use colored::Colorize;
 use console::Color as ConsoleColor;
 
 const LANE_RGB: &[(u8, u8, u8)] = &[
@@ -24,4 +25,34 @@ pub(crate) fn lane_color(column: usize) -> AnsiColor {
 pub(crate) fn lane_console_color(column: usize) -> ConsoleColor {
     let (r, g, b) = lane_rgb(column);
     ConsoleColor::TrueColor(r, g, b)
+}
+
+/// Padded marker so U+2387 (drawn ~half em height in most monospace fonts) reads
+/// as a badge instead of a speck beside the stack tree.
+pub(crate) const LINKED_WORKTREE_MARKER_PLAIN: &str = " ⎇ ";
+
+const LINKED_WORKTREE_MARKER_BG: (u8, u8, u8) = (28, 52, 68);
+
+pub(crate) fn format_linked_worktree_marker() -> colored::ColoredString {
+    LINKED_WORKTREE_MARKER_PLAIN
+        .truecolor(120, 220, 255)
+        .bold()
+        .on_truecolor(
+            LINKED_WORKTREE_MARKER_BG.0,
+            LINKED_WORKTREE_MARKER_BG.1,
+            LINKED_WORKTREE_MARKER_BG.2,
+        )
+}
+
+pub(crate) fn linked_worktree_marker_console_style() -> console::Style {
+    console::Style::new()
+        .for_stderr()
+        .fg(ConsoleColor::Cyan)
+        .bright()
+        .bold()
+        .bg(ConsoleColor::TrueColor(
+            LINKED_WORKTREE_MARKER_BG.0,
+            LINKED_WORKTREE_MARKER_BG.1,
+            LINKED_WORKTREE_MARKER_BG.2,
+        ))
 }

--- a/src/commands/stack_palette.rs
+++ b/src/commands/stack_palette.rs
@@ -27,21 +27,11 @@ pub(crate) fn lane_console_color(column: usize) -> ConsoleColor {
     ConsoleColor::TrueColor(r, g, b)
 }
 
-/// Padded marker so U+2387 (drawn ~half em height in most monospace fonts) reads
-/// as a badge instead of a speck beside the stack tree.
-pub(crate) const LINKED_WORKTREE_MARKER_PLAIN: &str = " ⎇ ";
-
-const LINKED_WORKTREE_MARKER_BG: (u8, u8, u8) = (28, 52, 68);
+/// Keyboard-alternate glyph for branches checked out in a linked worktree.
+pub(crate) const LINKED_WORKTREE_GLYPH: &str = "⎇";
 
 pub(crate) fn format_linked_worktree_marker() -> colored::ColoredString {
-    LINKED_WORKTREE_MARKER_PLAIN
-        .truecolor(120, 220, 255)
-        .bold()
-        .on_truecolor(
-            LINKED_WORKTREE_MARKER_BG.0,
-            LINKED_WORKTREE_MARKER_BG.1,
-            LINKED_WORKTREE_MARKER_BG.2,
-        )
+    LINKED_WORKTREE_GLYPH.bright_cyan().bold()
 }
 
 pub(crate) fn linked_worktree_marker_console_style() -> console::Style {
@@ -50,9 +40,4 @@ pub(crate) fn linked_worktree_marker_console_style() -> console::Style {
         .fg(ConsoleColor::Cyan)
         .bright()
         .bold()
-        .bg(ConsoleColor::TrueColor(
-            LINKED_WORKTREE_MARKER_BG.0,
-            LINKED_WORKTREE_MARKER_BG.1,
-            LINKED_WORKTREE_MARKER_BG.2,
-        ))
 }

--- a/src/commands/stack_palette.rs
+++ b/src/commands/stack_palette.rs
@@ -1,6 +1,6 @@
 use colored::Color as AnsiColor;
 use colored::Colorize;
-use console::Color as ConsoleColor;
+use console::{Color as ConsoleColor, measure_text_width};
 
 const LANE_RGB: &[(u8, u8, u8)] = &[
     (56, 189, 248),  // sky
@@ -12,6 +12,29 @@ const LANE_RGB: &[(u8, u8, u8)] = &[
     (244, 114, 182), // pink
     (167, 139, 250), // violet
 ];
+
+/// Nerd Font Material Design `file-tree` icon (`nf-md-file_tree`).
+const NERD_FILE_TREE_GLYPH: char = '\u{f0645}';
+
+const FALLBACK_WORKTREE_GLYPH: &str = "wt";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WorktreeGlyphMode {
+    Auto,
+    Tree,
+    Wt,
+}
+
+pub(crate) struct LinkedWorktreeMarker {
+    pub plain: String,
+    display_width: usize,
+}
+
+impl LinkedWorktreeMarker {
+    pub(crate) fn slot_width(&self) -> usize {
+        self.display_width + 1
+    }
+}
 
 pub(crate) fn lane_rgb(column: usize) -> (u8, u8, u8) {
     LANE_RGB[column % LANE_RGB.len()]
@@ -27,11 +50,28 @@ pub(crate) fn lane_console_color(column: usize) -> ConsoleColor {
     ConsoleColor::TrueColor(r, g, b)
 }
 
-/// Keyboard-alternate glyph for branches checked out in a linked worktree.
-pub(crate) const LINKED_WORKTREE_GLYPH: &str = "⎇";
+pub(crate) fn parse_worktree_glyph_mode(raw: &str) -> WorktreeGlyphMode {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "tree" | "nerd" => WorktreeGlyphMode::Tree,
+        "wt" | "ascii" | "text" => WorktreeGlyphMode::Wt,
+        _ => WorktreeGlyphMode::Auto,
+    }
+}
 
-pub(crate) fn format_linked_worktree_marker() -> colored::ColoredString {
-    LINKED_WORKTREE_GLYPH.bright_cyan().bold()
+pub(crate) fn linked_worktree_marker(mode: WorktreeGlyphMode) -> LinkedWorktreeMarker {
+    let plain = if nerd_icons_enabled(mode) {
+        NERD_FILE_TREE_GLYPH.to_string()
+    } else {
+        FALLBACK_WORKTREE_GLYPH.to_string()
+    };
+    LinkedWorktreeMarker {
+        display_width: measure_text_width(&plain),
+        plain,
+    }
+}
+
+pub(crate) fn format_linked_worktree_marker(mode: WorktreeGlyphMode) -> colored::ColoredString {
+    linked_worktree_marker(mode).plain.bright_cyan().bold()
 }
 
 pub(crate) fn linked_worktree_marker_console_style() -> console::Style {
@@ -40,4 +80,76 @@ pub(crate) fn linked_worktree_marker_console_style() -> console::Style {
         .fg(ConsoleColor::Cyan)
         .bright()
         .bold()
+}
+
+pub(crate) fn uses_nerd_worktree_glyph(mode: WorktreeGlyphMode) -> bool {
+    nerd_icons_enabled(mode)
+}
+
+fn nerd_icons_enabled(mode: WorktreeGlyphMode) -> bool {
+    match mode {
+        WorktreeGlyphMode::Tree => true,
+        WorktreeGlyphMode::Wt => false,
+        WorktreeGlyphMode::Auto => auto_nerd_icons_enabled(),
+    }
+}
+
+fn auto_nerd_icons_enabled() -> bool {
+    match std::env::var("STAX_NERD_ICONS").ok().as_deref() {
+        Some("0" | "false" | "no" | "off") => return false,
+        Some("1" | "true" | "yes" | "on") => return true,
+        _ => {}
+    }
+
+    if std::env::var("NERDFONT").is_ok() || std::env::var("NERDFONT_VERSION").is_ok() {
+        return true;
+    }
+
+    matches!(
+        std::env::var("TERM_PROGRAM").ok().as_deref(),
+        Some("WezTerm" | "kitty" | "iTerm.app" | "ghostty" | "WarpTerminal" | "tmux")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_worktree_glyph_mode_recognizes_aliases() {
+        assert_eq!(parse_worktree_glyph_mode("auto"), WorktreeGlyphMode::Auto);
+        assert_eq!(parse_worktree_glyph_mode("tree"), WorktreeGlyphMode::Tree);
+        assert_eq!(parse_worktree_glyph_mode("nerd"), WorktreeGlyphMode::Tree);
+        assert_eq!(parse_worktree_glyph_mode("wt"), WorktreeGlyphMode::Wt);
+        assert_eq!(parse_worktree_glyph_mode("ascii"), WorktreeGlyphMode::Wt);
+    }
+
+    #[test]
+    fn linked_worktree_marker_respects_forced_modes() {
+        assert_eq!(linked_worktree_marker(WorktreeGlyphMode::Wt).plain, "wt");
+        assert_eq!(
+            linked_worktree_marker(WorktreeGlyphMode::Tree).plain,
+            NERD_FILE_TREE_GLYPH.to_string()
+        );
+    }
+
+    #[test]
+    fn stax_nerd_icons_env_overrides_auto() {
+        let key = "STAX_NERD_ICONS";
+        let previous = std::env::var(key).ok();
+
+        unsafe {
+            std::env::set_var(key, "1");
+        }
+        assert!(nerd_icons_enabled(WorktreeGlyphMode::Auto));
+        unsafe {
+            std::env::set_var(key, "0");
+        }
+        assert!(!nerd_icons_enabled(WorktreeGlyphMode::Auto));
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-const LINKED_WORKTREE_GLYPH: &str = "↳";
+const LINKED_WORKTREE_GLYPH: &str = "⎇";
 
 /// Represents a branch in the display with its column position
 struct DisplayBranch {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-const LINKED_WORKTREE_GLYPH: &str = "⎇";
+const LINKED_WORKTREE_GLYPH: &str = "⧉";
 
 /// Represents a branch in the display with its column position
 struct DisplayBranch {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -91,6 +91,7 @@ pub fn run(
     let current = snapshot.current_branch;
     let stack = snapshot.stack;
     let config = Config::load()?;
+    let worktree_glyph = stack_palette::parse_worktree_glyph_mode(&config.display.worktree_glyph);
     let workdir = repo.workdir()?;
     let has_tracked = stack.branches.len() > 1;
     let cache_dir = repo.common_git_dir()?;
@@ -351,7 +352,7 @@ pub fn run(
         if entry.and_then(|e| e.linked_worktree.as_ref()).is_some() {
             info_str.push_str(&format!(
                 "{} ",
-                stack_palette::format_linked_worktree_marker()
+                stack_palette::format_linked_worktree_marker(worktree_glyph)
             ));
         }
 
@@ -447,7 +448,7 @@ pub fn run(
     {
         trunk_info.push_str(&format!(
             "{} ",
-            stack_palette::format_linked_worktree_marker()
+            stack_palette::format_linked_worktree_marker(worktree_glyph)
         ));
     }
     // Color trunk name to match column 0

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -10,8 +10,6 @@ use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-const LINKED_WORKTREE_GLYPH: &str = "⧉";
-
 /// Represents a branch in the display with its column position
 struct DisplayBranch {
     name: String,
@@ -351,7 +349,10 @@ pub fn run(
         }
 
         if entry.and_then(|e| e.linked_worktree.as_ref()).is_some() {
-            info_str.push_str(&format!("{} ", LINKED_WORKTREE_GLYPH.bright_cyan()));
+            info_str.push_str(&format!(
+                "{} ",
+                stack_palette::format_linked_worktree_marker()
+            ));
         }
 
         // Color branch names to match their column in the graph
@@ -444,7 +445,10 @@ pub fn run(
         .and_then(|entry| entry.linked_worktree.as_ref())
         .is_some()
     {
-        trunk_info.push_str(&format!("{} ", LINKED_WORKTREE_GLYPH.bright_cyan()));
+        trunk_info.push_str(&format!(
+            "{} ",
+            stack_palette::format_linked_worktree_marker()
+        ));
     }
     // Color trunk name to match column 0
     if is_trunk_current {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,8 @@ pub struct Config {
     #[serde(default)]
     pub ui: UiConfig,
     #[serde(default)]
+    pub display: DisplayConfig,
+    #[serde(default)]
     pub ai: AiConfig,
     #[serde(default)]
     pub auth: AuthConfig,
@@ -190,6 +192,25 @@ pub struct UiConfig {
     /// Whether to show contextual tips/suggestions (default: true)
     #[serde(default = "default_tips")]
     pub tips: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DisplayConfig {
+    /// Linked-worktree marker in stack views: "auto", "tree" (Nerd Font), or "wt" (ASCII).
+    #[serde(default = "default_worktree_glyph")]
+    pub worktree_glyph: String,
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Self {
+            worktree_glyph: default_worktree_glyph(),
+        }
+    }
+}
+
+fn default_worktree_glyph() -> String {
+    "auto".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -742,6 +742,7 @@ fn test_default_config() {
     assert!(config.ci.success_alert_sound.is_none());
     assert!(config.ci.error_alert_sound.is_none());
     assert!(config.ui.tips);
+    assert_eq!(config.display.worktree_glyph, "auto");
     assert!(config.auth.use_gh_cli);
     assert!(!config.auth.allow_github_token_env);
     assert!(config.auth.gh_hostname.is_none());
@@ -755,6 +756,18 @@ fn test_default_toml_serializes() {
     assert!(s.contains("[remote]"));
     assert!(s.contains("[submit]"));
     let _: Config = toml::from_str(&s).unwrap();
+}
+
+#[test]
+fn display_worktree_glyph_config_round_trip() {
+    let config: Config = toml::from_str(
+        r#"
+[display]
+worktree_glyph = "wt"
+"#,
+    )
+    .unwrap();
+    assert_eq!(config.display.worktree_glyph, "wt");
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -847,7 +847,7 @@ fn test_status_marks_branches_checked_out_in_linked_worktrees() {
         .find(|line| line.contains(&branch_name))
         .expect("Expected branch in status output");
     assert!(
-        line.contains("⎇"),
+        line.contains("⧉"),
         "Expected linked worktree glyph in status output line: {}",
         line
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -847,7 +847,7 @@ fn test_status_marks_branches_checked_out_in_linked_worktrees() {
         .find(|line| line.contains(&branch_name))
         .expect("Expected branch in status output");
     assert!(
-        line.contains("⧉"),
+        line.contains("⎇"),
         "Expected linked worktree glyph in status output line: {}",
         line
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -834,7 +834,12 @@ fn test_status_marks_branches_checked_out_in_linked_worktrees() {
         String::from_utf8_lossy(&git_output.stderr)
     );
 
-    let output = repo.run_stax(&["status"]);
+    let output = sanitized_stax_command()
+        .args(["status"])
+        .env("STAX_NERD_ICONS", "0")
+        .current_dir(repo.path())
+        .output()
+        .expect("Failed to execute stax status");
     assert!(
         output.status.success(),
         "Failed: {}",
@@ -847,8 +852,8 @@ fn test_status_marks_branches_checked_out_in_linked_worktrees() {
         .find(|line| line.contains(&branch_name))
         .expect("Expected branch in status output");
     assert!(
-        line.contains("⎇"),
-        "Expected linked worktree glyph in status output line: {}",
+        line.contains("wt"),
+        "Expected linked worktree marker in status output line: {}",
         line
     );
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -847,7 +847,7 @@ fn test_status_marks_branches_checked_out_in_linked_worktrees() {
         .find(|line| line.contains(&branch_name))
         .expect("Expected branch in status output");
     assert!(
-        line.contains("↳"),
+        line.contains("⎇"),
         "Expected linked worktree glyph in status output line: {}",
         line
     );

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -154,7 +154,7 @@ fn status_uses_cached_repo_data_without_git_subprocess_scans() {
 
     let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("☁") && stdout.contains("↳"),
+        stdout.contains("☁") && stdout.contains("⎇"),
         "expected status to preserve remote and linked-worktree indicators, got:\n{}",
         stdout
     );

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -154,7 +154,7 @@ fn status_uses_cached_repo_data_without_git_subprocess_scans() {
 
     let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("☁") && stdout.contains("⎇"),
+        stdout.contains("☁") && stdout.contains("⧉"),
         "expected status to preserve remote and linked-worktree indicators, got:\n{}",
         stdout
     );

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -148,13 +148,14 @@ fn status_uses_cached_repo_data_without_git_subprocess_scans() {
             ("PATH", path_env.as_str()),
             ("GIT_SHIM_LOG", log_env.as_str()),
             ("REAL_GIT", real_git.as_str()),
+            ("STAX_NERD_ICONS", "0"),
         ],
     );
     output.assert_success();
 
     let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("☁") && stdout.contains("⎇"),
+        stdout.contains("☁") && stdout.contains("wt"),
         "expected status to preserve remote and linked-worktree indicators, got:\n{}",
         stdout
     );

--- a/tests/worktree_tests.rs
+++ b/tests/worktree_tests.rs
@@ -154,7 +154,7 @@ fn status_uses_cached_repo_data_without_git_subprocess_scans() {
 
     let stdout = TestRepo::stdout(&output);
     assert!(
-        stdout.contains("☁") && stdout.contains("⧉"),
+        stdout.contains("☁") && stdout.contains("⎇"),
         "expected status to preserve remote and linked-worktree indicators, got:\n{}",
         stdout
     );


### PR DESCRIPTION
## Summary
- Replace the linked-worktree glyph `↳` with `⎇` in `st ls`, `st ll`, and `st co` output
- Document the new symbol in `docs/commands/navigation.md` and `skills.md`

## Motivation
`↳` visually echoed the stack tree connectors on the left and did not clearly signal "checked out in a parallel worktree." The option-key glyph reads as an alternate location and stays distinct from tree drawing characters.

## Test plan
- [x] `cargo nextest run integration_tests::test_status_marks_branches_checked_out_in_linked_worktrees worktree_tests::`
- [x] `cargo nextest run test_render_presence_markers_aligns_worktree_column`
- [x] `make lint-fast`


Made with [Cursor](https://cursor.com)