### PR TITLE
fix(track): set upstream on branches fetched by --all-prs

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -84,7 +84,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st rename` | | Rename current branch |
 | `st move [target]` | `mv` | Move the current branch and descendants onto a new parent (`st upstack onto` parity alias; picker when omitted) |
 | `st branch track` | | Track an existing branch |
-| `st branch track --all-prs` | | Track all open PRs (GitHub, GitLab, Gitea) |
+| `st branch track --all-prs` | | Track all open PRs (GitHub, GitLab, Gitea); sets upstream on branches it fetches |
 | `st branch untrack` | `ut` | Remove stax metadata |
 | `st branch reparent` | | Change parent |
 | `st branch submit` | `bs` | Submit current branch only; can temporarily restack the publish head when the excluded parent is remote-synced |

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -37,6 +37,7 @@ pub(crate) use submit::{
     SubmitPromptRequest, SubmitScope,
 };
 pub use track_plan::{
-    FetchPlan, ParentDecision, ParentSource, RepoFacts, TrackCandidate, plan_fetches,
-    resolve_parent, topological_order,
+    FetchPlan, ParentDecision, ParentSource, RepoFacts, TrackCandidate, branches_needing_upstream,
+    newly_created_branches, parse_branches_with_upstream, plan_fetches, resolve_parent,
+    topological_order,
 };

--- a/src/application/track_plan.rs
+++ b/src/application/track_plan.rs
@@ -164,3 +164,57 @@ pub fn resolve_parent(candidate: &TrackCandidate, facts: &RepoFacts<'_>) -> Pare
         },
     }
 }
+
+/// Branches this run actually created via fetch: present in `fetched`, absent
+/// from `local_before`, present in `local_after`. A pre-existing local branch
+/// may intentionally track a fork or a different remote, so it is excluded —
+/// only a branch that had no prior local existence is safe to touch. Order
+/// follows `fetched`, deduped.
+pub fn newly_created_branches(
+    fetched: &[String],
+    local_before: &HashSet<String>,
+    local_after: &HashSet<String>,
+) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+    for b in fetched {
+        if !local_before.contains(b) && local_after.contains(b) && seen.insert(b.as_str()) {
+            result.push(b.clone());
+        }
+    }
+    result
+}
+
+/// Parse `git config --local --get-regexp '^branch\..*\.remote$'` output into
+/// the set of branch names that already have an upstream remote configured.
+/// Splitting on the first space (rather than `.`) keeps dotted branch names
+/// like `release.1.x` intact.
+pub fn parse_branches_with_upstream(config_output: &str) -> HashSet<String> {
+    let mut result = HashSet::new();
+    for line in config_output.lines() {
+        let key = match line.split_once(' ') {
+            Some((k, _)) => k,
+            None => line,
+        };
+        if let Some(rest) = key.strip_prefix("branch.")
+            && let Some(name) = rest.strip_suffix(".remote")
+            && !name.is_empty()
+        {
+            result.insert(name.to_string());
+        }
+    }
+    result
+}
+
+/// Filter `newly_created` down to the branches that still need an upstream
+/// configured, preserving input order.
+pub fn branches_needing_upstream(
+    newly_created: &[String],
+    already_configured: &HashSet<String>,
+) -> Vec<String> {
+    newly_created
+        .iter()
+        .filter(|b| !already_configured.contains(b.as_str()))
+        .cloned()
+        .collect()
+}

--- a/src/commands/branch/track.rs
+++ b/src/commands/branch/track.rs
@@ -1,5 +1,6 @@
 use crate::application::{
-    ParentSource, RepoFacts, TrackCandidate, plan_fetches, resolve_parent, topological_order,
+    ParentSource, RepoFacts, TrackCandidate, branches_needing_upstream, newly_created_branches,
+    plan_fetches, resolve_parent, topological_order,
 };
 use crate::config::Config;
 use crate::engine::{BranchMetadata, PrInfo};
@@ -249,10 +250,46 @@ fn run_track_all_prs() -> Result<()> {
         }
     }
 
-    let fetched_count = to_fetch
-        .iter()
-        .filter(|b| local_after.contains(*b) && !local_before.contains(*b))
-        .count();
+    let newly_fetched = newly_created_branches(&to_fetch, &local_before, &local_after);
+    let fetched_count = newly_fetched.len();
+
+    // A refspec fetch (`<b>:<b>`) creates the local branch but configures no
+    // upstream, so a later plain `git pull` on it fails with "There is no
+    // tracking information for the current branch". Set it here, but only for
+    // branches this run created — never rewrite an upstream the user chose.
+    let already_configured = repo.branches_with_configured_upstream().unwrap_or_default();
+    let mut upstream_set = 0usize;
+    let mut upstream_failed: Vec<String> = Vec::new();
+    for b in branches_needing_upstream(&newly_fetched, &already_configured) {
+        match repo.set_branch_upstream(&b, remote_name) {
+            Ok(()) => upstream_set += 1,
+            Err(_) => upstream_failed.push(b),
+        }
+    }
+    if !upstream_failed.is_empty() {
+        let shown = upstream_failed
+            .iter()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let more = if upstream_failed.len() > 5 {
+            format!(" and {} more", upstream_failed.len() - 5)
+        } else {
+            String::new()
+        };
+        println!(
+            "{}",
+            format!(
+                "  ! Could not set upstream for {} branch(es): {}{}. Run `git branch --set-upstream-to={}/<branch> <branch>` if `git pull` fails there.",
+                upstream_failed.len(),
+                shown,
+                more,
+                remote_name
+            )
+            .yellow()
+        );
+    }
 
     let remote_branches: HashSet<String> = remote::get_remote_branches(workdir, remote_name)
         .unwrap_or_default()
@@ -342,12 +379,21 @@ fn run_track_all_prs() -> Result<()> {
         tracked_count += 1;
     }
 
+    let upstream_note = if upstream_set > 0 {
+        format!(
+            " Set upstream to '{}' on {} newly fetched branch(es).",
+            remote_name, upstream_set
+        )
+    } else {
+        String::new()
+    };
     println!();
     println!(
-        "Tracked {} branch(es), fetched {}, skipped {} (already tracked).",
+        "Tracked {} branch(es), fetched {}, skipped {} (already tracked).{}",
         tracked_count.to_string().green(),
         fetched_count.to_string().blue(),
-        skipped_count.to_string().dimmed()
+        skipped_count.to_string().dimmed(),
+        upstream_note.dimmed()
     );
 
     Ok(())

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1772,6 +1772,58 @@ Use --auto-stash-pop or stash/commit changes first.",
             .filter(|value| !value.trim().is_empty())
     }
 
+    /// Branch names that already have an upstream remote configured
+    /// (`branch.<name>.remote` set). Used to avoid overwriting an upstream a
+    /// pre-existing local branch may have intentionally pointed at a fork or a
+    /// different remote. Exit code 1 from `git config --get-regexp` means "no
+    /// matches" in a repo with no branch config yet — that is not an error, it
+    /// is the normal case, so it maps to an empty set rather than propagating.
+    pub fn branches_with_configured_upstream(&self) -> Result<HashSet<String>> {
+        let output = self.run_git(
+            self.workdir()?,
+            &["config", "--local", "--get-regexp", r"^branch\..*\.remote$"],
+        )?;
+        if !output.status.success() {
+            return Ok(HashSet::new());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(crate::application::parse_branches_with_upstream(&stdout))
+    }
+
+    /// Configure `branch` to pull from and push to `remote`. Writes
+    /// `branch.<branch>.merge` before `branch.<branch>.remote` deliberately: if
+    /// the second write fails, git defaults an unset `branch.<name>.remote` to
+    /// `origin`, so the partial state still usually works. The reverse order
+    /// would leave `git pull` erroring with "did not specify a branch".
+    ///
+    /// Uses `--local` rather than `--worktree` because branch upstream config
+    /// is shared across linked worktrees.
+    pub fn set_branch_upstream(&self, branch: &str, remote: &str) -> Result<()> {
+        let workdir = self.workdir()?;
+        let merge_key = format!("branch.{}.merge", branch);
+        let merge_value = format!("refs/heads/{}", branch);
+        let output = self.run_git(workdir, &["config", "--local", &merge_key, &merge_value])?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "Failed to set '{}': {}",
+                merge_key,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        let remote_key = format!("branch.{}.remote", branch);
+        let output = self.run_git(workdir, &["config", "--local", &remote_key, remote])?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "Failed to set '{}': {}",
+                remote_key,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        Ok(())
+    }
+
     /// Get underlying repository (for advanced operations)
     pub fn inner(&self) -> &Repository {
         &self.repo
@@ -2494,6 +2546,19 @@ mod tests {
         );
     }
 
+    /// Run git and return stdout, tolerating a non-zero exit. Callers assert on the
+    /// value, not the status: `git config --get <key>` exits 1 when the key is unset,
+    /// which is a legitimate "no value" answer (and exactly what the upstream tests
+    /// assert before configuring one).
+    fn run_git_capture(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("failed to run git");
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
+
     #[test]
     fn test_format_duration_just_now() {
         assert_eq!(format_duration(0), "just now");
@@ -2818,5 +2883,106 @@ mod tests {
         ]);
 
         assert_eq!(names, vec!["main", "00cb/stax", "073a/stax"]);
+    }
+
+    #[test]
+    fn set_branch_upstream_configures_pull_target() {
+        let remote_dir = TempDir::new().expect("tempdir");
+        run_git(remote_dir.path(), &["init", "--bare", "-b", "main"]);
+
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test User"]);
+        fs::write(path.join("README.md"), "base\n").expect("write readme");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-m", "Initial commit"]);
+        run_git(
+            path,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote_dir.path().to_str().expect("utf8 path"),
+            ],
+        );
+        run_git(path, &["push", "origin", "main"]);
+
+        // Mirror how `stax branch track --all-prs` creates a local branch: a
+        // refspec fetch from a remote that already has it, not `git branch`.
+        run_git(path, &["switch", "-c", "copied"]);
+        fs::write(path.join("copied.txt"), "copied\n").expect("write copied");
+        run_git(path, &["add", "copied.txt"]);
+        run_git(path, &["commit", "-m", "Copied commit"]);
+        run_git(path, &["push", "origin", "copied"]);
+        run_git(path, &["switch", "main"]);
+        run_git(path, &["branch", "-D", "copied"]);
+        run_git(path, &["fetch", "--no-tags", "origin", "copied:copied"]);
+
+        let before = run_git_capture(
+            path,
+            &["config", "--local", "--get", "branch.copied.remote"],
+        );
+        assert!(
+            before.trim().is_empty(),
+            "upstream should be unset before configuring it"
+        );
+
+        let repo = GitRepo::open_from_path(path).expect("open repo");
+        repo.set_branch_upstream("copied", "origin")
+            .expect("set upstream");
+
+        let remote_value = run_git_capture(
+            path,
+            &["config", "--local", "--get", "branch.copied.remote"],
+        );
+        assert_eq!(remote_value.trim(), "origin");
+        let merge_value =
+            run_git_capture(path, &["config", "--local", "--get", "branch.copied.merge"]);
+        assert_eq!(merge_value.trim(), "refs/heads/copied");
+
+        let upstream = run_git_capture(path, &["rev-parse", "--abbrev-ref", "copied@{upstream}"]);
+        assert_eq!(upstream.trim(), "origin/copied");
+    }
+
+    #[test]
+    fn set_branch_upstream_is_readable_by_branches_with_configured_upstream() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test User"]);
+        fs::write(path.join("README.md"), "base\n").expect("write readme");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-m", "Initial commit"]);
+        run_git(path, &["branch", "copied"]);
+
+        let repo = GitRepo::open_from_path(path).expect("open repo");
+        repo.set_branch_upstream("copied", "origin")
+            .expect("set upstream");
+
+        let configured = repo
+            .branches_with_configured_upstream()
+            .expect("read configured upstreams");
+        assert!(configured.contains("copied"));
+    }
+
+    #[test]
+    fn branches_with_configured_upstream_is_empty_when_no_branch_config() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test User"]);
+        fs::write(path.join("README.md"), "base\n").expect("write readme");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-m", "Initial commit"]);
+
+        let repo = GitRepo::open_from_path(path).expect("open repo");
+        let configured = repo
+            .branches_with_configured_upstream()
+            .expect("no branch config should not be an error");
+        assert!(configured.is_empty());
     }
 }

--- a/tests/track_plan_tests.rs
+++ b/tests/track_plan_tests.rs
@@ -3,7 +3,8 @@
 //! `topological_order`, `plan_fetches`, and `resolve_parent` directly.
 
 use stax::application::{
-    ParentSource, RepoFacts, TrackCandidate, plan_fetches, resolve_parent, topological_order,
+    ParentSource, RepoFacts, TrackCandidate, branches_needing_upstream, newly_created_branches,
+    parse_branches_with_upstream, plan_fetches, resolve_parent, topological_order,
 };
 use std::collections::HashSet;
 
@@ -195,4 +196,54 @@ fn plan_fetches_already_local_branches_appear_in_neither_list() {
 
     assert!(plan.required.is_empty());
     assert!(plan.optional.is_empty());
+}
+
+#[test]
+fn newly_created_branches_excludes_preexisting_locals() {
+    let fetched = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+    let local_before = set(&["a"]);
+    let local_after = set(&["a", "b", "c"]);
+
+    let result = newly_created_branches(&fetched, &local_before, &local_after);
+
+    assert_eq!(result, vec!["b".to_string(), "c".to_string()]);
+}
+
+#[test]
+fn newly_created_branches_excludes_failed_fetches() {
+    let fetched = vec!["a".to_string(), "b".to_string()];
+    let local_before = set(&[]);
+    let local_after = set(&["a"]);
+
+    let result = newly_created_branches(&fetched, &local_before, &local_after);
+
+    assert_eq!(result, vec!["a".to_string()]);
+}
+
+#[test]
+fn parse_branches_with_upstream_handles_dotted_and_slashed_names() {
+    let output = "branch.feat/x.remote origin\nbranch.release.1.x.remote upstream\n";
+
+    let result = parse_branches_with_upstream(output);
+
+    assert_eq!(result, set(&["feat/x", "release.1.x"]));
+}
+
+#[test]
+fn parse_branches_with_upstream_ignores_unrelated_keys() {
+    let output = "branch.a.merge refs/heads/a\nremote.origin.url git@x\n\n";
+
+    let result = parse_branches_with_upstream(output);
+
+    assert!(result.is_empty());
+}
+
+#[test]
+fn branches_needing_upstream_skips_already_configured() {
+    let newly_created = vec!["a".to_string(), "b".to_string()];
+    let already_configured = set(&["a"]);
+
+    let result = branches_needing_upstream(&newly_created, &already_configured);
+
+    assert_eq!(result, vec!["b".to_string()]);
 }


### PR DESCRIPTION
## Motivation

`stax branch track --all-prs` fetches branches with `<b>:<b>` refspecs (`fetch_branches_batch`, `fetch_branch_from_remote`). That form creates the local branch but configures **no** `branch.<b>.remote` / `branch.<b>.merge`, so a plain `git pull` on any branch the command just created fails with:

```
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.
```

Hit in a real monorepo after a `--all-prs` run.

## Description of changes / notes for reviewers

- After fetching, configure the upstream — **only for branches this run actually created** (in `local_after`, absent from `local_before`). A pre-existing local branch may intentionally track a fork or a different remote; rewriting that isn't stax's call, and it isn't undoable.
- Writes `branch.<b>.merge` + `branch.<b>.remote` config directly instead of shelling out to `git branch --set-upstream-to=<remote>/<b>`. Verified on git 2.54: that command **hard-fails** (`fatal: the requested upstream branch 'origin/feat1' does not exist`) when `refs/remotes/<remote>/<b>` is absent, and a `<b>:<b>` refspec fetch only writes the remote-tracking ref *opportunistically*, via the remote's default `remote.<name>.fetch`. Config-only works either way.
- `.merge` is written before `.remote` deliberately: if the second write fails, git defaults an unset `branch.<name>.remote` to `origin`, so the partial state still usually works. The reverse order leaves `git pull` erroring.
- Failures **warn once, aggregated, and never abort** the run. No per-branch line on the happy path; the summary gains a dimmed `Set upstream to 'origin' on N newly fetched branch(es).` only when at least one was set.
- `branches_with_configured_upstream()` treats `git config --get-regexp` exit code 1 as "no matches" (the normal case in a fresh repo), not an error.

New pure logic lives in `src/application/track_plan.rs` alongside the existing `--all-prs` decision logic; the two git-touching methods are on `GitRepo`.

## Tests

- 5 new pure-logic tests in `tests/track_plan_tests.rs` (already-registered file) — covers the conservative-selection guarantee, failed fetches, and config parsing for dotted/slashed branch names like `release.1.x` and `feat/x`.
- 3 new unit tests in `src/git/repo.rs` — the main one builds the branch via a real `git fetch --no-tags origin copied:copied` from a bare remote (mirroring what track does) and asserts `git rev-parse --abbrev-ref copied@{upstream}` resolves to `origin/copied`, i.e. the exact thing the user's `git pull` needs.
- Full suite: 2263 passed, 0 failed. `cargo clippy --all-targets -- -D warnings` clean.