### PR TITLE
feat(sync): warn on leaked auto-stash, stale stack fallback, and show deleted tip SHAs

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -316,6 +316,8 @@ st completions elvish
 - The completion footer summarizes the trunk commit, file, and line delta together with non-zero merged-cleanup, imported-update, and restack counts. It reuses sync's existing results and does not perform extra network or Git work.
 - When sync itself leaves exceptional work behind, it reports skipped cleanup with its reason, trunk update failures, and cleanup-driven checkout changes. It prints one prioritized next command: a diverged trunk gets non-destructive guidance to inspect and reconcile it with its remote; other trunk failures suggest `st trunk`; blocked cleanup suggests `st sweep`. Routine restack health remains visible in `st ls` and the TUI instead of appearing after every sync.
 - When `--restack` is requested, sync fails closed if its fetch did not succeed or the local trunk did not reach the fetched remote-trunk commit. It restores any sync auto-stash and exits non-zero before imported-branch refresh, merged-branch cleanup, or restacking can rewrite feature refs. `st refresh` (and `st update`) inherits this guard and exits before its submit phase, so it does not push or update PRs after either failure.
+- Deletion output lines for locally deleted branches (merged or upstream-gone) append the branch's tip SHA (first 7 characters, dimmed) so you can reference the exact commit that was removed.
+- If sync auto-stashed your working tree and then fails on an error path that cannot restore the stash, it prints a warning to stderr naming the stash "stax auto-stash" with instructions to run `git stash pop` to restore your changes.
 
 ### `st restack`
 

--- a/docs/workflows/multi-worktree.md
+++ b/docs/workflows/multi-worktree.md
@@ -28,7 +28,7 @@ st upstack restack --auto-stash-pop
 st sync --restack --auto-stash-pop
 ```
 
-If a conflict occurs, the stash entry is preserved so nothing is lost.
+If a conflict occurs, the stash entry is preserved so nothing is lost. When `st sync` auto-stashes your working tree and fails on an unrecoverable error path (for example, when restoring the stash itself conflicts with an updated trunk), it prints a warning to stderr naming the stash "stax auto-stash" with instructions to run `git stash pop` to restore your changes.
 
 ## Related
 

--- a/skills.md
+++ b/skills.md
@@ -319,6 +319,8 @@ stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 # The sync footer reports trunk commits/files/line changes plus non-zero cleanup/imported/restack counts.
 # Conditional attention lines name blocked cleanup, trunk failures, and checkout changes, followed by one prioritized next command. For a diverged trunk, inspect and reconcile it with its remote instead of treating `st trunk` as a repair; other trunk failures use `st trunk`. Routine restack health stays in stax ls and the TUI.
 # When --restack is requested, a failed fetch or trunk that did not reach the fetched remote commit stops sync before imported refresh, merged cleanup, or feature-branch rebases. Any sync auto-stash is restored first.
+# Deletion lines for locally deleted branches (merged or upstream-gone) show the branch tip SHA (7 chars, dimmed) for traceability.
+# If sync auto-stashed your working tree and fails on an error path that cannot restore it, stderr names the stash ("stax auto-stash") with instructions to run `git stash pop`.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
 stax sweep --delete                # Delete merged/tracked-merged PRs + upstream-gone branches with no unique work after confirmation

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -170,6 +170,49 @@ enum SyncFlow {
     Stop,
 }
 
+struct StashGuard {
+    armed: bool,
+}
+
+impl StashGuard {
+    fn new() -> Self {
+        Self { armed: false }
+    }
+
+    fn arm(&mut self) {
+        self.armed = true;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for StashGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            eprintln!("{}", stash_left_behind_warning());
+        }
+    }
+}
+
+fn stash_left_behind_warning() -> String {
+    format!(
+        "{}\n  {}",
+        r#"⚠ Your changes are still stashed as "stax auto-stash"."#.yellow(),
+        "Run `git stash pop` to restore them (`git stash list` to inspect).".dimmed()
+    )
+}
+
+fn stale_stack_warning(consequence: &str, error: &anyhow::Error) -> String {
+    format!(
+        "⚠ Could not reload stack metadata; {} ({})",
+        consequence, error
+    )
+    .yellow()
+    .to_string()
+}
+
 struct SyncContext {
     workdir: PathBuf,
     reopen_repo_path: PathBuf,
@@ -197,6 +240,8 @@ struct SyncContext {
     remote_trunk_after_fetch: Option<String>,
     updated_imported_branches: Vec<String>,
     stashed: bool,
+    stash_guard: StashGuard,
+    stale_stack_warning_shown: bool,
     trunk_update_deferred: bool,
     sync_started_at: Instant,
     step_timings: Vec<(String, Duration)>,
@@ -265,6 +310,8 @@ impl SyncContext {
                 remote_trunk_after_fetch: None,
                 updated_imported_branches: Vec::new(),
                 stashed: false,
+                stash_guard: StashGuard::new(),
+                stale_stack_warning_shown: false,
                 trunk_update_deferred: false,
                 sync_started_at,
                 step_timings: Vec::new(),
@@ -294,6 +341,9 @@ impl SyncContext {
                 let stash_started_at = Instant::now();
                 self.stashed = repo.stash_push()?;
                 self.auto_stash_pop = true;
+                if self.stashed {
+                    self.stash_guard.arm();
+                }
                 self.step_timings
                     .push(("stash working tree".to_string(), stash_started_at.elapsed()));
                 if !self.quiet {
@@ -446,6 +496,7 @@ impl SyncContext {
 
         if self.restack && !fetch_succeeded {
             restore_stashed_changes(repo, self.stashed, self.quiet)?;
+            self.stash_guard.disarm();
             anyhow::bail!(
                 "Cannot restack because fetching {} did not succeed.\n\
              Restore access to {}, then retry.",
@@ -634,7 +685,7 @@ impl SyncContext {
         Ok(())
     }
 
-    fn ensure_trunk_ready_for_restack(&self, repo: &GitRepo) -> Result<()> {
+    fn ensure_trunk_ready_for_restack(&mut self, repo: &GitRepo) -> Result<()> {
         // Restack is a history-rewriting operation, so fail closed before imported-branch
         // refresh or merged-branch cleanup can move any feature refs. Keep the later check
         // as a second boundary in case cleanup itself changes trunk state.
@@ -646,6 +697,7 @@ impl SyncContext {
             )
         {
             restore_stashed_changes(repo, self.stashed, self.quiet)?;
+            self.stash_guard.disarm();
             anyhow::bail!(
                 "Cannot restack because {} did not reach {}.\n\
              Inspect and reconcile {} with {}, then retry.",
@@ -1145,6 +1197,7 @@ impl SyncContext {
                         self.quiet,
                     )?;
 
+                    let tip_before_delete = repo.branch_commit(branch).ok();
                     let local_delete = self.delete_local_branch(
                         &repo,
                         branch,
@@ -1218,15 +1271,17 @@ impl SyncContext {
                     if !self.quiet {
                         if local_deleted && remote_deleted {
                             println!(
-                                "    {} {}",
+                                "    {} {}{}",
                                 branch.bright_black(),
-                                "deleted (local + remote)".green()
+                                "deleted (local + remote)".green(),
+                                deleted_tip_suffix(tip_before_delete.as_deref())
                             );
                         } else if local_deleted {
                             println!(
-                                "    {} {}",
+                                "    {} {}{}",
                                 branch.bright_black(),
-                                "deleted (local only)".green()
+                                "deleted (local only)".green(),
+                                deleted_tip_suffix(tip_before_delete.as_deref())
                             );
                         } else if remote_deleted {
                             println!(
@@ -1363,7 +1418,13 @@ impl SyncContext {
                 // reflected before we resolve upstream-gone branches. Fall back to
                 // the snapshot captured at the top of sync() if the reload fails,
                 // to degrade gracefully rather than aborting a mid-sync run.
-                let mut live_stack = Stack::load(repo).unwrap_or_else(|_| self.stack.clone());
+                let mut live_stack = match Stack::load(repo) {
+                    Ok(s) => s,
+                    Err(ref e) => {
+                        self.warn_stale_stack_fallback(e);
+                        self.stack.clone()
+                    }
+                };
 
                 // Initialize forge client once up-front for any PR base updates below.
                 let forge_client = init_forge_client(repo, &self.config);
@@ -1476,10 +1537,12 @@ impl SyncContext {
                     // just-reparented children under the new parent (preventing a
                     // later iteration from bouncing them again). Fall back to the
                     // current live_stack if the reload fails.
-                    if let Ok(refreshed) = Stack::load(repo) {
-                        live_stack = refreshed;
+                    match Stack::load(repo) {
+                        Ok(refreshed) => live_stack = refreshed,
+                        Err(ref e) => self.warn_stale_stack_fallback(e),
                     }
 
+                    let tip_before_delete = repo.branch_commit(branch).ok();
                     let local_delete = self.delete_local_branch(
                         repo,
                         branch,
@@ -1505,9 +1568,10 @@ impl SyncContext {
                     if !self.quiet {
                         if local_deleted {
                             println!(
-                                "    {} {}",
+                                "    {} {}{}",
                                 branch.bright_black(),
-                                "deleted (local only)".green()
+                                "deleted (local only)".green(),
+                                deleted_tip_suffix(tip_before_delete.as_deref())
                             );
                         } else {
                             print_blocked_or_skipped(
@@ -1805,7 +1869,11 @@ impl SyncContext {
                                 },
                             );
                             if self.stashed {
-                                println!("{}", "Stash kept to avoid conflicts.".yellow());
+                                println!(
+                                    "{}",
+                                    "Stash kept to avoid conflicts. Run `git stash pop` after resolving.".yellow()
+                                );
+                                self.stash_guard.disarm();
                             }
                             summary.push((branch.clone(), "conflict".to_string()));
 
@@ -1843,6 +1911,7 @@ impl SyncContext {
         if self.stashed {
             let stash_pop_started_at = Instant::now();
             repo.stash_pop()?;
+            self.stash_guard.disarm();
             self.step_timings
                 .push(("restore stash".to_string(), stash_pop_started_at.elapsed()));
             if !self.quiet {
@@ -1850,6 +1919,17 @@ impl SyncContext {
             }
         }
         Ok(())
+    }
+
+    fn warn_stale_stack_fallback(&mut self, error: &anyhow::Error) {
+        if self.quiet || self.stale_stack_warning_shown {
+            return;
+        }
+        self.stale_stack_warning_shown = true;
+        eprintln!(
+            "{}",
+            stale_stack_warning("using snapshot from sync start", error)
+        );
     }
 
     fn finalize(
@@ -2013,7 +2093,12 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
     let started_at = Instant::now();
     let stack = match Stack::load(repo) {
         Ok(s) => s,
-        Err(_) => return None,
+        Err(ref e) => {
+            if !quiet {
+                eprintln!("{}", stale_stack_warning("skipping PR metadata refresh", e));
+            }
+            return None;
+        }
     };
     let tracked_pr_branches: Vec<(String, u64)> = stack
         .branches
@@ -2807,8 +2892,8 @@ fn git_ref_exists(workdir: &Path, refname: &str) -> bool {
     Command::new("git")
         .args(["rev-parse", "--verify", "--quiet", &commit_ref])
         .current_dir(workdir)
-        .status()
-        .map(|s| s.success())
+        .output()
+        .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
@@ -3589,6 +3674,15 @@ fn trunk_reached_remote(workdir: &Path, trunk: &str, remote_oid: Option<&str>) -
     remote_oid.is_some_and(|remote| resolve_ref_oid(workdir, trunk).as_deref() == Some(remote))
 }
 
+fn deleted_tip_suffix(tip: Option<&str>) -> String {
+    match tip {
+        Some(sha) if !sha.is_empty() => format!(" · {}", &sha[..sha.len().min(7)])
+            .dimmed()
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
 fn restore_stashed_changes(repo: &GitRepo, stashed: bool, quiet: bool) -> Result<()> {
     if stashed {
         repo.stash_pop()?;
@@ -3984,6 +4078,57 @@ mod tests {
                 action,
                 SyncBranchDeleteAction::RemoveWorktree { .. }
             ))
+        );
+    }
+
+    #[test]
+    fn deleted_tip_suffix_renders_seven_char_short_sha() {
+        colored::control::set_override(false);
+        let sha = "abcdef1234567890";
+        let suffix = deleted_tip_suffix(Some(sha));
+        assert!(
+            suffix.contains("abcdef1"),
+            "expected 7-char sha in: {suffix}"
+        );
+        assert!(suffix.contains(" · "), "expected separator in: {suffix}");
+        assert!(
+            !suffix.contains("234567"),
+            "suffix must not exceed 7 chars of sha: {suffix}"
+        );
+    }
+
+    #[test]
+    fn deleted_tip_suffix_is_empty_without_a_tip() {
+        colored::control::set_override(false);
+        assert_eq!(deleted_tip_suffix(None), "");
+        assert_eq!(deleted_tip_suffix(Some("")), "");
+    }
+
+    #[test]
+    fn stale_stack_warning_names_consequence_and_error() {
+        colored::control::set_override(false);
+        let error = anyhow::anyhow!("metadata ref not found");
+        let msg = stale_stack_warning("using snapshot from sync start", &error);
+        assert!(msg.contains("using snapshot from sync start"));
+        assert!(msg.contains("metadata ref not found"));
+        assert!(msg.contains("⚠"));
+    }
+
+    #[test]
+    fn stash_left_behind_warning_tells_user_how_to_recover() {
+        colored::control::set_override(false);
+        let msg = stash_left_behind_warning();
+        assert!(
+            msg.contains("stax auto-stash"),
+            "must name the stash: {msg}"
+        );
+        assert!(
+            msg.contains("git stash pop"),
+            "must tell user how to restore: {msg}"
+        );
+        assert!(
+            msg.contains("git stash list"),
+            "must tell user how to inspect: {msg}"
         );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2482,6 +2482,81 @@ fn test_sync_restack_aborts_and_restores_stash_when_fetch_fails() {
 }
 
 #[test]
+fn test_sync_warns_when_dirty_worktree_failure_leaves_stash_behind() {
+    let repo = TestRepo::new_with_remote();
+
+    // Commit shared.txt on main and push to the test remote.
+    repo.create_file("shared.txt", "line one\nline two\nline three\n");
+    repo.commit("Add shared.txt");
+    repo.git(&["push", "origin", "main"]);
+
+    // From a second clone, rewrite all 3 lines and push to remote/main.
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let clone_dir = test_tempdir();
+    let run_remote_git = |args: &[&str]| {
+        let output = hermetic_git_command()
+            .args(args)
+            .current_dir(clone_dir.path())
+            .output()
+            .expect("Failed to run git in remote clone");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run_remote_git(&["clone", remote_path.to_str().unwrap(), "."]);
+    run_remote_git(&["checkout", "-B", "main", "origin/main"]);
+    run_remote_git(&["config", "user.email", "pusher@test.com"]);
+    run_remote_git(&["config", "user.name", "Pusher"]);
+    fs::write(clone_dir.path().join("shared.txt"), "alpha\nbeta\ngamma\n")
+        .expect("write shared.txt in remote clone");
+    run_remote_git(&["add", "shared.txt"]);
+    run_remote_git(&["commit", "-m", "Rewrite shared.txt on remote"]);
+    run_remote_git(&["push", "origin", "main"]);
+
+    // Dirty the same lines locally in the test repo (without fetching).
+    repo.create_file("shared.txt", "delta\nepsilon\nzeta\n");
+
+    // Run sync --force. Sync auto-stashes shared.txt (StashGuard armed), then
+    // fast-forwards trunk to the remote HEAD. The final git stash pop fails
+    // because the stash content conflicts with the rewritten trunk; the guard
+    // fires on that failure path and prints the recovery hint to stderr.
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        !output.status.success(),
+        "sync must fail when stash pop conflicts\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(
+        combined.contains(r#"still stashed as "stax auto-stash""#),
+        "output must name the stash: {combined}"
+    );
+    assert!(
+        combined.contains("git stash pop"),
+        "output must tell user how to restore: {combined}"
+    );
+
+    // Stash must still exist (guard never pops on failure).
+    let stash_list = repo.git(&["stash", "list"]);
+    assert!(stash_list.status.success());
+    let stash_out = TestRepo::stdout(&stash_list);
+    assert!(
+        !stash_out.trim().is_empty(),
+        "expected leftover stash entry after guard fired"
+    );
+    assert!(
+        stash_out.contains("stax auto-stash"),
+        "stash entry must be named 'stax auto-stash': {stash_out}"
+    );
+}
+
+#[test]
 fn test_update_no_submit_skips_merged_branch_cleanup() {
     let repo = TestRepo::new_with_remote();
 
@@ -3556,6 +3631,9 @@ fn test_sync_deletes_merged_branches() {
         "expected {feature_branch} to be merged into main before sync, got: {merged_str}"
     );
 
+    // Capture tip SHA before sync deletes the branch.
+    let feature_sha = repo.get_commit_sha(&feature_branch);
+
     // `--force` auto-confirms deletion of tracked branches merged into trunk.
     let output = repo.run_stax(&["sync", "--force"]);
     assert!(
@@ -3568,6 +3646,17 @@ fn test_sync_deletes_merged_branches() {
         "sync --force should delete the merged tracked branch {feature_branch}\nstdout:\n{}\nstderr:\n{}",
         TestRepo::stdout(&output),
         TestRepo::stderr(&output)
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let deletion_line = stdout
+        .lines()
+        .find(|l| l.contains("deleted (local"))
+        .unwrap_or_else(|| panic!("expected a 'deleted (local' line in output: {stdout}"));
+    assert!(
+        deletion_line.contains(&feature_sha[..7]),
+        "deletion line must contain tip SHA {}: {deletion_line}",
+        &feature_sha[..7]
     );
 }
 
@@ -5605,6 +5694,9 @@ fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
 
     repo.git(&["push", "origin", "--delete", "manual-upstream-gone"]);
 
+    // Capture tip SHA before sync deletes the branch.
+    let sha = repo.get_commit_sha("manual-upstream-gone");
+
     let output = repo.run_stax(&["sync", "--force", "--delete-upstream-gone"]);
     assert!(
         output.status.success(),
@@ -5616,6 +5708,17 @@ fn test_sync_delete_upstream_gone_deletes_untracked_local_branch() {
     assert!(
         !branches.iter().any(|b| b == "manual-upstream-gone"),
         "Expected --delete-upstream-gone to delete the stale local branch"
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let deletion_line = stdout
+        .lines()
+        .find(|l| l.contains("deleted (local"))
+        .unwrap_or_else(|| panic!("expected a 'deleted (local' line in output: {stdout}"));
+    assert!(
+        deletion_line.contains(&sha[..7]),
+        "deletion line must contain tip SHA {}: {deletion_line}",
+        &sha[..7]
     );
 }
 


### PR DESCRIPTION
## Summary

Adds sync safety guardrails:

- **StashGuard** — warns if sync auto-stash could not be restored on error paths
- **Stale stack** — clearer warning when stack metadata is stale (e.g. before PR refresh)
- **Deletion tips** — reports branch tip SHAs when cleaning merged/gone branches
- Fixes **`git_ref_exists`** so stdout is not polluted (callers that parse git output)

## Test plan

- [x] `make test`