### PR TITLE
feat: support GitLab stack merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,15 @@ Merge from the bottom of the stack up to your current branch, with CI and readin
 st merge                  # local cascade merge
 st merge --when-ready     # wait/poll until PRs are mergeable
 st merge --ds             # merge ancestors, rebase current branch
-st merge --stack          # target selected PRs to trunk; preserve lower PR merged state by default
+st merge --stack          # GitHub/GitLab: preserve lower PR/MR merged state through one tip merge
 st merge --stack --full   # stack-merge the full stack even from the middle
 st merge --remote         # merge remotely on GitHub while you keep working
 st merge --all            # merge the whole stack regardless of position
 ```
+
+GitLab stack merge checks project merge settings first, sends `squash: false`,
+and accepts only the default preserving method; explicit stack `rebase` or
+`squash` is rejected. Gitea/Forgejo stack merge is not supported.
 
 → [Merge and cascade](docs/workflows/merge-and-cascade.md)
 

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -42,7 +42,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
-| `st merge --stack` | Target the selected PRs to trunk and merge the tip with SHA-preserving `merge`, allowing GitHub to mark lower PRs merged (`--full` includes descendants; GitHub only) |
+| `st merge --stack` | Target selected PRs/MRs to trunk and merge the tip with SHA-preserving `merge`, allowing GitHub or GitLab to mark lower items merged (`--full` includes descendants) |
 | `st merge --remote` | Merge remotely via the GitHub API while you keep working |
 | `st merge --all` | Merge the entire stack regardless of where you are |
 | `st cascade` | Restack, push, and create/update PRs in one shot (no trunk fetch; offline-friendly) |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -47,7 +47,7 @@ st --trace status --json >/dev/null
 - `st merge` — local cascade merge with provenance-aware descendant rebases, then `st rs --force` unless `--no-sync`
 - `st merge --when-ready` — wait for CI + approvals + mergeability; incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`
 - `st merge --downstack-only` / `--ds` — merge ancestors below the current branch, then rebase the current branch onto trunk; composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`
-- `st merge --stack` — GitHub-only stack merge: target every selected PR to trunk, merge only the selected tip with SHA-preserving `merge`, and let GitHub mark lower PRs indirectly merged; timed-out lower PRs stay open, while explicit `rebase`/`squash` closes them as absorbed without waiting
+- `st merge --stack` — GitHub/GitLab stack merge: target every selected PR/MR to trunk, merge only the selected tip with SHA-preserving `merge`, and poll lower items for authoritative merged state; timed-out items stay open. GitLab first verifies project merge settings, sends `squash: false`, and rejects explicit `rebase`/`squash`; GitHub retains absorbed closure for those rewriting methods. Gitea/Forgejo is unsupported
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
 - `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -26,7 +26,7 @@ st merge --method squash|merge|rebase
 st merge --stack                           # validate current PR once, land through current
 st merge --stack --downstack-only          # land ancestors below current through one PR
 st merge --stack --full                    # land the full stack even from the middle
-st merge --stack --when-ready              # wait only for the selected tip PR, then land
+st merge --stack --when-ready              # wait only for the selected tip PR/MR, then land
 st merge --when-ready                       # wait for readiness explicitly
 st merge --when-ready --interval 10
 st merge --no-wait --no-delete --no-sync
@@ -37,7 +37,7 @@ st merge --timeout 60 --yes
 
 `--full` is only valid with `--stack`; it includes descendants above the current branch in the selected stack merge.
 
-`--when-ready` is incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`. With `--stack`, it waits only for the selected tip PR.
+`--when-ready` is incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`. With `--stack`, it waits only for the selected tip PR/MR.
 
 ### Partial stack merge
 
@@ -63,9 +63,9 @@ st merge --ds
 
 Merges `auth` and `auth-api`; `auth-ui` is rebased onto `main`, and `auth-tests` remains stacked on `auth-ui`.
 
-## `st merge --stack` (GitHub only)
+## `st merge --stack` (GitHub and GitLab)
 
-Lands the selected stack range through one GitHub PR merge. By default the selected range is stack bottom through the current branch:
+Lands the selected stack range through one SHA-preserving tip PR/MR merge. By default the selected range is stack bottom through the current branch:
 
 ```bash
 st merge --stack
@@ -75,13 +75,15 @@ st merge --stack --full
 st merge --stack --dry-run
 ```
 
-For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, and validates CI/mergeability on selected tip PR `B`. With the default `merge` method, Stax targets both `A` and `B` to `main` before merging only `B`. Preserving the existing commit SHAs and making them reachable from `main` lets GitHub mark `A` indirectly merged. PR `C` remains open and is rebased/retargeted onto `main`.
+For `main ← A ← B ← C` while checked out on `B`, stax checks that local `main` matches `origin/main`, verifies the local stack is linear, checks `A` for review blockers, and validates CI/mergeability on selected tip `B`. With the default `merge` method, Stax targets both `A` and `B` to `main` before merging only `B`. Preserving the existing commit SHAs and making them reachable from `main` lets GitHub or GitLab mark `A` indirectly merged. `C` remains open and is rebased/retargeted onto `main`.
 
-Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `merge`. Explicit `--method rebase` and `--method squash` rewrite commit SHAs, so Stax comments on and closes lower PRs as absorbed immediately instead of polling for an impossible indirect merge.
+Use `st merge --stack --downstack-only` to exclude the checked-out branch from the selected range. Use `st merge --stack --full` to include descendants above the current branch and land the full stack through the actual stack tip. The default merge method for `--stack` is `merge`. On GitLab, Stax first checks that the project uses `merge`, `rebase_merge`, or `ff` and does not require squashing, then sends `squash: false`; explicit stack `rebase` and `squash` are rejected before mutation. On GitHub, those explicit rewriting methods still comment on and close lower PRs as absorbed without polling.
 
 This avoids re-running CI for every lower PR because the selected tip already contains that range. The post-merge sync updates trunk and PR metadata without running generic merged-branch deletion; branch cleanup stays scoped to the stack range that was just landed. If trunk moves before the merge, stax aborts and asks you to restack and wait for fresh selected-tip CI.
 
-GitHub's indirect-merge detection is asynchronous. If a lower PR is still open after Stax's bounded poll under the default `merge` method, Stax leaves it open and reports it as pending so GitHub can mark it merged later. Any base changes are restored if retargeting, the final trunk check, or the selected-tip merge fails.
+Indirect-merge detection is asynchronous. Stax requires GitLab's authoritative `state: merged` (a merely closed MR does not count). If a lower PR/MR is still open after the bounded poll, Stax leaves it open and reports it as pending so the forge can reconcile it later. Any base changes are restored if retargeting, the final trunk check, or the selected-tip merge fails.
+
+Gitea/Forgejo does not support `st merge --stack`.
 
 For the no-extra-CI behavior, GitHub branch protection should require status checks but should not require branches to be up to date before merging. If GitHub requires up-to-date branches, it can force another revalidation at merge time.
 

--- a/skills.md
+++ b/skills.md
@@ -289,11 +289,11 @@ stax merge --downstack-only        # Merge ancestors below current, then rebase 
 stax merge --ds                    # Alias for --downstack-only
 stax merge --dry-run               # Preview merge plan only
 stax merge --method squash         # squash|merge|rebase
-stax merge --stack                 # GitHub only: target selected PRs to trunk, merge the tip, preserve lower PR merged state
-stax merge --stack --method rebase # Rewrite SHAs and close lower PRs as absorbed without polling (also: squash)
+stax merge --stack                 # GitHub/GitLab only: target selected items to trunk, merge the tip, preserve merged state
+stax merge --stack --method rebase # GitHub only: rewrite SHAs and absorb lower PRs (GitLab rejects rebase/squash)
 stax merge --stack --downstack-only # Stack-merge ancestors below current; keep current open
 stax merge --stack --full          # Stack-merge full stack even from the middle
-stax merge --stack --when-ready    # Wait only for selected tip PR readiness before the one-PR stack merge
+stax merge --stack --when-ready    # Wait only for selected tip PR/MR readiness before the one-item stack merge
 stax merge --when-ready            # Wait for CI + approval before each merge
 stax merge --remote                # Merge via GitHub API only — no local checkout/rebase/push
 stax merge --remote --all          # Include full stack (GitHub only)
@@ -564,7 +564,7 @@ stax ss --rerequest-review
 ```bash
 stax ready
 stax merge --when-ready --interval 15
-stax merge --stack --when-ready    # GitHub stack merge: selected tip CI only, defaults to SHA-preserving merge
+stax merge --stack --when-ready    # GitHub/GitLab stack merge: selected tip CI only, preserving merge
 ```
 
 ### After Base PR Merges

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -345,10 +345,10 @@ pub(crate) enum Commands {
         dry_run: bool,
         /// Merge method: squash, merge, rebase (default: squash; merge with --stack).
         ///
-        /// With --stack, merge targets the selected PRs to trunk and preserves commit
-        /// SHAs so GitHub may mark lower PRs indirectly merged. Timed-out lower PRs
-        /// stay open. Rebase and squash rewrite SHAs, so Stax closes lower PRs as
-        /// absorbed without waiting.
+        /// With --stack, merge targets selected PRs/MRs to trunk and preserves commit
+        /// SHAs so GitHub or GitLab may mark lower items indirectly merged. Timed-out
+        /// items stay open. GitLab rejects explicit rebase/squash; on GitHub those
+        /// methods rewrite SHAs and close lower PRs as absorbed without waiting.
         #[arg(long)]
         method: Option<String>,
         /// Keep branches after merge (don't delete)
@@ -366,7 +366,7 @@ pub(crate) enum Commands {
         /// Merge via GitHub API only (no local checkout/rebase/push); GitHub updates branches remotely
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "queue", "stack"])]
         remote: bool,
-        /// Prepare selected PR bases, validate the tip once, and merge the selected stack range once
+        /// Prepare selected PR/MR bases and merge the selected stack range once (GitHub/GitLab)
         #[arg(long, conflicts_with_all = ["no_wait", "remote", "queue"])]
         stack: bool,
         /// Enqueue PRs into the forge's merge queue instead of merging one-by-one.

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -1,8 +1,8 @@
-//! Stack merge through one GitHub PR merge.
+//! Stack merge through one forge pull/merge request.
 //!
-//! This is the serverless path from issue #293: validate the selected tip PR
-//! once, prepare the selected PR bases, merge the tip via GitHub's merge API,
-//! then reconcile selected lower PRs as merged, pending, or absorbed.
+//! Validate the selected tip once, prepare the selected item bases, merge the
+//! tip through the forge API, then reconcile selected lower items as merged,
+//! pending, or (on GitHub rewriting methods) absorbed.
 
 use crate::commands::merge_shared::{
     PrBaseUpdate, WaitResult, print_header, print_header_success,
@@ -57,7 +57,7 @@ struct ChangedPrBase {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DownstackOutcome {
-    GithubMerged,
+    IndirectlyMerged,
     Pending,
     Absorbed,
 }
@@ -84,6 +84,21 @@ fn stack_merge_confirmation(yes: bool, quiet: bool, is_terminal: bool) -> StackM
         StackMergeConfirmation::RequireYes
     } else {
         StackMergeConfirmation::Prompt
+    }
+}
+
+fn forge_name(forge: ForgeType) -> &'static str {
+    match forge {
+        ForgeType::GitHub => "GitHub",
+        ForgeType::GitLab => "GitLab",
+        ForgeType::Gitea => "Gitea/Forgejo",
+    }
+}
+
+fn item_label(forge: ForgeType, number: u64) -> String {
+    match forge {
+        ForgeType::GitLab => format!("MR !{}", number),
+        ForgeType::GitHub | ForgeType::Gitea => format!("PR #{}", number),
     }
 }
 
@@ -131,12 +146,13 @@ pub fn run(
     }
 
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
-    if remote_info.forge != ForgeType::GitHub {
+    if remote_info.forge == ForgeType::Gitea {
         anyhow::bail!(
-            "`stax merge --stack` is only supported for GitHub remotes (found {})",
-            remote_info.forge
+            "`stax merge --stack` is supported for GitHub and GitLab, not {}",
+            forge_name(remote_info.forge)
         );
     }
+    let forge = remote_info.forge;
 
     let scope = calculate_stack_merge_scope(&repo, &stack, &current, full, downstack_only)?;
     if scope.to_merge.is_empty() {
@@ -158,14 +174,14 @@ pub fn run(
 
     verify_linear_stack(&repo, &scope)?;
 
-    let pr_timer = LiveTimer::maybe_new(!quiet, "Fetching stack PRs...");
-    let resolved = resolve_stack_prs(&rt, &client, &scope)?;
+    let pr_timer = LiveTimer::maybe_new(!quiet, "Fetching stack pull/merge requests...");
+    let resolved = resolve_stack_prs(&rt, &client, &scope, forge)?;
     let remaining = resolve_remaining_branches(&rt, &client, &scope.remaining)?;
     LiveTimer::maybe_finish_ok(pr_timer, "done");
 
     let status_timer = LiveTimer::maybe_new(!quiet, "Checking stack eligibility...");
     let statuses = fetch_stack_statuses(&rt, &client, &resolved)?;
-    check_downstack_eligibility(&resolved, &statuses)?;
+    check_downstack_eligibility(&resolved, &statuses, forge)?;
     LiveTimer::maybe_finish_ok(status_timer, "done");
 
     let tip = resolved.last().context("stack merge scope is empty")?;
@@ -173,8 +189,8 @@ pub fn run(
 
     if !when_ready && let Some(reason) = tip_blocker(&tip_status) {
         anyhow::bail!(
-            "Selected tip PR #{} ({}) is not ready: {}.\n\nRun `stax merge --stack --when-ready` to wait.",
-            tip.pr_number,
+            "Selected tip {} ({}) is not ready: {}.\n\nRun `stax merge --stack --when-ready` to wait.",
+            item_label(forge, tip.pr_number),
             tip.branch,
             reason
         );
@@ -189,6 +205,7 @@ pub fn run(
             method,
             when_ready,
             scope.downstack_only,
+            forge,
         );
     }
 
@@ -231,42 +248,51 @@ pub fn run(
     if when_ready {
         let timeout = Duration::from_secs(timeout_mins * 60);
         let poll_interval = Duration::from_secs(interval_secs);
-        match wait_for_tip_ready(&rt, &client, tip.pr_number, timeout, poll_interval, quiet)? {
+        match wait_for_tip_ready(
+            &rt,
+            &client,
+            tip.pr_number,
+            timeout,
+            poll_interval,
+            quiet,
+            forge,
+        )? {
             WaitResult::Ready(status) => tip_status = status,
             WaitResult::Failed(reason) => {
                 anyhow::bail!(
-                    "Selected tip PR #{} ({}) is not ready: {}",
-                    tip.pr_number,
+                    "Selected tip {} ({}) is not ready: {}",
+                    item_label(forge, tip.pr_number),
                     tip.branch,
                     reason
                 )
             }
             WaitResult::Timeout => {
                 anyhow::bail!(
-                    "Timed out waiting for selected tip PR #{} ({}) to become ready",
-                    tip.pr_number,
+                    "Timed out waiting for selected tip {} ({}) to become ready",
+                    item_label(forge, tip.pr_number),
                     tip.branch
                 )
             }
         }
     }
 
-    verify_tip_head_matches_local(&repo, tip, &tip_status)?;
+    verify_tip_head_matches_local(&repo, tip, &tip_status, forge)?;
     ensure_trunk_unchanged(&repo, &remote_info, &scope.trunk, &trunk_sha)?;
+    rt.block_on(async { client.preflight_stack_merge(method).await })?;
 
     let changed_bases =
-        prepare_selected_pr_bases(&rt, &client, &resolved, &scope.trunk, method, quiet)?;
+        prepare_selected_pr_bases(&rt, &client, &resolved, &scope.trunk, method, quiet, forge)?;
 
     if let Err(e) = ensure_trunk_unchanged(&repo, &remote_info, &scope.trunk, &trunk_sha) {
-        rollback_changed_pr_bases(&rt, &client, &changed_bases, quiet);
+        rollback_changed_pr_bases(&rt, &client, &changed_bases, quiet, forge);
         return Err(e);
     }
 
     let merge_timer = LiveTimer::maybe_new(
         !quiet,
         &format!(
-            "Merging selected tip PR #{} ({})...",
-            tip.pr_number,
+            "Merging selected tip {} ({})...",
+            item_label(forge, tip.pr_number),
             method.as_str()
         ),
     );
@@ -278,12 +304,13 @@ pub fn run(
 
     if let Err(e) = merge_result {
         LiveTimer::maybe_finish_err(merge_timer, "failed");
-        rollback_changed_pr_bases(&rt, &client, &changed_bases, quiet);
+        rollback_changed_pr_bases(&rt, &client, &changed_bases, quiet, forge);
         return Err(e);
     }
     LiveTimer::maybe_finish_ok(merge_timer, "done");
 
-    let downstack_outcomes = reconcile_downstack_prs(&rt, &client, &resolved, tip, method, quiet)?;
+    let downstack_outcomes =
+        reconcile_downstack_prs(&rt, &client, &resolved, tip, method, quiet, forge)?;
 
     rebase_remaining_branches(
         &repo,
@@ -308,9 +335,9 @@ pub fn run(
         print_header_success("Stack Merged");
         println!();
         println!(
-            "Landed {} branches through selected tip PR #{} into {}:",
+            "Landed {} branches through selected tip {} into {}:",
             resolved.len(),
-            tip.pr_number,
+            item_label(forge, tip.pr_number),
             scope.trunk.cyan()
         );
         for pr in &resolved {
@@ -329,15 +356,18 @@ pub fn run(
                     .iter()
                     .find(|(number, _)| *number == pr.pr_number)
                     .map(|(_, outcome)| *outcome)
-                    .expect("every downstack PR has a reconciliation outcome")
+                    .expect("every downstack item has a reconciliation outcome")
                 {
-                    DownstackOutcome::GithubMerged => (
+                    DownstackOutcome::IndirectlyMerged => (
                         "✓".green().to_string(),
-                        "merged indirectly by GitHub".to_string(),
+                        format!("merged indirectly by {}", forge_name(forge)),
                     ),
                     DownstackOutcome::Pending => (
                         "○".yellow().to_string(),
-                        "pending GitHub indirect-merge detection; left open".to_string(),
+                        format!(
+                            "pending {} indirect-merge detection; left open",
+                            forge_name(forge)
+                        ),
                     ),
                     DownstackOutcome::Absorbed => (
                         "✓".green().to_string(),
@@ -348,14 +378,25 @@ pub fn run(
                     ),
                 }
             };
-            println!("  {} #{} {} -> {}", marker, pr.pr_number, pr.branch, action);
+            println!(
+                "  {} {} {} -> {}",
+                marker,
+                item_label(forge, pr.pr_number),
+                pr.branch,
+                action
+            );
         }
         if !remaining.is_empty() {
             println!();
             println!("Remaining in stack (rebased onto {}):", scope.trunk.cyan());
             for branch in &remaining {
                 if let Some(pr_number) = branch.pr_number {
-                    println!("  {} #{} {}", "○".dimmed(), pr_number, branch.branch);
+                    println!(
+                        "  {} {} {}",
+                        "○".dimmed(),
+                        item_label(forge, pr_number),
+                        branch.branch
+                    );
                 } else {
                     println!("  {} {}", "○".dimmed(), branch.branch);
                 }
@@ -483,6 +524,7 @@ fn resolve_stack_prs(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
     scope: &StackMergeScope,
+    forge: ForgeType,
 ) -> Result<Vec<ResolvedStackPr>> {
     let mut resolved = Vec::with_capacity(scope.to_merge.len());
 
@@ -494,7 +536,7 @@ fn resolve_stack_prs(
                 .map(|pr| pr.number)
                 .ok_or_else(|| {
                     anyhow::anyhow!(
-                        "Branch '{}' has no PR. Run 'stax submit' first.",
+                        "Branch '{}' has no pull/merge request. Run 'stax submit' first.",
                         branch.branch
                     )
                 })?,
@@ -503,8 +545,8 @@ fn resolve_stack_prs(
         let pr = rt.block_on(async { client.get_pr_with_head(pr_number).await })?;
         if pr.head != branch.branch {
             anyhow::bail!(
-                "PR #{} is for head branch '{}', expected '{}'",
-                pr_number,
+                "{} is for head branch '{}', expected '{}'",
+                item_label(forge, pr_number),
                 pr.head,
                 branch.branch
             );
@@ -553,7 +595,11 @@ fn fetch_stack_statuses(
         .collect()
 }
 
-fn check_downstack_eligibility(prs: &[ResolvedStackPr], statuses: &[PrMergeStatus]) -> Result<()> {
+fn check_downstack_eligibility(
+    prs: &[ResolvedStackPr],
+    statuses: &[PrMergeStatus],
+    forge: ForgeType,
+) -> Result<()> {
     for (pr, status) in prs
         .iter()
         .zip(statuses.iter())
@@ -561,8 +607,8 @@ fn check_downstack_eligibility(prs: &[ResolvedStackPr], statuses: &[PrMergeStatu
     {
         if let Some(reason) = downstack_blocker(status) {
             anyhow::bail!(
-                "Downstack PR #{} ({}) is not eligible for stack merge: {}",
-                pr.pr_number,
+                "Downstack {} ({}) is not eligible for stack merge: {}",
+                item_label(forge, pr.pr_number),
                 pr.branch,
                 reason
             );
@@ -574,10 +620,10 @@ fn check_downstack_eligibility(prs: &[ResolvedStackPr], statuses: &[PrMergeStatu
 
 fn downstack_blocker(status: &PrMergeStatus) -> Option<&'static str> {
     if status.state.to_lowercase() != "open" {
-        return Some("PR is closed");
+        return Some("item is closed");
     }
     if status.is_draft {
-        return Some("PR is draft");
+        return Some("item is draft");
     }
     if status.changes_requested {
         return Some("changes requested");
@@ -612,6 +658,7 @@ fn wait_for_tip_ready(
     timeout: Duration,
     poll_interval: Duration,
     quiet: bool,
+    forge: ForgeType,
 ) -> Result<WaitResult> {
     let start = Instant::now();
     let mut last_status: Option<String> = None;
@@ -633,8 +680,9 @@ fn wait_for_tip_ready(
                 if !quiet {
                     let elapsed = start.elapsed().as_secs();
                     let status_text = format!(
-                        "      {} Waiting for selected tip PR: {}... ({}s)",
+                        "      {} Waiting for selected tip {}: {}... ({}s)",
                         "⏳".yellow(),
+                        item_label(forge, pr_number),
                         reason,
                         elapsed
                     );
@@ -667,12 +715,13 @@ fn verify_tip_head_matches_local(
     repo: &GitRepo,
     tip: &ResolvedStackPr,
     tip_status: &PrMergeStatus,
+    forge: ForgeType,
 ) -> Result<()> {
     let local_sha = repo.rev_parse(&tip.branch)?;
     if local_sha != tip_status.head_sha {
         anyhow::bail!(
-            "Selected tip PR #{} head SHA ({}) does not match local branch '{}' ({}). Run `stax submit` or fetch the branch before stack merging.",
-            tip.pr_number,
+            "Selected tip {} head SHA ({}) does not match local branch '{}' ({}). Run `stax submit` or fetch the branch before stack merging.",
+            item_label(forge, tip.pr_number),
             tip_status.head_sha,
             tip.branch,
             local_sha
@@ -693,6 +742,7 @@ fn prepare_selected_pr_bases(
     trunk: &str,
     method: MergeMethod,
     quiet: bool,
+    forge: ForgeType,
 ) -> Result<Vec<ChangedPrBase>> {
     let first = if merge_method_preserves_commit_shas(method) {
         0
@@ -704,7 +754,11 @@ fn prepare_selected_pr_bases(
     for pr in &prs[first..] {
         let timer = LiveTimer::maybe_new(
             !quiet,
-            &format!("Retargeting PR #{} to {}...", pr.pr_number, trunk),
+            &format!(
+                "Retargeting {} to {}...",
+                item_label(forge, pr.pr_number),
+                trunk
+            ),
         );
         match update_pr_base_unless_current(rt, client, pr.pr_number, trunk, &pr.branch) {
             Ok(PrBaseUpdate::Updated) => {
@@ -719,7 +773,7 @@ fn prepare_selected_pr_bases(
             }
             Ok(PrBaseUpdate::NativeStackLocked) => {
                 LiveTimer::maybe_finish_err(timer, "locked");
-                rollback_changed_pr_bases(rt, client, &changed, quiet);
+                rollback_changed_pr_bases(rt, client, &changed, quiet, forge);
                 anyhow::bail!(
                     "PR #{} is registered in a native GitHub Stack, which locks its base branch. \
                      Merge it via the normal stack order (`st merge`) instead of merging out of \
@@ -729,7 +783,7 @@ fn prepare_selected_pr_bases(
             }
             Err(e) => {
                 LiveTimer::maybe_finish_err(timer, "failed");
-                rollback_changed_pr_bases(rt, client, &changed, quiet);
+                rollback_changed_pr_bases(rt, client, &changed, quiet, forge);
                 return Err(e);
             }
         }
@@ -743,13 +797,15 @@ fn rollback_changed_pr_bases(
     client: &ForgeClient,
     changed: &[ChangedPrBase],
     quiet: bool,
+    forge: ForgeType,
 ) {
     for pr in changed.iter().rev() {
         let timer = LiveTimer::maybe_new(
             !quiet,
             &format!(
-                "Restoring PR #{} base to {}...",
-                pr.pr_number, pr.original_base
+                "Restoring {} base to {}...",
+                item_label(forge, pr.pr_number),
+                pr.original_base
             ),
         );
         match rt.block_on(async { client.update_pr_base(pr.pr_number, &pr.original_base).await }) {
@@ -757,9 +813,9 @@ fn rollback_changed_pr_bases(
             Err(e) => {
                 LiveTimer::maybe_finish_err(timer, "failed");
                 eprintln!(
-                    "{} failed to restore PR #{} base to {}: {:#}",
+                    "{} failed to restore {} base to {}: {:#}",
                     "warning:".yellow().bold(),
-                    pr.pr_number,
+                    item_label(forge, pr.pr_number),
                     pr.original_base,
                     e
                 );
@@ -775,44 +831,58 @@ fn reconcile_downstack_prs(
     tip: &ResolvedStackPr,
     method: MergeMethod,
     quiet: bool,
+    forge: ForgeType,
 ) -> Result<Vec<(u64, DownstackOutcome)>> {
     let mut outcomes = Vec::new();
 
     for pr in prs.iter().filter(|pr| pr.pr_number != tip.pr_number) {
         let message = if merge_method_preserves_commit_shas(method) {
             format!(
-                "Waiting for downstack PR #{} to be marked indirectly merged...",
-                pr.pr_number
+                "Waiting for downstack {} to be marked indirectly merged...",
+                item_label(forge, pr.pr_number)
             )
         } else {
             format!(
-                "Closing downstack PR #{} as absorbed ({} rewrites commit SHAs)...",
-                pr.pr_number,
+                "Closing downstack {} as absorbed ({} rewrites commit SHAs)...",
+                item_label(forge, pr.pr_number),
                 method.as_str()
             )
         };
         let timer = LiveTimer::maybe_new(!quiet, &message);
-        if merge_method_preserves_commit_shas(method)
-            && wait_for_downstack_pr_merged(rt, client, pr.pr_number)?
-        {
-            outcomes.push((pr.pr_number, DownstackOutcome::GithubMerged));
-            LiveTimer::maybe_finish_ok(timer, "merged indirectly by GitHub");
-            continue;
-        }
-
         if merge_method_preserves_commit_shas(method) {
-            outcomes.push((pr.pr_number, DownstackOutcome::Pending));
-            LiveTimer::maybe_finish_err(timer, "still open; indirect merge pending");
-            if !quiet {
-                println!(
-                    "  {} PR #{} remains open; GitHub may still mark it indirectly merged asynchronously.",
-                    "warning:".yellow().bold(),
-                    pr.pr_number
-                );
+            match wait_for_downstack_pr_state(rt, client, pr.pr_number)? {
+                DownstackPrState::Merged => {
+                    outcomes.push((pr.pr_number, DownstackOutcome::IndirectlyMerged));
+                    LiveTimer::maybe_finish_ok(
+                        timer,
+                        &format!("merged indirectly by {}", forge_name(forge)),
+                    );
+                }
+                DownstackPrState::Open => {
+                    outcomes.push((pr.pr_number, DownstackOutcome::Pending));
+                    LiveTimer::maybe_finish_err(timer, "still open; indirect merge pending");
+                    if !quiet {
+                        println!(
+                            "  {} {} remains open; {} may still mark it indirectly merged asynchronously.",
+                            "warning:".yellow().bold(),
+                            item_label(forge, pr.pr_number),
+                            forge_name(forge)
+                        );
+                    }
+                }
+                DownstackPrState::Closed => {
+                    LiveTimer::maybe_finish_err(timer, "closed without being merged");
+                    anyhow::bail!(
+                        "Downstack {} is closed without being merged; {} cannot mark a closed item indirectly merged",
+                        item_label(forge, pr.pr_number),
+                        forge_name(forge)
+                    );
+                }
             }
             continue;
         }
 
+        debug_assert_eq!(forge, ForgeType::GitHub);
         let comment = downstack_absorbed_comment(tip.pr_number, method);
         rt.block_on(async { client.create_issue_comment(pr.pr_number, &comment).await })?;
         rt.block_on(async { client.close_pr(pr.pr_number).await })?;
@@ -829,21 +899,39 @@ fn reconcile_downstack_prs(
     Ok(outcomes)
 }
 
-fn wait_for_downstack_pr_merged(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownstackPrState {
+    Merged,
+    Open,
+    Closed,
+}
+
+fn wait_for_downstack_pr_state(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
     pr_number: u64,
-) -> Result<bool> {
+) -> Result<DownstackPrState> {
     let timeout = downstack_merged_wait();
     let interval = Duration::from_secs(2);
     let start = Instant::now();
 
     loop {
-        if rt.block_on(async { client.is_pr_merged(pr_number).await })? {
-            return Ok(true);
+        let state = rt.block_on(async { client.get_pr(pr_number).await })?.state;
+        if state.eq_ignore_ascii_case("merged") {
+            return Ok(DownstackPrState::Merged);
+        }
+        if state.eq_ignore_ascii_case("closed") {
+            return Ok(DownstackPrState::Closed);
+        }
+        if !state.eq_ignore_ascii_case("open") {
+            anyhow::bail!(
+                "Downstack PR/MR #{} returned unexpected state `{}`",
+                pr_number,
+                state
+            );
         }
         if start.elapsed() >= timeout {
-            return Ok(false);
+            return Ok(DownstackPrState::Open);
         }
         std::thread::sleep(interval);
     }
@@ -982,22 +1070,23 @@ fn print_stack_preview(
     method: MergeMethod,
     when_ready: bool,
     downstack_only: bool,
+    forge: ForgeType,
 ) {
     print_header("Stack Merge");
     println!();
     let tip = prs
         .last()
-        .expect("stack merge preview requires a selected tip PR");
+        .expect("stack merge preview requires a selected tip item");
     if merge_method_preserves_commit_shas(method) {
         println!(
-            "Will validate PR #{} once, target every selected PR to {}, then merge one PR:",
-            tip.pr_number,
+            "Will validate {} once, target every selected item to {}, then merge it:",
+            item_label(forge, tip.pr_number),
             trunk.cyan()
         );
     } else {
         println!(
-            "Will validate PR #{} once, retarget it to {}, then merge one PR:",
-            tip.pr_number,
+            "Will validate {} once, retarget it to {}, then merge it:",
+            item_label(forge, tip.pr_number),
             trunk.cyan()
         );
     }
@@ -1018,7 +1107,10 @@ fn print_stack_preview(
         let marker = if idx + 1 == prs.len() {
             format!("(selected tip, merged with {})", method.as_str())
         } else if merge_method_preserves_commit_shas(method) {
-            "(targeted to trunk; indirectly merged by GitHub or left pending)".to_string()
+            format!(
+                "(targeted to trunk; indirectly merged by {} or left pending)",
+                forge_name(forge)
+            )
         } else {
             format!(
                 "(closed as absorbed; {} rewrites commit SHAs)",
@@ -1026,10 +1118,10 @@ fn print_stack_preview(
             )
         };
         println!(
-            "  {}. {} (#{}) {}",
+            "  {}. {} ({}) {}",
             (idx + 1).to_string().bold(),
             pr.branch.bold(),
-            pr.pr_number,
+            item_label(forge, pr.pr_number),
             marker.dimmed()
         );
     }
@@ -1045,7 +1137,7 @@ fn print_stack_preview(
             };
             let pr_text = branch
                 .pr_number
-                .map(|number| format!(" (#{})", number))
+                .map(|number| format!(" ({})", item_label(forge, number)))
                 .unwrap_or_default();
             println!(
                 "  {} {}{} -> {}",
@@ -1062,7 +1154,8 @@ fn print_stack_preview(
         "Merge method: {} {}",
         method.as_str().cyan(),
         if merge_method_preserves_commit_shas(method) {
-            "(default for --stack; preserves commit SHAs; lower PRs may merge indirectly)".dimmed()
+            "(default for --stack; preserves commit SHAs; lower items may merge indirectly)"
+                .dimmed()
         } else {
             "(explicit; rewrites commit SHAs; lower PRs close as absorbed)".dimmed()
         }
@@ -1070,13 +1163,13 @@ fn print_stack_preview(
     if when_ready {
         println!(
             "{}",
-            "Will wait only for the selected tip PR's CI and mergeability; downstack PRs are checked for review blockers."
+            "Will wait only for the selected tip item's CI and mergeability; downstack items are checked for review blockers."
                 .dimmed()
         );
     } else {
         println!(
             "{}",
-            "Requires the selected tip PR to already be green; downstack PRs are checked for review blockers."
+            "Requires the selected tip item to already be green; downstack items are checked for review blockers."
                 .dimmed()
         );
     }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -42,6 +42,12 @@ struct GitLabMr {
 }
 
 #[derive(Debug, Deserialize)]
+struct GitLabProjectSettings {
+    merge_method: String,
+    squash_option: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct GitLabPipeline {
     status: Option<String>,
 }
@@ -156,6 +162,33 @@ impl GitLabClient {
             "{}/projects/{}{}",
             self.api_base_url, self.project_id, suffix
         )
+    }
+
+    pub async fn preflight_stack_merge(&self, method: MergeMethod) -> Result<()> {
+        if !matches!(method, MergeMethod::Merge) {
+            bail!(
+                "GitLab stack merge only supports the SHA-preserving default method `merge`; explicit `{}` rewrites commits",
+                method.as_str()
+            );
+        }
+
+        let settings: GitLabProjectSettings = get_json(&self.client, &self.project_url("")).await?;
+        if settings.squash_option == "always" {
+            bail!(
+                "GitLab project requires squashing (`squash_option: always`), which cannot preserve reviewed commit SHAs for `stax merge --stack`"
+            );
+        }
+        if !matches!(
+            settings.merge_method.as_str(),
+            "merge" | "rebase_merge" | "ff"
+        ) {
+            bail!(
+                "GitLab project merge method `{}` is not supported for SHA-preserving stack merge; use merge, rebase_merge, or ff",
+                settings.merge_method
+            );
+        }
+
+        Ok(())
     }
 
     pub async fn find_open_pr_by_head(&self, branch: &str) -> Result<Option<PrInfoWithHead>> {
@@ -787,6 +820,79 @@ mod tests {
             base_url: "https://gitlab.example.com".to_string(),
             api_base_url: Some(server.uri()),
         }
+    }
+
+    #[tokio::test]
+    async fn stack_merge_preflight_accepts_preserving_project_methods() {
+        ensure_crypto_provider();
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
+
+        for merge_method in ["merge", "rebase_merge", "ff"] {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/projects/group%2Fsubgroup%2Frepo"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "merge_method": merge_method,
+                    "squash_option": "default_off"
+                })))
+                .mount(&server)
+                .await;
+
+            GitLabClient::new(&remote_info(&server))
+                .unwrap()
+                .preflight_stack_merge(MergeMethod::Merge)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn stack_merge_preflight_rejects_required_squashing() {
+        ensure_crypto_provider();
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "merge_method": "merge",
+                "squash_option": "always"
+            })))
+            .mount(&server)
+            .await;
+
+        let error = GitLabClient::new(&remote_info(&server))
+            .unwrap()
+            .preflight_stack_merge(MergeMethod::Merge)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("requires squashing"));
+    }
+
+    #[tokio::test]
+    async fn merge_pr_rebase_retains_non_stack_behavior() {
+        ensure_crypto_provider();
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
+        let server = MockServer::start().await;
+
+        Mock::given(method("PUT"))
+            .and(path(
+                "/projects/group%2Fsubgroup%2Frepo/merge_requests/7/merge",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        GitLabClient::new(&remote_info(&server))
+            .unwrap()
+            .merge_pr(7, MergeMethod::Rebase, None, Some("abc123"))
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let payload: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(payload["sha"], "abc123");
+        assert_eq!(payload["squash"], false);
     }
 
     #[tokio::test]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -98,6 +98,14 @@ impl ForgeClient {
         }
     }
 
+    pub async fn preflight_stack_merge(&self, method: MergeMethod) -> Result<()> {
+        match self {
+            Self::GitHub(_) => Ok(()),
+            Self::GitLab(client) => client.preflight_stack_merge(method).await,
+            Self::Gitea(_) => bail!("`stax merge --stack` is not supported on Gitea/Forgejo"),
+        }
+    }
+
     /// Find an open PR by head branch.
     ///
     /// GitHub uses the stored owner for fork-aware lookup; other forges

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7700,6 +7700,20 @@ mod forge_mock_tests {
             .collect()
     }
 
+    fn assert_no_gitlab_absorb_mutations(requests: &[wiremock::Request]) {
+        assert!(
+            requests.iter().all(|request| {
+                !request.url.path().contains("/notes")
+                    && serde_json::from_slice::<Value>(&request.body)
+                        .ok()
+                        .and_then(|value| value.get("state_event").cloned())
+                        .is_none()
+            }),
+            "requests: {:?}",
+            requests
+        );
+    }
+
     /// Find a request to a PR/MR endpoint whose JSON payload contains a body/description key.
     /// This distinguishes body-update requests from title-update requests (both hit the same URL).
     /// Works for GitHub (PATCH + "body"), GitLab (PUT + "description"), and Gitea (PATCH + "body").
@@ -8094,7 +8108,12 @@ mod forge_mock_tests {
             "merge_status": "can_be_merged",
             "detailed_merge_status": "mergeable",
             "web_url": format!("https://gitlab.com/test/repo/-/merge_requests/{}", iid),
-            "sha": sha
+            "sha": sha,
+            "merged_at": if state == "merged" {
+                serde_json::json!("2026-07-28T00:00:00Z")
+            } else {
+                serde_json::Value::Null
+            }
         });
 
         if let Some(status) = pipeline_status {
@@ -8219,11 +8238,20 @@ mod forge_mock_tests {
     }
 
     #[derive(Clone, Copy, PartialEq, Eq)]
+    enum StackMergeForge {
+        GitHub,
+        GitLab,
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
     enum StackMergeScenario {
         LowerMerged,
         LowerPending,
+        LowerClosed,
         TipRetargetFails,
         TipMergeFails,
+        RequiredSquash,
+        SettingsChangedToRequiredSquash,
     }
 
     struct ThreeBranchStackMergeFixture {
@@ -8237,16 +8265,32 @@ mod forge_mock_tests {
     }
 
     async fn setup_three_branch_stack_merge_fixture(
+        forge: StackMergeForge,
         scenario: StackMergeScenario,
     ) -> ThreeBranchStackMergeFixture {
         ensure_crypto_provider();
         let mock_server = MockServer::start().await;
         let home = super::test_tempdir();
         let repo = TestRepo::new();
-        let remote_root = setup_fake_github_remote(&repo, home.path());
+        let (remote_root, token_env) = match forge {
+            StackMergeForge::GitHub => (
+                setup_fake_github_remote(&repo, home.path()),
+                "STAX_GITHUB_TOKEN",
+            ),
+            StackMergeForge::GitLab => (
+                setup_fake_remote(
+                    &repo,
+                    home.path(),
+                    "https://gitlab.com/test/repo.git",
+                    "https://gitlab.com/",
+                ),
+                "STAX_GITLAB_TOKEN",
+            ),
+        };
         write_test_config(home.path(), &mock_server.uri());
 
-        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-method-a"]);
+        let output =
+            run_stax_with_token_env(&repo, home.path(), token_env, &["bc", "stack-method-a"]);
         assert!(output.status.success(), "{}", TestRepo::stderr(&output));
         let branch_a = repo.current_branch();
         repo.create_file("parent.txt", "parent\n");
@@ -8255,7 +8299,8 @@ mod forge_mock_tests {
         let push_a = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_a]);
         assert!(push_a.status.success(), "{}", TestRepo::stderr(&push_a));
 
-        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-method-b"]);
+        let output =
+            run_stax_with_token_env(&repo, home.path(), token_env, &["bc", "stack-method-b"]);
         assert!(output.status.success(), "{}", TestRepo::stderr(&output));
         let branch_b = repo.current_branch();
         repo.create_file("middle.txt", "middle\n");
@@ -8264,7 +8309,8 @@ mod forge_mock_tests {
         let push_b = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
         assert!(push_b.status.success(), "{}", TestRepo::stderr(&push_b));
 
-        let output = run_stax_with_env(&repo, home.path(), &["bc", "stack-method-c"]);
+        let output =
+            run_stax_with_token_env(&repo, home.path(), token_env, &["bc", "stack-method-c"]);
         assert!(output.status.success(), "{}", TestRepo::stderr(&output));
         let branch_c = repo.current_branch();
         repo.create_file("child.txt", "child\n");
@@ -8277,14 +8323,60 @@ mod forge_mock_tests {
         write_branch_pr_metadata(&repo, &branch_b, &branch_a, 602, Some(false));
         write_branch_pr_metadata(&repo, &branch_c, &branch_b, 603, Some(false));
 
+        match forge {
+            StackMergeForge::GitHub => {
+                mount_github_three_branch_stack_merge(
+                    &mock_server,
+                    scenario,
+                    &branch_a,
+                    &branch_b,
+                    &branch_c,
+                    &branch_a_sha,
+                    &branch_b_sha,
+                    &tip_sha,
+                )
+                .await;
+            }
+            StackMergeForge::GitLab => {
+                mount_gitlab_three_branch_stack_merge(
+                    &mock_server,
+                    scenario,
+                    &branch_a,
+                    &branch_b,
+                    &branch_c,
+                    &branch_a_sha,
+                    &branch_b_sha,
+                    &tip_sha,
+                )
+                .await;
+            }
+        }
+
+        ThreeBranchStackMergeFixture {
+            mock_server,
+            home,
+            repo,
+            _remote_root: remote_root,
+            branch_a,
+            branch_b,
+            tip_sha,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn mount_github_three_branch_stack_merge(
+        mock_server: &MockServer,
+        scenario: StackMergeScenario,
+        branch_a: &str,
+        branch_b: &str,
+        branch_c: &str,
+        branch_a_sha: &str,
+        branch_b_sha: &str,
+        tip_sha: &str,
+    ) {
         for (number, branch, base, sha) in [
-            (601, branch_a.as_str(), "main", branch_a_sha.as_str()),
-            (
-                602,
-                branch_b.as_str(),
-                branch_a.as_str(),
-                branch_b_sha.as_str(),
-            ),
+            (601, branch_a, "main", branch_a_sha),
+            (602, branch_b, branch_a, branch_b_sha),
         ] {
             let lower_open = github_pull_fixture(number, branch, base, sha);
             if scenario == StackMergeScenario::LowerMerged {
@@ -8293,7 +8385,7 @@ mod forge_mock_tests {
                     .respond_with(ResponseTemplate::new(200).set_body_json(lower_open))
                     .with_priority(1)
                     .up_to_n_times(2)
-                    .mount(&mock_server)
+                    .mount(mock_server)
                     .await;
 
                 let mut lower_merged = github_pull_fixture(number, branch, "main", sha);
@@ -8303,13 +8395,13 @@ mod forge_mock_tests {
                     .and(path(format!("/repos/test/repo/pulls/{}", number)))
                     .respond_with(ResponseTemplate::new(200).set_body_json(lower_merged))
                     .with_priority(2)
-                    .mount(&mock_server)
+                    .mount(mock_server)
                     .await;
             } else {
                 Mock::given(method("GET"))
                     .and(path(format!("/repos/test/repo/pulls/{}", number)))
                     .respond_with(ResponseTemplate::new(200).set_body_json(lower_open))
-                    .mount(&mock_server)
+                    .mount(mock_server)
                     .await;
             }
         }
@@ -8318,28 +8410,26 @@ mod forge_mock_tests {
             .and(path("/repos/test/repo/pulls/603"))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_json(github_pull_fixture(603, &branch_c, &branch_b, &tip_sha)),
+                    .set_body_json(github_pull_fixture(603, branch_c, branch_b, tip_sha)),
             )
-            .mount(&mock_server)
+            .mount(mock_server)
             .await;
 
-        mount_github_merge_status_with_head(&mock_server, 601, "OPEN", "APPROVED", &branch_a_sha)
+        mount_github_merge_status_with_head(mock_server, 601, "OPEN", "APPROVED", branch_a_sha)
             .await;
-        mount_github_merge_status_with_head(&mock_server, 602, "OPEN", "APPROVED", &branch_b_sha)
+        mount_github_merge_status_with_head(mock_server, 602, "OPEN", "APPROVED", branch_b_sha)
             .await;
-        mount_github_merge_status_with_head(&mock_server, 603, "OPEN", "APPROVED", &tip_sha).await;
+        mount_github_merge_status_with_head(mock_server, 603, "OPEN", "APPROVED", tip_sha).await;
 
-        for (number, branch, sha) in [
-            (601, branch_a.as_str(), branch_a_sha.as_str()),
-            (602, branch_b.as_str(), branch_b_sha.as_str()),
-        ] {
+        for (number, branch, sha) in [(601, branch_a, branch_a_sha), (602, branch_b, branch_b_sha)]
+        {
             Mock::given(method("PATCH"))
                 .and(path(format!("/repos/test/repo/pulls/{}", number)))
                 .respond_with(
                     ResponseTemplate::new(200)
                         .set_body_json(github_pull_fixture(number, branch, "main", sha)),
                 )
-                .mount(&mock_server)
+                .mount(mock_server)
                 .await;
         }
 
@@ -8349,12 +8439,12 @@ mod forge_mock_tests {
             }))
         } else {
             ResponseTemplate::new(200)
-                .set_body_json(github_pull_fixture(603, &branch_c, "main", &tip_sha))
+                .set_body_json(github_pull_fixture(603, branch_c, "main", tip_sha))
         };
         Mock::given(method("PATCH"))
             .and(path("/repos/test/repo/pulls/603"))
             .respond_with(tip_retarget_response)
-            .mount(&mock_server)
+            .mount(mock_server)
             .await;
 
         let tip_merge_response = if scenario == StackMergeScenario::TipMergeFails {
@@ -8371,7 +8461,7 @@ mod forge_mock_tests {
         Mock::given(method("PUT"))
             .and(path("/repos/test/repo/pulls/603/merge"))
             .respond_with(tip_merge_response)
-            .mount(&mock_server)
+            .mount(mock_server)
             .await;
 
         for number in [601, 602] {
@@ -8381,19 +8471,200 @@ mod forge_mock_tests {
                     ResponseTemplate::new(201)
                         .set_body_json(issue_comment_fixture(9000 + number, "absorbed")),
                 )
-                .mount(&mock_server)
+                .mount(mock_server)
+                .await;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn mount_gitlab_three_branch_stack_merge(
+        mock_server: &MockServer,
+        scenario: StackMergeScenario,
+        branch_a: &str,
+        branch_b: &str,
+        branch_c: &str,
+        branch_a_sha: &str,
+        branch_b_sha: &str,
+        tip_sha: &str,
+    ) {
+        if scenario == StackMergeScenario::SettingsChangedToRequiredSquash {
+            Mock::given(method("GET"))
+                .and(path("/projects/test%2Frepo"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "merge_method": "merge",
+                    "squash_option": "default_off"
+                })))
+                .with_priority(1)
+                .up_to_n_times(1)
+                .mount(mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/projects/test%2Frepo"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "merge_method": "merge",
+                    "squash_option": "always"
+                })))
+                .with_priority(2)
+                .mount(mock_server)
+                .await;
+        } else {
+            Mock::given(method("GET"))
+                .and(path("/projects/test%2Frepo"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "merge_method": "merge",
+                    "squash_option": if scenario == StackMergeScenario::RequiredSquash {
+                        "always"
+                    } else {
+                        "default_off"
+                    }
+                })))
+                .mount(mock_server)
                 .await;
         }
 
-        ThreeBranchStackMergeFixture {
-            mock_server,
-            home,
-            repo,
-            _remote_root: remote_root,
-            branch_a,
-            branch_b,
-            tip_sha,
+        for (number, branch, base, sha) in [
+            (601, branch_a, "main", branch_a_sha),
+            (602, branch_b, branch_a, branch_b_sha),
+        ] {
+            let open = gitlab_mr_fixture(
+                number,
+                &format!("MR !{}", number),
+                branch,
+                base,
+                "opened",
+                "",
+                sha,
+                Some("success"),
+            );
+            if matches!(
+                scenario,
+                StackMergeScenario::LowerMerged | StackMergeScenario::LowerClosed
+            ) {
+                Mock::given(method("GET"))
+                    .and(path(format!(
+                        "/projects/test%2Frepo/merge_requests/{}",
+                        number
+                    )))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(open))
+                    .with_priority(1)
+                    .up_to_n_times(3)
+                    .mount(mock_server)
+                    .await;
+
+                let state = if scenario == StackMergeScenario::LowerMerged {
+                    "merged"
+                } else {
+                    "closed"
+                };
+                Mock::given(method("GET"))
+                    .and(path(format!(
+                        "/projects/test%2Frepo/merge_requests/{}",
+                        number
+                    )))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(gitlab_mr_fixture(
+                        number,
+                        &format!("MR !{}", number),
+                        branch,
+                        "main",
+                        state,
+                        "",
+                        sha,
+                        Some("success"),
+                    )))
+                    .with_priority(2)
+                    .mount(mock_server)
+                    .await;
+            } else {
+                Mock::given(method("GET"))
+                    .and(path(format!(
+                        "/projects/test%2Frepo/merge_requests/{}",
+                        number
+                    )))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(open))
+                    .mount(mock_server)
+                    .await;
+            }
         }
+
+        Mock::given(method("GET"))
+            .and(path("/projects/test%2Frepo/merge_requests/603"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(gitlab_mr_fixture(
+                603,
+                "MR !603",
+                branch_c,
+                branch_b,
+                "opened",
+                "",
+                tip_sha,
+                Some("success"),
+            )))
+            .mount(mock_server)
+            .await;
+
+        for (number, branch, sha) in [(601, branch_a, branch_a_sha), (602, branch_b, branch_b_sha)]
+        {
+            Mock::given(method("PUT"))
+                .and(path(format!(
+                    "/projects/test%2Frepo/merge_requests/{}",
+                    number
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(gitlab_mr_fixture(
+                    number,
+                    &format!("MR !{}", number),
+                    branch,
+                    "main",
+                    "opened",
+                    "",
+                    sha,
+                    Some("success"),
+                )))
+                .mount(mock_server)
+                .await;
+        }
+
+        let tip_retarget_response = if scenario == StackMergeScenario::TipRetargetFails {
+            ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "tip retarget failed"
+            }))
+        } else {
+            ResponseTemplate::new(200).set_body_json(gitlab_mr_fixture(
+                603,
+                "MR !603",
+                branch_c,
+                "main",
+                "opened",
+                "",
+                tip_sha,
+                Some("success"),
+            ))
+        };
+        Mock::given(method("PUT"))
+            .and(path("/projects/test%2Frepo/merge_requests/603"))
+            .respond_with(tip_retarget_response)
+            .mount(mock_server)
+            .await;
+
+        let tip_merge_response = if scenario == StackMergeScenario::TipMergeFails {
+            ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "message": "tip merge failed"
+            }))
+        } else {
+            ResponseTemplate::new(200).set_body_json(gitlab_mr_fixture(
+                603,
+                "MR !603",
+                branch_c,
+                "main",
+                "merged",
+                "",
+                tip_sha,
+                Some("success"),
+            ))
+        };
+        Mock::given(method("PUT"))
+            .and(path("/projects/test%2Frepo/merge_requests/603/merge"))
+            .respond_with(tip_merge_response)
+            .mount(mock_server)
+            .await;
     }
 
     fn run_stax_in_dir_with_env(cwd: &Path, home: &Path, args: &[&str]) -> Output {
@@ -11981,7 +12252,11 @@ mod forge_mock_tests {
 
     #[tokio::test]
     async fn test_merge_stack_default_retargets_selected_range_before_one_merge() {
-        let fixture = setup_three_branch_stack_merge_fixture(StackMergeScenario::LowerMerged).await;
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitHub,
+            StackMergeScenario::LowerMerged,
+        )
+        .await;
         let merge_output = run_stax_with_env(
             &fixture.repo,
             fixture.home.path(),
@@ -12044,8 +12319,11 @@ mod forge_mock_tests {
 
     #[tokio::test]
     async fn test_merge_stack_preserving_timeout_leaves_lower_prs_open() {
-        let fixture =
-            setup_three_branch_stack_merge_fixture(StackMergeScenario::LowerPending).await;
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitHub,
+            StackMergeScenario::LowerPending,
+        )
+        .await;
         let merge_output = run_stax_with_env(
             &fixture.repo,
             fixture.home.path(),
@@ -12095,8 +12373,11 @@ mod forge_mock_tests {
     #[tokio::test]
     async fn test_merge_stack_rewriting_methods_close_lower_pr_without_polling() {
         for method_name in ["rebase", "squash"] {
-            let fixture =
-                setup_three_branch_stack_merge_fixture(StackMergeScenario::LowerPending).await;
+            let fixture = setup_three_branch_stack_merge_fixture(
+                StackMergeForge::GitHub,
+                StackMergeScenario::LowerPending,
+            )
+            .await;
             let args = [
                 "merge",
                 "--stack",
@@ -12168,8 +12449,11 @@ mod forge_mock_tests {
 
     #[tokio::test]
     async fn test_merge_stack_rolls_back_changed_bases_when_later_retarget_fails() {
-        let fixture =
-            setup_three_branch_stack_merge_fixture(StackMergeScenario::TipRetargetFails).await;
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitHub,
+            StackMergeScenario::TipRetargetFails,
+        )
+        .await;
         let output = run_stax_with_env(
             &fixture.repo,
             fixture.home.path(),
@@ -12203,8 +12487,11 @@ mod forge_mock_tests {
 
     #[tokio::test]
     async fn test_merge_stack_rolls_back_all_changed_bases_when_tip_merge_fails() {
-        let fixture =
-            setup_three_branch_stack_merge_fixture(StackMergeScenario::TipMergeFails).await;
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitHub,
+            StackMergeScenario::TipMergeFails,
+        )
+        .await;
         let output = run_stax_with_env(
             &fixture.repo,
             fixture.home.path(),
@@ -12240,6 +12527,348 @@ mod forge_mock_tests {
                 .iter()
                 .all(|request| !request.url.path().contains("/comments"))
         );
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_retargets_range_and_merges_only_tip() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitLab,
+            StackMergeScenario::LowerMerged,
+        )
+        .await;
+        let output = run_stax_with_token_env(
+            &fixture.repo,
+            fixture.home.path(),
+            "STAX_GITLAB_TOKEN",
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            output.status.success(),
+            "{}\n{}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+        let stdout = TestRepo::stdout(&output);
+        assert!(stdout.contains("MR !601") && stdout.contains("merged indirectly by GitLab"));
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        let settings_idx = find_request_index(&requests, "GET", "/projects/test%2Frepo");
+        let b_update_idx =
+            find_request_index(&requests, "PUT", "/projects/test%2Frepo/merge_requests/602");
+        let c_update_idx =
+            find_request_index(&requests, "PUT", "/projects/test%2Frepo/merge_requests/603");
+        let merge_idx = find_request_index(
+            &requests,
+            "PUT",
+            "/projects/test%2Frepo/merge_requests/603/merge",
+        );
+        assert!(
+            settings_idx < b_update_idx && b_update_idx < c_update_idx && c_update_idx < merge_idx
+        );
+        assert!(
+            find_request_indices(&requests, "PUT", "/projects/test%2Frepo/merge_requests/601")
+                .is_empty()
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PUT" && request.url.path().ends_with("/merge")
+                })
+                .count(),
+            1
+        );
+
+        for index in [b_update_idx, c_update_idx] {
+            let payload: Value = serde_json::from_slice(&requests[index].body).unwrap();
+            assert_eq!(payload["target_branch"], "main");
+        }
+        let merge_payload: Value = serde_json::from_slice(&requests[merge_idx].body).unwrap();
+        assert_eq!(merge_payload["sha"], fixture.tip_sha);
+        assert_eq!(merge_payload["squash"], false);
+
+        for number in [601, 602] {
+            let path = format!("/projects/test%2Frepo/merge_requests/{}", number);
+            let gets = find_request_indices(&requests, "GET", &path);
+            assert_eq!(gets.len(), 4, "requests: {:?}", requests);
+            assert!(gets[2] < merge_idx && merge_idx < gets[3]);
+        }
+        assert_no_gitlab_absorb_mutations(&requests);
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_open_lower_mrs_remain_pending() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitLab,
+            StackMergeScenario::LowerPending,
+        )
+        .await;
+        let output = run_stax_with_token_env(
+            &fixture.repo,
+            fixture.home.path(),
+            "STAX_GITLAB_TOKEN",
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        assert!(
+            output.status.success(),
+            "{}\n{}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+        let stdout = TestRepo::stdout(&output);
+        assert!(
+            stdout.contains("GitLab may still mark it indirectly merged asynchronously")
+                && stdout.contains("pending GitLab indirect-merge detection; left open"),
+            "{stdout}"
+        );
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        assert_no_gitlab_absorb_mutations(&requests);
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_closed_lower_mr_is_not_reported_pending() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitLab,
+            StackMergeScenario::LowerClosed,
+        )
+        .await;
+        let output = run_stax_with_token_env(
+            &fixture.repo,
+            fixture.home.path(),
+            "STAX_GITLAB_TOKEN",
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("MR !601 is closed without being merged"));
+        assert!(!combined.contains("remains open"), "{combined}");
+        assert!(!combined.contains("pending GitLab indirect-merge detection"));
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        assert_eq!(
+            find_request_indices(
+                &requests,
+                "PUT",
+                "/projects/test%2Frepo/merge_requests/603/merge"
+            )
+            .len(),
+            1
+        );
+        assert_no_gitlab_absorb_mutations(&requests);
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_rejects_non_preserving_configuration_before_mutation() {
+        for (scenario, method, expected) in [
+            (
+                StackMergeScenario::RequiredSquash,
+                None,
+                "requires squashing",
+            ),
+            (
+                StackMergeScenario::LowerPending,
+                Some("rebase"),
+                "only supports the SHA-preserving default method",
+            ),
+            (
+                StackMergeScenario::LowerPending,
+                Some("squash"),
+                "only supports the SHA-preserving default method",
+            ),
+        ] {
+            let fixture =
+                setup_three_branch_stack_merge_fixture(StackMergeForge::GitLab, scenario).await;
+            let mut args = vec!["merge", "--stack"];
+            if let Some(method) = method {
+                args.extend(["--method", method]);
+            }
+            args.extend(["--yes", "--no-delete", "--no-sync"]);
+            let output = run_stax_with_token_env(
+                &fixture.repo,
+                fixture.home.path(),
+                "STAX_GITLAB_TOKEN",
+                &args,
+            );
+            let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+            assert!(!output.status.success(), "{combined}");
+            assert!(combined.contains(expected), "{combined}");
+
+            let requests = fixture.mock_server.received_requests().await.unwrap();
+            assert!(
+                requests.iter().all(|request| {
+                    request.method.as_str() != "PUT"
+                        || !request.url.path().contains("/merge_requests/")
+                }),
+                "requests: {:?}",
+                requests
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_rechecks_settings_after_when_ready_before_mutation() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitLab,
+            StackMergeScenario::SettingsChangedToRequiredSquash,
+        )
+        .await;
+
+        let initial_settings: Value = reqwest::get(format!(
+            "{}/projects/test%2Frepo",
+            fixture.mock_server.uri()
+        ))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+        assert_eq!(initial_settings["squash_option"], "default_off");
+
+        let output = run_stax_with_token_env(
+            &fixture.repo,
+            fixture.home.path(),
+            "STAX_GITLAB_TOKEN",
+            &[
+                "merge",
+                "--stack",
+                "--when-ready",
+                "--yes",
+                "--no-delete",
+                "--no-sync",
+            ],
+        );
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("requires squashing"), "{combined}");
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        let settings = find_request_indices(&requests, "GET", "/projects/test%2Frepo");
+        let tip_reads =
+            find_request_indices(&requests, "GET", "/projects/test%2Frepo/merge_requests/603");
+        assert_eq!(settings.len(), 2, "requests: {:?}", requests);
+        assert_eq!(tip_reads.len(), 3, "requests: {:?}", requests);
+        assert!(
+            tip_reads[2] < settings[1],
+            "settings must be checked after the when-ready poll: {:?}",
+            requests
+        );
+        assert!(
+            requests.iter().all(|request| {
+                request.method.as_str() != "PUT" || !request.url.path().contains("/merge_requests/")
+            }),
+            "requests: {:?}",
+            requests
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_rolls_back_after_tip_retarget_failure() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitLab,
+            StackMergeScenario::TipRetargetFails,
+        )
+        .await;
+        let output = run_stax_with_token_env(
+            &fixture.repo,
+            fixture.home.path(),
+            "STAX_GITLAB_TOKEN",
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        assert!(!output.status.success());
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        let b_updates =
+            find_request_indices(&requests, "PUT", "/projects/test%2Frepo/merge_requests/602");
+        let c_updates =
+            find_request_indices(&requests, "PUT", "/projects/test%2Frepo/merge_requests/603");
+        assert_eq!(b_updates.len(), 2);
+        assert_eq!(c_updates.len(), 1);
+        assert!(b_updates[0] < c_updates[0] && c_updates[0] < b_updates[1]);
+        let restored: Value = serde_json::from_slice(&requests[b_updates[1]].body).unwrap();
+        assert_eq!(restored["target_branch"], fixture.branch_a);
+        assert!(
+            find_request_indices(
+                &requests,
+                "PUT",
+                "/projects/test%2Frepo/merge_requests/603/merge"
+            )
+            .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitlab_rolls_back_after_tip_merge_failure() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitLab,
+            StackMergeScenario::TipMergeFails,
+        )
+        .await;
+        let output = run_stax_with_token_env(
+            &fixture.repo,
+            fixture.home.path(),
+            "STAX_GITLAB_TOKEN",
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        assert!(!output.status.success());
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        let b_updates =
+            find_request_indices(&requests, "PUT", "/projects/test%2Frepo/merge_requests/602");
+        let c_updates =
+            find_request_indices(&requests, "PUT", "/projects/test%2Frepo/merge_requests/603");
+        let merge_idx = find_request_index(
+            &requests,
+            "PUT",
+            "/projects/test%2Frepo/merge_requests/603/merge",
+        );
+        assert_eq!(b_updates.len(), 2);
+        assert_eq!(c_updates.len(), 2);
+        assert!(
+            b_updates[0] < c_updates[0]
+                && c_updates[0] < merge_idx
+                && merge_idx < c_updates[1]
+                && c_updates[1] < b_updates[1]
+        );
+        let c_restore: Value = serde_json::from_slice(&requests[c_updates[1]].body).unwrap();
+        let b_restore: Value = serde_json::from_slice(&requests[b_updates[1]].body).unwrap();
+        assert_eq!(c_restore["target_branch"], fixture.branch_b);
+        assert_eq!(b_restore["target_branch"], fixture.branch_a);
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_gitea_remains_unsupported_without_mutation() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let _remote_root = setup_fake_remote(
+            &repo,
+            home.path(),
+            "https://gitea.com/test/repo.git",
+            "https://gitea.com/",
+        );
+        write_test_config(home.path(), &mock_server.uri());
+        let output = run_stax_with_token_env(
+            &repo,
+            home.path(),
+            "STAX_GITEA_TOKEN",
+            &["bc", "stack-gitea"],
+        );
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        repo.create_file("gitea.txt", "gitea\n");
+        repo.commit("Gitea stack");
+
+        let output = run_stax_with_token_env(
+            &repo,
+            home.path(),
+            "STAX_GITEA_TOKEN",
+            &["merge", "--stack", "--yes", "--no-delete", "--no-sync"],
+        );
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("not Gitea/Forgejo"), "{combined}");
+        assert!(mock_server.received_requests().await.unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #700.

Depends on #699. The branch and local Stax metadata remain stacked directly on #699; this draft targets `main` only because GitHub cannot use a fork-only head branch as the base of an upstream PR. The displayed upstream diff will narrow automatically when #699 merges.

- Extend the one-tip, SHA-preserving `st merge --stack` flow from GitHub to GitLab while retaining GitHub behavior and the explicit Gitea/Forgejo rejection.
- Preflight GitLab project merge settings immediately before the first mutation, reject required squashing and explicit rewriting stack methods, retarget the selected range, then merge only the selected tip with its reviewed SHA and `squash: false`.
- Reuse provider-normalized polling and reverse-order rollback so lower MRs count only when GitLab reports `state: merged`; open timeouts remain untouched, and closed-but-unmerged MRs fail truthfully.
- Reuse the existing three-level repository fixture for GitHub and GitLab, with provider-specific HTTP mocks only.

## Verification

- `git diff --check` — passed.
- `cargo check` — passed.
- `cargo nextest run merge_stack` — 29 passed.
- `cargo nextest run stack_merge_preflight` — 2 passed.
- `cargo nextest run merge_pr_rebase_retains_non_stack_behavior` — 1 passed.
- `make lint` — formatting, boundary checks, lint-mode tests, and all-target/all-feature Clippy passed.
- `make test` — 2,170 Docker-backed tests passed with 0 skipped.

## Live GitLab acceptance

The installed candidate ran against `gitlab.com/jubust1/test-stax` with project settings `merge_method: merge` and `squash_option: default_off`.

- MR !4 — `state: merged`, `merged_at: 2026-07-28T17:44:47.295Z`.
- MR !5 — `state: merged`, `merged_at: 2026-07-28T17:44:47.904Z`.
- MR !6 — `state: merged`, `merged_at: 2026-07-28T17:44:45.940Z`.
- Only !6 used the merge endpoint; !4 and !5 were indirectly merged.
- All three reviewed head SHAs are ancestors of `main`, and the final `main` tree equals the selected tip tree.

## Empty-diff fixture lesson

An initial live stack using empty commits put all three SHAs on `main`, but GitLab left lower MRs !1 and !2 open. GitLab explicitly excludes merge requests whose stored diff state is `empty` from manually-merged detection. The acceptance fixture was therefore corrected to use one real, unique file change per level; the successful !4/!5/!6 run proves the production behavior without changing existing repository content.

## Documentation

Updated `README.md`, command/workflow documentation, CLI help, and `skills.md` for GitLab project preflight, preserving-only stack methods, authoritative merged-state polling, and provider-correct PR/MR terminology.
