### PR TITLE
fix(sync): don't prompt when the only change is a trunk fast-forward

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -957,7 +957,6 @@ impl SyncContext {
 
         let local_trunk = self.local_trunk_before_sync.as_deref();
         let remote_trunk = self.remote_trunk_after_fetch.as_deref();
-        let trunk_would_move = matches!((local_trunk, remote_trunk), (Some(l), Some(r)) if l != r);
 
         let mut merged_branch_names: Vec<String> = Vec::new();
         if self.delete_merged
@@ -996,8 +995,9 @@ impl SyncContext {
         let has_deletion_candidates =
             !merged_branch_names.is_empty() || !upstream_gone_deletable.is_empty();
 
-        let needs_confirm =
-            trunk_would_move || has_deletion_candidates || !restack_candidates.is_empty();
+        // A trunk fast-forward is what `stax sync` is *for* — don't ask about it on its own.
+        // Only branch deletions and history-rewriting restacks are worth a prompt.
+        let needs_confirm = has_deletion_candidates || !restack_candidates.is_empty();
 
         if !needs_confirm {
             return Ok(SyncFlow::Continue);

--- a/tests/sync_confirm_tests.rs
+++ b/tests/sync_confirm_tests.rs
@@ -111,6 +111,26 @@ fn sync_confirm_per_branch_mode_still_allows_skip() {
 }
 
 #[test]
+fn sync_does_not_prompt_when_only_trunk_moves() {
+    let repo = TestRepo::new_with_remote();
+    repo.git(&["push", "-u", "origin", "main"]);
+    // Advance origin/main only — nothing to delete, nothing to restack.
+    repo.simulate_remote_commit("upstream.txt", "content", "Upstream commit");
+
+    let out = repo.run_stax(&["sync"]);
+    assert!(
+        out.status.success(),
+        "sync failed: {}",
+        TestRepo::stderr(&out)
+    );
+    let stdout = TestRepo::stdout(&out);
+    assert!(
+        !stdout.contains("Sync plan") && !stdout.contains("How should sync proceed?"),
+        "a plain trunk fast-forward must not prompt: {stdout}"
+    );
+}
+
+#[test]
 fn sync_force_skips_interactive_sync_plan() {
     let (repo, feature) = repo_with_merged_feature("feat-plan-force");
 


### PR DESCRIPTION
## Problem

Running `st rs` (`stax sync`) on a clean repo with nothing to delete stops and asks:

```
Sync plan
  ▸ Trunk main:
      Would update main to match origin/main
? How should sync proceed? ›
❯ Continue sync
  Cancel sync
```

The plan gate added in #719 included `trunk_would_move`, so nearly every sync asked for permission to fast-forward trunk — which is the entire point of the command. Nothing destructive is pending in that case.

## Fix

Gate the interactive plan on deletions and restacks only:

```rust
let needs_confirm = has_deletion_candidates || !restack_candidates.is_empty();
```

Behavior after this change:

- Only a trunk update pending → runs straight through, no plan, no prompt.
- Merged / upstream-gone branches up for deletion → plan still prints (with the trunk line for context) and still prompts.
- `-r` with pending restacks → still prompts, since it rewrites branch history.

## Tests

- New `sync_confirm_tests::sync_does_not_prompt_when_only_trunk_moves` pins the no-prompt path.
- The four existing confirm tests all involve merged branches, so they're unaffected.
- `make test`: 2255 passed, 0 failed. `cargo check --all-targets` and `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)