### PR TITLE
sync: warn when a merged/closed-PR branch has unpushed commits

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -642,6 +642,16 @@ pub fn run(
                 .as_ref()
                 .expect("remote branch list when deleting merged branches"),
         )?;
+        let partially_merged_notes = find_partially_merged_notes(
+            &repo,
+            &workdir,
+            &stack,
+            &remote_name,
+            remote_branches_for_merged
+                .as_ref()
+                .expect("remote branch list when deleting merged branches"),
+            &merged,
+        )?;
         step_timings.push((
             "detect merged branches".to_string(),
             detect_merged_started_at.elapsed(),
@@ -1124,6 +1134,30 @@ pub fn run(
             }
         } else if !quiet {
             println!("    {}", "No merged branches to delete.".dimmed());
+        }
+
+        if !quiet {
+            for note in &partially_merged_notes {
+                let commit_word = if note.extra_commits == 1 {
+                    "commit"
+                } else {
+                    "commits"
+                };
+                let signal = match (note.pr_label, note.pr_number) {
+                    (PartialMergeReason::PrMerged, Some(n)) => format!("PR #{} merged", n),
+                    (PartialMergeReason::PrMerged, None) => "PR merged".to_string(),
+                    (PartialMergeReason::PrClosed, Some(n)) => format!("PR #{} closed", n),
+                    (PartialMergeReason::PrClosed, None) => "PR closed".to_string(),
+                    (PartialMergeReason::HistoryMerged, _) => {
+                        "earlier commits already merged into trunk".to_string()
+                    }
+                };
+                let detail = format!(
+                    "{}, but branch has {} additional {} not on trunk or any remote — not deleting",
+                    signal, note.extra_commits, commit_word
+                );
+                println!("    {} {}: {}", "⚠".yellow(), note.branch, detail.dimmed());
+            }
         }
 
         let delete_elapsed = delete_merged_started_at.elapsed();
@@ -2235,6 +2269,21 @@ struct MergedBranchInfo {
     merge_type: MergeType,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PartialMergeReason {
+    PrMerged,
+    PrClosed,
+    HistoryMerged,
+}
+
+#[derive(Debug, Clone)]
+struct PartiallyMergedNote {
+    branch: String,
+    pr_number: Option<u64>,
+    pr_label: PartialMergeReason,
+    extra_commits: usize,
+}
+
 fn should_spare_empty_never_submitted_branch(
     workdir: &Path,
     stack: &Stack,
@@ -2529,6 +2578,115 @@ fn find_merged_branches(
     Ok(merged)
 }
 
+/// Surface tracked branches that sync deliberately spares from deletion
+/// despite a merged/closed PR (or already-integrated history) because they
+/// carry local commits not present on trunk or any remote — turning what
+/// would otherwise be a silent skip into an explicit "not deleting" note.
+fn find_partially_merged_notes(
+    repo: &GitRepo,
+    workdir: &Path,
+    stack: &Stack,
+    remote_name: &str,
+    remote_branches: &HashSet<String>,
+    merged: &[MergedBranchInfo],
+) -> Result<Vec<PartiallyMergedNote>> {
+    let mut notes = Vec::new();
+    let trunk = stack.trunk.clone();
+
+    for branch in stack.branches.keys() {
+        let branch = branch.clone();
+        if branch == trunk {
+            continue;
+        }
+        if merged.iter().any(|m| m.branch == branch) {
+            continue;
+        }
+        let Some(info) = stack.branches.get(&branch) else {
+            continue;
+        };
+
+        let mut bases: Vec<String> = vec![trunk.clone()];
+        let remote_trunk_ref = format!("{}/{}", remote_name, trunk);
+        if git_ref_exists(workdir, &remote_trunk_ref) {
+            bases.push(remote_trunk_ref);
+        }
+        let remote_branch_ref = format!("{}/{}", remote_name, branch);
+        if remote_branches.contains(&branch) || git_ref_exists(workdir, &remote_branch_ref) {
+            bases.push(remote_branch_ref);
+        }
+        let base_refs: Vec<&str> = bases.iter().map(String::as_str).collect();
+
+        let extra = count_extra_commits(workdir, &branch, &base_refs)?;
+        if extra == 0 {
+            continue;
+        }
+
+        let reason = if matches!(
+            info.pr_state.as_deref(),
+            Some(state) if state.eq_ignore_ascii_case("merged")
+        ) {
+            PartialMergeReason::PrMerged
+        } else if matches!(
+            info.pr_state.as_deref(),
+            Some(state) if state.eq_ignore_ascii_case("closed")
+        ) {
+            PartialMergeReason::PrClosed
+        } else {
+            let Ok(merge_base) = repo.merge_base(&trunk, &branch) else {
+                continue;
+            };
+            let trunk_range = format!("{}..{}", merge_base, trunk);
+            let trunk_count = match repo.rev_list_count(workdir, &trunk_range) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if trunk_count == 0 || trunk_count > GitRepo::PATCH_ID_TRUNK_COMMIT_CAP {
+                continue;
+            }
+            let trunk_patch_ids = match repo.patch_ids_for_range(workdir, &trunk_range) {
+                Ok(ids) => ids,
+                Err(_) => continue,
+            };
+            let branch_range = format!("{}..{}", merge_base, branch);
+            let branch_patch_ids = match repo.patch_ids_for_range(workdir, &branch_range) {
+                Ok(ids) => ids,
+                Err(_) => continue,
+            };
+            if branch_patch_ids.is_disjoint(&trunk_patch_ids) {
+                continue;
+            }
+            PartialMergeReason::HistoryMerged
+        };
+
+        notes.push(PartiallyMergedNote {
+            branch: branch.clone(),
+            pr_number: info.pr_number,
+            pr_label: reason,
+            extra_commits: extra,
+        });
+    }
+
+    Ok(notes)
+}
+
+fn count_extra_commits(workdir: &Path, branch: &str, bases: &[&str]) -> Result<usize> {
+    let mut args: Vec<&str> = vec!["rev-list", "--count", branch, "--not"];
+    args.extend_from_slice(bases);
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to count extra commits for '{}'", branch))?;
+
+    if !output.status.success() {
+        return Ok(0);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.trim().parse::<usize>().unwrap_or(0))
+}
+
 fn branch_name_from_merged_output(line: &str) -> &str {
     let branch = line.trim();
     branch
@@ -2573,6 +2731,16 @@ fn local_branch_exists(workdir: &std::path::Path, branch: &str) -> bool {
     let local_ref = format!("refs/heads/{}", branch);
     Command::new("git")
         .args(["show-ref", "--verify", "--quiet", &local_ref])
+        .current_dir(workdir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn git_ref_exists(workdir: &Path, refname: &str) -> bool {
+    let commit_ref = format!("{}^{{commit}}", refname);
+    Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", &commit_ref])
         .current_dir(workdir)
         .status()
         .map(|s| s.success())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5412,6 +5412,180 @@ fn test_sync_does_not_treat_closed_unmerged_pr_as_merged() {
 }
 
 #[test]
+fn test_sync_notes_closed_pr_with_extra_local_commits() {
+    // A branch with a closed (unmerged) PR is spared from deletion. When it
+    // also carries a local commit never pushed anywhere, sync should surface
+    // an explicit "not deleting" note instead of silently skipping it.
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-closed-pr-extra"]);
+    let branch_name = repo.current_branch();
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", &branch_name]);
+
+    let main_sha = repo.get_commit_sha("main");
+    let metadata = serde_json::json!({
+        "parentBranchName": "main",
+        "parentBranchRevision": main_sha,
+        "prInfo": {
+            "number": 199,
+            "state": "CLOSED",
+            "isDraft": false
+        }
+    });
+    let metadata_json = metadata.to_string();
+
+    let mut hash_cmd = hermetic_git_command();
+    let metadata_oid_output = hash_cmd
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(metadata_json.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("Failed to write metadata blob");
+    assert!(
+        metadata_oid_output.status.success(),
+        "Failed to hash metadata: {}",
+        TestRepo::stderr(&metadata_oid_output)
+    );
+    let metadata_oid = TestRepo::stdout(&metadata_oid_output).trim().to_string();
+
+    let metadata_ref = format!("refs/branch-metadata/{}", branch_name);
+    let update_ref = repo.git(&["update-ref", &metadata_ref, &metadata_oid]);
+    assert!(
+        update_ref.status.success(),
+        "Failed to update metadata ref: {}",
+        TestRepo::stderr(&update_ref)
+    );
+
+    // Add a commit AFTER the push — never published anywhere.
+    repo.create_file("extra.txt", "extra content");
+    repo.commit("Extra unpushed commit");
+
+    repo.run_stax(&["t"]);
+
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|b| b == &branch_name),
+        "Expected closed-but-unmerged PR branch with extra local commits to remain after sync"
+    );
+
+    let stdout = TestRepo::stdout(&output).to_lowercase();
+    assert!(
+        stdout.contains("additional commit"),
+        "Expected sync output to mention the additional commit, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("not deleting"),
+        "Expected sync output to mention 'not deleting', got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("closed"),
+        "Expected sync output to mention the closed PR, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_sync_no_note_when_branch_fully_pushed() {
+    // Regression guard: a closed-but-unmerged PR branch whose commits are all
+    // pushed to its own remote must NOT get a "not deleting" note — the note
+    // only fires when work is genuinely at risk of loss.
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-closed-pr-pushed"]);
+    let branch_name = repo.current_branch();
+    repo.create_file("feature.txt", "feature content");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", &branch_name]);
+
+    let main_sha = repo.get_commit_sha("main");
+    let metadata = serde_json::json!({
+        "parentBranchName": "main",
+        "parentBranchRevision": main_sha,
+        "prInfo": {
+            "number": 200,
+            "state": "CLOSED",
+            "isDraft": false
+        }
+    });
+    let metadata_json = metadata.to_string();
+
+    let mut hash_cmd = hermetic_git_command();
+    let metadata_oid_output = hash_cmd
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(metadata_json.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("Failed to write metadata blob");
+    assert!(
+        metadata_oid_output.status.success(),
+        "Failed to hash metadata: {}",
+        TestRepo::stderr(&metadata_oid_output)
+    );
+    let metadata_oid = TestRepo::stdout(&metadata_oid_output).trim().to_string();
+
+    let metadata_ref = format!("refs/branch-metadata/{}", branch_name);
+    let update_ref = repo.git(&["update-ref", &metadata_ref, &metadata_oid]);
+    assert!(
+        update_ref.status.success(),
+        "Failed to update metadata ref: {}",
+        TestRepo::stderr(&update_ref)
+    );
+
+    repo.run_stax(&["t"]);
+
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        output.status.success(),
+        "Sync failed: {}",
+        TestRepo::stderr(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|b| b == &branch_name),
+        "Expected closed-but-unmerged PR branch to remain after sync"
+    );
+
+    let stdout = TestRepo::stdout(&output).to_lowercase();
+    assert!(
+        !stdout.contains("not deleting"),
+        "Expected no 'not deleting' note for a fully-pushed branch, got: {}",
+        stdout
+    );
+}
+
+#[test]
 fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
     let repo = TestRepo::new_with_remote();
 


### PR DESCRIPTION
## Summary

`st sync` (alias `st rs`) silently skips branches it decides not to delete, even when the reason is that the branch's PR is merged/closed but the branch still carries local commits that exist nowhere else. This surfaces that case instead of staying silent.

When "Detect merged branches" spares a branch for this reason, sync now prints a note like:

```
⚠ cesar/foo: PR #693 merged, but branch has 5 additional commits not on trunk or any remote — not deleting
```

## Changes

- `src/commands/sync.rs`: added `PartialMergeReason` (PrMerged / PrClosed / HistoryMerged), `PartiallyMergedNote`, and `find_partially_merged_notes()` — runs alongside the existing `find_merged_branches()` using only local metadata (no GitHub API calls). Only fires when the branch actually has commits missing from trunk and every remote (`count_extra_commits > 0`), so fully-pushed branches stay silent as before.
- Purely additive: deletion logic (`find_merged_branches`, the delete loop) is untouched — this only changes what gets printed.
- `tests/integration_tests.rs`: added `test_sync_notes_closed_pr_with_extra_local_commits` and `test_sync_no_note_when_branch_fully_pushed` to cover the new note and its conservative gate.

## Verification

- `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check` — all clean
- Targeted: `cargo nextest run test_sync_notes_closed_pr_with_extra_local_commits test_sync_no_note_when_branch_fully_pushed test_sync_does_not_treat_closed_unmerged_pr_as_merged test_sync_deletes_merged_branches test_sync_preserves_unmerged_branches` — 5/5 passed
- Full suite: `make test` — 2149/2149 passed