### PR TITLE
fix(test): make native tests resilient to PATH clobbering

### DIFF
--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -948,6 +948,38 @@ mod tests {
     use std::{fs, io::ErrorKind, path::Path, process::Command};
     use tempfile::tempdir;
 
+    #[cfg(unix)]
+    fn zsh_available_with_flags(flags: &str) -> bool {
+        let mut cmd = Command::new("zsh");
+        for flag in flags.split_whitespace() {
+            cmd.arg(flag);
+        }
+        cmd.arg("exit").arg("0");
+        match cmd.output() {
+            Ok(output) => output.status.success(),
+            Err(err) if err.kind() == ErrorKind::NotFound => false,
+            Err(err) => panic!("failed to probe zsh: {err}"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn zsh_posix_snippet_preamble(snippet_path: &Path, fake_stax: &Path) -> String {
+        format!(
+            "source \"{}\"; __STAX_BIN=\"{}\"",
+            snippet_path.display(),
+            fake_stax.display(),
+        )
+    }
+
+    #[cfg(unix)]
+    fn zsh_posix_snippet_path_preamble(snippet_path: &Path, bin_dir: &Path) -> String {
+        format!(
+            "export PATH=\"{}:$PATH\"; source \"{}\"",
+            bin_dir.display(),
+            snippet_path.display(),
+        )
+    }
+
     #[test]
     fn posix_shell_snippet_clears_aliases_before_function_definitions() {
         let snippet = shell_snippet(ShellKind::Posix);
@@ -996,11 +1028,8 @@ mod tests {
     fn posix_shell_snippet_wraps_worktree_promote_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
-            if err.kind() == ErrorKind::NotFound {
-                return;
-            }
-            panic!("failed to probe zsh: {err}");
+        if !zsh_available_with_flags("-dfc") {
+            return;
         }
 
         let dir = tempdir().expect("tempdir");
@@ -1018,13 +1047,13 @@ mod tests {
         let snippet_path = dir.path().join("shell-setup.sh");
         fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
 
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        let path_env = format!("{}:{original_path}", bin_dir.display());
-        let command = format!("source \"{}\"; st wt promote", snippet_path.display());
+        let command = format!(
+            "{}; st wt promote",
+            zsh_posix_snippet_preamble(&snippet_path, &fake_stax)
+        );
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
-            .env("PATH", path_env)
             .output()
             .expect("run zsh shell snippet");
 
@@ -1046,11 +1075,8 @@ mod tests {
     fn posix_shell_snippet_relocates_after_successful_promote_only() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-lc").arg("exit 0").output() {
-            if err.kind() == ErrorKind::NotFound {
-                return;
-            }
-            panic!("failed to probe zsh: {err}");
+        if !zsh_available_with_flags("-dfc") {
+            return;
         }
 
         let dir = tempdir().expect("tempdir");
@@ -1075,17 +1101,14 @@ mod tests {
 
         let snippet_path = dir.path().join("shell-setup.sh");
         fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        let path_env = format!("{}:{original_path}", bin_dir.display());
         let command = format!(
-            "source \"{}\"; cd \"{}\"; st wt promote; printf 'cwd:%s\\n' \"$PWD\"",
-            snippet_path.display(),
+            "{}; cd \"{}\"; st wt promote; printf 'cwd:%s\\n' \"$PWD\"",
+            zsh_posix_snippet_preamble(&snippet_path, &fake_stax),
             source.display()
         );
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
-            .env("PATH", &path_env)
             .env("PROMOTE_TARGET", &target)
             .output()
             .expect("run successful promote wrapper");
@@ -1100,14 +1123,13 @@ mod tests {
         )
         .expect("write failing fake stax");
         let command = format!(
-            "source \"{}\"; cd \"{}\"; st wt promote || true; printf 'cwd:%s\\n' \"$PWD\"",
-            snippet_path.display(),
+            "{}; cd \"{}\"; st wt promote || true; printf 'cwd:%s\\n' \"$PWD\"",
+            zsh_posix_snippet_preamble(&snippet_path, &fake_stax),
             source.display()
         );
         let output = Command::new("zsh")
-            .arg("-lc")
+            .arg("-dfc")
             .arg(&command)
-            .env("PATH", path_env)
             .env("PROMOTE_TARGET", &target)
             .output()
             .expect("run failing promote wrapper");
@@ -1122,11 +1144,8 @@ mod tests {
     fn posix_shell_snippet_resolves_real_binary_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
-            if err.kind() == ErrorKind::NotFound {
-                return;
-            }
-            panic!("failed to probe zsh: {err}");
+        if !zsh_available_with_flags("-dfc") {
+            return;
         }
 
         let dir = tempdir().expect("tempdir");
@@ -1148,13 +1167,13 @@ mod tests {
         let snippet_path = dir.path().join("shell-setup.sh");
         fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
 
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        let path_env = format!("{}:{original_path}", bin_dir.display());
-        let command = format!("source \"{}\"; st config", snippet_path.display());
+        let command = format!(
+            "{}; st config",
+            zsh_posix_snippet_path_preamble(&snippet_path, &bin_dir)
+        );
         let output = Command::new("zsh")
             .arg("-dfc")
             .arg(&command)
-            .env("PATH", path_env)
             .output()
             .expect("run zsh shell snippet");
 
@@ -1183,11 +1202,8 @@ mod tests {
     fn posix_shell_snippet_keeps_path_for_worktree_shell_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
-            if err.kind() == ErrorKind::NotFound {
-                return;
-            }
-            panic!("failed to probe zsh: {err}");
+        if !zsh_available_with_flags("-dfc") {
+            return;
         }
 
         let dir = tempdir().expect("tempdir");
@@ -1209,13 +1225,13 @@ mod tests {
         let snippet_path = dir.path().join("shell-setup.sh");
         fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
 
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        let path_env = format!("{}:{original_path}", bin_dir.display());
-        let command = format!("source \"{}\"; st wtgo demo-lane", snippet_path.display());
+        let command = format!(
+            "{}; st wtgo demo-lane",
+            zsh_posix_snippet_path_preamble(&snippet_path, &bin_dir)
+        );
         let output = Command::new("zsh")
             .arg("-dfc")
             .arg(&command)
-            .env("PATH", path_env)
             .output()
             .expect("run zsh shell snippet");
 
@@ -1244,11 +1260,8 @@ mod tests {
     fn posix_shell_snippet_wraps_lane_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
-            if err.kind() == ErrorKind::NotFound {
-                return;
-            }
-            panic!("failed to probe zsh: {err}");
+        if !zsh_available_with_flags("-dfc") {
+            return;
         }
 
         let dir = tempdir().expect("tempdir");
@@ -1270,13 +1283,13 @@ mod tests {
         let snippet_path = dir.path().join("shell-setup.sh");
         fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
 
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        let path_env = format!("{}:{original_path}", bin_dir.display());
-        let command = format!("source \"{}\"; st lane review-pass", snippet_path.display());
+        let command = format!(
+            "{}; st lane review-pass",
+            zsh_posix_snippet_preamble(&snippet_path, &fake_stax)
+        );
         let output = Command::new("zsh")
             .arg("-dfc")
             .arg(&command)
-            .env("PATH", path_env)
             .output()
             .expect("run zsh shell snippet");
 
@@ -1305,11 +1318,8 @@ mod tests {
     fn posix_shell_snippet_wraps_checkout_commands_in_zsh() {
         use std::os::unix::fs::PermissionsExt;
 
-        if let Err(err) = Command::new("zsh").arg("-dfc").arg("exit 0").output() {
-            if err.kind() == ErrorKind::NotFound {
-                return;
-            }
-            panic!("failed to probe zsh: {err}");
+        if !zsh_available_with_flags("-dfc") {
+            return;
         }
 
         let dir = tempdir().expect("tempdir");
@@ -1331,13 +1341,13 @@ mod tests {
         let snippet_path = dir.path().join("shell-setup.sh");
         fs::write(&snippet_path, shell_snippet(ShellKind::Posix)).expect("write snippet");
 
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        let path_env = format!("{}:{original_path}", bin_dir.display());
-        let command = format!("source \"{}\"; st bco feature", snippet_path.display());
+        let command = format!(
+            "{}; st bco feature",
+            zsh_posix_snippet_preamble(&snippet_path, &fake_stax)
+        );
         let output = Command::new("zsh")
             .arg("-dfc")
             .arg(&command)
-            .env("PATH", path_env)
             .output()
             .expect("run zsh shell snippet");
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -154,11 +154,18 @@ pub fn run_stax_in_script_with_env(
     fs::write(&transcript_path, "").expect("create TUI transcript");
     let quoted_transcript = sh_quote(&transcript_path.to_string_lossy());
     let quoted_input_status = sh_quote(&input_status_path.to_string_lossy());
-    let command = std::iter::once(stax_bin.to_string_lossy().into_owned())
+    let stax_command = std::iter::once(stax_bin.to_string_lossy().into_owned())
         .chain(args.iter().map(|arg| (*arg).to_string()))
         .map(|part| sh_quote(&part))
         .collect::<Vec<_>>()
         .join(" ");
+    // Linux `script -qefc` can re-import PATH from system init files after startup,
+    // so re-export test PATH overrides inside the recorded command shell.
+    let command = env
+        .iter()
+        .find(|(key, _)| *key == "PATH")
+        .map(|(_, path)| format!("export PATH={}; {stax_command}", sh_quote(path)))
+        .unwrap_or(stax_command);
 
     let input_with_readiness = format!(
         r#"set -e


### PR DESCRIPTION
## Summary
- Fix native zsh integration tests in `shell_setup.rs` that failed on machines where `/etc/zsh/zshenv` re-imports `PATH` from `/etc/environment` after startup.
- Add shared test helpers that set `__STAX_BIN` (for wrapper behavior tests) or inline `export PATH=…` (for PATH lookup tests) inside the zsh command body, after global shell init.
- Fix Linux integration tests that use `script -qefc` by re-exporting `PATH` inside the recorded command shell, so fake `gh` binaries are not bypassed by the same system PATH reset.
- Standardize zsh shell-setup tests on `zsh -dfc` instead of `-lc` so user shell config and installed `stax` binaries do not interfere.

## Test plan
- [x] `cargo nextest run shell_setup::tests::posix_shell_snippet` (9/9 passed)
- [x] `cargo nextest run doctor_fix_installs_missing_gh_stack_extension doctor_fix_upgrades_outdated_gh_stack_extension` (2/2 passed)
- [x] `make test-native` (2176/2176 passed on Azure dev VM)
- [x] `make lint-fast`

No user-visible behavior changes; docs not updated.