### PR TITLE
feat(sync): make sync undoable and add GitRepo::refresh()

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ one-line notice. Silence the notice with `[restack] preflight_warn = false` or
 
 ### Undo / redo
 
-`restack`, `submit`, and `reorder` each snapshot branch state before they touch anything. Recovery is one command away.
+`restack`, `submit`, `sync`, and `reorder` each snapshot branch state before they touch anything. Recovery is one command away.
 
 ```bash
 st restack

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -55,7 +55,7 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 
 | Command | What it does |
 |---|---|
-| `st rs` | Pull trunk, clean merged branches, reparent children |
+| `st rs` | Pull trunk, clean merged branches, reparent children — undoable via `st undo` |
 | `st rs --restack` | `rs` **plus** rebase the current stack onto updated trunk |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -312,6 +312,7 @@ st completions elvish
 - `--restack` · `--restack --auto-stash-pop`
 - `--delete-upstream-gone`
 - `--force` / `--safe` / `--continue` / `--quiet` / `--verbose`
+- Sync is transactional and undoable via `st undo`. A single receipt covers trunk fast-forwards, deleted branch heads, deleted metadata refs, reparented children's metadata, and the optional restack phase. A no-op sync (nothing changed) writes no receipt so the previous undoable operation remains on the undo stack.
 - Imported branches from `st get` are remote-delete exempt: once they are detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch.
 - The completion footer summarizes the trunk commit, file, and line delta together with non-zero merged-cleanup, imported-update, and restack counts. It reuses sync's existing results and does not perform extra network or Git work.
 - When sync itself leaves exceptional work behind, it reports skipped cleanup with its reason, trunk update failures, and cleanup-driven checkout changes. It prints one prioritized next command: a diverged trunk gets non-destructive guidance to inspect and reconcile it with its remote; other trunk failures suggest `st trunk`; blocked cleanup suggests `st sweep`. Routine restack health remains visible in `st ls` and the TUI instead of appearing after every sync.

--- a/docs/safety/undo-redo.md
+++ b/docs/safety/undo-redo.md
@@ -10,7 +10,7 @@ st undo
 
 ## Transaction model
 
-For potentially destructive operations (`restack`, `submit`, `sync --restack`, TUI reorder, `split`, `fix`), stax:
+For potentially destructive operations (`restack`, `submit`, `sync`, TUI reorder, `split`, `fix`), stax:
 
 1. Snapshots affected branch SHAs
 2. Creates backup refs at `refs/stax/backups/<op-id>/<branch>`
@@ -18,6 +18,32 @@ For potentially destructive operations (`restack`, `submit`, `sync --restack`, T
 4. Writes a receipt to `.git/stax/ops/<op-id>.json`
 
 `st undo` restores branches to their exact pre-operation commits.
+
+### What a sync receipt covers
+
+`stax sync` uses a single lazily-snapshotted transaction. Each branch is snapshotted
+right before it is mutated, so `stax undo` can restore:
+
+- **Trunk head** — fast-forwarded (or reset) local trunk is rolled back, regardless of
+  whether trunk was checked out in the main worktree or in a linked worktree.
+- **Deleted branch heads** — branches removed as merged or upstream-gone are re-created
+  at their original tips.
+- **Deleted metadata refs** — stax metadata (`refs/branch-metadata/<branch>`) is restored.
+- **Reparented children's metadata** — when a deleted branch's children were moved to a
+  new parent, their parent metadata is restored to point back to the deleted branch.
+- **Rebased squash-merge children** — children rebased onto trunk during squash-merge
+  cleanup are restored to their pre-rebase SHAs.
+- **Restack phase** — if `--restack` was used, branches rebased during the restack phase
+  are also restored.
+
+`stax redo` replays the operation forward: deleted branches are re-deleted and trunk is
+re-advanced to the post-sync SHA.
+
+**Not restored by undo** (intentional scope limits):
+
+- Removed linked worktrees (`stax worktree remove` within sync is not tracked).
+- Forge PR base updates (GitHub/GitLab API side-effects are external to git).
+- CI history writes.
 
 ## Commands
 

--- a/skills.md
+++ b/skills.md
@@ -56,7 +56,7 @@ stax split                     # Interactive branch split into stack
 
 stax continue|cont             # Continue after conflict resolution
 stax abort                     # Abort in-progress rebase/conflict flow
-stax undo [op-id]              # Undo last/specific operation
+stax undo [op-id]              # Undo last/specific operation — covers restack, submit, sync (trunk ff + deletions + reparents + restack phase)
 stax redo [op-id]              # Redo last/specific undone operation
 
 stax pr                        # Open current branch PR
@@ -321,6 +321,7 @@ stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 # When --restack is requested, a failed fetch or trunk that did not reach the fetched remote commit stops sync before imported refresh, merged cleanup, or feature-branch rebases. Any sync auto-stash is restored first.
 # Deletion lines for locally deleted branches (merged or upstream-gone) show the branch tip SHA (7 chars, dimmed) for traceability.
 # If sync auto-stashed your working tree and fails on an error path that cannot restore it, stderr names the stash ("stax auto-stash") with instructions to run `git stash pop`.
+# sync is transactional: trunk fast-forwards, merged/gone branch deletions, reparented-child metadata, and the optional restack phase are all covered by one receipt. A no-op sync writes no receipt so the previous undoable operation remains on the undo stack. Recover any sync run with `stax undo`.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
 stax sweep --delete                # Delete merged/tracked-merged PRs + upstream-gone branches with no unique work after confirmation

--- a/src/commands/continue_cmd.rs
+++ b/src/commands/continue_cmd.rs
@@ -52,7 +52,7 @@ pub(crate) fn latest_failed_restack_receipt(repo: &GitRepo) -> Result<Option<OpR
     Ok(OpReceipt::load_latest(git_dir)?.filter(|receipt| {
         matches!(
             receipt.kind,
-            OpKind::Restack | OpKind::SyncRestack | OpKind::UpstackRestack
+            OpKind::Restack | OpKind::SyncRestack | OpKind::UpstackRestack | OpKind::Sync
         ) && receipt.status == OpStatus::Failed
             && receipt.repo_workdir == workdir
     }))

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -215,7 +215,6 @@ fn stale_stack_warning(consequence: &str, error: &anyhow::Error) -> String {
 
 struct SyncContext {
     workdir: PathBuf,
-    reopen_repo_path: PathBuf,
     config: Config,
     remote_name: String,
     remote_trunk_ref: String,
@@ -247,6 +246,10 @@ struct SyncContext {
     step_timings: Vec<(String, Duration)>,
     restack_branch_timings: Vec<RestackBranchTiming>,
     stats: SyncStats,
+    /// Sync-wide undo transaction; lazily snapshotted — None until begin_transaction is called.
+    tx: Option<Transaction>,
+    /// Whether trunk has already been planned in the sync transaction.
+    trunk_planned: bool,
 }
 
 impl SyncContext {
@@ -268,7 +271,6 @@ impl SyncContext {
         let stack = Stack::load(&repo)?;
         let current = repo.current_branch()?;
         let workdir = repo.workdir()?.to_path_buf();
-        let reopen_repo_path = repo.git_dir()?.to_path_buf();
         let config = Config::load()?;
         let remote_name = config.remote_name().to_string();
         let remote_trunk_ref = format!("{}/{}", remote_name, stack.trunk);
@@ -285,7 +287,6 @@ impl SyncContext {
         Ok((
             Self {
                 workdir,
-                reopen_repo_path,
                 config,
                 remote_name,
                 remote_trunk_ref,
@@ -317,6 +318,8 @@ impl SyncContext {
                 step_timings: Vec::new(),
                 restack_branch_timings: Vec::new(),
                 stats: SyncStats::default(),
+                tx: None,
+                trunk_planned: false,
             },
             repo,
         ))
@@ -355,6 +358,30 @@ impl SyncContext {
             }
         }
         Ok(SyncFlow::Continue)
+    }
+
+    fn begin_transaction(&mut self, repo: &GitRepo) -> Result<()> {
+        let tx = Transaction::begin(OpKind::Sync, repo, self.quiet)?;
+        self.tx = Some(tx);
+        Ok(())
+    }
+
+    /// Close the sync-wide transaction.
+    ///
+    /// A no-op sync (nothing was snapshotted) leaves NO receipt so the previous
+    /// undoable receipt stays on top of the undo stack.  When the transaction
+    /// was snapshotted at least once we record the final head branch and
+    /// auto-stash state before writing the success receipt.
+    fn finish_transaction(&mut self, current_after: &str) -> Result<()> {
+        let Some(mut tx) = self.tx.take() else {
+            return Ok(());
+        };
+        if !tx.is_snapshotted() {
+            return Ok(());
+        }
+        tx.set_auto_stash_pop(self.auto_stash_pop);
+        tx.set_head_branch_after(current_after);
+        tx.finish_ok()
     }
 
     fn fetch_remote(&mut self, repo: &GitRepo) -> Result<()> {
@@ -540,13 +567,14 @@ impl SyncContext {
             let update_timer =
                 LiveTimer::maybe_new(!self.quiet, &format!("Update {}", self.stack.trunk));
 
-            self.fast_forward_trunk_in(&self.workdir, update_timer, false)?;
+            let workdir = self.workdir.clone();
+            self.fast_forward_trunk_in(repo, &workdir, update_timer, false)?;
         } else {
             let update_timer =
                 LiveTimer::maybe_new(!self.quiet, &format!("Update {}", self.stack.trunk));
 
             if let Some(trunk_worktree_path) = repo.branch_worktree_path(&self.stack.trunk)? {
-                self.fast_forward_trunk_in(&trunk_worktree_path, update_timer, true)?;
+                self.fast_forward_trunk_in(repo, &trunk_worktree_path, update_timer, true)?;
             } else {
                 // Trunk isn't checked out in any worktree.
                 // Resolve the two SHAs so we can give an accurate status message.
@@ -564,6 +592,8 @@ impl SyncContext {
                             is_ancestor(&self.workdir, &self.stack.trunk, &self.remote_trunk_ref);
 
                         if ff_possible {
+                            let workdir = self.workdir.clone();
+                            self.plan_trunk_move(repo, &workdir)?;
                             let output = Command::new("git")
                                 .args([
                                     "update-ref",
@@ -579,6 +609,14 @@ impl SyncContext {
 
                             if output.status.success() {
                                 LiveTimer::maybe_finish_timed(update_timer);
+                                let workdir = self.workdir.clone();
+                                if let Some(ref mut tx) = self.tx {
+                                    let trunk_after = resolve_ref_oid(&workdir, &self.stack.trunk);
+                                    tx.record_known_after(
+                                        &self.stack.trunk.clone(),
+                                        trunk_after.as_deref(),
+                                    );
+                                }
                             } else {
                                 self.trunk_update_deferred = true;
                                 LiveTimer::maybe_finish_skipped(
@@ -616,12 +654,37 @@ impl SyncContext {
         Ok(())
     }
 
+    /// Snapshot the trunk branch in the sync transaction before we touch it.
+    ///
+    /// Idempotent: returns immediately if already planned, or if local and
+    /// remote already agree (nothing will change).
+    fn plan_trunk_move(&mut self, repo: &GitRepo, dir: &Path) -> Result<()> {
+        if self.trunk_planned {
+            return Ok(());
+        }
+        let trunk_name = self.stack.trunk.clone();
+        let remote_trunk_ref = self.remote_trunk_ref.clone();
+        let local_oid = resolve_ref_oid(dir, &trunk_name);
+        let remote_oid = resolve_ref_oid(dir, &remote_trunk_ref);
+        if local_oid.is_some() && local_oid == remote_oid {
+            return Ok(());
+        }
+        if let Some(ref mut tx) = self.tx {
+            tx.plan_branch(repo, &trunk_name)?;
+            tx.snapshot()?;
+        }
+        self.trunk_planned = true;
+        Ok(())
+    }
+
     fn fast_forward_trunk_in(
-        &self,
+        &mut self,
+        repo: &GitRepo,
         dir: &Path,
         timer: Option<LiveTimer>,
         in_linked_worktree: bool,
     ) -> Result<()> {
+        self.plan_trunk_move(repo, dir)?;
         let output = Command::new("git")
             .args(["merge", "--ff-only", &self.remote_trunk_ref])
             .current_dir(dir)
@@ -634,6 +697,10 @@ impl SyncContext {
 
         if output.status.success() {
             LiveTimer::maybe_finish_timed(timer);
+            if let Some(ref mut tx) = self.tx {
+                let trunk_after = resolve_ref_oid(dir, &self.stack.trunk);
+                tx.record_known_after(&self.stack.trunk.clone(), trunk_after.as_deref());
+            }
             if !in_linked_worktree && !self.quiet && self.verbose {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 if !stdout.trim().is_empty() {
@@ -670,6 +737,10 @@ impl SyncContext {
 
             if reset_output.status.success() {
                 LiveTimer::maybe_finish_warn(timer, "reset to remote");
+                if let Some(ref mut tx) = self.tx {
+                    let trunk_after = resolve_ref_oid(dir, &self.stack.trunk);
+                    tx.record_known_after(&self.stack.trunk.clone(), trunk_after.as_deref());
+                }
             } else {
                 LiveTimer::maybe_finish_err(timer, "failed");
                 if !self.quiet && self.verbose {
@@ -924,8 +995,7 @@ impl SyncContext {
             LiveTimer::maybe_finish_timed(detect_timer);
 
             let delete_merged_started_at = Instant::now();
-            drop(repo);
-            let repo = GitRepo::open_from_path(&self.reopen_repo_path)?;
+            let repo = repo.refresh()?;
 
             // Initialize forge client once up-front for any PR base updates below.
             let forge_client = init_forge_client(&repo, &self.config);
@@ -1099,6 +1169,11 @@ impl SyncContext {
                                     continue;
                                 }
 
+                                // Snapshot child head+metadata before rebase so undo can restore.
+                                if let Some(ref mut tx) = self.tx {
+                                    tx.snapshot_branch_with_metadata(&repo, child)?;
+                                }
+
                                 // Use existing provenance-aware rebase
                                 match repo.rebase_branch_onto_with_provenance(
                                     child,
@@ -1115,6 +1190,26 @@ impl SyncContext {
                                             metadata.parent_branch_revision =
                                                 repo.rev_parse(&self.stack.trunk)?;
                                             metadata.write(repo.inner(), child)?;
+                                        }
+
+                                        // Record after-OIDs so redo can replay the rebase.
+                                        if let Some(ref mut tx) = self.tx {
+                                            let child_head_after = resolve_ref_oid(
+                                                &self.workdir,
+                                                &format!("refs/heads/{}", child),
+                                            );
+                                            tx.record_known_after(
+                                                child,
+                                                child_head_after.as_deref(),
+                                            );
+                                            let child_meta_after = resolve_ref_oid(
+                                                &self.workdir,
+                                                &format!("refs/branch-metadata/{}", child),
+                                            );
+                                            tx.record_known_metadata_after(
+                                                child,
+                                                child_meta_after.as_deref(),
+                                            );
                                         }
 
                                         if !self.quiet {
@@ -1185,6 +1280,12 @@ impl SyncContext {
                         }
                     }
 
+                    // Snapshot the deleted branch + reparented children BEFORE the
+                    // reparent so we capture the original metadata for undo.
+                    let reparented_for_tx =
+                        children_to_reparent(&self.stack, branch, &confirmed_deletions);
+                    self.snapshot_deletion(&repo, branch, &reparented_for_tx)?;
+
                     // Reparent tracked children onto the surviving parent before
                     // deleting, preserving the old-parent boundary for later restack.
                     reparent_children_for_deletion(
@@ -1235,27 +1336,35 @@ impl SyncContext {
                     // Imported branches are read-only remote references. Clean them
                     // up locally after merge, but never push-delete someone else's
                     // remote branch.
-                    let remote_deleted =
-                        if self.remote_delete_exempt_imported_branches.contains(branch)
-                            || !remote_branch_present
-                        {
-                            false
-                        } else {
-                            let remote_status = Command::new("git")
-                                .args(["push", &self.remote_name, "--delete", branch])
-                                .current_dir(&self.workdir)
-                                .stdout(std::process::Stdio::null())
-                                .stderr(std::process::Stdio::null())
-                                .status();
+                    let will_push_delete =
+                        !self.remote_delete_exempt_imported_branches.contains(branch)
+                            && remote_branch_present;
+                    if will_push_delete {
+                        let remote_name = self.remote_name.clone();
+                        if let Some(ref mut tx) = self.tx {
+                            tx.plan_remote_branch(&repo, &remote_name, branch)?;
+                        }
+                    }
+                    let remote_deleted = if will_push_delete {
+                        let remote_status = Command::new("git")
+                            .args(["push", &self.remote_name, "--delete", branch])
+                            .current_dir(&self.workdir)
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::null())
+                            .status();
 
-                            remote_status.map(|s| s.success()).unwrap_or(false)
-                        };
+                        remote_status.map(|s| s.success()).unwrap_or(false)
+                    } else {
+                        false
+                    };
 
                     // Only delete metadata if branch no longer exists locally.
                     let local_still_exists = local_branch_exists(&self.workdir, branch);
 
                     let metadata_deleted =
                         self.delete_branch_metadata(&repo, branch, local_still_exists);
+
+                    self.record_deletion_after(branch, local_still_exists, &reparented_for_tx);
 
                     if metadata_deleted {
                         self.stats.merged_branches_cleaned += 1;
@@ -1520,6 +1629,12 @@ impl SyncContext {
                         }
                     }
 
+                    // Snapshot the deleted branch + reparented children BEFORE the
+                    // reparent so we capture the original metadata for undo.
+                    let gone_reparented =
+                        children_to_reparent(&live_stack, branch, &gone_deletions);
+                    self.snapshot_deletion(repo, branch, &gone_reparented)?;
+
                     // Reparent tracked children to the fallback parent before
                     // deleting. The shared helper also mirrors the merged-branch
                     // path's ancestor-check rationale from issue #120.
@@ -1557,6 +1672,8 @@ impl SyncContext {
 
                     let metadata_deleted =
                         self.delete_branch_metadata(repo, branch, local_still_exists);
+
+                    self.record_deletion_after(branch, local_still_exists, &gone_reparented);
 
                     if !local_deleted && local_still_exists {
                         self.record_local_branch_kept_skip(
@@ -1606,13 +1723,14 @@ impl SyncContext {
 
     // If we deferred trunk update (refspec fetch failed while not on trunk) and we're
     // now on trunk after branch deletions, retry with git pull which is more reliable
-    fn retry_deferred_trunk_update(&mut self) -> Result<()> {
+    fn retry_deferred_trunk_update(&mut self, repo: &GitRepo) -> Result<()> {
         if self.trunk_update_deferred && self.current_after_deletions == self.stack.trunk {
             let deferred_update_started_at = Instant::now();
             let deferred_timer =
                 LiveTimer::maybe_new(!self.quiet, &format!("Update {}", self.stack.trunk));
 
-            self.fast_forward_trunk_in(&self.workdir, deferred_timer, false)?;
+            let workdir = self.workdir.clone();
+            self.fast_forward_trunk_in(repo, &workdir, deferred_timer, false)?;
 
             self.step_timings.push((
                 format!("retry update {}", self.stack.trunk),
@@ -1709,8 +1827,13 @@ impl SyncContext {
                     );
                 }
             } else {
-                // Begin transaction for restack phase
-                let mut tx = Transaction::begin(OpKind::SyncRestack, repo, self.quiet)?;
+                // Take the sync-wide transaction for the restack phase.  Using take()
+                // avoids a borrow conflict: &mut self.tx cannot coexist with the
+                // &mut self that all subsequent method calls on self need.
+                let mut tx = self
+                    .tx
+                    .take()
+                    .context("sync transaction was already finished")?;
                 tx.plan_branches(repo, &restack_scope_order)?;
                 let restack_count = branches_to_restack.len();
                 let summary = PlanSummary {
@@ -1887,8 +2010,8 @@ impl SyncContext {
 
                 repo.checkout(&self.current_after_deletions)?;
 
-                // Finish transaction successfully
-                tx.finish_ok()?;
+                // Return the transaction to SyncContext so finish_transaction can close it.
+                self.tx = Some(tx);
                 self.stats.restacked_branches = restacked_branches;
 
                 if !self.quiet && !summary.is_empty() {
@@ -1919,6 +2042,68 @@ impl SyncContext {
             }
         }
         Ok(())
+    }
+
+    /// Snapshot a branch (head + metadata) that is about to be deleted, together
+    /// with the metadata of each child that will be reparented.
+    ///
+    /// Must be called BEFORE the reparent so the original metadata is captured.
+    fn snapshot_deletion(
+        &mut self,
+        repo: &GitRepo,
+        branch: &str,
+        reparented: &[String],
+    ) -> Result<()> {
+        if let Some(ref mut tx) = self.tx {
+            tx.plan_branch(repo, branch)?;
+            tx.plan_metadata_ref(repo, branch)?;
+            for child in reparented {
+                let child = child.clone();
+                tx.plan_branch(repo, &child)?;
+                tx.plan_metadata_ref(repo, &child)?;
+            }
+            tx.snapshot()?;
+        }
+        Ok(())
+    }
+
+    /// Record the after-states for a deleted branch and its reparented children.
+    ///
+    /// After-OIDs are resolved via `resolve_ref_oid` (git subprocess) so that
+    /// libgit2's cached refdb — which may not see subprocess-written refs — is
+    /// never used for absent refs.
+    fn record_deletion_after(
+        &mut self,
+        branch: &str,
+        local_still_exists: bool,
+        reparented: &[String],
+    ) {
+        if let Some(ref mut tx) = self.tx {
+            // Branch head: None when deleted, existing OID when still present.
+            let branch_after = if local_still_exists {
+                resolve_ref_oid(&self.workdir, &format!("refs/heads/{}", branch))
+            } else {
+                None
+            };
+            tx.record_known_after(branch, branch_after.as_deref());
+
+            // Metadata ref: same absence logic.
+            let meta_after = if local_still_exists {
+                resolve_ref_oid(&self.workdir, &format!("refs/branch-metadata/{}", branch))
+            } else {
+                None
+            };
+            tx.record_known_metadata_after(branch, meta_after.as_deref());
+
+            // Reparented children — their head did not move but their metadata did.
+            for child in reparented {
+                let head_after = resolve_ref_oid(&self.workdir, &format!("refs/heads/{}", child));
+                tx.record_known_after(child, head_after.as_deref());
+                let child_meta_after =
+                    resolve_ref_oid(&self.workdir, &format!("refs/branch-metadata/{}", child));
+                tx.record_known_metadata_after(child, child_meta_after.as_deref());
+            }
+        }
     }
 
     fn warn_stale_stack_fallback(&mut self, error: &anyhow::Error) {
@@ -2050,6 +2235,8 @@ pub fn run(
         return Ok(());
     }
 
+    ctx.begin_transaction(&repo)?;
+
     if !ctx.quiet {
         println!("{}", "Syncing repository...".bold());
     }
@@ -2072,13 +2259,16 @@ pub fn run(
 
     ctx.cleanup_upstream_gone(&repo)?;
 
-    ctx.retry_deferred_trunk_update()?;
+    ctx.retry_deferred_trunk_update(&repo)?;
 
     ctx.ensure_trunk_ready_for_restack(&repo)?;
 
     ctx.restack_phase(&repo)?;
 
     ctx.restore_stash(&repo)?;
+
+    let current_after = ctx.current_after_deletions.clone();
+    ctx.finish_transaction(&current_after)?;
 
     ctx.finalize(trunk_stats_worker)?;
 
@@ -3328,6 +3518,22 @@ fn resolve_fallback_parent_skipping_doomed(
 /// updates the PR base on the forge when a child has a tracked PR.
 ///
 /// Used by both the merged-branch and upstream-gone cleanup paths.
+/// Return the names of children that will be reparented when `branch` is deleted.
+/// Excludes any child whose name appears in `skipped_deletions` (i.e. also being deleted).
+fn children_to_reparent(
+    stack_snapshot: &Stack,
+    branch: &str,
+    skipped_deletions: &HashSet<String>,
+) -> Vec<String> {
+    stack_snapshot
+        .branches
+        .iter()
+        .filter(|(_, info)| info.parent.as_deref() == Some(branch))
+        .map(|(name, _)| name.clone())
+        .filter(|name| !skipped_deletions.contains(name))
+        .collect()
+}
+
 fn reparent_children_for_deletion(
     repo: &GitRepo,
     stack_snapshot: &Stack,
@@ -3337,13 +3543,7 @@ fn reparent_children_for_deletion(
     forge_client: Option<&(tokio::runtime::Runtime, ForgeClient)>,
     quiet: bool,
 ) -> Result<()> {
-    let children: Vec<String> = stack_snapshot
-        .branches
-        .iter()
-        .filter(|(_, info)| info.parent.as_deref() == Some(branch))
-        .map(|(name, _)| name.clone())
-        .filter(|name| !skipped_children.contains(name))
-        .collect();
+    let children: Vec<String> = children_to_reparent(stack_snapshot, branch, skipped_children);
     let doomed_tip = repo.branch_commit(branch).ok();
 
     for child in &children {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -273,6 +273,18 @@ impl GitRepo {
         Ok(Self { repo })
     }
 
+    /// Re-open this repository from scratch, returning a new `GitRepo` with a fresh libgit2
+    /// handle.
+    ///
+    /// libgit2's refdb caches ref-OIDs in memory for the lifetime of the `Repository` object.
+    /// Any branch created, moved, or deleted by a git subprocess (e.g. `git update-ref`, `git
+    /// fetch`, or `git push`) will not be visible through the stale handle.  Call `refresh()`
+    /// after subprocess-driven ref mutations to obtain a handle that sees the current on-disk
+    /// state.
+    pub fn refresh(&self) -> Result<Self> {
+        Self::open_from_path(self.repo.path())
+    }
+
     /// Get the repository root path
     pub fn workdir(&self) -> Result<&Path> {
         self.repo
@@ -2546,6 +2558,31 @@ mod tests {
             std::fs::canonicalize(repo.workdir().expect("repo workdir"))
                 .expect("canonical workdir"),
             std::fs::canonicalize(path).expect("canonical temp repo path")
+        );
+    }
+
+    #[test]
+    fn refresh_sees_a_branch_created_by_a_subprocess() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test User"]);
+        fs::write(path.join("README.md"), "base\n").expect("write readme");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-m", "Initial commit"]);
+
+        let repo = GitRepo::open_from_path(path).expect("open repo");
+
+        // Create a branch via subprocess — the original handle's refdb cache will not see it.
+        run_git(path, &["branch", "new-branch"]);
+
+        let refreshed = repo.refresh().expect("refresh");
+        let oid = refreshed.rev_parse("new-branch");
+        assert!(
+            oid.is_ok(),
+            "refreshed repo should see subprocess-created branch"
         );
     }
 

--- a/src/ops/receipt.rs
+++ b/src/ops/receipt.rs
@@ -25,6 +25,7 @@ pub enum OpKind {
     Restack,
     UpstackRestack,
     SyncRestack,
+    Sync,
     Submit,
     Reorder,
     Split,
@@ -44,6 +45,7 @@ impl OpKind {
             OpKind::Restack => "restack",
             OpKind::UpstackRestack => "upstack restack",
             OpKind::SyncRestack => "sync --restack",
+            OpKind::Sync => "sync",
             OpKind::Submit => "submit",
             OpKind::Reorder => "reorder",
             OpKind::Split => "split",
@@ -175,8 +177,16 @@ impl OpReceipt {
         }
     }
 
-    /// Add a local ref to track
+    /// Add a local ref to track.
+    ///
+    /// Idempotent by label: if an entry with the same `branch` name already
+    /// exists, the call is a no-op, preserving the earliest `oid_before`
+    /// snapshot.  This prevents duplicate receipt entries when planning code
+    /// (e.g. `plan_trunk_move` + `plan_branches`) touches the same ref twice.
     pub fn add_local_ref(&mut self, branch: &str, oid_before: Option<&str>) {
+        if self.local_refs.iter().any(|e| e.branch == branch) {
+            return;
+        }
         self.local_refs.push(LocalRefEntry {
             branch: branch.to_string(),
             refname: format!("refs/heads/{}", branch),
@@ -192,9 +202,16 @@ impl OpReceipt {
     /// The label gets a `@meta` suffix so it doesn't collide with the
     /// matching `add_local_ref(branch, ...)` entry — both can coexist for
     /// one branch, which `fold` relies on.
+    ///
+    /// Idempotent by label: if the `<branch>@meta` entry already exists the
+    /// call is a no-op, preserving the earliest `oid_before` snapshot.
     pub fn add_metadata_ref(&mut self, branch: &str, oid_before: Option<&str>) {
+        let label = format!("{}{}", branch, super::tx::METADATA_REF_LABEL_SUFFIX);
+        if self.local_refs.iter().any(|e| e.branch == label) {
+            return;
+        }
         self.local_refs.push(LocalRefEntry {
-            branch: format!("{}{}", branch, super::tx::METADATA_REF_LABEL_SUFFIX),
+            branch: label,
             refname: crate::git::refs::metadata_refname(branch),
             existed_before: oid_before.is_some(),
             oid_before: oid_before.map(|s| s.to_string()),
@@ -503,8 +520,18 @@ mod tests {
         assert_eq!(OpKind::Restack.display_name(), "restack");
         assert_eq!(OpKind::UpstackRestack.display_name(), "upstack restack");
         assert_eq!(OpKind::SyncRestack.display_name(), "sync --restack");
+        assert_eq!(OpKind::Sync.display_name(), "sync");
         assert_eq!(OpKind::Submit.display_name(), "submit");
         assert_eq!(OpKind::Reorder.display_name(), "reorder");
+    }
+
+    #[test]
+    fn sync_op_kind_roundtrips_as_snake_case() {
+        let kind = OpKind::Sync;
+        let json = serde_json::to_string(&kind).expect("serialize");
+        assert_eq!(json, "\"sync\"");
+        let loaded: OpKind = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(loaded, OpKind::Sync);
     }
 
     #[test]

--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -30,12 +30,15 @@ pub struct Transaction {
     receipt: OpReceipt,
     git_dir: PathBuf,
     workdir: PathBuf,
-    /// Whether snapshot() has been called
+    /// Whether snapshot() has been called at least once
     snapshotted: bool,
     /// Whether the transaction has been finished
     finished: bool,
     /// Whether to print status messages
     quiet: bool,
+    /// Number of `local_refs` entries that have already been backed up.
+    /// Incremental snapshot() backs up only entries at index >= this value.
+    backed_up: usize,
 }
 
 pub(crate) struct ReceiptFinalization {
@@ -67,6 +70,7 @@ impl Transaction {
             snapshotted: false,
             finished: false,
             quiet,
+            backed_up: 0,
         })
     }
 
@@ -127,29 +131,56 @@ impl Transaction {
         self.receipt.completed_branches.push(branch.to_string());
     }
 
-    /// Create backup refs and write the in-progress receipt
+    /// Create backup refs and write the in-progress receipt.
+    ///
+    /// Incremental: each call backs up only the `local_refs` entries that were
+    /// added since the previous call.  The snapshot message is printed only on
+    /// the first call.  Callers may therefore `plan_branch` → `snapshot` →
+    /// `plan_branch` → `snapshot` in a loop; each call is a no-op when no new
+    /// entries have been added.
     pub fn snapshot(&mut self) -> Result<()> {
-        if self.snapshotted {
-            return Ok(());
+        let first_snapshot = !self.snapshotted;
+
+        // Back up any entries that were planned since the last snapshot.
+        let entries_to_back_up: Vec<(String, String)> = self.receipt.local_refs[self.backed_up..]
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .oid_before
+                    .as_ref()
+                    .map(|oid| (entry.branch.clone(), oid.clone()))
+            })
+            .collect();
+
+        for (branch, oid) in entries_to_back_up {
+            super::create_backup_ref(&self.workdir, &self.receipt.op_id, &branch, &oid)?;
         }
 
-        // Create backup refs for all planned branches
-        for entry in &self.receipt.local_refs {
-            if let Some(oid) = &entry.oid_before {
-                super::create_backup_ref(&self.workdir, &self.receipt.op_id, &entry.branch, oid)?;
-            }
-        }
+        self.backed_up = self.receipt.local_refs.len();
 
         // Write the in-progress receipt
         self.receipt.save(&self.git_dir)?;
 
-        self.snapshotted = true;
-
-        if !self.quiet {
-            self.print_snapshot_info();
+        if first_snapshot {
+            self.snapshotted = true;
+            if !self.quiet {
+                self.print_snapshot_info();
+            }
         }
 
         Ok(())
+    }
+
+    /// Plan a branch + its metadata ref, then immediately snapshot both.
+    ///
+    /// Convenience helper for sync's per-branch lazy snapshot pattern: each
+    /// branch is snapshotted right before it is mutated so that a partial sync
+    /// (interrupted by an error or conflict) only records the branches it
+    /// actually touched.
+    pub fn snapshot_branch_with_metadata(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
+        self.plan_branch(repo, branch)?;
+        self.plan_metadata_ref(repo, branch)?;
+        self.snapshot()
     }
 
     /// Print snapshot information
@@ -205,6 +236,23 @@ impl Transaction {
         self.receipt
             .update_metadata_ref_after(branch, oid.as_deref());
         Ok(())
+    }
+
+    /// Record a known after-OID for a branch ref without querying the repo.
+    ///
+    /// Sync resolves after-OIDs via a git subprocess (`resolve_ref_oid`) rather
+    /// than libgit2, because libgit2's cached refdb may not see refs written by
+    /// subprocesses (e.g. `git update-ref`, `git push`, `git branch -D`).
+    /// Call this after resolving the OID yourself; pass `None` to record
+    /// explicit deletion.
+    pub fn record_known_after(&mut self, branch: &str, oid: Option<&str>) {
+        self.receipt.update_local_ref_after_optional(branch, oid);
+    }
+
+    /// Record a known after-OID for a branch-metadata ref without querying the
+    /// repo.  Same subprocess-vs-libgit2 rationale as `record_known_after`.
+    pub fn record_known_metadata_after(&mut self, branch: &str, oid: Option<&str>) {
+        self.receipt.update_metadata_ref_after(branch, oid);
     }
 
     /// Record after-OIDs for all planned branches
@@ -312,7 +360,6 @@ impl Transaction {
     }
 
     /// Check if the transaction has been snapshotted
-    #[allow(dead_code)]
     pub fn is_snapshotted(&self) -> bool {
         self.snapshotted
     }
@@ -383,6 +430,7 @@ mod tests {
             snapshotted: false,
             finished: false,
             quiet: true,
+            backed_up: 0,
         }
     }
 
@@ -457,6 +505,7 @@ mod tests {
             snapshotted: true,
             finished: false,
             quiet: true,
+            backed_up: 0,
         };
 
         let finalized = transaction.finish_ok_preserving_receipt();
@@ -465,6 +514,74 @@ mod tests {
         let persistence_error = finalized.persistence_error.unwrap();
         let io_error = persistence_error.downcast_ref::<std::io::Error>().unwrap();
         assert_eq!(io_error.kind(), std::io::ErrorKind::IsADirectory);
+    }
+
+    #[test]
+    fn snapshot_backs_up_branches_planned_after_the_first_snapshot() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+
+        // Minimal git repo with two commits so we have real OIDs.
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git");
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(path.join("f.txt"), "a").unwrap();
+        run(&["add", "f.txt"]);
+        run(&["commit", "-m", "first"]);
+        run(&["branch", "branch-a"]);
+        std::fs::write(path.join("f.txt"), "b").unwrap();
+        run(&["add", "f.txt"]);
+        run(&["commit", "-m", "second"]);
+        run(&["branch", "branch-b"]);
+
+        let repo = GitRepo::open_from_path(path).unwrap();
+        let ops_dir = path.join(".git/stax/ops");
+        std::fs::create_dir_all(&ops_dir).unwrap();
+
+        let mut tx = Transaction::begin(OpKind::Sync, &repo, true).unwrap();
+        tx.plan_branch(&repo, "branch-a").unwrap();
+        tx.snapshot().unwrap();
+
+        // First snapshot: only branch-a is backed up (plan_branch adds 1 entry).
+        assert_eq!(tx.backed_up, 1);
+        let backed_up_after_first = tx.backed_up;
+
+        tx.plan_branch(&repo, "branch-b").unwrap();
+        assert!(tx.receipt.local_refs.len() > backed_up_after_first);
+
+        tx.snapshot().unwrap();
+        // After second snapshot, backed_up catches up.
+        assert_eq!(tx.backed_up, tx.receipt.local_refs.len());
+
+        // Both backup refs must exist as git refs.
+        let op_id = tx.receipt.op_id.clone();
+        let ref_a = format!("refs/stax/backups/{}/branch-a", op_id);
+        let ref_b = format!("refs/stax/backups/{}/branch-b", op_id);
+        let ok_a = Command::new("git")
+            .args(["rev-parse", "--verify", &ref_a])
+            .current_dir(path)
+            .output()
+            .expect("git")
+            .status
+            .success();
+        let ok_b = Command::new("git")
+            .args(["rev-parse", "--verify", &ref_b])
+            .current_dir(path)
+            .output()
+            .expect("git")
+            .status
+            .success();
+        assert!(ok_a, "backup ref for branch-a should exist");
+        assert!(ok_b, "backup ref for branch-b should exist");
     }
 
     #[test]
@@ -483,6 +600,7 @@ mod tests {
             snapshotted: true,
             finished: false,
             quiet: true,
+            backed_up: 0,
         };
 
         let receipt = transaction

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -126,6 +126,8 @@ mod submit_plan_completions_tests;
 mod submit_pr_base_tests;
 #[path = "sweep_tests.rs"]
 mod sweep_tests;
+#[path = "sync_undo_tests.rs"]
+mod sync_undo_tests;
 #[path = "track_all_prs_tests.rs"]
 mod track_all_prs_tests;
 #[path = "track_merge_base_tests.rs"]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5290,33 +5290,39 @@ fn test_sync_restack_creates_receipt() {
     let git_dir = repo.path().join(".git");
     let stax_ops_dir = git_dir.join("stax").join("ops");
 
-    if stax_ops_dir.exists() {
-        let ops: Vec<_> = std::fs::read_dir(&stax_ops_dir)
-            .expect("Failed to read stax ops dir")
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.path()
-                    .extension()
-                    .map(|ext| ext == "json")
-                    .unwrap_or(false)
-            })
-            .collect();
+    assert!(
+        stax_ops_dir.exists(),
+        "Expected .git/stax/ops directory to exist after sync"
+    );
 
-        // Find the sync_restack receipt
-        let _sync_receipt = ops.iter().find(|op| {
-            let content = std::fs::read_to_string(op.path()).unwrap_or_default();
-            content.contains("sync_restack")
-        });
+    let ops: Vec<_> = std::fs::read_dir(&stax_ops_dir)
+        .expect("Failed to read stax ops dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "json")
+                .unwrap_or(false)
+        })
+        .collect();
 
-        // May not have a receipt if nothing needed restacking
-        if !ops.is_empty() {
-            // At least verify the ops directory structure
-            assert!(
-                ops.iter()
-                    .all(|op| op.path().extension().map(|e| e == "json").unwrap_or(false))
-            );
-        }
-    }
+    assert!(
+        !ops.is_empty(),
+        "Expected at least one receipt after sync --restack"
+    );
+
+    // Find the sync receipt and assert its kind is "sync".
+    let sync_receipt = ops.iter().find(|op| {
+        let content = std::fs::read_to_string(op.path()).unwrap_or_default();
+        let v: serde_json::Value =
+            serde_json::from_str(&content).unwrap_or(serde_json::Value::Null);
+        v["kind"].as_str() == Some("sync")
+    });
+
+    assert!(
+        sync_receipt.is_some(),
+        "Expected a receipt with kind == \"sync\" after sync --restack"
+    );
 }
 
 #[test]

--- a/tests/sync_undo_tests.rs
+++ b/tests/sync_undo_tests.rs
@@ -1,0 +1,468 @@
+use crate::common::TestRepo;
+
+/// Helper: read the parentBranchName from stax metadata for `branch`.
+fn read_parent_branch(repo: &TestRepo, branch: &str) -> String {
+    let metadata_ref = format!("refs/branch-metadata/{}", branch);
+    let out = repo.git(&["show", &metadata_ref]);
+    assert!(
+        out.status.success(),
+        "failed to read metadata for {branch}: {}",
+        TestRepo::stderr(&out)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&out)).expect("invalid metadata JSON");
+    json["parentBranchName"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Helper: resolve a local ref to its SHA via git rev-parse (returns None if the ref doesn't
+/// exist).
+fn resolve_ref(repo: &TestRepo, refname: &str) -> Option<String> {
+    let out = repo.git(&["rev-parse", "--verify", refname]);
+    if out.status.success() {
+        Some(TestRepo::stdout(&out).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Helper: check that a local branch exists.
+fn branch_exists(repo: &TestRepo, branch: &str) -> bool {
+    resolve_ref(repo, &format!("refs/heads/{branch}")).is_some()
+}
+
+/// Helper: count the number of stax receipts in `.git/stax/ops/`.
+fn receipt_count(repo: &TestRepo) -> usize {
+    let ops_dir = repo.path().join(".git/stax/ops");
+    if !ops_dir.exists() {
+        return 0;
+    }
+    std::fs::read_dir(&ops_dir)
+        .expect("read ops dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "json")
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+// ─── Test 1 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_undo_restores_a_merged_branch_at_its_old_tip() {
+    let repo = TestRepo::new_with_remote();
+
+    // Create feature-a on main, push it, and merge it on the remote.
+    repo.run_stax(&["bc", "feature-a"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature-a.txt", "feature content");
+    repo.commit("Feature A commit");
+    let feature_sha_before = repo.get_commit_sha(&feature);
+
+    repo.git(&["push", "-u", "origin", &feature]);
+
+    repo.run_stax(&["t"]);
+    repo.merge_branch_on_remote(&feature);
+    repo.git(&["pull", "origin", "main"]);
+
+    // Precondition: branch is already merged.
+    let merged_out = repo.git(&["branch", "--merged", "main"]);
+    let merged_str = TestRepo::stdout(&merged_out);
+    assert!(
+        merged_str.contains(&feature),
+        "expected {feature} merged into main before sync"
+    );
+
+    // Run sync --force, which should delete the merged branch.
+    let sync_out = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        sync_out.status.success(),
+        "sync failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+    assert!(
+        !branch_exists(&repo, &feature),
+        "branch {feature} should have been deleted by sync"
+    );
+
+    // Metadata ref should also be gone.
+    assert!(
+        resolve_ref(&repo, &format!("refs/branch-metadata/{feature}")).is_none(),
+        "metadata ref for {feature} should have been deleted by sync"
+    );
+
+    // Now undo.
+    let undo_out = repo.run_stax(&["undo", "--yes"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    // Branch head should be restored to the pre-delete SHA.
+    assert!(
+        branch_exists(&repo, &feature),
+        "undo should have restored the branch {feature}"
+    );
+    let feature_sha_after_undo = repo.get_commit_sha(&feature);
+    assert_eq!(
+        feature_sha_before, feature_sha_after_undo,
+        "undo should restore the branch to its original tip"
+    );
+
+    // Metadata ref should also be restored.
+    assert!(
+        resolve_ref(&repo, &format!("refs/branch-metadata/{feature}")).is_some(),
+        "undo should restore the metadata ref for {feature}"
+    );
+}
+
+// ─── Test 2 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_undo_restores_reparented_child_metadata() {
+    let repo = TestRepo::new_with_remote();
+
+    // Build stack: main → a → b
+    repo.run_stax(&["bc", "branch-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a");
+    repo.commit("Branch A commit");
+    repo.git(&["push", "-u", "origin", &branch_a]);
+
+    repo.run_stax(&["bc", "branch-b"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("b.txt", "b");
+    repo.commit("Branch B commit");
+
+    // Merge A on the remote (so sync sees it as merged).
+    repo.run_stax(&["t"]);
+    repo.merge_branch_on_remote(&branch_a);
+    repo.git(&["pull", "origin", "main"]);
+
+    let merged_out = repo.git(&["branch", "--merged", "main"]);
+    let merged_str = TestRepo::stdout(&merged_out);
+    assert!(
+        merged_str.contains(&branch_a),
+        "expected {branch_a} merged into main before sync"
+    );
+
+    // Verify b's parent is a before sync.
+    let b_parent_before = read_parent_branch(&repo, &branch_b);
+    assert_eq!(b_parent_before, branch_a, "b should point to a before sync");
+
+    // sync --force: deletes a and reparents b → main.
+    let sync_out = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        sync_out.status.success(),
+        "sync failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+    assert!(
+        !branch_exists(&repo, &branch_a),
+        "branch_a should have been deleted"
+    );
+
+    // After sync, b's parent should have moved away from a.
+    let b_parent_after_sync = read_parent_branch(&repo, &branch_b);
+    assert_ne!(
+        b_parent_after_sync, branch_a,
+        "after sync, b should no longer point to the deleted a"
+    );
+
+    // Undo — should restore a AND restore b's parent → a.
+    let undo_out = repo.run_stax(&["undo", "--yes"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    assert!(
+        branch_exists(&repo, &branch_a),
+        "undo should restore branch_a"
+    );
+
+    let b_parent_after_undo = read_parent_branch(&repo, &branch_b);
+    assert_eq!(
+        b_parent_after_undo, branch_a,
+        "undo should restore b's parent metadata back to a"
+    );
+}
+
+// ─── Test 3 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_that_changes_nothing_leaves_the_previous_receipt_undoable() {
+    let repo = TestRepo::new_with_remote();
+
+    // Create a branch, commit, and restack to produce a restack receipt.
+    repo.run_stax(&["bc", "feature-noop"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature");
+    repo.commit("Feature commit");
+
+    repo.run_stax(&["t"]);
+    repo.create_file("main-update.txt", "main update");
+    repo.commit("Main update");
+
+    repo.run_stax(&["checkout", &feature]);
+    let restack_out = repo.run_stax(&["restack", "--quiet"]);
+    assert!(
+        restack_out.status.success(),
+        "restack failed: {}",
+        TestRepo::stderr(&restack_out)
+    );
+
+    let receipts_after_restack = receipt_count(&repo);
+    assert!(
+        receipts_after_restack >= 1,
+        "expected at least one receipt after restack"
+    );
+
+    let feature_sha_after_restack = repo.get_commit_sha(&feature);
+
+    // Now run sync with no remote changes — nothing should be snapshotted.
+    // (No remote, so fetch either uses a dummy or is skipped for a no-change run.)
+    // We just run sync with --force to skip interactive prompts; since nothing changed
+    // on the remote, the sync transaction is a no-op and leaves no new receipt.
+    let sync_out = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        sync_out.status.success(),
+        "sync failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+
+    let receipts_after_noop_sync = receipt_count(&repo);
+    assert_eq!(
+        receipts_after_restack, receipts_after_noop_sync,
+        "a no-op sync must not create a new receipt (lazy snapshot guard)"
+    );
+
+    // Undo should still undo the RESTACK (the previous receipt), not the sync.
+    let undo_out = repo.run_stax(&["undo", "--yes"]);
+    assert!(
+        undo_out.status.success(),
+        "undo after no-op sync failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    // After undoing the restack, feature should be back at its pre-restack SHA.
+    // (The feature commit SHA changed during restack so post-undo != post-restack.)
+    let feature_sha_after_undo = repo.get_commit_sha(&feature);
+    assert_ne!(
+        feature_sha_after_restack, feature_sha_after_undo,
+        "undo should have reversed the restack, changing the feature branch SHA"
+    );
+}
+
+// ─── Test 4 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_undo_restores_trunk_after_fast_forward() {
+    let repo = TestRepo::new_with_remote();
+
+    // Capture trunk SHA before any remote changes.
+    let trunk_sha_before = repo.get_commit_sha("main");
+
+    // Create feature and push it (not on trunk).
+    repo.run_stax(&["bc", "feature-ff"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature");
+    repo.commit("Feature commit");
+    repo.git(&["push", "-u", "origin", &feature]);
+
+    // Simulate a remote commit on trunk (so sync has to fast-forward trunk).
+    repo.simulate_remote_commit("remote-main.txt", "from remote", "Remote main commit");
+
+    // Checkout feature so we're NOT on trunk — this exercises the non-checkout
+    // path (bare git update-ref fast-forward), which is where plan_trunk_move is
+    // called in that code branch.
+    let sync_out = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        sync_out.status.success(),
+        "sync failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+
+    let trunk_sha_after_sync = repo.get_commit_sha("main");
+    assert_ne!(
+        trunk_sha_before, trunk_sha_after_sync,
+        "trunk should have moved during sync"
+    );
+
+    // Undo — should restore trunk to its pre-sync SHA.
+    let undo_out = repo.run_stax(&["undo", "--yes"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    let trunk_sha_after_undo = repo.get_commit_sha("main");
+    assert_eq!(
+        trunk_sha_before, trunk_sha_after_undo,
+        "undo should restore trunk to its pre-sync SHA"
+    );
+}
+
+// ─── Test 5 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_undo_then_redo_replays_deletions_and_trunk() {
+    let repo = TestRepo::new_with_remote();
+
+    // Build stack: main → feature-del (to be deleted by sync).
+    repo.run_stax(&["bc", "feature-del"]);
+    let feature = repo.current_branch();
+    repo.create_file("del.txt", "del");
+    repo.commit("Feature del commit");
+    repo.git(&["push", "-u", "origin", &feature]);
+
+    // Merge feature on remote so sync will delete it.
+    repo.run_stax(&["t"]);
+    repo.merge_branch_on_remote(&feature);
+
+    // Pull so local main sees the merged commit first.
+    repo.git(&["pull", "origin", "main"]);
+
+    // Simulate a remote commit on trunk AFTER the pull so sync has something to fast-forward.
+    repo.simulate_remote_commit("remote-trunk.txt", "from remote", "Remote trunk commit");
+
+    let trunk_sha_before_sync = repo.get_commit_sha("main");
+    let feature_sha = resolve_ref(&repo, &format!("refs/heads/{feature}"))
+        .expect("feature branch should exist before sync");
+
+    // Checkout feature so trunk is updated via the non-checked-out path.
+    repo.run_stax(&["checkout", &feature]);
+
+    let sync_out = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        sync_out.status.success(),
+        "sync failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+
+    // Verify sync deleted feature and advanced trunk.
+    assert!(
+        !branch_exists(&repo, &feature),
+        "feature should have been deleted by sync"
+    );
+    let trunk_sha_after_sync = repo.get_commit_sha("main");
+    assert_ne!(
+        trunk_sha_before_sync, trunk_sha_after_sync,
+        "trunk should have moved during sync"
+    );
+
+    // Undo — restore feature and roll back trunk.
+    let undo_out = repo.run_stax(&["undo", "--yes", "--no-push"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    assert!(
+        branch_exists(&repo, &feature),
+        "undo should restore the deleted feature branch"
+    );
+    assert_eq!(
+        resolve_ref(&repo, &format!("refs/heads/{feature}")).as_deref(),
+        Some(feature_sha.as_str()),
+        "undo should restore feature to its original SHA"
+    );
+    let trunk_sha_after_undo = repo.get_commit_sha("main");
+    assert_eq!(
+        trunk_sha_before_sync, trunk_sha_after_undo,
+        "undo should roll trunk back to its pre-sync SHA"
+    );
+
+    // Redo — delete feature again and re-advance trunk.
+    let redo_out = repo.run_stax(&["redo", "--yes", "--no-push"]);
+    assert!(
+        redo_out.status.success(),
+        "redo failed: {}",
+        TestRepo::stderr(&redo_out)
+    );
+
+    assert!(
+        !branch_exists(&repo, &feature),
+        "redo should delete feature again"
+    );
+    let trunk_sha_after_redo = repo.get_commit_sha("main");
+    assert_eq!(
+        trunk_sha_after_sync, trunk_sha_after_redo,
+        "redo should re-advance trunk to the post-sync SHA"
+    );
+}
+
+// ─── Test 6 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_restack_undo_rolls_back_trunk_fast_forward() {
+    // Regression test: sync --restack used to leave a duplicate `main` entry in
+    // the receipt (plan_trunk_move added it with the pre-ff OID; plan_branches
+    // added it again with the post-ff OID).  On undo, apply_transaction iterated
+    // both entries, first resetting main to pre-ff, then forward to post-ff again
+    // — leaving trunk un-rolled-back.  The dedup fix in add_local_ref keeps only
+    // the earliest snapshot, so undo now correctly restores trunk.
+    let repo = TestRepo::new_with_remote();
+
+    // Create a feature branch off main.
+    repo.run_stax(&["bc", "feature-restack"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature.txt", "feature");
+    repo.commit("Feature commit");
+
+    // Return to main so sync can fast-forward it in the non-checkout path.
+    repo.run_stax(&["t"]);
+
+    // Capture trunk SHA before any sync activity.
+    let trunk_sha_before_sync = repo.get_commit_sha("main");
+
+    // Advance origin/main so sync has a fast-forward to perform.
+    repo.simulate_remote_commit(
+        "remote-sync-restack.txt",
+        "remote",
+        "Remote commit for sync",
+    );
+
+    // Run sync with restack so both plan_trunk_move AND plan_branches(restack_scope) fire.
+    let sync_out = repo.run_stax(&["sync", "--force", "--restack"]);
+    assert!(
+        sync_out.status.success(),
+        "sync --force --restack failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+
+    let trunk_sha_after_sync = repo.get_commit_sha("main");
+    assert_ne!(
+        trunk_sha_before_sync, trunk_sha_after_sync,
+        "trunk should have moved during sync"
+    );
+
+    // Undo — trunk must be rolled all the way back to the pre-sync SHA.
+    let undo_out = repo.run_stax(&["undo", "--yes", "--no-push"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    let trunk_sha_after_undo = repo.get_commit_sha("main");
+    assert_eq!(
+        trunk_sha_before_sync, trunk_sha_after_undo,
+        "undo should restore trunk to its pre-sync SHA (duplicate receipt entry bug)"
+    );
+
+    // Feature branch should still exist (nothing was deleted by this sync).
+    assert!(
+        branch_exists(&repo, &feature),
+        "feature branch should still exist after undo"
+    );
+}


### PR DESCRIPTION
## Summary

Makes **`stax sync` undoable** via `OpKind::Sync` transaction coverage (trunk ff, deletions, reparent metadata, optional restack phase). Adds **`GitRepo::refresh()`** so tests and sync phases see updated refs after mutations. Dedupes receipt labels where sync overlapped with other ops.

## Test plan

- [x] `tests/sync_undo_tests.rs`
- [x] `make test`