### PR TITLE
feat(sync): add --stash/--no-stash, actionable dirty-tree error, deprecate --prune

### DIFF
--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -58,6 +58,8 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 | `st rs` | Pull trunk, clean merged branches, reparent children — undoable via `st undo` |
 | `st rs --restack` | `rs` **plus** rebase the current stack onto updated trunk |
 | `st rs --delete-upstream-gone` | Also delete local branches whose upstream is gone |
+| `st rs --stash` | Stash the current working tree before sync starts, without prompting; works with `--quiet`/`--json`; does NOT auto-confirm branch deletions |
+| `st rs --no-stash` | Fail on a dirty working tree; overrides `--force`; conflicts with `--stash` at parse time |
 | `st rs --dry-run` / `st rs --plan` | Preview what sync would do — no fetch, no stash, no ref writes (read-only) |
 | `st rs --dry-run --json` | Same as `--dry-run` but emits a single JSON document (`kind: "sync_plan"`) instead of human text |
 | `st rs --json` | Run sync and emit the result as a versioned JSON document (`kind: "sync"`, schema version 1); implies non-interactive; failures still emit JSON and exit non-zero |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -27,7 +27,9 @@ st --trace status --json >/dev/null
 | `st sync` | `rs` | Pull trunk, delete merged branches (incl. squash merges), reparent children |
 | `st sync --restack` | `rs --restack` | `sync` **plus** rebase current stack onto updated parents |
 | `st sync --delete-upstream-gone` | | Also delete local branches whose upstream tracking ref is gone |
-| `st sync --dry-run` / `st sync --plan` | | Preview what sync would do — ls-remote only, no fetch/stash/ref-writes/push/metadata writes; always exits 0; composes with `--restack`, `--delete-upstream-gone`, `--safe`; `--force`, `--auto-stash-pop`, `--full`, and `--verbose` emit a warning and are otherwise ignored; `--continue` is rejected |
+| `st sync --stash` | `rs --stash` | Stash the current working tree before sync starts without prompting; works with `--quiet` and `--json`; does NOT auto-confirm branch deletions; conflicts with `--no-stash` at parse time |
+| `st sync --no-stash` | `rs --no-stash` | Fail if the working tree is dirty; overrides `--force`; conflicts with `--stash` at parse time |
+| `st sync --dry-run` / `st sync --plan` | | Preview what sync would do — ls-remote only, no fetch/stash/ref-writes/push/metadata writes; always exits 0; composes with `--restack`, `--delete-upstream-gone`, `--safe`; `--force`, `--auto-stash-pop`, `--full`, `--stash`, `--no-stash`, and `--verbose` emit a warning and are otherwise ignored; `--continue` is rejected |
 | `st sync --dry-run --json` | | Same as `--dry-run` but emits a single JSON document (`kind: "sync_plan"`, `schema_version: 1`, `dry_run: true`) instead of human text |
 | `st sync --json` | | Emit the sync result as a single JSON document (`kind: "sync"`, `schema_version: 1`); implies non-interactive; failures emit JSON + non-zero exit; conflicts with `--continue` |
 | `st sweep` | | Classify all local branches as merged / upstream-gone / stale / active (read-only by default) |
@@ -315,7 +317,9 @@ st completions elvish
 - `--restack` · `--restack --auto-stash-pop`
 - `--delete-upstream-gone`
 - `--force` / `--safe` / `--continue` / `--quiet` / `--verbose`
-- `--dry-run` (alias `--plan`) — read-only preview: probes the remote with ls-remote (no fetch, no FETCH_HEAD write), patches PR states in-memory, classifies the trunk transition, reports merged/upstream-gone candidates and per-branch disposition, previews the restack scope with conflict predictions; always exits 0. `--force`, `--auto-stash-pop`, `--full`, and `--verbose` are accepted but ignored (stderr warning emitted for each). `--continue` conflicts and is rejected by clap.
+- `--stash` / `--no-stash` — dirty-tree handling before sync starts: `--stash` auto-stashes without prompting (works with `--quiet`/`--json`; does NOT auto-confirm branch deletions); `--no-stash` fails on a dirty tree and overrides `--force`; the two conflict at parse time; the dirty-tree error message names `--stash`. In dry-run mode both flags are accepted but ignored (stderr warning emitted).
+- `--prune` — **deprecated**; accepted for compatibility and emits a stderr warning; use `--full` to fetch `--prune` all remote-tracking refs
+- `--dry-run` (alias `--plan`) — read-only preview: probes the remote with ls-remote (no fetch, no FETCH_HEAD write), patches PR states in-memory, classifies the trunk transition, reports merged/upstream-gone candidates and per-branch disposition, previews the restack scope with conflict predictions; always exits 0. `--force`, `--auto-stash-pop`, `--full`, `--stash`, `--no-stash`, and `--verbose` are accepted but ignored (stderr warning emitted for each). `--continue` conflicts and is rejected by clap.
 - `--json` — emit the sync result as a single JSON document on stdout (schema version 1). Implies non-interactive (`quiet=true`); does **not** imply `--force` (branches that need confirmation are recorded in `skipped_branches` and left intact). Conflicts with `--continue` (rejected by clap). Failures still emit the JSON envelope with `success: false` and exit non-zero. `--verbose` is ignored (stderr warning emitted). `--dry-run --json` emits `kind: "sync_plan"` with `dry_run: true` and always exits 0.
 - JSON schema (`kind: "sync"`, `schema_version: 1`; action/kind strings are extensible — consumers should treat unknown values as forwards-compatible additions):
 

--- a/docs/workflows/multi-worktree.md
+++ b/docs/workflows/multi-worktree.md
@@ -28,6 +28,8 @@ st upstack restack --auto-stash-pop
 st sync --restack --auto-stash-pop
 ```
 
+`--stash` and `--no-stash` control the **current** working tree before sync starts, not the linked target worktrees. `--stash` auto-stashes the current tree without prompting (works with `--quiet`/`--json`; does NOT auto-confirm branch deletions); `--no-stash` makes sync fail immediately on a dirty current tree, overriding `--force`. In contrast, `--auto-stash-pop` acts during the restack phase on each **linked target** worktree as branches are rebased. The two mechanisms are orthogonal: you can combine `--stash --restack --auto-stash-pop` to handle both the current tree and any linked worktrees in a single `st rs` invocation.
+
 If a conflict occurs, the stash entry is preserved so nothing is lost. When `st sync` auto-stashes your working tree and fails on an unrecoverable error path (for example, when restoring the stash itself conflicts with an updated trunk), it prints a warning to stderr naming the stash "stax auto-stash" with instructions to run `git stash pop` to restore your changes.
 
 ## Related

--- a/skills.md
+++ b/skills.md
@@ -314,10 +314,12 @@ stax sync --json --force           # Same as --json but also auto-confirms branc
 stax sync --continue               # Continue after resolved sync conflicts
 stax sync --safe                   # Avoid hard reset on trunk update
 stax sync --force                  # Force sync without prompts; preserve linked worktrees during cleanup
-stax sync --prune                  # No-op: kept for CLI compatibility (use --full to fetch --prune all remote-tracking refs)
+stax sync --prune                  # Deprecated: accepted for compatibility, emits a stderr warning; use --full instead
 stax sync --full                   # Fetch all remote branches with --prune (slower; default is trunk-only fetch + ls-remote)
 stax sync --no-delete              # Keep merged branches
-stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
+stax sync --auto-stash-pop         # Stash/pop dirty target worktrees during the restack phase
+stax sync --stash                  # Stash the current working tree before sync starts without prompting; works with --quiet/--json; does NOT auto-confirm branch deletions; conflicts with --no-stash at parse time
+stax sync --no-stash               # Fail on a dirty working tree; overrides --force; conflicts with --stash at parse time
 # sync cleanup switches/detaches linked worktrees before deleting merged/gone branches; interactive removal remains explicit.
 # Imported support branches may still be deleted locally after merge/gone, but their remotes are never push-deleted.
 # The sync footer reports trunk commits/files/line changes plus non-zero cleanup/imported/restack counts.
@@ -326,7 +328,7 @@ stax sync --auto-stash-pop         # Stash/pop dirty target worktrees
 # Deletion lines for locally deleted branches (merged or upstream-gone) show the branch tip SHA (7 chars, dimmed) for traceability.
 # If sync auto-stashed your working tree and fails on an error path that cannot restore it, stderr names the stash ("stax auto-stash") with instructions to run `git stash pop`.
 # sync is transactional: trunk fast-forwards, merged/gone branch deletions, reparented-child metadata, and the optional restack phase are all covered by one receipt. A no-op sync writes no receipt so the previous undoable operation remains on the undo stack. Recover any sync run with `stax undo`.
-# --json scripting entry points: stax sync --json --force (delete all merged); stax sync --json (skip deletions needing confirmation); stax sync --dry-run --json (read-only plan); dirty tree → success:false, error.kind:dirty_working_tree, non-zero exit; --json conflicts with --continue.
+# --json scripting entry points: stax sync --json --force (delete all merged); stax sync --json (skip deletions needing confirmation); stax sync --dry-run --json (read-only plan); dirty tree → success:false, error.kind:dirty_working_tree, non-zero exit; error message names --stash; stax sync --json --stash succeeds on a dirty tree (stashes before sync, restores after); --json conflicts with --continue.
 # trunk.action values: up_to_date · fast_forwarded · reset · diverged · failed · unknown. On early-bail paths (dirty tree, non-interactive) trunk.action is "unknown" because finalize never runs — intended.
 
 stax sweep                         # Classify ALL local branches (merged/gone/stale/active) — read-only

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -428,7 +428,7 @@ pub(crate) enum Commands {
         /// Also restack branches after syncing
         #[arg(short, long)]
         restack: bool,
-        /// No-op: kept for CLI compatibility (use `--full` for fetch --prune of all remote-tracking refs)
+        /// Deprecated no-op, accepted for compatibility (use `--full` for fetch --prune of all remote-tracking refs)
         #[arg(long)]
         prune: bool,
         /// Fetch all remote branches with `--prune` (slower; default is trunk-only fetch + ls-remote)
@@ -458,6 +458,12 @@ pub(crate) enum Commands {
         /// Auto-stash and auto-pop dirty target worktrees during restack operations
         #[arg(long)]
         auto_stash_pop: bool,
+        /// Automatically stash uncommitted changes before sync and restore them after
+        #[arg(long, conflicts_with = "no_stash")]
+        stash: bool,
+        /// Never stash uncommitted changes; bail if the working tree is dirty (wins over --force)
+        #[arg(long, conflicts_with = "stash")]
+        no_stash: bool,
         /// Output the sync result as JSON (implies non-interactive; exits non-zero on failure)
         #[arg(long, conflicts_with = "continue")]
         json: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -330,9 +330,15 @@ pub fn run() -> Result<()> {
             quiet,
             verbose,
             auto_stash_pop,
+            stash,
+            no_stash,
             dry_run,
             json,
         } => {
+            if prune {
+                eprintln!("{}", commands::sync::prune_deprecation_warning());
+            }
+            let stash_policy = commands::sync::StashPolicy::from_flags(stash, no_stash);
             if dry_run {
                 commands::sync_plan::run(commands::sync_plan::SyncPlanOptions {
                     restack,
@@ -344,12 +350,12 @@ pub fn run() -> Result<()> {
                     quiet,
                     verbose,
                     auto_stash_pop,
+                    stash_policy,
                     json,
                 })
             } else {
                 commands::sync::run(
                     restack,
-                    prune,
                     full,
                     !no_delete,
                     delete_upstream_gone,
@@ -359,6 +365,7 @@ pub fn run() -> Result<()> {
                     quiet,
                     verbose,
                     auto_stash_pop,
+                    stash_policy,
                     json,
                     &[],
                 )

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -48,16 +48,16 @@ pub fn run(options: GetOptions) -> Result<()> {
     let Some(requested) = options.branch.as_deref() else {
         return crate::commands::sync::run(
             !options.no_restack,
-            false,
-            false,
-            true,
-            false,
+            false, // full
+            true,  // delete_merged
+            false, // delete_upstream_gone
             options.force,
-            false,
-            false,
-            false,
-            false,
-            false,
+            false, // safe
+            false, // continue
+            false, // quiet
+            false, // verbose
+            false, // auto_stash_pop
+            crate::commands::sync::StashPolicy::Prompt,
             false, // json
             &[],
         );

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -507,7 +507,6 @@ pub fn run(
 
             if let Err(err) = crate::commands::sync::run(
                 false,      // restack
-                false,      // prune
                 false,      // full (fast trunk + ls-remote when deleting merged)
                 !no_delete, // delete merged branches unless explicitly kept
                 false,      // delete upstream-gone branches
@@ -517,6 +516,7 @@ pub fn run(
                 quiet,
                 false, // verbose
                 false, // auto_stash_pop
+                crate::commands::sync::StashPolicy::Prompt,
                 false, // json
                 &[],
             ) && !quiet

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -494,7 +494,6 @@ pub fn run(
 
         if let Err(err) = crate::commands::sync::run(
             false, // restack
-            false, // prune
             false, // full
             true,  // delete merged branches
             false, // delete upstream-gone
@@ -504,6 +503,7 @@ pub fn run(
             quiet,
             false, // verbose
             false, // auto_stash_pop
+            crate::commands::sync::StashPolicy::Prompt,
             false, // json
             &[],
         ) && !quiet

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -1037,7 +1037,6 @@ fn run_post_merge_sync(quiet: bool) {
 
     if let Err(err) = crate::commands::sync::run(
         false, // restack
-        false, // prune
         false, // full
         false, // keep branch cleanup scoped to this stack merge
         false, // delete upstream-gone branches
@@ -1047,6 +1046,7 @@ fn run_post_merge_sync(quiet: bool) {
         quiet,
         false, // verbose
         false, // auto_stash_pop
+        crate::commands::sync::StashPolicy::Prompt,
         false, // json
         &[],
     ) && !quiet

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -625,7 +625,6 @@ pub fn run(
 
             if let Err(err) = crate::commands::sync::run(
                 false,      // restack
-                false,      // prune
                 false,      // full (fast trunk + ls-remote when deleting merged)
                 !no_delete, // delete merged branches unless explicitly kept
                 false,      // delete upstream-gone branches
@@ -635,6 +634,7 @@ pub fn run(
                 quiet,
                 false, // verbose
                 false, // auto_stash_pop
+                crate::commands::sync::StashPolicy::Prompt,
                 false, // json
                 &[],
             ) && !quiet

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -46,7 +46,6 @@ pub fn run(
 
     commands::sync::run(
         true,  // restack
-        false, // prune
         false, // full
         false, // delete_merged
         false, // delete_upstream_gone
@@ -56,6 +55,7 @@ pub fn run(
         false, // quiet
         verbose,
         auto_stash_pop,
+        commands::sync::StashPolicy::Prompt,
         false, // json
         &submit_fetch_refs,
     )?;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -197,6 +197,36 @@ enum SyncFlow {
     Stop,
 }
 
+/// Controls how sync handles a dirty working tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StashPolicy {
+    /// Prompt the user (default). In quiet/json mode, bail.
+    Prompt,
+    /// Stash automatically without prompting (--stash).
+    Always,
+    /// Never stash; bail if dirty (--no-stash). Wins over --force.
+    Never,
+}
+
+impl StashPolicy {
+    pub(crate) fn from_flags(stash: bool, no_stash: bool) -> Self {
+        if no_stash {
+            StashPolicy::Never
+        } else if stash {
+            StashPolicy::Always
+        } else {
+            StashPolicy::Prompt
+        }
+    }
+}
+
+pub(crate) fn prune_deprecation_warning() -> String {
+    format!(
+        "{}",
+        "warning: --prune is deprecated and has no effect. Use --full for fetch --prune of all remote-tracking refs.".yellow()
+    )
+}
+
 struct StashGuard {
     armed: bool,
 }
@@ -257,6 +287,7 @@ struct SyncContext {
     quiet: bool,
     verbose: bool,
     auto_stash_pop: bool,
+    stash_policy: StashPolicy,
     json: bool,
     auto_confirm: bool,
     sync_extra_fetch_refs: Vec<String>,
@@ -294,6 +325,7 @@ impl SyncContext {
         quiet: bool,
         verbose: bool,
         auto_stash_pop: bool,
+        stash_policy: StashPolicy,
         json: bool,
         extra_fetch_refs: &[String],
     ) -> Result<(Self, GitRepo)> {
@@ -333,6 +365,7 @@ impl SyncContext {
                 quiet: effective_quiet,
                 verbose,
                 auto_stash_pop,
+                stash_policy,
                 json,
                 auto_confirm,
                 sync_extra_fetch_refs,
@@ -360,36 +393,58 @@ impl SyncContext {
 
     fn handle_dirty_tree(&mut self, repo: &GitRepo) -> Result<SyncFlow> {
         if repo.is_dirty()? {
-            if self.quiet {
-                return Err(DirtyWorkingTree.into());
-            }
+            match self.stash_policy {
+                StashPolicy::Never => {
+                    return Err(DirtyWorkingTree.into());
+                }
+                StashPolicy::Always => {
+                    let stash_started_at = Instant::now();
+                    self.stashed = repo.stash_push()?;
+                    self.auto_stash_pop = true;
+                    if self.stashed {
+                        self.stash_guard.arm();
+                    }
+                    self.step_timings
+                        .push(("stash working tree".to_string(), stash_started_at.elapsed()));
+                    if !self.quiet {
+                        println!("{}", "✓ Stashed working tree changes.".green());
+                    }
+                }
+                StashPolicy::Prompt => {
+                    if self.quiet {
+                        return Err(DirtyWorkingTree.into());
+                    }
 
-            let stash = if self.auto_confirm {
-                true
-            } else {
-                Confirm::with_theme(&ColorfulTheme::default())
-                    .with_prompt("Working tree has uncommitted changes. Stash them before sync?")
-                    .default(true)
-                    .interact()?
-            };
+                    let stash = if self.auto_confirm {
+                        true
+                    } else {
+                        Confirm::with_theme(&ColorfulTheme::default())
+                            .with_prompt(
+                                "Working tree has uncommitted changes. Stash them before sync?",
+                            )
+                            .default(true)
+                            .interact()?
+                    };
 
-            if stash {
-                let stash_started_at = Instant::now();
-                self.stashed = repo.stash_push()?;
-                self.auto_stash_pop = true;
-                if self.stashed {
-                    self.stash_guard.arm();
+                    if stash {
+                        let stash_started_at = Instant::now();
+                        self.stashed = repo.stash_push()?;
+                        self.auto_stash_pop = true;
+                        if self.stashed {
+                            self.stash_guard.arm();
+                        }
+                        self.step_timings
+                            .push(("stash working tree".to_string(), stash_started_at.elapsed()));
+                        if !self.quiet {
+                            println!("{}", "✓ Stashed working tree changes.".green());
+                        }
+                    } else {
+                        if !self.json {
+                            println!("{}", "Aborted.".red());
+                        }
+                        return Ok(SyncFlow::Stop);
+                    }
                 }
-                self.step_timings
-                    .push(("stash working tree".to_string(), stash_started_at.elapsed()));
-                if !self.quiet {
-                    println!("{}", "✓ Stashed working tree changes.".green());
-                }
-            } else {
-                if !self.json {
-                    println!("{}", "Aborted.".red());
-                }
-                return Ok(SyncFlow::Stop);
             }
         }
         Ok(SyncFlow::Continue)
@@ -2289,7 +2344,6 @@ impl SyncContext {
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     restack: bool,
-    #[allow(unused_variables)] prune: bool,
     full: bool,
     delete_merged: bool,
     delete_upstream_gone: bool,
@@ -2299,6 +2353,7 @@ pub fn run(
     quiet: bool,
     verbose: bool,
     auto_stash_pop: bool,
+    stash_policy: StashPolicy,
     json: bool,
     extra_fetch_refs: &[String],
 ) -> Result<()> {
@@ -2314,6 +2369,7 @@ pub fn run(
         quiet,
         verbose,
         auto_stash_pop,
+        stash_policy,
         json,
         extra_fetch_refs,
     )?;
@@ -4489,5 +4545,34 @@ mod tests {
             msg.contains("git stash list"),
             "must tell user how to inspect: {msg}"
         );
+    }
+
+    #[test]
+    fn stash_policy_from_flags_returns_never_when_no_stash() {
+        assert_eq!(StashPolicy::from_flags(false, true), StashPolicy::Never);
+    }
+
+    #[test]
+    fn stash_policy_from_flags_returns_always_when_stash() {
+        assert_eq!(StashPolicy::from_flags(true, false), StashPolicy::Always);
+    }
+
+    #[test]
+    fn stash_policy_from_flags_returns_prompt_when_neither() {
+        assert_eq!(StashPolicy::from_flags(false, false), StashPolicy::Prompt);
+    }
+
+    #[test]
+    fn stash_policy_from_flags_no_stash_takes_precedence() {
+        // clap enforces conflicts_with, but belt-and-suspenders: Never when no_stash=true
+        assert_eq!(StashPolicy::from_flags(false, true), StashPolicy::Never);
+    }
+
+    #[test]
+    fn prune_deprecation_warning_names_both_flags() {
+        colored::control::set_override(false);
+        let msg = prune_deprecation_warning();
+        assert!(msg.contains("--prune"), "must name --prune: {msg}");
+        assert!(msg.contains("--full"), "must name --full: {msg}");
     }
 }

--- a/src/commands/sync_json.rs
+++ b/src/commands/sync_json.rs
@@ -426,7 +426,7 @@ mod tests {
         let stats = make_default_stats();
         let err = ErrorJson {
             kind: "dirty_working_tree",
-            message: "Working tree is dirty. Please stash or commit changes first.".to_string(),
+            message: "Working tree is dirty. Commit or stash your changes, or re-run with --stash to stash them automatically.".to_string(),
         };
         let output = build(
             "main",

--- a/src/commands/sync_plan.rs
+++ b/src/commands/sync_plan.rs
@@ -1,5 +1,5 @@
 use crate::commands::sync::{
-    BlockingWorktreeCleanup, MergeType, MergedBranchInfo, PartialMergeReason,
+    BlockingWorktreeCleanup, MergeType, MergedBranchInfo, PartialMergeReason, StashPolicy,
     count_commits_between, diff_line_stats_between, find_merged_branches,
     find_partially_merged_notes, find_upstream_gone_branches, imported_branches_for_cleanup,
     init_forge_client, is_ancestor, local_branch_exists, plan_blocking_worktree_cleanup,
@@ -27,6 +27,7 @@ pub struct SyncPlanOptions {
     pub quiet: bool,
     pub verbose: bool,
     pub auto_stash_pop: bool,
+    pub stash_policy: StashPolicy,
     pub json: bool,
 }
 
@@ -312,6 +313,7 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
         mut quiet,
         verbose,
         auto_stash_pop,
+        stash_policy,
         json,
     } = options;
 
@@ -351,6 +353,19 @@ pub fn run(options: SyncPlanOptions) -> Result<()> {
         eprintln!(
             "{}",
             "warning: --verbose is ignored by --dry-run (output detail is fixed)".yellow()
+        );
+    }
+    if matches!(stash_policy, StashPolicy::Always) {
+        eprintln!(
+            "{}",
+            "warning: --stash is ignored by --dry-run (no stash operations are performed)".yellow()
+        );
+    }
+    if matches!(stash_policy, StashPolicy::Never) {
+        eprintln!(
+            "{}",
+            "warning: --no-stash is ignored by --dry-run (no stash operations are performed)"
+                .yellow()
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -122,9 +122,8 @@ impl std::fmt::Display for SilentExit {
 impl std::error::Error for SilentExit {}
 
 /// Sentinel error returned when sync detects a dirty working tree and cannot
-/// proceed (quiet/json mode — no prompt available). The Display text is
-/// byte-identical to the historic `bail!` message so the JSON `error.message`
-/// field stays stable.
+/// proceed. The Display text is the stable JSON `error.message` value — type
+/// (`dirty_working_tree`) is the machine-readable contract, not this string.
 #[derive(Debug)]
 pub struct DirtyWorkingTree;
 
@@ -132,7 +131,7 @@ impl std::fmt::Display for DirtyWorkingTree {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Working tree is dirty. Please stash or commit changes first."
+            "Working tree is dirty. Commit or stash your changes, or re-run with --stash to stash them automatically."
         )
     }
 }

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -130,6 +130,8 @@ mod sweep_tests;
 mod sync_dry_run_tests;
 #[path = "sync_json_tests.rs"]
 mod sync_json_tests;
+#[path = "sync_stash_tests.rs"]
+mod sync_stash_tests;
 #[path = "sync_undo_tests.rs"]
 mod sync_undo_tests;
 #[path = "track_all_prs_tests.rs"]

--- a/tests/sync_json_tests.rs
+++ b/tests/sync_json_tests.rs
@@ -265,6 +265,13 @@ fn json_dirty_tree_emits_error_envelope_and_exits_nonzero() {
             .contains("dirty"),
         "error message must mention 'dirty'"
     );
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("--stash"),
+        "error message must mention '--stash' so the user knows how to resolve"
+    );
 
     // stderr must be empty (no duplicated "Error:" line from anyhow propagation)
     let stderr = TestRepo::stderr(&out);

--- a/tests/sync_stash_tests.rs
+++ b/tests/sync_stash_tests.rs
@@ -1,0 +1,264 @@
+use crate::common::TestRepo;
+
+/// Helper: count entries in `git stash list`.
+fn stash_count(repo: &TestRepo) -> usize {
+    let out = repo.git(&["stash", "list"]);
+    TestRepo::stdout(&out)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .count()
+}
+
+// ─── Test 1: --stash auto-stashes a dirty working tree ───────────────────────
+
+#[test]
+fn stash_flag_auto_stashes_dirty_tree_and_syncs() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    // Dirty the working tree without staging
+    repo.create_file("dirty.txt", "unstaged change");
+
+    let before = stash_count(&repo);
+
+    let out = repo.run_stax(&["sync", "--stash", "--force"]);
+    assert!(
+        out.status.success(),
+        "sync --stash should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    // --stash is a stash-then-restore round trip: the stash list returns to
+    // baseline and stdout shows both halves of the trip.
+    assert_eq!(
+        stash_count(&repo),
+        before,
+        "sync --stash must pop its stash on success"
+    );
+    let stdout = TestRepo::stdout(&out);
+    assert!(
+        stdout.contains("Stashed working tree changes."),
+        "expected stash confirmation in stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Restored stashed changes."),
+        "expected stash restore confirmation in stdout: {stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.path().join("dirty.txt")).unwrap(),
+        "unstaged change",
+        "dirty file content must survive the stash round trip"
+    );
+}
+
+// ─── Test 2: --stash works in --quiet mode ────────────────────────────────────
+
+#[test]
+fn stash_flag_works_in_quiet_mode() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    repo.create_file("quiet-dirty.txt", "unstaged change");
+
+    let before = stash_count(&repo);
+
+    let out = repo.run_stax(&["sync", "--stash", "--quiet", "--force"]);
+    assert!(
+        out.status.success(),
+        "sync --stash --quiet should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    // Quiet mode prints nothing; exit 0 alone proves the Always arm ran
+    // (Prompt + --quiet would bail with DirtyWorkingTree and exit 1).
+    assert_eq!(
+        stash_count(&repo),
+        before,
+        "sync --stash --quiet must pop its stash on success"
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.path().join("quiet-dirty.txt")).unwrap(),
+        "unstaged change",
+        "dirty file content must survive the stash round trip"
+    );
+}
+
+// ─── Test 3: --stash with --json shows stash outcome in JSON ─────────────────
+
+#[test]
+fn stash_flag_with_json_reports_stash_outcome() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    repo.create_file("json-dirty.txt", "unstaged change");
+
+    let out = repo.run_stax(&["sync", "--stash", "--json"]);
+    assert!(
+        out.status.success(),
+        "sync --stash --json should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["success"], true);
+    assert_eq!(
+        parsed["stash"]["stashed"], true,
+        "stash.stashed must be true when --stash auto-stashed"
+    );
+}
+
+// ─── Test 4: --no-stash bails even with --force ──────────────────────────────
+
+#[test]
+fn no_stash_bails_even_with_force_flag() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    repo.create_file("force-dirty.txt", "unstaged change");
+
+    let before = stash_count(&repo);
+
+    let out = repo.run_stax(&["sync", "--no-stash", "--force"]);
+    assert!(
+        !out.status.success(),
+        "sync --no-stash --force should exit non-zero when dirty"
+    );
+
+    // Nothing should have been stashed
+    assert_eq!(
+        stash_count(&repo),
+        before,
+        "sync --no-stash must not create any stash entry"
+    );
+}
+
+// ─── Test 5: --no-stash with --json emits dirty_working_tree JSON ────────────
+
+#[test]
+fn no_stash_with_json_emits_dirty_working_tree_error() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    repo.create_file("json-no-stash-dirty.txt", "unstaged change");
+
+    let out = repo.run_stax(&["sync", "--no-stash", "--json"]);
+    assert!(
+        !out.status.success(),
+        "sync --no-stash --json should exit non-zero when dirty"
+    );
+
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+
+    assert_eq!(parsed["success"], false);
+    assert_eq!(
+        parsed["error"]["kind"], "dirty_working_tree",
+        "error kind must be dirty_working_tree; got: {}",
+        parsed["error"]["kind"]
+    );
+}
+
+// ─── Test 6: --stash and --no-stash together are rejected by clap ─────────────
+
+#[test]
+fn stash_and_no_stash_conflict_exits_nonzero() {
+    let repo = TestRepo::new_with_remote();
+
+    let out = repo.run_stax(&["sync", "--stash", "--no-stash"]);
+    assert!(
+        !out.status.success(),
+        "--stash and --no-stash together should be rejected with non-zero exit"
+    );
+
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflict"),
+        "should report a conflict between --stash and --no-stash; stderr: {stderr}"
+    );
+
+    // clap typically uses exit code 2 for usage errors
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "exit code for flag conflict must be 2; got: {:?}",
+        out.status.code()
+    );
+}
+
+// ─── Test 7: --prune emits a deprecation warning on stderr ───────────────────
+
+#[test]
+fn prune_flag_emits_deprecation_warning_on_stderr() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    let out = repo.run_stax(&["sync", "--prune", "--force"]);
+    assert!(
+        out.status.success(),
+        "sync --prune should still exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("--prune") && stderr.contains("deprecated"),
+        "stderr must contain a deprecation warning mentioning --prune; got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("--full"),
+        "deprecation warning must suggest --full; got: {stderr:?}"
+    );
+}
+
+// ─── Test 8: --prune deprecation warning appears even with --json ─────────────
+
+#[test]
+fn prune_flag_deprecation_warning_appears_with_json() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    let out = repo.run_stax(&["sync", "--prune", "--json", "--force"]);
+    assert!(
+        out.status.success(),
+        "sync --prune --json should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    // Warning must be on stderr (JSON stays on stdout)
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("--prune") && stderr.contains("deprecated"),
+        "stderr must contain --prune deprecation warning even with --json; got: {stderr:?}"
+    );
+
+    // stdout must still be valid JSON
+    let stdout = TestRepo::stdout(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not valid JSON: {e}\n---\n{stdout}"));
+    assert_eq!(parsed["kind"], "sync");
+}
+
+// ─── Test 9: --dry-run warns that --stash is ignored ─────────────────────────
+
+#[test]
+fn dry_run_warns_stash_flags_are_ignored() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+
+    let out = repo.run_stax(&["sync", "--dry-run", "--stash"]);
+    assert!(
+        out.status.success(),
+        "sync --dry-run --stash should exit 0; stderr: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        stderr.contains("--stash") && stderr.contains("ignored"),
+        "stderr must warn that --stash is ignored by --dry-run; got: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- **`--stash` / `--no-stash`** — explicit dirty-tree policy before sync starts (`--stash` works with `--quiet`/`--json`; does not auto-confirm deletions)
- Dirty-tree error message names **`--stash`**
- **`--prune`** deprecated (stderr warning; use **`--full`**)

## Test plan

- [x] `tests/sync_stash_tests.rs`
- [x] `make test`