### PR TITLE
feat(sync): add --json machine-readable output

### DIFF
--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -59,6 +59,9 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 | `st rs --restack` | `rs` **plus** rebase the current stack onto updated trunk |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
 | `st rs --dry-run` / `st rs --plan` | Preview what sync would do — no fetch, no stash, no ref writes (read-only) |
+| `st rs --dry-run --json` | Same as `--dry-run` but emits a single JSON document (`kind: "sync_plan"`) instead of human text |
+| `st rs --json` | Run sync and emit the result as a versioned JSON document (`kind: "sync"`, schema version 1); implies non-interactive; failures still emit JSON and exit non-zero |
+| `st rs --json --force` | Same as `--json` but also auto-confirms branch deletions |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
 | `st refresh` | Sync trunk without merged-branch cleanup, restack, then push and update PRs (`st update` is a back-compat alias) |
 | `st refresh --force --yes --no-prompt` | Full refresh flow without sync or submit prompts |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -28,6 +28,8 @@ st --trace status --json >/dev/null
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
 | `st sync --dry-run` / `st sync --plan` | | Preview what sync would do — ls-remote only, no fetch/stash/ref-writes/push/metadata writes; always exits 0; composes with `--restack`, `--delete-upstream-gone`, `--safe`; `--force`, `--auto-stash-pop`, `--full`, and `--verbose` emit a warning and are otherwise ignored; `--continue` is rejected |
+| `st sync --dry-run --json` | | Same as `--dry-run` but emits a single JSON document (`kind: "sync_plan"`, `schema_version: 1`, `dry_run: true`) instead of human text |
+| `st sync --json` | | Emit the sync result as a single JSON document (`kind: "sync"`, `schema_version: 1`); implies non-interactive; failures emit JSON + non-zero exit; conflicts with `--continue` |
 | `st sweep` | | Classify all local branches as merged / upstream-gone / stale / active (read-only by default) |
 | `st sweep --delete` | | Delete merged branches (including tracked merged PRs) and upstream-gone branches with no unique work after confirmation |
 | `st sweep --delete --include-stale` | | Also delete stale branches (older than `--stale-days` / `branch.stale_days` config key) |
@@ -314,6 +316,65 @@ st completions elvish
 - `--delete-upstream-gone`
 - `--force` / `--safe` / `--continue` / `--quiet` / `--verbose`
 - `--dry-run` (alias `--plan`) — read-only preview: probes the remote with ls-remote (no fetch, no FETCH_HEAD write), patches PR states in-memory, classifies the trunk transition, reports merged/upstream-gone candidates and per-branch disposition, previews the restack scope with conflict predictions; always exits 0. `--force`, `--auto-stash-pop`, `--full`, and `--verbose` are accepted but ignored (stderr warning emitted for each). `--continue` conflicts and is rejected by clap.
+- `--json` — emit the sync result as a single JSON document on stdout (schema version 1). Implies non-interactive (`quiet=true`); does **not** imply `--force` (branches that need confirmation are recorded in `skipped_branches` and left intact). Conflicts with `--continue` (rejected by clap). Failures still emit the JSON envelope with `success: false` and exit non-zero. `--verbose` is ignored (stderr warning emitted). `--dry-run --json` emits `kind: "sync_plan"` with `dry_run: true` and always exits 0.
+- JSON schema (`kind: "sync"`, `schema_version: 1`; action/kind strings are extensible — consumers should treat unknown values as forwards-compatible additions):
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | `number` | Always `1` |
+| `kind` | `string` | `"sync"` (run) · `"sync_plan"` (dry-run) |
+| `success` | `bool` | `false` on any error |
+| `dry_run` | `bool` | `true` for `--dry-run --json` |
+| `duration_ms` | `number` | Wall-clock time in milliseconds |
+| `trunk.branch` | `string` | Local trunk name |
+| `trunk.remote_ref` | `string` | Remote-tracking ref (e.g. `origin/main`) |
+| `trunk.action` | `string` | `up_to_date` · `fast_forwarded` · `reset` · `diverged` · `failed` · `unknown` |
+| `trunk.commits?` | `number` | Present on `fast_forwarded` |
+| `trunk.files?` | `number` | Present on `fast_forwarded` |
+| `trunk.additions?` | `number` | Present on `fast_forwarded` |
+| `trunk.deletions?` | `number` | Present on `fast_forwarded` |
+| `deleted_branches[]` | `array` | Absent when empty |
+| `deleted_branches[].name` | `string` | Branch name |
+| `deleted_branches[].category` | `string` | `merged` · `upstream_gone` |
+| `deleted_branches[].scope` | `string` | `both` · `local` · `remote` |
+| `deleted_branches[].tip?` | `string` | Tip SHA at deletion time |
+| `deleted_branches[].metadata_deleted` | `bool` | Whether the metadata ref was also deleted |
+| `skipped_branches[]` | `array` | Absent when empty; branches that needed confirmation but `--force` was not given |
+| `skipped_branches[].name` | `string` | Branch name |
+| `skipped_branches[].reason` | `string` | Why deletion was skipped (e.g. `"not confirmed"`) |
+| `protected_branches[]` | `array` | Absent when empty; upstream-gone branches skipped due to unique local commits |
+| `partially_merged[]` | `array` | Absent when empty; branches with a signal of merging but with uncommitted local commits |
+| `partially_merged[].name` | `string` | Branch name |
+| `partially_merged[].reason` | `string` | `pr_merged` · `pr_closed` · `history_merged` |
+| `partially_merged[].pr_number?` | `number` | Present when a PR was detected |
+| `partially_merged[].extra_commits` | `number` | Number of local commits beyond what was merged |
+| `restacked_branches[]` | `array` | Absent when empty |
+| `imported_branches_updated[]` | `array` | Absent when empty |
+| `checkout_change?` | `object` | Present when the current branch changed during sync; `{from, to}` |
+| `stash.stashed` | `bool` | Whether working tree was auto-stashed |
+| `stash.restored` | `bool` | Whether the stash was successfully restored |
+| `stash.left_stashed` | `bool` | `stashed && !restored` |
+| `merged_candidates[]` | `array` | **`sync_plan` only.** Absent when empty; per-branch disposition for merged-branch candidates |
+| `merged_candidates[].name` | `string` | Branch name |
+| `merged_candidates[].disposition` | `string` | `would_delete` · `would_prompt_then_delete` · `would_keep_worktree` · `would_skip` · `would_rebase_children` |
+| `merged_candidates[].scope?` | `string` | `both` · `local`; present when disposition is `would_delete` or `would_prompt_then_delete` |
+| `merged_candidates[].keep_reason?` | `string` | Human-readable reason; present when disposition is `would_keep_worktree` or `would_skip` |
+| `merged_candidates[].children?` | `array` | Child branch names; present when disposition is `would_rebase_children` |
+| `upstream_gone_protected[]` | `array` | **`sync_plan` only.** Absent when empty; upstream-gone branches protected because they have unique local commits |
+| `upstream_gone_deletable[]` | `array` | **`sync_plan` only.** Absent when empty; upstream-gone branches that would be deleted |
+| `upstream_gone_deletable[].name` | `string` | Branch name |
+| `upstream_gone_deletable[].disposition` | `string` | `would_delete` (with `--force`) or `would_prompt_then_delete` |
+| `frozen_branches[]` | `array` | **`sync_plan` only.** Absent when empty; branches skipped because they are frozen |
+| `branches_to_restack[]` | `array` | **`sync_plan` only.** Absent when empty; branches that would be restacked |
+| `predicted_conflicts[]` | `array` | **`sync_plan` only.** Absent when empty; branches predicted to have merge conflicts during restack |
+| `predicted_conflicts[].branch` | `string` | Branch that would conflict |
+| `predicted_conflicts[].onto` | `string` | Parent branch it would rebase onto |
+| `predicted_conflicts[].files` | `array` | Files predicted to conflict |
+| `would_stash` | `bool` | **`sync_plan` only.** Whether the working tree is dirty (real sync would auto-stash) |
+| `error?` | `object` | Present on failure; `{kind, message}` |
+| `error.kind` | `string` | `dirty_working_tree` · `restack_conflict` · `error` |
+
+- On early-bail paths (e.g. dirty working tree in non-interactive mode) and on restack-conflict paths where finalize never runs, `trunk.action` is `"unknown"` — this is intentional.
 - Sync is transactional and undoable via `st undo`. A single receipt covers trunk fast-forwards, deleted branch heads, deleted metadata refs, reparented children's metadata, and the optional restack phase. A no-op sync (nothing changed) writes no receipt so the previous undoable operation remains on the undo stack.
 - Imported branches from `st get` are remote-delete exempt: once they are detected as merged or upstream-gone, sync may delete the local support branch and metadata, but it will not push-delete the imported remote branch.
 - The completion footer summarizes the trunk commit, file, and line delta together with non-zero merged-cleanup, imported-update, and restack counts. It reuses sync's existing results and does not perform extra network or Git work.

--- a/skills.md
+++ b/skills.md
@@ -308,6 +308,9 @@ stax merge-when-ready              # Backward-compatible alias
 stax rs                            # Sync trunk + clean merged branches
 stax rs --restack                  # Sync then restack
 stax sync --dry-run                # Preview sync plan (read-only — no fetch, no stash, no ref writes); alias: --plan
+stax sync --dry-run --json         # Same as --dry-run but emits a single JSON doc (kind:"sync_plan", schema_version:1, dry_run:true); always exits 0; no receipt written
+stax sync --json                   # Run sync and emit result as JSON (kind:"sync", schema_version:1); implies non-interactive (quiet); does NOT imply --force; failures emit JSON + non-zero exit
+stax sync --json --force           # Same as --json but also auto-confirms branch deletions (scripting entry point)
 stax sync --continue               # Continue after resolved sync conflicts
 stax sync --safe                   # Avoid hard reset on trunk update
 stax sync --force                  # Force sync without prompts; preserve linked worktrees during cleanup
@@ -323,6 +326,8 @@ stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 # Deletion lines for locally deleted branches (merged or upstream-gone) show the branch tip SHA (7 chars, dimmed) for traceability.
 # If sync auto-stashed your working tree and fails on an error path that cannot restore it, stderr names the stash ("stax auto-stash") with instructions to run `git stash pop`.
 # sync is transactional: trunk fast-forwards, merged/gone branch deletions, reparented-child metadata, and the optional restack phase are all covered by one receipt. A no-op sync writes no receipt so the previous undoable operation remains on the undo stack. Recover any sync run with `stax undo`.
+# --json scripting entry points: stax sync --json --force (delete all merged); stax sync --json (skip deletions needing confirmation); stax sync --dry-run --json (read-only plan); dirty tree → success:false, error.kind:dirty_working_tree, non-zero exit; --json conflicts with --continue.
+# trunk.action values: up_to_date · fast_forwarded · reset · diverged · failed · unknown. On early-bail paths (dirty tree, non-interactive) trunk.action is "unknown" because finalize never runs — intended.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only
 stax sweep --delete                # Delete merged/tracked-merged PRs + upstream-gone branches with no unique work after confirmation

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -458,6 +458,9 @@ pub(crate) enum Commands {
         /// Auto-stash and auto-pop dirty target worktrees during restack operations
         #[arg(long)]
         auto_stash_pop: bool,
+        /// Output the sync result as JSON (implies non-interactive; exits non-zero on failure)
+        #[arg(long, conflicts_with = "continue")]
+        json: bool,
     },
 
     /// List and optionally clean up local branches (merged, upstream-gone, stale)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -331,6 +331,7 @@ pub fn run() -> Result<()> {
             verbose,
             auto_stash_pop,
             dry_run,
+            json,
         } => {
             if dry_run {
                 commands::sync_plan::run(commands::sync_plan::SyncPlanOptions {
@@ -343,6 +344,7 @@ pub fn run() -> Result<()> {
                     quiet,
                     verbose,
                     auto_stash_pop,
+                    json,
                 })
             } else {
                 commands::sync::run(
@@ -357,6 +359,7 @@ pub fn run() -> Result<()> {
                     quiet,
                     verbose,
                     auto_stash_pop,
+                    json,
                     &[],
                 )
             }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -58,6 +58,7 @@ pub fn run(options: GetOptions) -> Result<()> {
             false,
             false,
             false,
+            false, // json
             &[],
         );
     };

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -517,6 +517,7 @@ pub fn run(
                 quiet,
                 false, // verbose
                 false, // auto_stash_pop
+                false, // json
                 &[],
             ) && !quiet
             {

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -504,6 +504,7 @@ pub fn run(
             quiet,
             false, // verbose
             false, // auto_stash_pop
+            false, // json
             &[],
         ) && !quiet
         {

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -1047,6 +1047,7 @@ fn run_post_merge_sync(quiet: bool) {
         quiet,
         false, // verbose
         false, // auto_stash_pop
+        false, // json
         &[],
     ) && !quiet
     {

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -635,6 +635,7 @@ pub fn run(
                 quiet,
                 false, // verbose
                 false, // auto_stash_pop
+                false, // json
                 &[],
             ) && !quiet
             {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -58,6 +58,7 @@ pub mod submit;
 pub(crate) mod submit_plan;
 pub mod sweep;
 pub mod sync;
+pub(crate) mod sync_json;
 pub mod sync_plan;
 pub mod tmux;
 pub mod undo;

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -56,6 +56,7 @@ pub fn run(
         false, // quiet
         verbose,
         auto_stash_pop,
+        false, // json
         &submit_fetch_refs,
     )?;
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -8,7 +8,7 @@ use crate::commands::worktree::{
 use crate::config::Config;
 use crate::engine::branch_detect::has_unique_commits_since_any_base;
 use crate::engine::{BranchMetadata, PrInfo, Stack};
-use crate::errors::ConflictStopped;
+use crate::errors::{ConflictStopped, DirtyWorkingTree, SilentExit, exit_codes};
 use crate::forge::ForgeClient;
 use crate::git::repo::{BranchDeleteResolution, BranchDeleteSwitchTarget};
 use crate::git::{GitRepo, RebaseResult, RebaseTimings};
@@ -29,39 +29,66 @@ use std::time::{Duration, Instant};
 const PR_METADATA_REFRESH_CONCURRENCY: usize = 8;
 
 #[derive(Debug, Default)]
-struct SyncStats {
-    trunk: Option<TrunkSummary>,
-    merged_branches_cleaned: usize,
-    restacked_branches: usize,
-    imported_branches_updated: usize,
-    trunk_not_updated: Option<TrunkNotUpdated>,
-    cleanup_skips: Vec<CleanupSkip>,
-    checkout_change: Option<CheckoutChange>,
+pub(super) struct SyncStats {
+    pub(super) trunk: Option<TrunkSummary>,
+    pub(super) merged_branches_cleaned: usize,
+    pub(super) deleted_branches: Vec<DeletedBranchRecord>,
+    pub(super) restacked_branches: Vec<String>,
+    pub(super) imported_branches_updated: Vec<String>,
+    pub(super) partially_merged: Vec<PartialMergeRecord>,
+    pub(super) protected_branches: Vec<String>,
+    pub(super) trunk_not_updated: Option<TrunkNotUpdated>,
+    pub(super) cleanup_skips: Vec<CleanupSkip>,
+    pub(super) checkout_change: Option<CheckoutChange>,
+    pub(super) stash: StashOutcome,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DeletedBranchRecord {
+    pub(super) branch: String,
+    pub(super) category: &'static str,
+    pub(super) scope: &'static str,
+    pub(super) tip: Option<String>,
+    pub(super) metadata_deleted: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PartialMergeRecord {
+    pub(super) branch: String,
+    pub(super) reason: &'static str,
+    pub(super) pr_number: Option<u64>,
+    pub(super) extra_commits: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct StashOutcome {
+    pub(super) stashed: bool,
+    pub(super) restored: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct TrunkNotUpdated {
-    branch: String,
-    remote_ref: String,
-    failure: TrunkUpdateFailure,
+pub(super) struct TrunkNotUpdated {
+    pub(super) branch: String,
+    pub(super) remote_ref: String,
+    pub(super) failure: TrunkUpdateFailure,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TrunkUpdateFailure {
+pub(super) enum TrunkUpdateFailure {
     Diverged,
     Other,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct CleanupSkip {
-    branch: String,
-    reason: String,
+pub(super) struct CleanupSkip {
+    pub(super) branch: String,
+    pub(super) reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct CheckoutChange {
-    from: String,
-    to: String,
+pub(super) struct CheckoutChange {
+    pub(super) from: String,
+    pub(super) to: String,
 }
 
 impl SyncStats {
@@ -90,7 +117,7 @@ impl RestackBranchTiming {
 }
 
 #[derive(Debug)]
-enum TrunkSummary {
+pub(super) enum TrunkSummary {
     UpToDate {
         branch: String,
     },
@@ -230,6 +257,7 @@ struct SyncContext {
     quiet: bool,
     verbose: bool,
     auto_stash_pop: bool,
+    json: bool,
     auto_confirm: bool,
     sync_extra_fetch_refs: Vec<String>,
     imported_branches: Vec<String>,
@@ -239,6 +267,7 @@ struct SyncContext {
     remote_trunk_after_fetch: Option<String>,
     updated_imported_branches: Vec<String>,
     stashed: bool,
+    stash_restored: bool,
     stash_guard: StashGuard,
     stale_stack_warning_shown: bool,
     trunk_update_deferred: bool,
@@ -265,6 +294,7 @@ impl SyncContext {
         quiet: bool,
         verbose: bool,
         auto_stash_pop: bool,
+        json: bool,
         extra_fetch_refs: &[String],
     ) -> Result<(Self, GitRepo)> {
         let repo = GitRepo::open()?;
@@ -284,6 +314,7 @@ impl SyncContext {
         }
         let auto_confirm = force;
         let current_after_deletions = current.clone();
+        let effective_quiet = quiet || json;
         Ok((
             Self {
                 workdir,
@@ -299,9 +330,10 @@ impl SyncContext {
                 delete_upstream_gone,
                 force,
                 safe,
-                quiet,
+                quiet: effective_quiet,
                 verbose,
                 auto_stash_pop,
+                json,
                 auto_confirm,
                 sync_extra_fetch_refs,
                 imported_branches,
@@ -311,6 +343,7 @@ impl SyncContext {
                 remote_trunk_after_fetch: None,
                 updated_imported_branches: Vec::new(),
                 stashed: false,
+                stash_restored: false,
                 stash_guard: StashGuard::new(),
                 stale_stack_warning_shown: false,
                 trunk_update_deferred: false,
@@ -328,7 +361,7 @@ impl SyncContext {
     fn handle_dirty_tree(&mut self, repo: &GitRepo) -> Result<SyncFlow> {
         if repo.is_dirty()? {
             if self.quiet {
-                anyhow::bail!("Working tree is dirty. Please stash or commit changes first.");
+                return Err(DirtyWorkingTree.into());
             }
 
             let stash = if self.auto_confirm {
@@ -353,7 +386,9 @@ impl SyncContext {
                     println!("{}", "✓ Stashed working tree changes.".green());
                 }
             } else {
-                println!("{}", "Aborted.".red());
+                if !self.json {
+                    println!("{}", "Aborted.".red());
+                }
                 return Ok(SyncFlow::Stop);
             }
         }
@@ -792,7 +827,7 @@ impl SyncContext {
             self.quiet,
             self.verbose,
         )?;
-        self.stats.imported_branches_updated = self.updated_imported_branches.len();
+        self.stats.imported_branches_updated = self.updated_imported_branches.clone();
         if !self.imported_branches.is_empty() {
             self.step_timings.push((
                 "update imported branches".to_string(),
@@ -945,10 +980,14 @@ impl SyncContext {
             Err(e) => {
                 self.stats
                     .record_cleanup_skip(branch, "metadata cleanup failed");
-                println!(
-                    "{}",
-                    format!("Warning: failed to delete metadata for '{}': {}", branch, e).yellow()
-                );
+                let msg = format!("Warning: failed to delete metadata for '{}': {}", branch, e)
+                    .yellow()
+                    .to_string();
+                if self.json {
+                    eprintln!("{}", msg);
+                } else {
+                    println!("{}", msg);
+                }
                 false
             }
         }
@@ -1370,6 +1409,23 @@ impl SyncContext {
                         self.stats.merged_branches_cleaned += 1;
                     }
 
+                    // Record JSON stat for deleted branch (outside !quiet gate)
+                    if local_deleted || remote_deleted {
+                        let scope = match (local_deleted, remote_deleted) {
+                            (true, true) => "both",
+                            (true, false) => "local",
+                            (false, true) => "remote",
+                            _ => "local",
+                        };
+                        self.stats.deleted_branches.push(DeletedBranchRecord {
+                            branch: branch.clone(),
+                            category: "merged",
+                            scope,
+                            tip: tip_before_delete.clone(),
+                            metadata_deleted,
+                        });
+                    }
+
                     if !local_deleted && local_still_exists {
                         self.record_local_branch_kept_skip(
                             branch,
@@ -1419,6 +1475,21 @@ impl SyncContext {
                 }
             } else if !self.quiet {
                 println!("    {}", "No merged branches to delete.".dimmed());
+            }
+
+            // Record partially-merged notes OUTSIDE !quiet gate for JSON stats
+            for note in &partially_merged_notes {
+                let reason = match note.pr_label {
+                    PartialMergeReason::PrMerged => "pr_merged",
+                    PartialMergeReason::PrClosed => "pr_closed",
+                    PartialMergeReason::HistoryMerged => "history_merged",
+                };
+                self.stats.partially_merged.push(PartialMergeRecord {
+                    branch: note.branch.clone(),
+                    reason,
+                    pr_number: note.pr_number,
+                    extra_commits: note.extra_commits,
+                });
             }
 
             if !self.quiet {
@@ -1493,6 +1564,11 @@ impl SyncContext {
                 detect_gone_started_at.elapsed(),
             ));
             LiveTimer::maybe_finish_timed(detect_timer);
+
+            // Record protected-gone branches OUTSIDE !quiet gate for JSON stats
+            self.stats
+                .protected_branches
+                .extend(protected_gone.iter().cloned());
 
             if !self.quiet && !protected_gone.is_empty() {
                 let branch_word = if protected_gone.len() == 1 {
@@ -1675,6 +1751,17 @@ impl SyncContext {
 
                     self.record_deletion_after(branch, local_still_exists, &gone_reparented);
 
+                    // Record JSON stat for upstream-gone deleted branch (outside !quiet gate)
+                    if local_deleted {
+                        self.stats.deleted_branches.push(DeletedBranchRecord {
+                            branch: branch.clone(),
+                            category: "upstream_gone",
+                            scope: "local",
+                            tip: tip_before_delete.clone(),
+                            metadata_deleted,
+                        });
+                    }
+
                     if !local_deleted && local_still_exists {
                         self.record_local_branch_kept_skip(
                             branch,
@@ -1855,7 +1942,7 @@ impl SyncContext {
                 tx.snapshot()?;
 
                 let mut summary: Vec<(String, String)> = Vec::new();
-                let mut restacked_branches = 0usize;
+                let mut restacked_branches: Vec<String> = Vec::new();
 
                 for (index, branch) in restack_scope_order.iter().enumerate() {
                     let needs_restack = live_stack
@@ -1957,7 +2044,7 @@ impl SyncContext {
                             }
 
                             LiveTimer::maybe_finish_timed(restack_timer);
-                            restacked_branches += 1;
+                            restacked_branches.push(branch.clone());
                             summary.push((branch.clone(), "ok".to_string()));
                         }
                         RebaseResult::Conflict => {
@@ -1976,22 +2063,26 @@ impl SyncContext {
                                 .map(|(name, _)| name.clone())
                                 .collect();
                             let conflict_stack = live_stack.current_stack(branch);
-                            print_restack_conflict(
-                                repo,
-                                &RestackConflictContext {
-                                    branch,
-                                    parent_branch: &parent_branch_name,
-                                    completed_branches: &completed_branches,
-                                    remaining_branches: scope_order.len().saturating_sub(index + 1),
-                                    continue_commands: &[
-                                        "stax resolve",
-                                        "stax continue",
-                                        "stax sync --continue",
-                                    ],
-                                    stack_branches: &conflict_stack,
-                                },
-                            );
-                            if self.stashed {
+                            if !self.json {
+                                print_restack_conflict(
+                                    repo,
+                                    &RestackConflictContext {
+                                        branch,
+                                        parent_branch: &parent_branch_name,
+                                        completed_branches: &completed_branches,
+                                        remaining_branches: scope_order
+                                            .len()
+                                            .saturating_sub(index + 1),
+                                        continue_commands: &[
+                                            "stax resolve",
+                                            "stax continue",
+                                            "stax sync --continue",
+                                        ],
+                                        stack_branches: &conflict_stack,
+                                    },
+                                );
+                            }
+                            if self.stashed && !self.json {
                                 println!(
                                     "{}",
                                     "Stash kept to avoid conflicts. Run `git stash pop` after resolving.".yellow()
@@ -2035,6 +2126,7 @@ impl SyncContext {
             let stash_pop_started_at = Instant::now();
             repo.stash_pop()?;
             self.stash_guard.disarm();
+            self.stash_restored = true;
             self.step_timings
                 .push(("restore stash".to_string(), stash_pop_started_at.elapsed()));
             if !self.quiet {
@@ -2207,6 +2299,7 @@ pub fn run(
     quiet: bool,
     verbose: bool,
     auto_stash_pop: bool,
+    json: bool,
     extra_fetch_refs: &[String],
 ) -> Result<()> {
     let sync_started_at = Instant::now();
@@ -2221,6 +2314,7 @@ pub fn run(
         quiet,
         verbose,
         auto_stash_pop,
+        json,
         extra_fetch_refs,
     )?;
 
@@ -2231,10 +2325,69 @@ pub fn run(
         }
     }
 
-    if ctx.handle_dirty_tree(&repo)? == SyncFlow::Stop {
-        return Ok(());
-    }
+    if json {
+        if verbose {
+            eprintln!(
+                "{}",
+                "warning: --verbose is ignored by --json (output is machine-readable)".yellow()
+            );
+        }
+        let phase_result = match ctx.handle_dirty_tree(&repo) {
+            Err(e) => Err(e),
+            Ok(SyncFlow::Stop) => Ok(()),
+            Ok(SyncFlow::Continue) => run_sync_phases(&mut ctx, repo),
+        };
 
+        ctx.stats.stash = StashOutcome {
+            stashed: ctx.stashed,
+            restored: ctx.stash_restored,
+        };
+
+        let duration = sync_started_at.elapsed();
+        let trunk_branch = ctx.stack.trunk.clone();
+        let remote_trunk_ref = ctx.remote_trunk_ref.clone();
+
+        match phase_result {
+            Ok(()) => {
+                let output = crate::commands::sync_json::build(
+                    &trunk_branch,
+                    &remote_trunk_ref,
+                    &ctx.stats,
+                    false,
+                    duration,
+                    None,
+                );
+                println!("{}", crate::commands::sync_json::emit(&output));
+                Ok(())
+            }
+            Err(e) => {
+                let is_conflict = e.downcast_ref::<ConflictStopped>().is_some();
+                let err_json = crate::commands::sync_json::classify_error(&e);
+                let output = crate::commands::sync_json::build(
+                    &trunk_branch,
+                    &remote_trunk_ref,
+                    &ctx.stats,
+                    false,
+                    duration,
+                    Some(err_json),
+                );
+                println!("{}", crate::commands::sync_json::emit(&output));
+                if is_conflict {
+                    Err(ConflictStopped.into())
+                } else {
+                    Err(SilentExit(exit_codes::GENERAL).into())
+                }
+            }
+        }
+    } else {
+        if ctx.handle_dirty_tree(&repo)? == SyncFlow::Stop {
+            return Ok(());
+        }
+        run_sync_phases(&mut ctx, repo)
+    }
+}
+
+fn run_sync_phases(ctx: &mut SyncContext, repo: GitRepo) -> Result<()> {
     ctx.begin_transaction(&repo)?;
 
     if !ctx.quiet {
@@ -3751,19 +3904,19 @@ fn render_sync_footer(stats: &SyncStats, total_duration: Duration) -> String {
         ));
     }
 
-    if stats.restacked_branches > 0 {
+    if !stats.restacked_branches.is_empty() {
         parts.push(format!(
             "{} {}",
             "restacked".dimmed(),
-            stats.restacked_branches.to_string().cyan().bold()
+            stats.restacked_branches.len().to_string().cyan().bold()
         ));
     }
 
-    if stats.imported_branches_updated > 0 {
+    if !stats.imported_branches_updated.is_empty() {
         parts.push(format!(
             "{} {}",
             "updated".dimmed(),
-            format!("{} imported", stats.imported_branches_updated)
+            format!("{} imported", stats.imported_branches_updated.len())
                 .cyan()
                 .bold()
         ));
@@ -4029,8 +4182,8 @@ mod tests {
                     deletions: 22,
                 }),
                 merged_branches_cleaned: 2,
-                restacked_branches: 1,
-                imported_branches_updated: 1,
+                restacked_branches: vec!["feat".to_string()],
+                imported_branches_updated: vec!["base".to_string()],
                 ..SyncStats::default()
             },
             Duration::from_millis(14_022),
@@ -4061,8 +4214,8 @@ mod tests {
                     branch: "main".to_string(),
                 }),
                 merged_branches_cleaned: 0,
-                restacked_branches: 0,
-                imported_branches_updated: 0,
+                restacked_branches: vec![],
+                imported_branches_updated: vec![],
                 ..SyncStats::default()
             },
             Duration::from_secs(2),

--- a/src/commands/sync_json.rs
+++ b/src/commands/sync_json.rs
@@ -1,0 +1,760 @@
+use crate::commands::sync::{SyncStats, TrunkNotUpdated, TrunkSummary, TrunkUpdateFailure};
+use crate::commands::sync_plan::TrunkPlan;
+use crate::errors::{ConflictStopped, DirtyWorkingTree};
+use anyhow::Error;
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Serialize)]
+pub struct SyncOutput {
+    pub schema_version: u8,
+    pub kind: &'static str,
+    pub success: bool,
+    pub dry_run: bool,
+    pub duration_ms: u64,
+    pub trunk: TrunkJson,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub deleted_branches: Vec<DeletedBranchJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skipped_branches: Vec<SkippedBranchJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub protected_branches: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub partially_merged: Vec<PartiallyMergedJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub restacked_branches: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub imported_branches_updated: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkout_change: Option<CheckoutChangeJson>,
+    pub stash: StashJson,
+    // Plan-mode fields (sync_plan kind only; absent in sync kind via skip_serializing_if)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub merged_candidates: Vec<MergedCandidateJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub upstream_gone_protected: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub upstream_gone_deletable: Vec<UpstreamGoneDeleteJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub frozen_branches: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub branches_to_restack: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub predicted_conflicts: Vec<PredictedConflictJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub would_stash: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorJson>,
+}
+
+#[derive(Serialize)]
+pub struct TrunkJson {
+    pub branch: String,
+    pub remote_ref: String,
+    pub action: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additions: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<usize>,
+}
+
+#[derive(Serialize)]
+pub struct DeletedBranchJson {
+    pub name: String,
+    pub category: &'static str,
+    pub scope: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tip: Option<String>,
+    pub metadata_deleted: bool,
+}
+
+#[derive(Serialize)]
+pub struct SkippedBranchJson {
+    pub name: String,
+    pub reason: String,
+}
+
+#[derive(Serialize)]
+pub struct PartiallyMergedJson {
+    pub name: String,
+    pub reason: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    pub extra_commits: usize,
+}
+
+#[derive(Serialize)]
+pub struct CheckoutChangeJson {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Serialize)]
+pub struct StashJson {
+    pub stashed: bool,
+    pub restored: bool,
+    pub left_stashed: bool,
+}
+
+/// Per-branch disposition in a dry-run merged-branch plan.
+#[derive(Serialize)]
+pub struct MergedCandidateJson {
+    pub name: String,
+    /// `would_delete` · `would_prompt_then_delete` · `would_keep_worktree` · `would_skip` ·
+    /// `would_rebase_children`
+    pub disposition: &'static str,
+    /// `both` · `local` — present when disposition is `would_delete` or
+    /// `would_prompt_then_delete`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<&'static str>,
+    /// Human-readable reason — present when disposition is `would_keep_worktree` or
+    /// `would_skip`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_reason: Option<String>,
+    /// Child branch names — present when disposition is `would_rebase_children`
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<String>,
+}
+
+/// Per-branch disposition for an upstream-gone branch in a dry-run plan.
+#[derive(Serialize)]
+pub struct UpstreamGoneDeleteJson {
+    pub name: String,
+    /// `would_delete` (with `--force`) or `would_prompt_then_delete` (without)
+    pub disposition: &'static str,
+}
+
+/// Predicted merge conflict for a single branch restack.
+#[derive(Serialize)]
+pub struct PredictedConflictJson {
+    pub branch: String,
+    pub onto: String,
+    pub files: Vec<String>,
+}
+
+/// All plan-specific data accumulated during a `--dry-run --json` run.
+/// Passed from `sync_plan::run()` to `build_plan()`.
+pub(super) struct SyncPlanData {
+    pub merged_candidates: Vec<MergedCandidateJson>,
+    pub partially_merged: Vec<PartiallyMergedJson>,
+    pub upstream_gone_protected: Vec<String>,
+    pub upstream_gone_deletable: Vec<UpstreamGoneDeleteJson>,
+    pub frozen_branches: Vec<String>,
+    pub branches_to_restack: Vec<String>,
+    pub predicted_conflicts: Vec<PredictedConflictJson>,
+    /// Whether the working tree is dirty (real sync would auto-stash).
+    pub would_stash: bool,
+}
+
+#[derive(Serialize)]
+pub struct ErrorJson {
+    pub kind: &'static str,
+    pub message: String,
+}
+
+/// Map TrunkSummary / TrunkNotUpdated to a stable JSON action string.
+/// Action strings are extensible — consumers should treat unknown values as "unknown".
+fn trunk_action(
+    trunk_summary: Option<&TrunkSummary>,
+    trunk_not_updated: Option<&TrunkNotUpdated>,
+) -> &'static str {
+    if let Some(summary) = trunk_summary {
+        return match summary {
+            TrunkSummary::UpToDate { .. } => "up_to_date",
+            TrunkSummary::Pulled { .. } => "fast_forwarded",
+            TrunkSummary::Updated { .. } => "reset",
+        };
+    }
+    if let Some(not_updated) = trunk_not_updated {
+        return match not_updated.failure {
+            TrunkUpdateFailure::Diverged => "diverged",
+            TrunkUpdateFailure::Other => "failed",
+        };
+    }
+    "unknown"
+}
+
+/// Map a TrunkPlan variant (from --dry-run) to the same action vocab as run-mode.
+pub(super) fn trunk_plan_to_action(plan: &TrunkPlan) -> &'static str {
+    match plan {
+        TrunkPlan::UpToDate => "up_to_date",
+        TrunkPlan::FastForward { .. } => "fast_forwarded",
+        TrunkPlan::ResetToRemote { .. } => "reset",
+        TrunkPlan::SkippedSafeMode { .. } => "failed",
+        TrunkPlan::Diverged { .. } => "diverged",
+        TrunkPlan::RemoteUnknown | TrunkPlan::ObjectsAbsent { .. } => "failed",
+    }
+}
+
+/// Build a SyncOutput from the sync stats collected during a run.
+pub(super) fn build(
+    trunk_branch: &str,
+    remote_trunk_ref: &str,
+    stats: &SyncStats,
+    dry_run: bool,
+    duration: Duration,
+    error: Option<ErrorJson>,
+) -> SyncOutput {
+    let action = trunk_action(stats.trunk.as_ref(), stats.trunk_not_updated.as_ref());
+
+    let (commits, files, additions, deletions) = match &stats.trunk {
+        Some(TrunkSummary::Pulled {
+            commits,
+            files,
+            additions,
+            deletions,
+            ..
+        }) => (
+            Some(*commits),
+            Some(*files),
+            Some(*additions),
+            Some(*deletions),
+        ),
+        _ => (None, None, None, None),
+    };
+
+    let trunk = TrunkJson {
+        branch: trunk_branch.to_string(),
+        remote_ref: remote_trunk_ref.to_string(),
+        action,
+        commits,
+        files,
+        additions,
+        deletions,
+    };
+
+    let deleted_branches = stats
+        .deleted_branches
+        .iter()
+        .map(|r| DeletedBranchJson {
+            name: r.branch.clone(),
+            category: r.category,
+            scope: r.scope,
+            tip: r.tip.clone(),
+            metadata_deleted: r.metadata_deleted,
+        })
+        .collect();
+
+    let skipped_branches = stats
+        .cleanup_skips
+        .iter()
+        .map(|s| SkippedBranchJson {
+            name: s.branch.clone(),
+            reason: s.reason.clone(),
+        })
+        .collect();
+
+    let partially_merged = stats
+        .partially_merged
+        .iter()
+        .map(|r| PartiallyMergedJson {
+            name: r.branch.clone(),
+            reason: r.reason,
+            pr_number: r.pr_number,
+            extra_commits: r.extra_commits,
+        })
+        .collect();
+
+    let checkout_change = stats.checkout_change.as_ref().map(|c| CheckoutChangeJson {
+        from: c.from.clone(),
+        to: c.to.clone(),
+    });
+
+    let stash = StashJson {
+        stashed: stats.stash.stashed,
+        restored: stats.stash.restored,
+        left_stashed: stats.stash.stashed && !stats.stash.restored,
+    };
+
+    let success = error.is_none();
+
+    SyncOutput {
+        schema_version: 1,
+        kind: "sync",
+        success,
+        dry_run,
+        duration_ms: duration.as_millis() as u64,
+        trunk,
+        deleted_branches,
+        skipped_branches,
+        protected_branches: stats.protected_branches.clone(),
+        partially_merged,
+        restacked_branches: stats.restacked_branches.clone(),
+        imported_branches_updated: stats.imported_branches_updated.clone(),
+        checkout_change,
+        stash,
+        // Plan-mode fields are absent in run-mode output.
+        merged_candidates: vec![],
+        upstream_gone_protected: vec![],
+        upstream_gone_deletable: vec![],
+        frozen_branches: vec![],
+        branches_to_restack: vec![],
+        predicted_conflicts: vec![],
+        would_stash: None,
+        error,
+    }
+}
+
+/// Build a SyncOutput for --dry-run --json from a sync_plan run.
+pub(super) fn build_plan(
+    trunk_branch: &str,
+    remote_trunk_ref: &str,
+    trunk_plan: &TrunkPlan,
+    plan_data: SyncPlanData,
+    duration: Duration,
+) -> SyncOutput {
+    let action = trunk_plan_to_action(trunk_plan);
+
+    let (commits, files, additions, deletions) = match trunk_plan {
+        TrunkPlan::FastForward {
+            commits,
+            files,
+            additions,
+            deletions,
+        } => (
+            Some(*commits),
+            Some(*files),
+            Some(*additions),
+            Some(*deletions),
+        ),
+        _ => (None, None, None, None),
+    };
+
+    let trunk = TrunkJson {
+        branch: trunk_branch.to_string(),
+        remote_ref: remote_trunk_ref.to_string(),
+        action,
+        commits,
+        files,
+        additions,
+        deletions,
+    };
+
+    SyncOutput {
+        schema_version: 1,
+        kind: "sync_plan",
+        success: true,
+        dry_run: true,
+        duration_ms: duration.as_millis() as u64,
+        trunk,
+        deleted_branches: vec![],
+        skipped_branches: vec![],
+        protected_branches: vec![],
+        partially_merged: plan_data.partially_merged,
+        restacked_branches: vec![],
+        imported_branches_updated: vec![],
+        checkout_change: None,
+        stash: StashJson {
+            stashed: false,
+            restored: false,
+            left_stashed: false,
+        },
+        merged_candidates: plan_data.merged_candidates,
+        upstream_gone_protected: plan_data.upstream_gone_protected,
+        upstream_gone_deletable: plan_data.upstream_gone_deletable,
+        frozen_branches: plan_data.frozen_branches,
+        branches_to_restack: plan_data.branches_to_restack,
+        predicted_conflicts: plan_data.predicted_conflicts,
+        would_stash: Some(plan_data.would_stash),
+        error: None,
+    }
+}
+
+/// Serialize a SyncOutput to a pretty-printed JSON string.
+pub(super) fn emit(output: &SyncOutput) -> String {
+    serde_json::to_string_pretty(output).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Classify an anyhow error into a JSON error envelope.
+pub(super) fn classify_error(e: &Error) -> ErrorJson {
+    if e.downcast_ref::<DirtyWorkingTree>().is_some() {
+        ErrorJson {
+            kind: "dirty_working_tree",
+            message: e.to_string(),
+        }
+    } else if e.downcast_ref::<ConflictStopped>().is_some() {
+        ErrorJson {
+            kind: "restack_conflict",
+            message: e.to_string(),
+        }
+    } else {
+        ErrorJson {
+            kind: "error",
+            message: e.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::sync::{StashOutcome, SyncStats, TrunkNotUpdated, TrunkUpdateFailure};
+    use std::time::Duration;
+
+    fn make_default_stats() -> SyncStats {
+        SyncStats::default()
+    }
+
+    #[test]
+    fn build_success_round_trips_to_valid_json() {
+        let stats = make_default_stats();
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_secs(1),
+            None,
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["kind"], "sync");
+        assert_eq!(parsed["success"], true);
+        assert_eq!(parsed["dry_run"], false);
+        assert_eq!(parsed["trunk"]["branch"], "main");
+        assert_eq!(parsed["trunk"]["remote_ref"], "origin/main");
+        assert_eq!(parsed["trunk"]["action"], "unknown");
+    }
+
+    #[test]
+    fn build_error_sets_success_false_and_error_field() {
+        let stats = make_default_stats();
+        let err = ErrorJson {
+            kind: "dirty_working_tree",
+            message: "Working tree is dirty. Please stash or commit changes first.".to_string(),
+        };
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_millis(500),
+            Some(err),
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+        assert_eq!(parsed["success"], false);
+        assert_eq!(parsed["error"]["kind"], "dirty_working_tree");
+        assert!(
+            parsed["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("dirty")
+        );
+    }
+
+    #[test]
+    fn diverged_trunk_action_maps_correctly() {
+        let stats = SyncStats {
+            trunk_not_updated: Some(TrunkNotUpdated {
+                branch: "main".to_string(),
+                remote_ref: "origin/main".to_string(),
+                failure: TrunkUpdateFailure::Diverged,
+            }),
+            ..SyncStats::default()
+        };
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_secs(1),
+            None,
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+        assert_eq!(parsed["trunk"]["action"], "diverged");
+    }
+
+    #[test]
+    fn failed_trunk_action_maps_correctly() {
+        let stats = SyncStats {
+            trunk_not_updated: Some(TrunkNotUpdated {
+                branch: "main".to_string(),
+                remote_ref: "origin/main".to_string(),
+                failure: TrunkUpdateFailure::Other,
+            }),
+            ..SyncStats::default()
+        };
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_secs(1),
+            None,
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+        assert_eq!(parsed["trunk"]["action"], "failed");
+    }
+
+    #[test]
+    fn default_stats_omits_optional_vec_keys() {
+        let stats = make_default_stats();
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_secs(1),
+            None,
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+        assert!(
+            parsed.get("deleted_branches").is_none(),
+            "absent when empty"
+        );
+        assert!(
+            parsed.get("skipped_branches").is_none(),
+            "absent when empty"
+        );
+        assert!(
+            parsed.get("restacked_branches").is_none(),
+            "absent when empty"
+        );
+        assert!(parsed.get("checkout_change").is_none(), "absent when None");
+    }
+
+    #[test]
+    fn stash_left_stashed_is_computed() {
+        let stats = SyncStats {
+            stash: StashOutcome {
+                stashed: true,
+                restored: false,
+            },
+            ..SyncStats::default()
+        };
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_secs(1),
+            None,
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+        assert_eq!(parsed["stash"]["stashed"], true);
+        assert_eq!(parsed["stash"]["restored"], false);
+        assert_eq!(parsed["stash"]["left_stashed"], true);
+    }
+
+    #[test]
+    fn classify_error_dirty_working_tree() {
+        let err: anyhow::Error = DirtyWorkingTree.into();
+        let classified = classify_error(&err);
+        assert_eq!(classified.kind, "dirty_working_tree");
+        assert!(classified.message.contains("dirty"));
+    }
+
+    #[test]
+    fn classify_error_conflict_stopped() {
+        let err: anyhow::Error = ConflictStopped.into();
+        let classified = classify_error(&err);
+        assert_eq!(classified.kind, "restack_conflict");
+    }
+
+    #[test]
+    fn classify_error_generic_error() {
+        let err: anyhow::Error = anyhow::anyhow!("something went wrong");
+        let classified = classify_error(&err);
+        assert_eq!(classified.kind, "error");
+        assert!(classified.message.contains("went wrong"));
+    }
+
+    #[test]
+    fn trunk_plan_to_action_maps_all_variants() {
+        use crate::commands::sync_plan::TrunkPlan;
+        assert_eq!(trunk_plan_to_action(&TrunkPlan::UpToDate), "up_to_date");
+        assert_eq!(
+            trunk_plan_to_action(&TrunkPlan::FastForward {
+                commits: 1,
+                files: 1,
+                additions: 1,
+                deletions: 0
+            }),
+            "fast_forwarded"
+        );
+        assert_eq!(
+            trunk_plan_to_action(&TrunkPlan::ResetToRemote {
+                target: "abc".to_string()
+            }),
+            "reset"
+        );
+        assert_eq!(
+            trunk_plan_to_action(&TrunkPlan::Diverged {
+                ahead: 1,
+                behind: 1
+            }),
+            "diverged"
+        );
+        assert_eq!(trunk_plan_to_action(&TrunkPlan::RemoteUnknown), "failed");
+    }
+
+    #[test]
+    fn build_plan_includes_merged_candidates_and_partially_merged() {
+        use crate::commands::sync_plan::TrunkPlan;
+
+        let plan_data = SyncPlanData {
+            merged_candidates: vec![
+                MergedCandidateJson {
+                    name: "feat-a".to_string(),
+                    disposition: "would_prompt_then_delete",
+                    scope: Some("both"),
+                    keep_reason: None,
+                    children: vec![],
+                },
+                MergedCandidateJson {
+                    name: "feat-b".to_string(),
+                    disposition: "would_keep_worktree",
+                    scope: None,
+                    keep_reason: Some("it has uncommitted changes".to_string()),
+                    children: vec![],
+                },
+            ],
+            partially_merged: vec![PartiallyMergedJson {
+                name: "feat-c".to_string(),
+                reason: "pr_merged",
+                pr_number: Some(42),
+                extra_commits: 2,
+            }],
+            upstream_gone_protected: vec!["gone-safe".to_string()],
+            upstream_gone_deletable: vec![UpstreamGoneDeleteJson {
+                name: "gone-del".to_string(),
+                disposition: "would_prompt_then_delete",
+            }],
+            frozen_branches: vec!["frozen-x".to_string()],
+            branches_to_restack: vec!["feat-d".to_string()],
+            predicted_conflicts: vec![PredictedConflictJson {
+                branch: "feat-d".to_string(),
+                onto: "main".to_string(),
+                files: vec!["src/lib.rs".to_string()],
+            }],
+            would_stash: false,
+        };
+
+        let output = build_plan(
+            "main",
+            "origin/main",
+            &TrunkPlan::UpToDate,
+            plan_data,
+            Duration::from_secs(1),
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+
+        assert_eq!(parsed["kind"], "sync_plan");
+        assert_eq!(parsed["dry_run"], true);
+
+        // merged_candidates
+        let candidates = parsed["merged_candidates"]
+            .as_array()
+            .expect("merged_candidates present");
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0]["name"], "feat-a");
+        assert_eq!(candidates[0]["disposition"], "would_prompt_then_delete");
+        assert_eq!(candidates[0]["scope"], "both");
+        assert_eq!(candidates[1]["disposition"], "would_keep_worktree");
+        assert!(candidates[1]["keep_reason"].is_string());
+
+        // partially_merged
+        let pm = parsed["partially_merged"]
+            .as_array()
+            .expect("partially_merged present");
+        assert_eq!(pm.len(), 1);
+        assert_eq!(pm[0]["name"], "feat-c");
+        assert_eq!(pm[0]["reason"], "pr_merged");
+        assert_eq!(pm[0]["pr_number"], 42);
+        assert_eq!(pm[0]["extra_commits"], 2);
+
+        // upstream_gone
+        assert_eq!(
+            parsed["upstream_gone_protected"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(
+            parsed["upstream_gone_deletable"].as_array().unwrap()[0]["name"],
+            "gone-del"
+        );
+
+        // frozen + restack + conflicts
+        assert_eq!(parsed["frozen_branches"].as_array().unwrap()[0], "frozen-x");
+        assert_eq!(
+            parsed["branches_to_restack"].as_array().unwrap()[0],
+            "feat-d"
+        );
+        let conflicts = parsed["predicted_conflicts"].as_array().unwrap();
+        assert_eq!(conflicts[0]["branch"], "feat-d");
+        assert_eq!(conflicts[0]["files"].as_array().unwrap()[0], "src/lib.rs");
+
+        // would_stash present in plan mode
+        assert_eq!(parsed["would_stash"], false);
+    }
+
+    #[test]
+    fn build_plan_would_stash_true_when_dirty() {
+        use crate::commands::sync_plan::TrunkPlan;
+
+        let plan_data = SyncPlanData {
+            merged_candidates: vec![],
+            partially_merged: vec![],
+            upstream_gone_protected: vec![],
+            upstream_gone_deletable: vec![],
+            frozen_branches: vec![],
+            branches_to_restack: vec![],
+            predicted_conflicts: vec![],
+            would_stash: true,
+        };
+
+        let output = build_plan(
+            "main",
+            "origin/main",
+            &TrunkPlan::UpToDate,
+            plan_data,
+            Duration::from_millis(200),
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+
+        assert_eq!(parsed["would_stash"], true);
+        // plan-only fields that are empty/None must be absent
+        assert!(parsed.get("merged_candidates").is_none());
+        assert!(parsed.get("frozen_branches").is_none());
+    }
+
+    #[test]
+    fn build_run_mode_omits_plan_only_fields() {
+        let stats = make_default_stats();
+        let output = build(
+            "main",
+            "origin/main",
+            &stats,
+            false,
+            Duration::from_secs(1),
+            None,
+        );
+        let json_str = emit(&output);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+
+        // Plan-only fields must be absent in run mode
+        assert!(
+            parsed.get("merged_candidates").is_none(),
+            "merged_candidates must be absent in run mode"
+        );
+        assert!(
+            parsed.get("would_stash").is_none(),
+            "would_stash must be absent in run mode"
+        );
+        assert!(
+            parsed.get("branches_to_restack").is_none(),
+            "branches_to_restack must be absent in run mode"
+        );
+    }
+}

--- a/src/commands/sync_plan.rs
+++ b/src/commands/sync_plan.rs
@@ -27,6 +27,7 @@ pub struct SyncPlanOptions {
     pub quiet: bool,
     pub verbose: bool,
     pub auto_stash_pop: bool,
+    pub json: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -308,13 +309,20 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
         delete_upstream_gone,
         force,
         safe,
-        quiet,
+        mut quiet,
         verbose,
         auto_stash_pop,
+        json,
     } = options;
+
+    // --json suppresses all human stdout (machine-readable output replaces it)
+    if json {
+        quiet = true;
+    }
 
     let repo = GitRepo::open()?;
     let workdir = repo.workdir()?.to_path_buf();
+    let sync_started_at = std::time::Instant::now();
     let config = Config::load()?;
     let remote_name = config.remote_name().to_string();
     let trunk = repo.trunk_branch()?;
@@ -433,6 +441,18 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
         );
     }
 
+    // Accumulator for JSON plan output (populated always; consumed only when json=true).
+    let mut plan_data = crate::commands::sync_json::SyncPlanData {
+        merged_candidates: Vec::new(),
+        partially_merged: Vec::new(),
+        upstream_gone_protected: Vec::new(),
+        upstream_gone_deletable: Vec::new(),
+        frozen_branches: Vec::new(),
+        branches_to_restack: Vec::new(),
+        predicted_conflicts: Vec::new(),
+        would_stash: dirty,
+    };
+
     // --- Dirty tree section ---
     if dirty && !quiet {
         println!();
@@ -471,6 +491,23 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
             &merged,
         )?;
 
+        // Collect partially_merged for JSON (always, outside !quiet gate).
+        for note in &partially_merged_notes {
+            let reason = match note.pr_label {
+                PartialMergeReason::PrMerged => "pr_merged",
+                PartialMergeReason::PrClosed => "pr_closed",
+                PartialMergeReason::HistoryMerged => "history_merged",
+            };
+            plan_data
+                .partially_merged
+                .push(crate::commands::sync_json::PartiallyMergedJson {
+                    name: note.branch.clone(),
+                    reason,
+                    pr_number: note.pr_number,
+                    extra_commits: note.extra_commits,
+                });
+        }
+
         if merged.is_empty() {
             if !quiet {
                 println!("  {}", "No merged branches detected.".dimmed());
@@ -481,20 +518,35 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
 
             if !quiet {
                 print_cleanup_candidates("merged", &merged_names);
+            }
 
-                for merged_info in &merged {
-                    let branch = &merged_info.branch;
-                    let is_current = *branch == current;
-                    let blocking =
-                        plan_blocking_worktree_cleanup(&repo, branch, force).unwrap_or(None);
-                    let (fallback_parent, _) = resolve_fallback_parent_skipping_doomed(
-                        &workdir,
-                        &stack,
-                        branch,
-                        &merged_names,
-                    );
-                    let parent_exists = local_branch_exists(&workdir, &fallback_parent);
+            // Collect disposition + render per branch (always collect; render only when !quiet).
+            for merged_info in &merged {
+                let branch = &merged_info.branch;
+                let is_current = *branch == current;
+                let blocking = plan_blocking_worktree_cleanup(&repo, branch, force).unwrap_or(None);
+                let (fallback_parent, _) = resolve_fallback_parent_skipping_doomed(
+                    &workdir,
+                    &stack,
+                    branch,
+                    &merged_names,
+                );
+                let parent_exists = local_branch_exists(&workdir, &fallback_parent);
 
+                // Always collect for JSON.
+                plan_data.merged_candidates.push(classify_merged_candidate(
+                    branch,
+                    merged_info,
+                    blocking.as_ref(),
+                    &fallback_parent,
+                    parent_exists,
+                    force,
+                    &stack,
+                    &exempt_imported,
+                    &remote_branch_set,
+                ));
+
+                if !quiet {
                     render_merged_branch_plan(
                         branch,
                         merged_info,
@@ -582,14 +634,31 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
                 }
             }
 
-            if !protected.is_empty() && !quiet {
-                for b in &protected {
-                    println!(
-                        "  {} {} {}",
-                        "↷".yellow(),
-                        b.cyan(),
-                        "(upstream-gone; protected — has unique commits)".dimmed()
-                    );
+            // Collect for JSON (always, before the rendering blocks).
+            plan_data.upstream_gone_protected = protected.clone();
+            for b in &deletable {
+                plan_data.upstream_gone_deletable.push(
+                    crate::commands::sync_json::UpstreamGoneDeleteJson {
+                        name: b.clone(),
+                        disposition: if force {
+                            "would_delete"
+                        } else {
+                            "would_prompt_then_delete"
+                        },
+                    },
+                );
+            }
+
+            if !protected.is_empty() {
+                if !quiet {
+                    for b in &protected {
+                        println!(
+                            "  {} {} {}",
+                            "↷".yellow(),
+                            b.cyan(),
+                            "(upstream-gone; protected — has unique commits)".dimmed()
+                        );
+                    }
                 }
                 gone_protected_count = protected.len();
             }
@@ -651,6 +720,9 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
             .cloned()
             .collect();
 
+        // Always collect frozen branches for JSON.
+        plan_data.frozen_branches = frozen_branches.clone();
+
         if !frozen_branches.is_empty() && !quiet {
             println!(
                 "  {} Skipping frozen {}: {}",
@@ -691,20 +763,35 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
         } else {
             restack_count = branches_to_restack.len();
 
+            // Always collect restack data for JSON.
+            plan_data.branches_to_restack = branches_to_restack.clone();
+
+            let branch_parent_pairs: Vec<(String, String)> = branches_to_restack
+                .iter()
+                .filter_map(|branch| {
+                    stack
+                        .branches
+                        .get(branch.as_str())
+                        .and_then(|br| br.parent.clone().map(|p| (branch.clone(), p)))
+                })
+                .collect();
+
+            // Conflict prediction runs always (for JSON accumulation); spinner only when !quiet.
+            let timer = LiveTimer::maybe_new(!quiet, "Checking for conflicts...");
+            let predictions = repo.predict_restack_conflicts(&branch_parent_pairs);
+
+            // Always collect predicted conflicts for JSON.
+            for prediction in &predictions {
+                plan_data.predicted_conflicts.push(
+                    crate::commands::sync_json::PredictedConflictJson {
+                        branch: prediction.branch.clone(),
+                        onto: prediction.onto.clone(),
+                        files: prediction.conflicting_files.clone(),
+                    },
+                );
+            }
+
             if !quiet {
-                let branch_parent_pairs: Vec<(String, String)> = branches_to_restack
-                    .iter()
-                    .filter_map(|branch| {
-                        stack
-                            .branches
-                            .get(branch.as_str())
-                            .and_then(|br| br.parent.clone().map(|p| (branch.clone(), p)))
-                    })
-                    .collect();
-
-                let timer = LiveTimer::maybe_new(!quiet, "Checking for conflicts...");
-                let predictions = repo.predict_restack_conflicts(&branch_parent_pairs);
-
                 if predictions.is_empty() {
                     LiveTimer::maybe_finish_ok(timer, "no conflicts predicted");
                 } else {
@@ -764,6 +851,18 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
             "Plan complete — no changes made.".green().bold(),
             format!("({})", summary).dimmed()
         );
+    }
+
+    if json {
+        let duration = sync_started_at.elapsed();
+        let output = crate::commands::sync_json::build_plan(
+            &trunk,
+            &remote_trunk_ref,
+            &trunk_plan,
+            plan_data,
+            duration,
+        );
+        println!("{}", crate::commands::sync_json::emit(&output));
     }
 
     Ok(())
@@ -869,6 +968,82 @@ fn render_merged_branch_plan(
             branch.bright_black(),
             format!(" — would prompt, then delete{} if confirmed", scope_suffix).dimmed()
         );
+    }
+}
+
+/// Classify a merged branch's dry-run disposition for JSON output.
+/// Mirrors the decision tree in `render_merged_branch_plan` without producing any output.
+#[allow(clippy::too_many_arguments)]
+fn classify_merged_candidate(
+    branch: &str,
+    merged_info: &MergedBranchInfo,
+    blocking: Option<&BlockingWorktreeCleanup>,
+    fallback_parent: &str,
+    parent_exists: bool,
+    force: bool,
+    stack: &Stack,
+    exempt_imported: &HashSet<String>,
+    remote_branches: &HashSet<String>,
+) -> crate::commands::sync_json::MergedCandidateJson {
+    use crate::commands::sync_json::MergedCandidateJson;
+
+    if let Some(blocker) = blocking
+        && let Some(reason) = blocker.blocker_summary()
+    {
+        return MergedCandidateJson {
+            name: branch.to_string(),
+            disposition: "would_keep_worktree",
+            scope: None,
+            keep_reason: Some(reason),
+            children: vec![],
+        };
+    }
+
+    if !parent_exists && fallback_parent != stack.trunk {
+        return MergedCandidateJson {
+            name: branch.to_string(),
+            disposition: "would_skip",
+            scope: None,
+            keep_reason: Some(format!("parent '{}' not found locally", fallback_parent)),
+            children: vec![],
+        };
+    }
+
+    if matches!(merged_info.merge_type, MergeType::SquashMerge) {
+        let children: Vec<String> = stack
+            .branches
+            .values()
+            .filter(|info| info.parent.as_deref() == Some(branch))
+            .map(|info| info.name.clone())
+            .collect();
+        if !children.is_empty() {
+            return MergedCandidateJson {
+                name: branch.to_string(),
+                disposition: "would_rebase_children",
+                scope: None,
+                keep_reason: None,
+                children,
+            };
+        }
+    }
+
+    let remote_still_exists = remote_branches.contains(branch);
+    let scope = if exempt_imported.contains(branch) || remote_still_exists {
+        Some("local")
+    } else {
+        Some("both")
+    };
+
+    MergedCandidateJson {
+        name: branch.to_string(),
+        disposition: if force {
+            "would_delete"
+        } else {
+            "would_prompt_then_delete"
+        },
+        scope,
+        keep_reason: None,
+        children: vec![],
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -120,3 +120,21 @@ impl std::fmt::Display for SilentExit {
 }
 
 impl std::error::Error for SilentExit {}
+
+/// Sentinel error returned when sync detects a dirty working tree and cannot
+/// proceed (quiet/json mode — no prompt available). The Display text is
+/// byte-identical to the historic `bail!` message so the JSON `error.message`
+/// field stays stable.
+#[derive(Debug)]
+pub struct DirtyWorkingTree;
+
+impl std::fmt::Display for DirtyWorkingTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Working tree is dirty. Please stash or commit changes first."
+        )
+    }
+}
+
+impl std::error::Error for DirtyWorkingTree {}

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -128,6 +128,8 @@ mod submit_pr_base_tests;
 mod sweep_tests;
 #[path = "sync_dry_run_tests.rs"]
 mod sync_dry_run_tests;
+#[path = "sync_json_tests.rs"]
+mod sync_json_tests;
 #[path = "sync_undo_tests.rs"]
 mod sync_undo_tests;
 #[path = "track_all_prs_tests.rs"]

--- a/tests/sync_json_tests.rs
+++ b/tests/sync_json_tests.rs
@@ -1,0 +1,364 @@
+use crate::common::TestRepo;
+
+/// Helper: resolve a local ref to its SHA (None if ref doesn't exist).
+fn resolve_ref(repo: &TestRepo, refname: &str) -> Option<String> {
+    let out = repo.git(&["rev-parse", "--verify", refname]);
+    if out.status.success() {
+        Some(TestRepo::stdout(&out).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Helper: return true if the local branch exists.
+fn branch_exists(repo: &TestRepo, branch: &str) -> bool {
+    resolve_ref(repo, &format!("refs/heads/{branch}")).is_some()
+}
+
+/// Helper: count stax receipts so we can assert that --dry-run writes none.
+fn receipt_count(repo: &TestRepo) -> usize {
+    let ops_dir = repo.path().join(".git/stax/ops");
+    if !ops_dir.exists() {
+        return 0;
+    }
+    std::fs::read_dir(&ops_dir)
+        .expect("read ops dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "json")
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+// ─── Test (a): --json --force deletes the merged branch ──────────────────────
+// --json --force runs sync non-interactively; deleted_branches has the entry
+// with tip and scope set.
+
+#[test]
+fn json_force_deletes_merged_branch_and_emits_deleted_entry() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-json-a"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature-json-a.txt", "content");
+    repo.commit("Feature-a commit");
+    repo.git(&["push", "-u", "origin", &feature]);
+
+    repo.run_stax(&["t"]);
+    repo.merge_branch_on_remote(&feature);
+    repo.git(&["pull", "origin", "main"]);
+
+    let out = repo.run_stax(&["sync", "--json", "--force"]);
+    assert!(
+        out.status.success(),
+        "sync --json --force should exit 0 when successful; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["schema_version"], 1);
+    assert_eq!(parsed["kind"], "sync");
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["dry_run"], false);
+
+    let deleted = parsed["deleted_branches"]
+        .as_array()
+        .unwrap_or_else(|| panic!("deleted_branches missing or not an array; got:\n{parsed}"));
+    let names: Vec<&str> = deleted.iter().filter_map(|d| d["name"].as_str()).collect();
+    assert!(
+        names.contains(&feature.as_str()),
+        "deleted_branches should contain {feature}; got: {names:?}"
+    );
+
+    let entry = deleted
+        .iter()
+        .find(|d| d["name"] == feature.as_str())
+        .unwrap();
+    // category must be "merged", scope must be "both" or "local"
+    let category = entry["category"].as_str().unwrap_or("");
+    assert!(
+        category == "merged" || category == "upstream_gone",
+        "unexpected category: {category}"
+    );
+    // tip must be a 40-char SHA or at least a non-empty string
+    let tip = entry["tip"].as_str().unwrap_or("");
+    assert!(!tip.is_empty(), "tip should be set on a deleted branch");
+
+    assert!(
+        !branch_exists(&repo, &feature),
+        "branch {feature} should be deleted after sync --json --force"
+    );
+}
+
+// ─── Test (a2): --json alone skips deletions that need confirmation ───────────
+// --json without --force forces quiet=true (non-interactive); branches that
+// would need a prompt are recorded in skipped_branches and survive.
+
+#[test]
+fn json_without_force_skips_branch_deletion() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "feature-json-a2"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature-json-a2.txt", "content");
+    repo.commit("Feature-a2 commit");
+    repo.git(&["push", "-u", "origin", &feature]);
+
+    repo.run_stax(&["t"]);
+    repo.merge_branch_on_remote(&feature);
+    repo.git(&["pull", "origin", "main"]);
+
+    let out = repo.run_stax(&["sync", "--json"]);
+    assert!(
+        out.status.success(),
+        "sync --json (no --force) should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["success"], true);
+
+    // In non-force mode, the merged branch should appear in skipped_branches
+    // (because interactive confirmation is suppressed by quiet=true).
+    // The branch should still exist locally.
+    assert!(
+        branch_exists(&repo, &feature),
+        "branch {feature} should survive when --force is not provided"
+    );
+
+    // The branch must appear in skipped_branches with reason "not confirmed".
+    let skipped = parsed["skipped_branches"].as_array().unwrap_or_else(|| {
+        panic!("skipped_branches missing or not an array; parsed JSON:\n{parsed}")
+    });
+    let branch_skipped = skipped
+        .iter()
+        .any(|s| s["name"].as_str() == Some(feature.as_str()));
+    assert!(
+        branch_skipped,
+        "merged branch {feature} should appear in skipped_branches; got: {skipped:?}"
+    );
+    let skip_entry = skipped
+        .iter()
+        .find(|s| s["name"].as_str() == Some(feature.as_str()))
+        .unwrap();
+    assert_eq!(
+        skip_entry["reason"].as_str().unwrap_or(""),
+        "not confirmed",
+        "skipped_branches reason should be 'not confirmed'"
+    );
+}
+
+// ─── Test (b): --json produces exactly one JSON document, no human lines ──────
+
+#[test]
+fn json_output_is_single_valid_json_document_no_human_lines() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    let out = repo.run_stax(&["sync", "--json", "--force"]);
+    assert!(
+        out.status.success(),
+        "sync --json should exit 0 on clean repo; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stdout = TestRepo::stdout(&out);
+
+    // Must parse as a single JSON object (not an array, not multiple docs)
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert!(
+        parsed.is_object(),
+        "output must be a JSON object, got: {parsed}"
+    );
+
+    // No human-readable prefix lines before the JSON
+    let first_non_empty = stdout.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+    assert!(
+        first_non_empty.starts_with('{'),
+        "first non-empty stdout line must be the JSON opening brace; got: {first_non_empty:?}"
+    );
+
+    // Required top-level fields
+    assert_eq!(parsed["schema_version"], 1);
+    assert_eq!(parsed["kind"], "sync");
+    assert!(parsed["duration_ms"].is_number());
+    assert!(parsed["trunk"].is_object());
+    assert!(parsed["stash"].is_object());
+}
+
+// ─── Test (c): --dry-run --json emits kind=sync_plan, dry_run=true, exit 0, no receipt ──
+
+#[test]
+fn dry_run_json_emits_sync_plan_kind_and_no_receipt() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    let pre_receipts = receipt_count(&repo);
+
+    let out = repo.run_stax(&["sync", "--dry-run", "--json"]);
+    assert!(
+        out.status.success(),
+        "sync --dry-run --json should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["kind"], "sync_plan");
+    assert_eq!(parsed["dry_run"], true);
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["schema_version"], 1);
+    assert!(parsed["trunk"].is_object());
+    assert!(parsed["duration_ms"].is_number());
+
+    assert_eq!(
+        receipt_count(&repo),
+        pre_receipts,
+        "--dry-run --json must write no receipt"
+    );
+}
+
+// ─── Test (d): dirty tree with --json → success=false, kind=dirty_working_tree, non-zero exit ──
+
+#[test]
+fn json_dirty_tree_emits_error_envelope_and_exits_nonzero() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    // Create an uncommitted modification so the tree is dirty
+    repo.create_file("dirty.txt", "unstaged change");
+
+    let out = repo.run_stax(&["sync", "--json"]);
+    assert!(
+        !out.status.success(),
+        "sync --json with dirty tree should exit non-zero; exit: {:?}",
+        out.status.code()
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_object(),
+        "error field must be present on failure"
+    );
+    assert_eq!(parsed["error"]["kind"], "dirty_working_tree");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("dirty"),
+        "error message must mention 'dirty'"
+    );
+
+    // stderr must be empty (no duplicated "Error:" line from anyhow propagation)
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.is_empty(),
+        "stderr should be empty for --json dirty-tree error (no duplicated Error: line); got: {stderr:?}"
+    );
+
+    // exit code must be exactly 1
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "exit code for dirty-tree --json must be 1; got: {:?}",
+        out.status.code()
+    );
+
+    // The dirty file should be untouched
+    assert!(
+        repo.path().join("dirty.txt").exists(),
+        "dirty file must still exist after failed --json sync"
+    );
+}
+
+// ─── Test (c2): --dry-run --json includes merged_candidates with disposition ──
+
+#[test]
+fn dry_run_json_includes_merged_candidate_with_disposition() {
+    let repo = TestRepo::new_with_remote();
+
+    // Create a branch, push it, merge it on remote, then pull to advance local trunk.
+    repo.run_stax(&["bc", "feature-dry-plan"]);
+    let feature = repo.current_branch();
+    repo.create_file("feature-dry-plan.txt", "content");
+    repo.commit("Feature commit for dry-run JSON plan test");
+    repo.git(&["push", "-u", "origin", &feature]);
+
+    repo.run_stax(&["t"]);
+    repo.merge_branch_on_remote(&feature);
+    repo.git(&["pull", "origin", "main"]);
+
+    // feature is still a local branch but its remote has been merged into trunk.
+    let out = repo.run_stax(&["sync", "--dry-run", "--json"]);
+    assert!(
+        out.status.success(),
+        "sync --dry-run --json should exit 0 even with merged candidates; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["kind"], "sync_plan");
+    assert_eq!(parsed["dry_run"], true);
+
+    // merged_candidates must be non-empty and contain the feature branch.
+    let candidates = parsed["merged_candidates"]
+        .as_array()
+        .unwrap_or_else(|| panic!("merged_candidates missing or not an array; got:\n{parsed}"));
+    assert!(
+        !candidates.is_empty(),
+        "merged_candidates should be non-empty; got:\n{parsed}"
+    );
+
+    let entry = candidates
+        .iter()
+        .find(|c| c["name"].as_str() == Some(feature.as_str()))
+        .unwrap_or_else(|| {
+            panic!("merged_candidates should contain '{feature}'; got: {candidates:?}")
+        });
+
+    let disposition = entry["disposition"].as_str().unwrap_or("");
+    assert!(
+        matches!(disposition, "would_delete" | "would_prompt_then_delete"),
+        "disposition should be would_delete or would_prompt_then_delete; got: {disposition}"
+    );
+}
+
+// ─── Test (e): --json --continue is rejected by clap ──────────────────────────
+
+#[test]
+fn json_and_continue_are_mutually_exclusive() {
+    let repo = TestRepo::new_with_remote();
+
+    let out = repo.run_stax(&["sync", "--json", "--continue"]);
+    assert!(
+        !out.status.success(),
+        "--json and --continue should be rejected with a non-zero exit"
+    );
+
+    // clap prints an error to stderr for conflicting args
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflict"),
+        "should report a conflict between --json and --continue; stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds **`stax sync --json`**: single JSON document on stdout (`kind: "sync"`, `schema_version: 1`). Implies non-interactive (`quiet`); does **not** imply `--force` (branches needing confirmation go to `skipped_branches`). **`--dry-run --json`** emits `kind: "sync_plan"`. Failures still emit JSON + non-zero exit.

## Test plan

- [x] `tests/sync_json_tests.rs`
- [x] `make test`