### PR TITLE
fix(cli): allow read-only commands during an active rebase

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1833,6 +1833,38 @@ impl Commands {
             | Commands::Sync {
                 r#continue: true, ..
             } => CommandPolicy::RebaseSafe,
+            // Read-only commands that do not touch the in-progress rebase.
+            Commands::Status { .. }
+            | Commands::Ll { .. }
+            | Commands::Log { .. }
+            | Commands::Ready { .. }
+            | Commands::Ci { .. }
+            | Commands::Watch { .. }
+            | Commands::Diff { .. }
+            | Commands::RangeDiff { .. }
+            | Commands::Doctor { .. }
+            | Commands::Comments { .. }
+            | Commands::Open
+            | Commands::Gui(_)
+            | Commands::W
+            | Commands::Wtll { .. }
+            | Commands::Wtls => CommandPolicy::RebaseSafe,
+            Commands::Issue { command } => match command {
+                None | Some(IssueCommands::List { .. }) => CommandPolicy::RebaseSafe,
+            },
+            Commands::Pr { command } => match command {
+                None | Some(PrCommands::Open) | Some(PrCommands::List { .. }) => {
+                    CommandPolicy::RebaseSafe
+                }
+                Some(PrCommands::Body { .. }) => CommandPolicy::RequiresCleanRepoState,
+            },
+            Commands::Worktree { command } => match command {
+                None
+                | Some(WorktreeCommands::List { .. })
+                | Some(WorktreeCommands::LongList { .. })
+                | Some(WorktreeCommands::Path { .. }) => CommandPolicy::RebaseSafe,
+                Some(_) => CommandPolicy::RequiresCleanRepoState,
+            },
             _ => CommandPolicy::RequiresCleanRepoState,
         }
     }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -428,8 +428,24 @@ fn sync_continue_is_marked_as_rebase_safe() {
 }
 
 #[test]
-fn status_requires_clean_repo_state() {
+fn status_is_read_only_during_rebase() {
     let cli = parse_cli(&["stax", "status"]);
+    let cmd = cli.command.expect("command");
+    assert_eq!(cmd.policy(), CommandPolicy::RebaseSafe);
+    assert!(cmd.allows_during_rebase());
+}
+
+#[test]
+fn ready_is_read_only_during_rebase() {
+    let cli = parse_cli(&["stax", "ready"]);
+    let cmd = cli.command.expect("command");
+    assert_eq!(cmd.policy(), CommandPolicy::RebaseSafe);
+    assert!(cmd.allows_during_rebase());
+}
+
+#[test]
+fn submit_requires_clean_repo_state() {
+    let cli = parse_cli(&["stax", "submit"]);
     let cmd = cli.command.expect("command");
     assert_eq!(cmd.policy(), CommandPolicy::RequiresCleanRepoState);
     assert!(!cmd.allows_during_rebase());

--- a/tests/conflict_handling_tests.rs
+++ b/tests/conflict_handling_tests.rs
@@ -141,41 +141,40 @@ fn restack_conflict_failed_receipt_lists_only_completed_branches() {
 // =============================================================================
 
 #[test]
-fn test_status_during_rebase_gives_clear_error() {
+fn test_read_only_commands_allowed_during_rebase() {
     let repo = TestRepo::new();
     repo.create_conflict_scenario();
     let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
 
     assert!(repo.has_rebase_in_progress(), "Expected rebase in progress");
 
-    let output = repo.run_stax(&["status"]);
-
-    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
-    assert!(
-        combined.contains("rebase is in progress") || combined.contains("rebase in progress"),
-        "Expected 'rebase in progress' message, got:\n{}",
-        combined
-    );
-    output.assert_failure();
+    for args in [&["status"][..], &["log"][..], &["ready", "--plain"][..]] {
+        let output = repo.run_stax(args);
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(
+            !combined.contains("A rebase is in progress. Resolve"),
+            "{:?} should not be blocked by rebase guard, got:\n{combined}",
+            args
+        );
+    }
 
     repo.abort_rebase();
 }
 
 #[test]
-fn test_log_during_rebase_gives_clear_error() {
+fn test_mutating_commands_blocked_during_rebase() {
     let repo = TestRepo::new();
     repo.create_conflict_scenario();
     let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
 
     assert!(repo.has_rebase_in_progress(), "Expected rebase in progress");
 
-    let output = repo.run_stax(&["log"]);
+    let output = repo.run_stax(&["submit", "--no-verify"]);
 
     let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
     assert!(
-        combined.contains("rebase is in progress") || combined.contains("rebase in progress"),
-        "Expected 'rebase in progress' message, got:\n{}",
-        combined
+        combined.contains("A rebase is in progress. Resolve"),
+        "submit should be blocked by rebase guard, got:\n{combined}"
     );
     output.assert_failure();
 


### PR DESCRIPTION
## Summary

- Allow read-only commands (`st ready`, `st status`, `st ci`, `st log`, etc.) to run during an active rebase
- Keep mutating commands (`st submit`, `st restack`, branch ops, etc.) blocked until the rebase is resolved
- Update integration tests to assert the new policy instead of expecting read-only commands to fail mid-rebase

## Test plan

- [x] `cargo check`
- [x] `make lint-fast`
- [x] `cargo nextest run conflict_handling_tests::test_read_only_commands_allowed_during_rebase conflict_handling_tests::test_mutating_commands_blocked_during_rebase cli::tests::status_is_read_only_during_rebase cli::tests::ready_is_read_only_during_rebase`
- [ ] Full suite (`make test`) before merge