### PR TITLE
fix: preserve stacked PR merged state

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Merge from the bottom of the stack up to your current branch, with CI and readin
 st merge                  # local cascade merge
 st merge --when-ready     # wait/poll until PRs are mergeable
 st merge --ds             # merge ancestors, rebase current branch
-st merge --stack          # validate current PR once; let GitHub mark lower PRs merged when possible
+st merge --stack          # target selected PRs to trunk; preserve lower PR merged state by default
 st merge --stack --full   # stack-merge the full stack even from the middle
 st merge --remote         # merge remotely on GitHub while you keep working
 st merge --all            # merge the whole stack regardless of position

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -42,7 +42,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
-| `st merge --stack` | Validate the selected tip PR once, retarget it to trunk, merge that PR, and let GitHub mark lower PRs merged when possible (`--full` includes descendants; GitHub only) |
+| `st merge --stack` | Target the selected PRs to trunk and merge the tip with SHA-preserving `merge`, allowing GitHub to mark lower PRs merged (`--full` includes descendants; GitHub only) |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
 | `st cascade` | Restack, push, and create/update PRs in one shot (no trunk fetch; offline-friendly) |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -47,7 +47,7 @@ st --trace status --json >/dev/null
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`
 - `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
-- `st merge --stack` — GitHub-only fast-forward stack merge: validate the selected tip PR once, retarget it to trunk, merge only that PR, wait briefly for selected downstack PRs to become merged in GitHub, and rebase/retarget remaining descendants; defaults to `--method rebase`
+- `st merge --stack` — GitHub-only stack merge: target every selected PR to trunk, merge only the selected tip with SHA-preserving `merge`, and let GitHub mark lower PRs indirectly merged; timed-out lower PRs stay open, while explicit `rebase`/`squash` closes them as absorbed without waiting
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -65,7 +65,7 @@ Merges `auth` and `auth-api`; `auth-ui` is rebased onto `main`, and `auth-tests`
 
 ## `st merge --stack` (GitHub only)
 
-Fast-forwards the selected stack range through one GitHub PR merge. By default the selected range is stack bottom through the current branch:
+Lands the selected stack range through one GitHub PR merge. By default the selected range is stack bottom through the current branch:
 
 ```bash
 st merge --stack
@@ -75,13 +75,13 @@ st merge --stack --full
 st merge --stack --dry-run
 ```
 
-For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, validates CI/mergeability on selected tip PR `B`, retargets `B` to `main`, and merges only `B` through GitHub's merge API. Stax then waits briefly for GitHub to mark PR `A` merged; if GitHub does not, Stax marks `A` as absorbed with a comment pointing at `B`. PR `C` remains open and is rebased/retargeted onto `main`.
+For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, and validates CI/mergeability on selected tip PR `B`. With the default `merge` method, Stax targets both `A` and `B` to `main` before merging only `B`. Preserving the existing commit SHAs and making them reachable from `main` lets GitHub mark `A` indirectly merged. PR `C` remains open and is rebased/retargeted onto `main`.
 
-Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `rebase`; pass `--method squash` only when you explicitly want GitHub to squash the selected range into one commit.
+Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `merge`. Explicit `--method rebase` and `--method squash` rewrite commit SHAs, so Stax comments on and closes lower PRs as absorbed immediately instead of polling for an impossible indirect merge.
 
 This avoids re-running CI for every lower PR because the selected tip already contains that range. The post-merge sync updates trunk and PR metadata without running generic merged-branch deletion; branch cleanup stays scoped to the stack range that was just landed. If trunk moves before the merge, stax aborts and asks you to restack and wait for fresh selected-tip CI.
 
-GitHub may still display an absorbed lower PR as closed rather than merged if its background merge detection does not fire. In that fallback, Stax leaves an explicit absorbed-by comment so the closure is intentional and traceable.
+GitHub's indirect-merge detection is asynchronous. If a lower PR is still open after Stax's bounded poll under the default `merge` method, Stax leaves it open and reports it as pending so GitHub can mark it merged later. Any base changes are restored if retargeting, the final trunk check, or the selected-tip merge fails.
 
 For the no-extra-CI behavior, GitHub branch protection should require status checks but should not require branches to be up to date before merging. If GitHub requires up-to-date branches, it can force another revalidation at merge time.
 

--- a/skills.md
+++ b/skills.md
@@ -289,10 +289,11 @@ stax merge --downstack-only        # Merge ancestors below current, then rebase 
 stax merge --ds                    # Alias for --downstack-only
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
-stax merge --stack                 # GitHub only: validate selected tip once, merge it, and let lower PRs become merged when GitHub detects it
+stax merge --stack                 # GitHub only: target selected PRs to trunk, merge the tip, preserve lower PR merged state
+stax merge --stack --method rebase # Rewrite SHAs and close lower PRs as absorbed without polling (also: squash)
 stax merge --stack --downstack-only # Stack-merge ancestors below current; keep current open
 stax merge --stack --full          # Stack-merge full stack even from the middle
-stax merge --stack --when-ready    # Wait only for selected tip PR readiness before stack fast-forward merge
+stax merge --stack --when-ready    # Wait only for selected tip PR readiness before the one-PR stack merge
 stax merge --when-ready            # Wait for CI + approval before each merge
 stax merge --remote                # Merge via GitHub API only — no local checkout/rebase/push
 stax merge --remote --all          # Include full stack (GitHub only)
@@ -563,7 +564,7 @@ stax ss --rerequest-review
 ```bash
 stax ready
 stax merge --when-ready --interval 15
-stax merge --stack --when-ready    # GitHub stack fast-forward: selected tip CI only, defaults to rebase
+stax merge --stack --when-ready    # GitHub stack merge: selected tip CI only, defaults to SHA-preserving merge
 ```
 
 ### After Base PR Merges

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -343,7 +343,12 @@ pub(crate) enum Commands {
         /// Show merge plan without merging
         #[arg(long)]
         dry_run: bool,
-        /// Merge method: squash, merge, rebase (default: squash; rebase with --stack)
+        /// Merge method: squash, merge, rebase (default: squash; merge with --stack).
+        ///
+        /// With --stack, merge targets the selected PRs to trunk and preserves commit
+        /// SHAs so GitHub may mark lower PRs indirectly merged. Timed-out lower PRs
+        /// stay open. Rebase and squash rewrite SHAs, so Stax closes lower PRs as
+        /// absorbed without waiting.
         #[arg(long)]
         method: Option<String>,
         /// Keep branches after merge (don't delete)
@@ -361,7 +366,7 @@ pub(crate) enum Commands {
         /// Merge via GitHub API only (no local checkout/rebase/push); GitHub updates branches remotely
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "queue", "stack"])]
         remote: bool,
-        /// Validate the selected tip PR, retarget it to trunk, and merge the selected stack range once
+        /// Prepare selected PR bases, validate the tip once, and merge the selected stack range once
         #[arg(long, conflicts_with_all = ["no_wait", "remote", "queue"])]
         stack: bool,
         /// Enqueue PRs into the forge's merge queue instead of merging one-by-one.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -238,7 +238,7 @@ pub fn run() -> Result<()> {
             yes,
             quiet,
         } => {
-            let default_method = if stack { "rebase" } else { "squash" };
+            let default_method = if stack { "merge" } else { "squash" };
             let merge_method = method.as_deref().unwrap_or(default_method).parse()?;
             if queue {
                 commands::merge_queue::run(all, timeout, interval, no_sync, yes, quiet)

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -1,8 +1,8 @@
-//! Fast-forward stack merge through one GitHub PR merge.
+//! Stack merge through one GitHub PR merge.
 //!
 //! This is the serverless path from issue #293: validate the selected tip PR
-//! once, retarget that PR to trunk, merge it via GitHub's merge API, then
-//! reconcile selected lower PRs as merged or absorbed.
+//! once, prepare the selected PR bases, merge the tip via GitHub's merge API,
+//! then reconcile selected lower PRs as merged, pending, or absorbed.
 
 use crate::commands::merge_shared::{
     PrBaseUpdate, WaitResult, print_header, print_header_success,
@@ -47,6 +47,19 @@ struct ResolvedStackPr {
 struct RemainingStackBranch {
     branch: String,
     pr_number: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChangedPrBase {
+    pr_number: u64,
+    original_base: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownstackOutcome {
+    GithubMerged,
+    Pending,
+    Absorbed,
 }
 
 /// How the stack-merge confirmation should be resolved.
@@ -199,7 +212,7 @@ pub fn run(
         }
         StackMergeConfirmation::Prompt => {
             let confirm = Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt("Proceed with fast-forward stack merge?")
+                .with_prompt("Proceed with stack merge?")
                 .default(false)
                 .interact()?;
 
@@ -212,7 +225,7 @@ pub fn run(
 
     if !quiet {
         println!();
-        print_header("Stack Fast-Forward Merge");
+        print_header("Stack Merge");
     }
 
     if when_ready {
@@ -241,44 +254,11 @@ pub fn run(
     verify_tip_head_matches_local(&repo, tip, &tip_status)?;
     ensure_trunk_unchanged(&repo, &remote_info, &scope.trunk, &trunk_sha)?;
 
-    let original_tip_base = tip.base.clone();
-    let retarget_timer = LiveTimer::maybe_new(
-        !quiet,
-        &format!(
-            "Retargeting selected tip PR #{} to {}...",
-            tip.pr_number, scope.trunk
-        ),
-    );
-    let retargeted =
-        match update_pr_base_unless_current(&rt, &client, tip.pr_number, &scope.trunk, &tip.branch)
-        {
-            Ok(PrBaseUpdate::Updated) => {
-                LiveTimer::maybe_finish_ok(retarget_timer, "done");
-                true
-            }
-            Ok(PrBaseUpdate::AlreadyTargeted) => {
-                LiveTimer::maybe_finish_ok(retarget_timer, "already on base");
-                false
-            }
-            Ok(PrBaseUpdate::NativeStackLocked) => {
-                LiveTimer::maybe_finish_err(retarget_timer, "locked");
-                anyhow::bail!(
-                    "PR #{} is registered in a native GitHub Stack, which locks its base branch. \
-                     Merge it via the normal stack order (`st merge`) instead of merging out of \
-                     order, or run `st stack unlink` first if you need to retarget it manually.",
-                    tip.pr_number
-                );
-            }
-            Err(e) => {
-                LiveTimer::maybe_finish_err(retarget_timer, "failed");
-                return Err(e);
-            }
-        };
+    let changed_bases =
+        prepare_selected_pr_bases(&rt, &client, &resolved, &scope.trunk, method, quiet)?;
 
     if let Err(e) = ensure_trunk_unchanged(&repo, &remote_info, &scope.trunk, &trunk_sha) {
-        if retargeted {
-            restore_tip_base(&rt, &client, tip, &original_tip_base, quiet);
-        }
+        rollback_changed_pr_bases(&rt, &client, &changed_bases, quiet);
         return Err(e);
     }
 
@@ -298,14 +278,12 @@ pub fn run(
 
     if let Err(e) = merge_result {
         LiveTimer::maybe_finish_err(merge_timer, "failed");
-        if retargeted {
-            restore_tip_base(&rt, &client, tip, &original_tip_base, quiet);
-        }
+        rollback_changed_pr_bases(&rt, &client, &changed_bases, quiet);
         return Err(e);
     }
     LiveTimer::maybe_finish_ok(merge_timer, "done");
 
-    let github_merged_downstack = absorb_downstack_prs(&rt, &client, &resolved, tip, quiet)?;
+    let downstack_outcomes = reconcile_downstack_prs(&rt, &client, &resolved, tip, method, quiet)?;
 
     rebase_remaining_branches(
         &repo,
@@ -330,26 +308,47 @@ pub fn run(
         print_header_success("Stack Merged");
         println!();
         println!(
-            "Merged {} PRs through tip #{} into {}:",
+            "Landed {} branches through selected tip PR #{} into {}:",
             resolved.len(),
             tip.pr_number,
             scope.trunk.cyan()
         );
         for pr in &resolved {
-            let action = if pr.pr_number == tip.pr_number {
-                "merged"
-            } else if github_merged_downstack.contains(&pr.pr_number) {
-                "merged by GitHub"
+            let (marker, action) = if pr.pr_number == tip.pr_number {
+                let behavior = if merge_method_preserves_commit_shas(method) {
+                    "preserves commit SHAs"
+                } else {
+                    "rewrites commit SHAs"
+                };
+                (
+                    "✓".green().to_string(),
+                    format!("merged with {} ({})", method.as_str(), behavior),
+                )
             } else {
-                "absorbed"
+                match downstack_outcomes
+                    .iter()
+                    .find(|(number, _)| *number == pr.pr_number)
+                    .map(|(_, outcome)| *outcome)
+                    .expect("every downstack PR has a reconciliation outcome")
+                {
+                    DownstackOutcome::GithubMerged => (
+                        "✓".green().to_string(),
+                        "merged indirectly by GitHub".to_string(),
+                    ),
+                    DownstackOutcome::Pending => (
+                        "○".yellow().to_string(),
+                        "pending GitHub indirect-merge detection; left open".to_string(),
+                    ),
+                    DownstackOutcome::Absorbed => (
+                        "✓".green().to_string(),
+                        format!(
+                            "closed as absorbed ({} rewrites commit SHAs)",
+                            method.as_str()
+                        ),
+                    ),
+                }
             };
-            println!(
-                "  {} #{} {} -> {}",
-                "✓".green(),
-                pr.pr_number,
-                pr.branch,
-                action
-            );
+            println!("  {} #{} {} -> {}", marker, pr.pr_number, pr.branch, action);
         }
         if !remaining.is_empty() {
             println!();
@@ -683,30 +682,85 @@ fn verify_tip_head_matches_local(
     Ok(())
 }
 
-fn restore_tip_base(
+fn merge_method_preserves_commit_shas(method: MergeMethod) -> bool {
+    matches!(method, MergeMethod::Merge)
+}
+
+fn prepare_selected_pr_bases(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
-    tip: &ResolvedStackPr,
-    original_base: &str,
+    prs: &[ResolvedStackPr],
+    trunk: &str,
+    method: MergeMethod,
+    quiet: bool,
+) -> Result<Vec<ChangedPrBase>> {
+    let first = if merge_method_preserves_commit_shas(method) {
+        0
+    } else {
+        prs.len().saturating_sub(1)
+    };
+    let mut changed = Vec::new();
+
+    for pr in &prs[first..] {
+        let timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!("Retargeting PR #{} to {}...", pr.pr_number, trunk),
+        );
+        match update_pr_base_unless_current(rt, client, pr.pr_number, trunk, &pr.branch) {
+            Ok(PrBaseUpdate::Updated) => {
+                changed.push(ChangedPrBase {
+                    pr_number: pr.pr_number,
+                    original_base: pr.base.clone(),
+                });
+                LiveTimer::maybe_finish_ok(timer, "done");
+            }
+            Ok(PrBaseUpdate::AlreadyTargeted) => {
+                LiveTimer::maybe_finish_ok(timer, "already on base");
+            }
+            Ok(PrBaseUpdate::NativeStackLocked) => {
+                LiveTimer::maybe_finish_err(timer, "locked");
+                rollback_changed_pr_bases(rt, client, &changed, quiet);
+                anyhow::bail!(
+                    "PR #{} is registered in a native GitHub Stack, which locks its base branch. \
+                     Merge it via the normal stack order (`st merge`) instead of merging out of \
+                     order, or run `st stack unlink` first if you need to retarget it manually.",
+                    pr.pr_number
+                );
+            }
+            Err(e) => {
+                LiveTimer::maybe_finish_err(timer, "failed");
+                rollback_changed_pr_bases(rt, client, &changed, quiet);
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(changed)
+}
+
+fn rollback_changed_pr_bases(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    changed: &[ChangedPrBase],
     quiet: bool,
 ) {
-    let timer = LiveTimer::maybe_new(
-        !quiet,
-        &format!(
-            "Restoring selected tip PR #{} base to {}...",
-            tip.pr_number, original_base
-        ),
-    );
-    match rt.block_on(async { client.update_pr_base(tip.pr_number, original_base).await }) {
-        Ok(()) => LiveTimer::maybe_finish_ok(timer, "done"),
-        Err(e) => {
-            LiveTimer::maybe_finish_err(timer, "failed");
-            if !quiet {
+    for pr in changed.iter().rev() {
+        let timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!(
+                "Restoring PR #{} base to {}...",
+                pr.pr_number, pr.original_base
+            ),
+        );
+        match rt.block_on(async { client.update_pr_base(pr.pr_number, &pr.original_base).await }) {
+            Ok(()) => LiveTimer::maybe_finish_ok(timer, "done"),
+            Err(e) => {
+                LiveTimer::maybe_finish_err(timer, "failed");
                 eprintln!(
                     "{} failed to restore PR #{} base to {}: {:#}",
                     "warning:".yellow().bold(),
-                    tip.pr_number,
-                    original_base,
+                    pr.pr_number,
+                    pr.original_base,
                     e
                 );
             }
@@ -714,36 +768,65 @@ fn restore_tip_base(
     }
 }
 
-fn absorb_downstack_prs(
+fn reconcile_downstack_prs(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
     prs: &[ResolvedStackPr],
     tip: &ResolvedStackPr,
+    method: MergeMethod,
     quiet: bool,
-) -> Result<Vec<u64>> {
-    let mut github_merged = Vec::new();
+) -> Result<Vec<(u64, DownstackOutcome)>> {
+    let mut outcomes = Vec::new();
 
     for pr in prs.iter().filter(|pr| pr.pr_number != tip.pr_number) {
-        let timer = LiveTimer::maybe_new(
-            !quiet,
-            &format!(
-                "Waiting for downstack PR #{} to be marked merged...",
+        let message = if merge_method_preserves_commit_shas(method) {
+            format!(
+                "Waiting for downstack PR #{} to be marked indirectly merged...",
                 pr.pr_number
-            ),
-        );
-        if wait_for_downstack_pr_merged(rt, client, pr.pr_number)? {
-            github_merged.push(pr.pr_number);
-            LiveTimer::maybe_finish_ok(timer, "merged by GitHub");
+            )
+        } else {
+            format!(
+                "Closing downstack PR #{} as absorbed ({} rewrites commit SHAs)...",
+                pr.pr_number,
+                method.as_str()
+            )
+        };
+        let timer = LiveTimer::maybe_new(!quiet, &message);
+        if merge_method_preserves_commit_shas(method)
+            && wait_for_downstack_pr_merged(rt, client, pr.pr_number)?
+        {
+            outcomes.push((pr.pr_number, DownstackOutcome::GithubMerged));
+            LiveTimer::maybe_finish_ok(timer, "merged indirectly by GitHub");
             continue;
         }
 
-        let comment = downstack_absorbed_comment(tip.pr_number);
+        if merge_method_preserves_commit_shas(method) {
+            outcomes.push((pr.pr_number, DownstackOutcome::Pending));
+            LiveTimer::maybe_finish_err(timer, "still open; indirect merge pending");
+            if !quiet {
+                println!(
+                    "  {} PR #{} remains open; GitHub may still mark it indirectly merged asynchronously.",
+                    "warning:".yellow().bold(),
+                    pr.pr_number
+                );
+            }
+            continue;
+        }
+
+        let comment = downstack_absorbed_comment(tip.pr_number, method);
         rt.block_on(async { client.create_issue_comment(pr.pr_number, &comment).await })?;
         rt.block_on(async { client.close_pr(pr.pr_number).await })?;
-        LiveTimer::maybe_finish_ok(timer, "closed as absorbed");
+        outcomes.push((pr.pr_number, DownstackOutcome::Absorbed));
+        LiveTimer::maybe_finish_ok(
+            timer,
+            &format!(
+                "{} rewrites commit SHAs; closed as absorbed without waiting",
+                method.as_str()
+            ),
+        );
     }
 
-    Ok(github_merged)
+    Ok(outcomes)
 }
 
 fn wait_for_downstack_pr_merged(
@@ -767,7 +850,7 @@ fn wait_for_downstack_pr_merged(
 }
 
 fn downstack_merged_wait() -> Duration {
-    let seconds = std::env::var("STAX_STACK_MERGE_ABSORBED_WAIT_SECS")
+    let seconds = std::env::var("STAX_STACK_MERGE_INDIRECT_WAIT_SECS")
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(20);
@@ -814,10 +897,11 @@ fn rebase_remaining_branches(
     Ok(())
 }
 
-fn downstack_absorbed_comment(tip_pr_number: u64) -> String {
+fn downstack_absorbed_comment(tip_pr_number: u64, method: MergeMethod) -> String {
     format!(
-        "Absorbed into stack merge of #{}. This PR's commits landed through the selected tip PR.",
-        tip_pr_number
+        "Absorbed into stack merge of #{}. The selected tip was merged with {}, which rewrites commit SHAs, so GitHub cannot mark this PR indirectly merged.",
+        tip_pr_number,
+        method.as_str()
     )
 }
 
@@ -899,16 +983,24 @@ fn print_stack_preview(
     when_ready: bool,
     downstack_only: bool,
 ) {
-    print_header("Stack Fast-Forward Merge");
+    print_header("Stack Merge");
     println!();
     let tip = prs
         .last()
         .expect("stack merge preview requires a selected tip PR");
-    println!(
-        "Will validate PR #{} once, retarget it to {}, then merge one PR:",
-        tip.pr_number,
-        trunk.cyan()
-    );
+    if merge_method_preserves_commit_shas(method) {
+        println!(
+            "Will validate PR #{} once, target every selected PR to {}, then merge one PR:",
+            tip.pr_number,
+            trunk.cyan()
+        );
+    } else {
+        println!(
+            "Will validate PR #{} once, retarget it to {}, then merge one PR:",
+            tip.pr_number,
+            trunk.cyan()
+        );
+    }
     if downstack_only {
         println!(
             "{}",
@@ -924,9 +1016,14 @@ fn print_stack_preview(
 
     for (idx, pr) in prs.iter().enumerate() {
         let marker = if idx + 1 == prs.len() {
-            "(tip, merged)"
+            format!("(selected tip, merged with {})", method.as_str())
+        } else if merge_method_preserves_commit_shas(method) {
+            "(targeted to trunk; indirectly merged by GitHub or left pending)".to_string()
         } else {
-            "(reconciled after tip merge)"
+            format!(
+                "(closed as absorbed; {} rewrites commit SHAs)",
+                method.as_str()
+            )
         };
         println!(
             "  {}. {} (#{}) {}",
@@ -964,10 +1061,10 @@ fn print_stack_preview(
     println!(
         "Merge method: {} {}",
         method.as_str().cyan(),
-        if matches!(method, MergeMethod::Rebase) {
-            "(default for --stack)".dimmed()
+        if merge_method_preserves_commit_shas(method) {
+            "(default for --stack; preserves commit SHAs; lower PRs may merge indirectly)".dimmed()
         } else {
-            "(explicit)".dimmed()
+            "(explicit; rewrites commit SHAs; lower PRs close as absorbed)".dimmed()
         }
     );
     if when_ready {
@@ -1200,8 +1297,19 @@ mod tests {
     #[test]
     fn downstack_comment_links_to_tip() {
         assert_eq!(
-            downstack_absorbed_comment(42),
-            "Absorbed into stack merge of #42. This PR's commits landed through the selected tip PR."
+            downstack_absorbed_comment(42, MergeMethod::Rebase),
+            "Absorbed into stack merge of #42. The selected tip was merged with rebase, which rewrites commit SHAs, so GitHub cannot mark this PR indirectly merged."
         );
+    }
+
+    #[test]
+    fn merge_method_commit_sha_behavior() {
+        for (method, preserves) in [
+            (MergeMethod::Merge, true),
+            (MergeMethod::Rebase, false),
+            (MergeMethod::Squash, false),
+        ] {
+            assert_eq!(merge_method_preserves_commit_shas(method), preserves);
+        }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7685,6 +7685,21 @@ mod forge_mock_tests {
             .unwrap_or_else(|| panic!("Did not find request {} {}", method_name, path_name))
     }
 
+    fn find_request_indices(
+        requests: &[wiremock::Request],
+        method_name: &str,
+        path_name: &str,
+    ) -> Vec<usize> {
+        requests
+            .iter()
+            .enumerate()
+            .filter(|(_, request)| {
+                request.method.as_str() == method_name && request.url.path() == path_name
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
     /// Find a request to a PR/MR endpoint whose JSON payload contains a body/description key.
     /// This distinguishes body-update requests from title-update requests (both hit the same URL).
     /// Works for GitHub (PATCH + "body"), GitLab (PUT + "description"), and Gitea (PATCH + "body").
@@ -8174,6 +8189,184 @@ mod forge_mock_tests {
         run_stax_with_token_env(repo, home, "STAX_GITHUB_TOKEN", args)
     }
 
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum StackMergeScenario {
+        LowerMerged,
+        LowerPending,
+        TipRetargetFails,
+        TipMergeFails,
+    }
+
+    struct ThreeBranchStackMergeFixture {
+        mock_server: MockServer,
+        home: TempDir,
+        repo: TestRepo,
+        _remote_root: TempDir,
+        branch_a: String,
+        branch_b: String,
+        tip_sha: String,
+    }
+
+    async fn setup_three_branch_stack_merge_fixture(
+        scenario: StackMergeScenario,
+    ) -> ThreeBranchStackMergeFixture {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-method-a"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_a = repo.current_branch();
+        repo.create_file("parent.txt", "parent\n");
+        repo.commit("Parent commit");
+        let branch_a_sha = repo.get_commit_sha(&branch_a);
+        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
+        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-method-b"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_b = repo.current_branch();
+        repo.create_file("middle.txt", "middle\n");
+        repo.commit("Middle commit");
+        let branch_b_sha = repo.get_commit_sha(&branch_b);
+        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-method-c"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch_c = repo.current_branch();
+        repo.create_file("child.txt", "child\n");
+        repo.commit("Child commit");
+        let tip_sha = repo.get_commit_sha(&branch_c);
+        let push_c = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_c]);
+        assert!(push_c.status.success(), "{}", TestRepo::stderr(&push_c));
+
+        write_branch_pr_metadata(&repo, &branch_a, "main", 601, Some(false));
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 602, Some(false));
+        write_branch_pr_metadata(&repo, &branch_c, &branch_b, 603, Some(false));
+
+        for (number, branch, base, sha) in [
+            (601, branch_a.as_str(), "main", branch_a_sha.as_str()),
+            (
+                602,
+                branch_b.as_str(),
+                branch_a.as_str(),
+                branch_b_sha.as_str(),
+            ),
+        ] {
+            let lower_open = github_pull_fixture(number, branch, base, sha);
+            if scenario == StackMergeScenario::LowerMerged {
+                Mock::given(method("GET"))
+                    .and(path(format!("/repos/test/repo/pulls/{}", number)))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(lower_open))
+                    .with_priority(1)
+                    .up_to_n_times(2)
+                    .mount(&mock_server)
+                    .await;
+
+                let mut lower_merged = github_pull_fixture(number, branch, "main", sha);
+                lower_merged["state"] = serde_json::json!("closed");
+                lower_merged["merged_at"] = serde_json::json!("2026-07-28T00:00:00Z");
+                Mock::given(method("GET"))
+                    .and(path(format!("/repos/test/repo/pulls/{}", number)))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(lower_merged))
+                    .with_priority(2)
+                    .mount(&mock_server)
+                    .await;
+            } else {
+                Mock::given(method("GET"))
+                    .and(path(format!("/repos/test/repo/pulls/{}", number)))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(lower_open))
+                    .mount(&mock_server)
+                    .await;
+            }
+        }
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/603"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(github_pull_fixture(603, &branch_c, &branch_b, &tip_sha)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        mount_github_merge_status_with_head(&mock_server, 601, "OPEN", "APPROVED", &branch_a_sha)
+            .await;
+        mount_github_merge_status_with_head(&mock_server, 602, "OPEN", "APPROVED", &branch_b_sha)
+            .await;
+        mount_github_merge_status_with_head(&mock_server, 603, "OPEN", "APPROVED", &tip_sha).await;
+
+        for (number, branch, sha) in [
+            (601, branch_a.as_str(), branch_a_sha.as_str()),
+            (602, branch_b.as_str(), branch_b_sha.as_str()),
+        ] {
+            Mock::given(method("PATCH"))
+                .and(path(format!("/repos/test/repo/pulls/{}", number)))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(github_pull_fixture(number, branch, "main", sha)),
+                )
+                .mount(&mock_server)
+                .await;
+        }
+
+        let tip_retarget_response = if scenario == StackMergeScenario::TipRetargetFails {
+            ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "tip retarget failed"
+            }))
+        } else {
+            ResponseTemplate::new(200)
+                .set_body_json(github_pull_fixture(603, &branch_c, "main", &tip_sha))
+        };
+        Mock::given(method("PATCH"))
+            .and(path("/repos/test/repo/pulls/603"))
+            .respond_with(tip_retarget_response)
+            .mount(&mock_server)
+            .await;
+
+        let tip_merge_response = if scenario == StackMergeScenario::TipMergeFails {
+            ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "message": "tip merge failed"
+            }))
+        } else {
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "merge-c-commit",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            }))
+        };
+        Mock::given(method("PUT"))
+            .and(path("/repos/test/repo/pulls/603/merge"))
+            .respond_with(tip_merge_response)
+            .mount(&mock_server)
+            .await;
+
+        for number in [601, 602] {
+            Mock::given(method("POST"))
+                .and(path(format!("/repos/test/repo/issues/{}/comments", number)))
+                .respond_with(
+                    ResponseTemplate::new(201)
+                        .set_body_json(issue_comment_fixture(9000 + number, "absorbed")),
+                )
+                .mount(&mock_server)
+                .await;
+        }
+
+        ThreeBranchStackMergeFixture {
+            mock_server,
+            home,
+            repo,
+            _remote_root: remote_root,
+            branch_a,
+            branch_b,
+            tip_sha,
+        }
+    }
+
     fn run_stax_in_dir_with_env(cwd: &Path, home: &Path, args: &[&str]) -> Output {
         run_stax_in_dir_with_token_env(cwd, home, "STAX_GITHUB_TOKEN", args)
     }
@@ -8195,7 +8388,7 @@ mod forge_mock_tests {
             .env(token_env, "mock-token")
             .env("STAX_DISABLE_UPDATE_CHECK", "1")
             .env("STAX_TEST_DISABLE_HEAD_SYNC", "1")
-            .env("STAX_STACK_MERGE_ABSORBED_WAIT_SECS", "0");
+            .env("STAX_STACK_MERGE_INDIRECT_WAIT_SECS", "0");
         command.output().expect("Failed to execute stax")
     }
 
@@ -11758,88 +11951,11 @@ mod forge_mock_tests {
     }
 
     #[tokio::test]
-    async fn test_merge_stack_does_not_close_downstack_pr_when_github_marks_it_merged() {
-        ensure_crypto_provider();
-        let mock_server = MockServer::start().await;
-
-        let home = super::test_tempdir();
-        let repo = TestRepo::new();
-        let _remote_root = setup_fake_github_remote(&repo, home.path());
-        write_test_config(home.path(), &mock_server.uri());
-
-        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-ff-a"]);
-        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
-        let branch_a = repo.current_branch();
-        repo.create_file("parent.txt", "parent\n");
-        repo.commit("Parent commit");
-        let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
-        assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
-
-        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-ff-b"]);
-        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
-        let branch_b = repo.current_branch();
-        repo.create_file("child.txt", "child\n");
-        repo.commit("Child commit");
-        let branch_b_sha = repo.get_commit_sha(&branch_b);
-        let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
-        assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
-
-        write_branch_pr_metadata(&repo, &branch_a, "main", 601, Some(false));
-        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 602, Some(false));
-
-        let mut merged_branch_a = github_pull_fixture(601, &branch_a, "main", "sha-a");
-        merged_branch_a["state"] = serde_json::json!("closed");
-        merged_branch_a["merged_at"] = serde_json::json!("2024-01-01T00:00:00Z");
-
-        Mock::given(method("GET"))
-            .and(path("/repos/test/repo/pulls/601"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(merged_branch_a))
-            .mount(&mock_server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/repos/test/repo/pulls/602"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(github_pull_fixture(
-                    602,
-                    &branch_b,
-                    &branch_a,
-                    &branch_b_sha,
-                )),
-            )
-            .mount(&mock_server)
-            .await;
-
-        mount_github_merge_status_with_head(&mock_server, 601, "OPEN", "APPROVED", "sha-a").await;
-        mount_github_merge_status_with_head(&mock_server, 602, "OPEN", "APPROVED", &branch_b_sha)
-            .await;
-
-        Mock::given(method("PATCH"))
-            .and(path("/repos/test/repo/pulls/602"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(github_pull_fixture(
-                    602,
-                    &branch_b,
-                    "main",
-                    &branch_b_sha,
-                )),
-            )
-            .mount(&mock_server)
-            .await;
-
-        Mock::given(method("PUT"))
-            .and(path("/repos/test/repo/pulls/602/merge"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "sha": "merge-b-commit",
-                "merged": true,
-                "message": "Pull Request successfully merged"
-            })))
-            .mount(&mock_server)
-            .await;
-
+    async fn test_merge_stack_default_retargets_selected_range_before_one_merge() {
+        let fixture = setup_three_branch_stack_merge_fixture(StackMergeScenario::LowerMerged).await;
         let merge_output = run_stax_with_env(
-            &repo,
-            home.path(),
+            &fixture.repo,
+            fixture.home.path(),
             &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
         );
         assert!(
@@ -11848,54 +11964,253 @@ mod forge_mock_tests {
             TestRepo::stderr(&merge_output),
             TestRepo::stdout(&merge_output)
         );
+        assert!(
+            TestRepo::stdout(&merge_output).contains("merged indirectly by GitHub"),
+            "{}",
+            TestRepo::stdout(&merge_output)
+        );
 
-        let requests = mock_server
+        let requests = fixture
+            .mock_server
             .received_requests()
             .await
             .expect("request recording enabled");
-        assert!(
-            requests.iter().all(|request| {
-                request.method.as_str() != "PUT"
-                    || request.url.path() != "/repos/test/repo/pulls/601/merge"
-            }),
-            "Expected no merge call for downstack PR #601, requests were: {:?}",
-            requests
-                .iter()
-                .map(|request| format!("{} {}", request.method, request.url.path()))
-                .collect::<Vec<_>>()
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/603/merge");
+        let b_patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/602");
+        let c_patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/603");
+        assert!(b_patch_idx < c_patch_idx && c_patch_idx < merge_idx);
+
+        for patch_idx in [b_patch_idx, c_patch_idx] {
+            let payload: Value = serde_json::from_slice(&requests[patch_idx].body).unwrap();
+            assert_eq!(payload["base"], "main");
+        }
+        let merge_payload: Value = serde_json::from_slice(&requests[merge_idx].body).unwrap();
+        assert_eq!(merge_payload["merge_method"], "merge");
+        assert_eq!(merge_payload["sha"], fixture.tip_sha);
+
+        for number in [601, 602] {
+            let path = format!("/repos/test/repo/pulls/{}", number);
+            let gets = find_request_indices(&requests, "GET", &path);
+            assert_eq!(gets.len(), 3, "requests: {:?}", requests);
+            assert!(gets[1] < merge_idx && merge_idx < gets[2]);
+            assert!(
+                find_request_indices(
+                    &requests,
+                    "POST",
+                    &format!("/repos/test/repo/issues/{}/comments", number)
+                )
+                .is_empty()
+            );
+            assert!(
+                find_request_indices(&requests, "PATCH", &path)
+                    .iter()
+                    .all(|index| {
+                        serde_json::from_slice::<Value>(&requests[*index].body).unwrap()["state"]
+                            != "closed"
+                    })
+            );
+        }
+        assert!(find_request_indices(&requests, "PATCH", "/repos/test/repo/pulls/601").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_preserving_timeout_leaves_lower_prs_open() {
+        let fixture =
+            setup_three_branch_stack_merge_fixture(StackMergeScenario::LowerPending).await;
+        let merge_output = run_stax_with_env(
+            &fixture.repo,
+            fixture.home.path(),
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
         );
         assert!(
-            requests.iter().all(|request| {
-                request.url.path() != "/repos/test/repo/issues/601/comments"
-                    && !(request.method.as_str() == "PATCH"
-                        && request.url.path() == "/repos/test/repo/pulls/601")
-            }),
-            "Expected no absorbed comment or close call once GitHub reports PR #601 merged, requests were: {:?}",
-            requests
-                .iter()
-                .map(|request| format!("{} {}", request.method, request.url.path()))
-                .collect::<Vec<_>>()
+            merge_output.status.success(),
+            "merge --stack failed: {}\n{}",
+            TestRepo::stderr(&merge_output),
+            TestRepo::stdout(&merge_output)
         );
-
-        let tip_patch_idx = find_request_index(&requests, "PATCH", "/repos/test/repo/pulls/602");
-        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/602/merge");
+        let stdout = TestRepo::stdout(&merge_output);
         assert!(
-            tip_patch_idx < merge_idx,
-            "Expected retarget -> tip merge order, requests were: {:?}",
-            requests
-                .iter()
-                .map(|request| format!("{} {}", request.method, request.url.path()))
-                .collect::<Vec<_>>()
+            stdout.contains("GitHub may still mark it indirectly merged asynchronously")
+                && stdout.contains("pending GitHub indirect-merge detection; left open"),
+            "{}",
+            stdout
         );
 
-        let tip_patch = &requests[tip_patch_idx];
-        let tip_patch_payload: Value = serde_json::from_slice(&tip_patch.body).unwrap();
-        assert_eq!(tip_patch_payload["base"], "main");
+        let requests = fixture
+            .mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        for number in [601, 602] {
+            let pull_path = format!("/repos/test/repo/pulls/{}", number);
+            assert_eq!(find_request_indices(&requests, "GET", &pull_path).len(), 3);
+            assert!(
+                find_request_indices(
+                    &requests,
+                    "POST",
+                    &format!("/repos/test/repo/issues/{}/comments", number)
+                )
+                .is_empty()
+            );
+            assert!(
+                find_request_indices(&requests, "PATCH", &pull_path)
+                    .iter()
+                    .all(|index| {
+                        serde_json::from_slice::<Value>(&requests[*index].body).unwrap()["state"]
+                            != "closed"
+                    })
+            );
+        }
+    }
 
-        let merge_request = &requests[merge_idx];
-        let merge_payload: Value = serde_json::from_slice(&merge_request.body).unwrap();
-        assert_eq!(merge_payload["merge_method"], "rebase");
-        assert_eq!(merge_payload["sha"], branch_b_sha);
+    #[tokio::test]
+    async fn test_merge_stack_rewriting_methods_close_lower_pr_without_polling() {
+        for method_name in ["rebase", "squash"] {
+            let fixture =
+                setup_three_branch_stack_merge_fixture(StackMergeScenario::LowerPending).await;
+            let args = [
+                "merge",
+                "--stack",
+                "--method",
+                method_name,
+                "--yes",
+                "--no-delete",
+                "--no-sync",
+            ];
+
+            let merge_output = run_stax_with_env(&fixture.repo, fixture.home.path(), &args);
+            assert!(
+                merge_output.status.success(),
+                "{} merge --stack failed: {}\n{}",
+                method_name,
+                TestRepo::stderr(&merge_output),
+                TestRepo::stdout(&merge_output)
+            );
+            assert!(
+                TestRepo::stdout(&merge_output).contains(&format!(
+                    "{} rewrites commit SHAs; closed as absorbed without waiting",
+                    method_name
+                )),
+                "{}",
+                TestRepo::stdout(&merge_output)
+            );
+
+            let requests = fixture
+                .mock_server
+                .received_requests()
+                .await
+                .expect("request recording enabled");
+            let merge_idx =
+                find_request_index(&requests, "PUT", "/repos/test/repo/pulls/603/merge");
+            let merge_payload: Value = serde_json::from_slice(&requests[merge_idx].body).unwrap();
+            assert_eq!(merge_payload["merge_method"], method_name);
+            assert_eq!(merge_payload["sha"], fixture.tip_sha);
+
+            for number in [601, 602] {
+                let pull_path = format!("/repos/test/repo/pulls/{}", number);
+                assert_eq!(
+                    find_request_indices(&requests, "GET", &pull_path).len(),
+                    1,
+                    "{} unexpectedly polled PR #{}: {:?}",
+                    method_name,
+                    number,
+                    requests
+                );
+                let comment_idx = find_request_index(
+                    &requests,
+                    "POST",
+                    &format!("/repos/test/repo/issues/{}/comments", number),
+                );
+                let close_idx = find_request_index(&requests, "PATCH", &pull_path);
+                assert!(merge_idx < comment_idx && comment_idx < close_idx);
+
+                let close_payload: Value =
+                    serde_json::from_slice(&requests[close_idx].body).unwrap();
+                assert_eq!(close_payload["state"], "closed");
+                let comment_payload: Value =
+                    serde_json::from_slice(&requests[comment_idx].body).unwrap();
+                assert!(comment_payload["body"].as_str().unwrap().contains(&format!(
+                    "merged with {}, which rewrites commit SHAs",
+                    method_name
+                )));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_rolls_back_changed_bases_when_later_retarget_fails() {
+        let fixture =
+            setup_three_branch_stack_merge_fixture(StackMergeScenario::TipRetargetFails).await;
+        let output = run_stax_with_env(
+            &fixture.repo,
+            fixture.home.path(),
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("failed to retarget PR #603 to main"));
+
+        let requests = fixture
+            .mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let b_patches = find_request_indices(&requests, "PATCH", "/repos/test/repo/pulls/602");
+        let c_patches = find_request_indices(&requests, "PATCH", "/repos/test/repo/pulls/603");
+        assert_eq!(b_patches.len(), 2);
+        assert_eq!(c_patches.len(), 1);
+        assert!(b_patches[0] < c_patches[0] && c_patches[0] < b_patches[1]);
+
+        let b_target: Value = serde_json::from_slice(&requests[b_patches[0]].body).unwrap();
+        let c_target: Value = serde_json::from_slice(&requests[c_patches[0]].body).unwrap();
+        let b_restore: Value = serde_json::from_slice(&requests[b_patches[1]].body).unwrap();
+        assert_eq!(b_target["base"], "main");
+        assert_eq!(c_target["base"], "main");
+        assert_eq!(b_restore["base"], fixture.branch_a);
+        assert!(
+            find_request_indices(&requests, "PUT", "/repos/test/repo/pulls/603/merge").is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_rolls_back_all_changed_bases_when_tip_merge_fails() {
+        let fixture =
+            setup_three_branch_stack_merge_fixture(StackMergeScenario::TipMergeFails).await;
+        let output = run_stax_with_env(
+            &fixture.repo,
+            fixture.home.path(),
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("tip merge failed"), "{combined}");
+
+        let requests = fixture
+            .mock_server
+            .received_requests()
+            .await
+            .expect("request recording enabled");
+        let b_patches = find_request_indices(&requests, "PATCH", "/repos/test/repo/pulls/602");
+        let c_patches = find_request_indices(&requests, "PATCH", "/repos/test/repo/pulls/603");
+        let merge_idx = find_request_index(&requests, "PUT", "/repos/test/repo/pulls/603/merge");
+        assert_eq!(b_patches.len(), 2);
+        assert_eq!(c_patches.len(), 2);
+        assert!(
+            b_patches[0] < c_patches[0]
+                && c_patches[0] < merge_idx
+                && merge_idx < c_patches[1]
+                && c_patches[1] < b_patches[1]
+        );
+
+        let c_restore: Value = serde_json::from_slice(&requests[c_patches[1]].body).unwrap();
+        let b_restore: Value = serde_json::from_slice(&requests[b_patches[1]].body).unwrap();
+        assert_eq!(c_restore["base"], fixture.branch_b);
+        assert_eq!(b_restore["base"], fixture.branch_a);
+        assert!(
+            requests
+                .iter()
+                .all(|request| !request.url.path().contains("/comments"))
+        );
     }
 
     #[tokio::test]
@@ -12004,24 +12319,6 @@ mod forge_mock_tests {
                 "merged": true,
                 "message": "Pull Request successfully merged"
             })))
-            .mount(&mock_server)
-            .await;
-
-        Mock::given(method("POST"))
-            .and(path("/repos/test/repo/issues/611/comments"))
-            .respond_with(ResponseTemplate::new(201).set_body_json(issue_comment_fixture(
-                9002,
-                "Absorbed into stack merge of #612. This PR's commits landed through the selected tip PR.",
-            )))
-            .mount(&mock_server)
-            .await;
-
-        Mock::given(method("PATCH"))
-            .and(path("/repos/test/repo/pulls/611"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(github_pull_fixture(611, &branch_a, "main", "sha-a")),
-            )
             .mount(&mock_server)
             .await;
 


### PR DESCRIPTION
## Summary

Closes #697.

- Make plain `st merge --stack` default to GitHub's SHA-preserving `merge` method while leaving ordinary non-stack merge defaulted to `squash`.
- Retarget the whole selected PR range to trunk before merging the selected tip once, allowing GitHub to mark downstack PRs as indirectly merged.
- Roll back every changed PR base to its exact original value when preparation or the selected-tip merge fails.
- Leave preserving-method timeouts open and report them as pending; explicit `rebase` and `squash` remain rewriting opt-ins that immediately comment and close lower PRs as absorbed.
- Reuse the shared three-level GitHub API fixture for default, pending, rewriting, request-order, and rollback coverage.

## Verification

- `cargo check` — passed.
- `cargo nextest run merge_stack` — 21 passed.
- `make lint` — passed across all targets and features.
- `make test` — 2,159 Docker-backed tests passed.
- Live GitHub E2E on `geoHeil/stax-dummy-test` — passed:
  - [PR #1](https://github.com/geoHeil/stax-dummy-test/pull/1) — indirectly `MERGED`, original head SHA preserved.
  - [PR #2](https://github.com/geoHeil/stax-dummy-test/pull/2) — indirectly `MERGED`, original head SHA preserved.
  - [PR #3](https://github.com/geoHeil/stax-dummy-test/pull/3) — selected tip merged once with GitHub method `merge`.

## Documentation

Updated `README.md`, command/workflow documentation, and `skills.md` for the new default, whole-range retargeting, pending behavior, rewriting opt-ins, and rollback semantics.

## Residual risk

GitHub's indirect-merge recognition is asynchronous. If it exceeds Stax's bounded wait, Stax now leaves the lower PR open instead of destructively closing it, so GitHub can mark it merged later.
