### PR TITLE
Let setup and skills update target selected agent harnesses only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The bundle id is `com.cesarferreira.stax`. `st gui [path]` is macOS-only; it can
 <a id="quickstart"></a>
 ## Quickstart
 
-`st setup` handles shell integration, AI agent skills, and GitHub auth in a single step:
+`st setup` handles shell integration, AI agent skills, and GitHub auth in a single step. When you install skills interactively (or with `--yes`), stax asks which agent harnesses should receive the skill file, pre-checking the ones it detects on disk. Use `--skills all|detected|<ids>` for non-interactive control.
 
 ```bash
 st setup --yes

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -177,8 +177,8 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st init` | Initialize stax or reconfigure trunk (`--trunk <branch>`) |
 | `st cli upgrade` | Detect install method and run the matching upgrade |
 | `st doctor` | Check repo health |
-| `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config, stale AI skills, and optional `gh-stack` install) |
-| `st skills` | Manage installed AI agent skill files (`list`, `update`, `update --dry-run`) |
+| `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config, stale AI skills for selected harnesses, and optional `gh-stack` install) |
+| `st skills` | Manage installed AI agent skill files (`list`, `update`, `update --all`, `update --skills <list>`, `update --dry-run`) |
 | `st continue` | Continue after conflicts |
 | `st open` | Open repository in browser |
 | `st demo` | Interactive tutorial — no auth or repo required |
@@ -216,6 +216,7 @@ Full guide: [Worktrees](../worktrees/index.md) · [AI lanes](../workflows/agent-
 | `st setup` | One-shot onboarding: shell integration + optional skills + auth |
 | `st setup --yes` | Accept defaults, install skills, import auth from `gh` when available |
 | `st setup --install-skills` / `--skip-skills` | Control AI agent skills prompt |
+| `st setup --skills <list>` | Choose harnesses (`all`, `detected`, `auto`, `none`, or comma-separated ids) |
 | `st setup --auth-from-gh` / `--skip-auth` | Control auth onboarding |
 | `st setup --print` | Print shell integration snippet for manual install |
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -73,6 +73,10 @@ single_stack = "on"    # "on" | "off"
                                # boundary would replay a much larger range
 # preflight_warn = true        # print a notice when that automatic repair happens
 
+[skills]
+# harnesses = ["claude", "codex"] # agent harnesses that receive skill files
+#   valid ids: claude, codex, cursor, opencode, pi. Unset = auto (detected + already installed).
+
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" | "pi" — global default
 # model = "claude-opus-4-8"

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -90,7 +90,8 @@ cargo install --path . --locked --features vendored-openssl
 
 ```bash
 stax --version
-st setup --yes       # shell integration, AI skills, and auth from gh (if available)
+st setup --yes       # shell integration; skills for detected agents only; auth from gh (if available)
+st setup --yes --skills all   # install skills for every known harness (previous default)
 st cli upgrade       # later, upgrade via the install method you used
 ```
 

--- a/skills.md
+++ b/skills.md
@@ -121,7 +121,9 @@ stax worktree cleanup          # Prune stale bookkeeping + bulk-remove merged/de
 stax worktree restack          # Restack all stax-managed worktrees
 stax setup                     # Install shell integration, then optionally offer AI agent skills + auth onboarding
 stax setup --yes               # Accept shell setup defaults, install skills, and import auth from gh when available
-stax setup --install-skills    # Install shell integration and accept the skills install automatically
+stax setup --install-skills    # Install shell integration and skills for all harnesses (non-interactive)
+stax setup --install-skills --skills claude,cursor   # Only selected harnesses
+stax setup --yes               # Skills for detected harnesses only
 stax setup --skip-skills       # Install shell integration without the skills prompt
 stax setup --auth-from-gh      # Install shell integration and import GitHub auth from gh without prompting
 stax setup --skip-auth         # Install shell integration without the auth onboarding step
@@ -619,8 +621,9 @@ stax fix --yes
 ```bash
 # One-time shell integration (enables transparent cd)
 stax setup
-stax setup --yes               # Shell integration + skills + auth import from gh when available
-stax setup --install-skills    # Non-interactive onboarding: shell integration + AI agent skills
+stax setup --yes               # Shell integration + skills for detected agents + auth import from gh when available
+stax setup --install-skills    # Non-interactive: shell integration + skills for all harnesses
+stax skills update --all         # Update every harness, ignoring configured selection
 
 # Create a worktree for an existing local branch
 stax worktree create feature/payments-api

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1281,6 +1281,13 @@ pub(crate) enum Commands {
         /// Install AI agent skills without prompting
         #[arg(long, conflicts_with_all = ["skip_skills", "print", "refresh"])]
         install_skills: bool,
+        /// Which agent harnesses get skills: all | detected | auto | none | comma-separated ids (claude,codex,cursor,opencode,pi)
+        #[arg(
+            long,
+            value_name = "LIST",
+            conflicts_with_all = ["skip_skills", "print", "refresh"]
+        )]
+        skills: Option<String>,
         /// Skip the optional GitHub auth onboarding step
         #[arg(long, conflicts_with_all = ["auth_from_gh", "print", "refresh"])]
         skip_auth: bool,
@@ -1685,11 +1692,17 @@ pub(crate) enum SkillsCommands {
     /// List installed AI agent skill files and their version status
     List,
 
-    /// Download the latest skills from GitHub and update all installed skill files
+    /// Download the latest skills from GitHub and update installed skill files
     Update {
         /// Preview what would be updated without writing any files
         #[arg(long)]
         dry_run: bool,
+        /// Update every known harness, ignoring the configured selection
+        #[arg(long)]
+        all: bool,
+        /// Limit this run to specific harnesses: all | detected | auto | none | comma-separated ids
+        #[arg(long, value_name = "LIST", conflicts_with = "all")]
+        skills: Option<String>,
     },
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -55,12 +55,25 @@ pub fn run() -> Result<()> {
         skip_auth,
         auth_from_gh,
         yes,
+        skills,
     }) = &cli.command
     {
-        let skill_install_mode = if *install_skills {
-            commands::shell_setup::SkillInstallMode::Install
-        } else if *skip_skills {
+        let skill_selection = skills
+            .as_deref()
+            .map(commands::skills::parse_harness_selection)
+            .transpose()?;
+        let skill_install_mode = if *skip_skills
+            || matches!(
+                skill_selection.as_ref(),
+                Some(commands::skills::HarnessSelection::Only(ids)) if ids.is_empty()
+            ) {
             commands::shell_setup::SkillInstallMode::Skip
+        } else if *install_skills
+            || skill_selection
+                .as_ref()
+                .is_some_and(|sel| !matches!(sel, commands::skills::HarnessSelection::Only(ids) if ids.is_empty()))
+        {
+            commands::shell_setup::SkillInstallMode::Install
         } else {
             commands::shell_setup::SkillInstallMode::Ask
         };
@@ -75,6 +88,7 @@ pub fn run() -> Result<()> {
             auto_accept: *yes,
             skill_install_mode,
             auth_setup_mode,
+            skill_selection,
         };
         let result = commands::shell_setup::run(*print, *refresh, setup_options);
         update::show_update_notification();
@@ -168,7 +182,28 @@ pub fn run() -> Result<()> {
         Commands::Skills { command } => {
             let result = match command {
                 None | Some(SkillsCommands::List) => commands::skills::run_list(),
-                Some(SkillsCommands::Update { dry_run }) => commands::skills::run_update(*dry_run),
+                Some(SkillsCommands::Update {
+                    dry_run,
+                    all,
+                    skills,
+                }) => {
+                    let (sel, origin) = if *all {
+                        (
+                            commands::skills::HarnessSelection::All,
+                            commands::skills::SkillsUpdateOrigin::AllFlag,
+                        )
+                    } else if let Some(spec) = skills.as_deref() {
+                        (
+                            commands::skills::parse_harness_selection(spec)?,
+                            commands::skills::SkillsUpdateOrigin::Cli {
+                                spec: spec.to_string(),
+                            },
+                        )
+                    } else {
+                        commands::skills::configured_selection_with_origin()
+                    };
+                    commands::skills::run_update_with(*dry_run, &sel, origin)
+                }
             };
             update::show_update_notification();
             return result;

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
-use dialoguer::{Confirm, theme::ColorfulTheme};
+use dialoguer::{Confirm, MultiSelect, theme::ColorfulTheme};
 use std::fs;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -29,11 +29,12 @@ pub enum AuthSetupMode {
     ImportFromGh,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetupOptions {
     pub auto_accept: bool,
     pub skill_install_mode: SkillInstallMode,
     pub auth_setup_mode: AuthSetupMode,
+    pub skill_selection: Option<crate::commands::skills::HarnessSelection>,
 }
 
 /// The shell function block that users source in their shell config.
@@ -402,8 +403,8 @@ pub fn run(print: bool, refresh: bool, options: SetupOptions) -> Result<()> {
     // Always enable rerere when in a git repo (unless we're just printing)
     if shell_setup_completed && !print {
         enable_rerere_if_in_repo()?;
-        maybe_install_skills(options)?;
-        maybe_setup_auth(options)?;
+        maybe_install_skills(&options)?;
+        maybe_setup_auth(&options)?;
     }
 
     Ok(())
@@ -548,28 +549,64 @@ fn install_to_shell_config(auto_accept: bool) -> Result<bool> {
     Ok(true)
 }
 
-fn maybe_install_skills(options: SetupOptions) -> Result<()> {
-    let should_install = match options.skill_install_mode {
-        SkillInstallMode::Install => true,
-        SkillInstallMode::Skip => false,
-        SkillInstallMode::Ask => {
-            if options.auto_accept {
-                true
-            } else {
-                prompt_for_skill_install()?
-            }
-        }
-    };
+fn maybe_install_skills(options: &SetupOptions) -> Result<()> {
+    use crate::commands::skills::{self, HarnessSelection};
 
-    if !should_install {
+    if matches!(options.skill_install_mode, SkillInstallMode::Skip) {
         return Ok(());
     }
 
+    let selection = if let Some(sel) = &options.skill_selection {
+        sel.clone()
+    } else {
+        match options.skill_install_mode {
+            SkillInstallMode::Install => {
+                if can_prompt() {
+                    prompt_for_harness_selection()?
+                } else {
+                    HarnessSelection::All
+                }
+            }
+            SkillInstallMode::Ask => {
+                if options.auto_accept {
+                    HarnessSelection::Detected
+                } else if !can_prompt() {
+                    return Ok(());
+                } else if !prompt_for_skill_install()? {
+                    return Ok(());
+                } else {
+                    prompt_for_harness_selection()?
+                }
+            }
+            SkillInstallMode::Skip => return Ok(()),
+        }
+    };
+
+    let ids = skills::resolve_ids(&selection);
+    if ids.is_empty() {
+        println!(
+            "{}",
+            "No agent harnesses selected — skipping skills install.".dimmed()
+        );
+        return Ok(());
+    }
+
+    if let Err(err) = crate::config::Config::set_skill_harnesses(&ids) {
+        eprintln!(
+            "{}",
+            format!("Warning: could not save skills harness selection: {err}").yellow()
+        );
+    }
+
     println!();
-    crate::commands::skills::run_update(false)
+    skills::run_update_with(
+        false,
+        &HarnessSelection::Only(ids),
+        skills::SkillsUpdateOrigin::Setup,
+    )
 }
 
-fn maybe_setup_auth(options: SetupOptions) -> Result<()> {
+fn maybe_setup_auth(options: &SetupOptions) -> Result<()> {
     let status = crate::config::Config::github_auth_status();
     if has_non_gh_auth(&status) {
         return Ok(());
@@ -633,6 +670,54 @@ fn prompt_for_skill_install() -> Result<bool> {
         .with_prompt("Install stax AI agent skills too?")
         .default(true)
         .interact()?)
+}
+
+fn prompt_for_harness_selection() -> Result<crate::commands::skills::HarnessSelection> {
+    use crate::commands::skills::{self, HarnessSelection};
+
+    if !can_prompt() {
+        return Ok(HarnessSelection::Detected);
+    }
+
+    let harnesses = skills::harnesses();
+    let items: Vec<String> = harnesses
+        .iter()
+        .map(|h| {
+            let path = harness_detect_path(h.id);
+            if h.detected {
+                format!("{}  ~/{} (detected)", h.name, path)
+            } else {
+                format!("{}  ~/{}", h.name, path)
+            }
+        })
+        .collect();
+    let defaults: Vec<bool> = harnesses.iter().map(|h| h.detected).collect();
+
+    eprintln!();
+    let selected = MultiSelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(
+            "Which agent harnesses should get stax skills? (space toggles, enter confirms)",
+        )
+        .items(&items)
+        .defaults(&defaults)
+        .interact()?;
+
+    let ids: Vec<String> = selected
+        .into_iter()
+        .map(|idx| harnesses[idx].id.to_string())
+        .collect();
+    Ok(HarnessSelection::Only(ids))
+}
+
+fn harness_detect_path(id: &str) -> &'static str {
+    match id {
+        "codex" => ".codex/skills/stax/SKILL.md",
+        "opencode" => ".config/opencode/skills/stax/SKILL.md",
+        "claude" => ".claude/skills/stax/SKILL.md",
+        "cursor" => ".cursor/skills/stax/SKILL.md",
+        "pi" => ".pi/agent/skills/stax/SKILL.md",
+        _ => "",
+    }
 }
 
 fn prompt_for_gh_auth_import() -> Result<bool> {

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use std::path::PathBuf;
 
@@ -6,42 +6,223 @@ const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const REMOTE_URL: &str = "https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md";
 
 /// Known agent skill file locations (relative to `$HOME`).
-struct SkillLocation {
+pub struct SkillLocation {
+    /// Stable slug for `--skills` and config (`claude`, `codex`, …).
+    pub id: &'static str,
     /// Display name shown in output.
-    name: &'static str,
+    pub name: &'static str,
     /// Path relative to the user's home directory.
     relative_path: &'static str,
+    /// Harness root under `$HOME`; existence means the agent is likely installed.
+    detect_relative_path: &'static str,
     /// Whether this file uses YAML frontmatter (SKILL.md format).
     has_frontmatter: bool,
 }
 
 const SKILL_LOCATIONS: &[SkillLocation] = &[
     SkillLocation {
+        id: "codex",
         name: "Codex",
         relative_path: ".codex/skills/stax/SKILL.md",
+        detect_relative_path: ".codex",
         has_frontmatter: true,
     },
     SkillLocation {
+        id: "opencode",
         name: "OpenCode",
         relative_path: ".config/opencode/skills/stax/SKILL.md",
+        detect_relative_path: ".config/opencode",
         has_frontmatter: true,
     },
     SkillLocation {
+        id: "claude",
         name: "Claude Code (global)",
         relative_path: ".claude/skills/stax/SKILL.md",
+        detect_relative_path: ".claude",
         has_frontmatter: true,
     },
     SkillLocation {
+        id: "cursor",
         name: "Cursor",
         relative_path: ".cursor/skills/stax/SKILL.md",
+        detect_relative_path: ".cursor",
         has_frontmatter: true,
     },
     SkillLocation {
+        id: "pi",
         name: "pi",
         relative_path: ".pi/agent/skills/stax/SKILL.md",
+        detect_relative_path: ".pi",
         has_frontmatter: true,
     },
 ];
+
+/// Which harnesses receive skill installs/updates.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HarnessSelection {
+    All,
+    Detected,
+    /// Detected on disk plus any harness that already has a skill file.
+    Auto,
+    Only(Vec<String>),
+}
+
+/// How the harness set was chosen for a `skills update` run (shown in CLI output).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SkillsUpdateOrigin {
+    AllFlag,
+    Cli { spec: String },
+    Config,
+    Auto,
+    Setup,
+}
+
+pub struct HarnessInfo {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub detected: bool,
+}
+
+pub fn harnesses() -> Vec<HarnessInfo> {
+    SKILL_LOCATIONS
+        .iter()
+        .map(|loc| HarnessInfo {
+            id: loc.id,
+            name: loc.name,
+            detected: is_detected(loc),
+        })
+        .collect()
+}
+
+fn is_detected(loc: &SkillLocation) -> bool {
+    dirs::home_dir()
+        .map(|h| h.join(loc.detect_relative_path).is_dir())
+        .unwrap_or(false)
+}
+
+pub fn parse_harness_selection(spec: &str) -> Result<HarnessSelection> {
+    let trimmed = spec.trim();
+    if trimmed.is_empty() {
+        bail!("--skills requires a value (all, detected, auto, none, or comma-separated ids)");
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    match lower.as_str() {
+        "all" => return Ok(HarnessSelection::All),
+        "detected" => return Ok(HarnessSelection::Detected),
+        "auto" => return Ok(HarnessSelection::Auto),
+        "none" => return Ok(HarnessSelection::Only(vec![])),
+        _ => {}
+    }
+
+    let parts: Vec<&str> = trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if parts.is_empty() {
+        bail!("--skills requires at least one harness id");
+    }
+
+    for part in &parts {
+        let id = part.to_ascii_lowercase();
+        if matches!(id.as_str(), "all" | "detected" | "auto" | "none") {
+            bail!("keyword `{part}` cannot be combined with other harness ids");
+        }
+    }
+
+    let valid_ids: Vec<&str> = SKILL_LOCATIONS.iter().map(|l| l.id).collect();
+    let mut chosen = Vec::new();
+    for part in parts {
+        let id = part.to_ascii_lowercase();
+        if !valid_ids.contains(&id.as_str()) {
+            bail!(
+                "unknown harness `{part}` — valid ids: {}",
+                valid_ids.join(", ")
+            );
+        }
+        if !chosen.iter().any(|existing: &String| existing == &id) {
+            chosen.push(id);
+        }
+    }
+
+    // Preserve canonical SKILL_LOCATIONS order.
+    let ordered: Vec<String> = SKILL_LOCATIONS
+        .iter()
+        .filter(|loc| chosen.iter().any(|id| id == loc.id))
+        .map(|loc| loc.id.to_string())
+        .collect();
+
+    Ok(HarnessSelection::Only(ordered))
+}
+
+pub fn resolve_locations(sel: &HarnessSelection) -> Vec<&'static SkillLocation> {
+    match sel {
+        HarnessSelection::All => SKILL_LOCATIONS.iter().collect(),
+        HarnessSelection::Detected => SKILL_LOCATIONS
+            .iter()
+            .filter(|loc| is_detected(loc))
+            .collect(),
+        HarnessSelection::Auto => SKILL_LOCATIONS
+            .iter()
+            .filter(|loc| is_detected(loc) || skill_path(loc).map(|p| p.exists()).unwrap_or(false))
+            .collect(),
+        HarnessSelection::Only(ids) => SKILL_LOCATIONS
+            .iter()
+            .filter(|loc| ids.iter().any(|id| id == loc.id))
+            .collect(),
+    }
+}
+
+pub fn resolve_ids(sel: &HarnessSelection) -> Vec<String> {
+    resolve_locations(sel)
+        .iter()
+        .map(|loc| loc.id.to_string())
+        .collect()
+}
+
+pub fn configured_selection() -> HarnessSelection {
+    configured_selection_with_origin().0
+}
+
+pub fn configured_selection_with_origin() -> (HarnessSelection, SkillsUpdateOrigin) {
+    match crate::config::Config::load() {
+        Ok(config) => match config.skills.harnesses {
+            Some(ids) => (HarnessSelection::Only(ids), SkillsUpdateOrigin::Config),
+            None => (HarnessSelection::Auto, SkillsUpdateOrigin::Auto),
+        },
+        Err(_) => (HarnessSelection::Auto, SkillsUpdateOrigin::Auto),
+    }
+}
+
+fn format_update_command_line(dry_run: bool, origin: &SkillsUpdateOrigin) -> String {
+    let mut parts = vec!["stax skills update".to_string()];
+    if dry_run {
+        parts.push("--dry-run".to_string());
+    }
+    match origin {
+        SkillsUpdateOrigin::AllFlag => parts.push("--all".to_string()),
+        SkillsUpdateOrigin::Cli { spec } => parts.push(format!("--skills {spec}")),
+        SkillsUpdateOrigin::Config | SkillsUpdateOrigin::Auto | SkillsUpdateOrigin::Setup => {}
+    }
+    parts.join(" ")
+}
+
+fn format_harness_selection_summary(ids: &[String], origin: &SkillsUpdateOrigin) -> String {
+    let id_list = ids.join(", ");
+    let source = match origin {
+        SkillsUpdateOrigin::AllFlag => "all known harnesses (--all)".to_string(),
+        SkillsUpdateOrigin::Cli { spec } => format!("--skills {spec}"),
+        SkillsUpdateOrigin::Config => "config [skills] harnesses".to_string(),
+        SkillsUpdateOrigin::Auto => {
+            "auto: detected on disk or existing skill file (set [skills] harnesses or run st setup to narrow)"
+                .to_string()
+        }
+        SkillsUpdateOrigin::Setup => "st setup selection".to_string(),
+    };
+    format!("Harnesses ({source}): {id_list}")
+}
 
 /// Parse `<!-- stax-skills-version: X.Y.Z -->` or `stax_version: "X.Y.Z"` from the
 /// first 40 lines of a skill file's content.
@@ -107,16 +288,26 @@ fn fetch_remote_skills() -> Result<String> {
     Ok(body)
 }
 
+fn location_selected(loc: &SkillLocation, sel: &HarnessSelection) -> bool {
+    resolve_locations(sel)
+        .iter()
+        .any(|selected| selected.id == loc.id)
+}
+
 pub fn run_list() -> Result<()> {
     println!("{}", "stax skills".bold());
     println!();
 
+    let selection = configured_selection();
     let mut any_found = false;
 
     for loc in SKILL_LOCATIONS {
         let Some(path) = skill_path(loc) else {
             continue;
         };
+
+        let selected = location_selected(loc, &selection);
+        let not_selected_suffix = if selected { "" } else { "  not selected" };
 
         match std::fs::read_to_string(&path) {
             Ok(content) => {
@@ -128,37 +319,51 @@ pub fn run_list() -> Result<()> {
                 match &installed {
                     Some(v) if v == PKG_VERSION => {
                         println!(
-                            "{}  {} {}  {}",
+                            "{}  {} {}  {}{}",
                             "✓".green(),
                             label,
                             format!("(v{v})").dimmed(),
                             path_str,
+                            not_selected_suffix.dimmed(),
                         );
                     }
                     Some(v) => {
                         println!(
-                            "{}  {} {}  {}",
+                            "{}  {} {}  {}{}",
                             "⚠".yellow(),
                             label,
                             format!("(v{v} → v{PKG_VERSION} available)").yellow(),
                             path_str,
+                            not_selected_suffix.dimmed(),
                         );
                     }
                     None => {
                         println!(
-                            "{}  {} {}  {}",
+                            "{}  {} {}  {}{}",
                             "⚠".yellow(),
                             label,
                             "(no version marker — may be out of date)".yellow(),
                             path_str,
+                            not_selected_suffix.dimmed(),
                         );
                     }
                 }
             }
             Err(_) => {
-                // File doesn't exist — show it as "not installed".
                 let path_str = path.display().to_string().dimmed();
-                println!("{}  {}  {}", "–".dimmed(), loc.name.dimmed(), path_str,);
+                let detected = if is_detected(loc) {
+                    " (detected)".dimmed().to_string()
+                } else {
+                    String::new()
+                };
+                println!(
+                    "{}  {}{}  {}{}",
+                    "–".dimmed(),
+                    loc.name.dimmed(),
+                    detected,
+                    path_str,
+                    not_selected_suffix.dimmed(),
+                );
             }
         }
     }
@@ -171,7 +376,7 @@ pub fn run_list() -> Result<()> {
         );
     } else {
         println!(
-            "Run {} to bring all skill files up to date.",
+            "Run {} to bring selected skill files up to date.",
             "`stax skills update`".cyan()
         );
     }
@@ -180,21 +385,36 @@ pub fn run_list() -> Result<()> {
 }
 
 pub fn run_update(dry_run: bool) -> Result<()> {
-    if dry_run {
-        println!("{}", "stax skills update --dry-run".bold());
-    } else {
-        println!("{}", "stax skills update".bold());
+    let (sel, origin) = configured_selection_with_origin();
+    run_update_with(dry_run, &sel, origin)
+}
+
+pub fn run_update_with(
+    dry_run: bool,
+    sel: &HarnessSelection,
+    origin: SkillsUpdateOrigin,
+) -> Result<()> {
+    let locations = resolve_locations(sel);
+    if locations.is_empty() {
+        println!(
+            "{}",
+            "No agent harnesses selected — nothing to update. Run `stax skills update --all` or re-run `stax setup`.".dimmed()
+        );
+        return Ok(());
     }
+
+    let harness_ids: Vec<String> = locations.iter().map(|loc| loc.id.to_string()).collect();
+
+    println!("{}", format_update_command_line(dry_run, &origin).bold());
+    println!(
+        "{}",
+        format_harness_selection_summary(&harness_ids, &origin).dimmed()
+    );
     println!();
 
     println!("Fetching latest skills from GitHub…");
     let remote_body = fetch_remote_skills()?;
 
-    // The target is always the running binary's version — that's what
-    // `build_content` stamps into each skill file and what drives update/staleness
-    // decisions. The remote skills.md marker is informational only; when it lags
-    // behind (the upstream comment isn't always bumped in lockstep), surface it as
-    // a dimmed note rather than something that looks like a mismatch to worry about.
     let remote_body_version = extract_skills_version(&remote_body);
 
     println!("Target version: {}", format!("v{PKG_VERSION}").green());
@@ -212,7 +432,7 @@ pub fn run_update(dry_run: bool) -> Result<()> {
     let mut updated = 0usize;
     let mut skipped = 0usize;
 
-    for loc in SKILL_LOCATIONS {
+    for loc in locations {
         let Some(path) = skill_path(loc) else {
             continue;
         };
@@ -221,10 +441,6 @@ pub fn run_update(dry_run: bool) -> Result<()> {
             .ok()
             .and_then(|c| extract_skills_version(&c));
 
-        // Compare against the local PKG_VERSION (what `build_content` stamps
-        // into the file), not against the remote skills.md marker. This keeps
-        // `skills update` and `skills list` consistent, and works even when the
-        // upstream skills.md marker hasn't been bumped for a release.
         let needs_update = installed_version
             .as_deref()
             .map(|v| v != PKG_VERSION)
@@ -299,8 +515,9 @@ pub fn run_update(dry_run: bool) -> Result<()> {
 /// that are out of date relative to PKG_VERSION.  Used by `stax doctor`.
 pub fn stale_skill_files() -> Vec<(String, Option<String>)> {
     let mut stale = Vec::new();
+    let selection = configured_selection();
 
-    for loc in SKILL_LOCATIONS {
+    for loc in resolve_locations(&selection) {
         let Some(path) = skill_path(loc) else {
             continue;
         };
@@ -385,7 +602,96 @@ mod tests {
 
     #[test]
     fn test_stale_files_skips_missing() {
-        // Should not panic when no files are installed.
         let _ = stale_skill_files();
+    }
+
+    #[test]
+    fn test_skill_location_ids_unique_and_detect_paths() {
+        let mut seen = std::collections::HashSet::new();
+        for loc in SKILL_LOCATIONS {
+            assert!(!loc.id.is_empty());
+            assert!(seen.insert(loc.id), "duplicate id: {}", loc.id);
+            assert!(
+                loc.relative_path.starts_with(loc.detect_relative_path),
+                "{} detect path should prefix relative_path",
+                loc.id
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_harness_selection_keywords() {
+        assert_eq!(
+            parse_harness_selection("all").unwrap(),
+            HarnessSelection::All
+        );
+        assert_eq!(
+            parse_harness_selection("detected").unwrap(),
+            HarnessSelection::Detected
+        );
+        assert_eq!(
+            parse_harness_selection("auto").unwrap(),
+            HarnessSelection::Auto
+        );
+        assert_eq!(
+            parse_harness_selection("none").unwrap(),
+            HarnessSelection::Only(vec![])
+        );
+    }
+
+    #[test]
+    fn test_parse_harness_selection_ids() {
+        assert_eq!(
+            parse_harness_selection("Codex, cursor").unwrap(),
+            HarnessSelection::Only(vec!["codex".into(), "cursor".into()])
+        );
+    }
+
+    #[test]
+    fn test_parse_harness_selection_unknown_id() {
+        let err = parse_harness_selection("bogus").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("bogus"));
+        assert!(msg.contains("codex"));
+    }
+
+    #[test]
+    fn test_parse_harness_selection_keyword_mix_error() {
+        assert!(parse_harness_selection("all,codex").is_err());
+    }
+
+    #[test]
+    fn test_parse_harness_selection_dedupes() {
+        assert_eq!(
+            parse_harness_selection("codex,codex,claude").unwrap(),
+            HarnessSelection::Only(vec!["codex".into(), "claude".into()])
+        );
+    }
+
+    #[test]
+    fn test_format_update_command_line_shows_flags() {
+        assert_eq!(
+            format_update_command_line(false, &SkillsUpdateOrigin::AllFlag),
+            "stax skills update --all"
+        );
+        assert_eq!(
+            format_update_command_line(
+                true,
+                &SkillsUpdateOrigin::Cli {
+                    spec: "codex".into()
+                }
+            ),
+            "stax skills update --dry-run --skills codex"
+        );
+    }
+
+    #[test]
+    fn test_format_harness_selection_summary_auto() {
+        let line = format_harness_selection_summary(
+            &["codex".into(), "cursor".into()],
+            &SkillsUpdateOrigin::Auto,
+        );
+        assert!(line.contains("auto:"));
+        assert!(line.contains("codex, cursor"));
     }
 }

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -45,6 +45,10 @@
 # preflight_auto_repair = true # use merge-base when stored parent boundary would replay too much
 # preflight_warn = true        # print a notice when that automatic repair happens
 
+[skills]
+# harnesses = ["claude", "codex"] # which agent harnesses get skill files
+#   valid ids: claude, codex, cursor, opencode, pi. Unset = auto (detected + already installed).
+
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" | "pi" — global default
 # model = "claude-opus-4-8"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,17 @@ pub struct Config {
     pub git: GitConfig,
     #[serde(default)]
     pub restack: RestackConfig,
+    #[serde(default)]
+    pub skills: SkillsConfig,
+}
+
+/// Which agent harnesses receive stax skill files.
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct SkillsConfig {
+    /// Harness ids to manage (`claude`, `codex`, `cursor`, `opencode`, `pi`).
+    /// Unset = auto (detected harnesses plus any that already have a skill file).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harnesses: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -671,6 +682,14 @@ impl Config {
         let content = toml::to_string_pretty(self)?;
         fs::write(&path, content)?;
         Ok(())
+    }
+
+    /// Persist which agent harnesses should receive skill files (global config only).
+    pub fn set_skill_harnesses(harnesses: &[String]) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.skills.harnesses = Some(harnesses.to_vec());
+        config.save()
     }
 
     /// Clear any saved AI agent/model defaults so interactive commands can re-prompt.

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -106,6 +106,8 @@ mod restack_provenance_tests;
 mod runtime_safety_tests;
 #[path = "scoped_submit_tests.rs"]
 mod scoped_submit_tests;
+#[path = "skills_selection_tests.rs"]
+mod skills_selection_tests;
 #[path = "split_hunk_tests.rs"]
 mod split_hunk_tests;
 #[path = "split_tests.rs"]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -606,6 +606,7 @@ fn test_shell_setup_help_uses_static_install_language() {
     assert!(stdout.contains("~/.config/stax"));
     assert!(stdout.contains("--skip-skills"));
     assert!(stdout.contains("--install-skills"));
+    assert!(stdout.contains("--skills"));
     assert!(stdout.contains("--skip-auth"));
     assert!(stdout.contains("--auth-from-gh"));
     assert!(stdout.contains("--yes"));
@@ -1048,6 +1049,7 @@ async fn test_shell_setup_yes_installs_skills_and_imports_auth_from_gh() {
     ensure_crypto_provider();
     let mock_server = MockServer::start().await;
     let home = tempdir().expect("temp home");
+    std::fs::create_dir_all(home.path().join(".codex")).expect("simulate detected codex");
     let _snippet_path = configure_existing_shell_setup(home.path(), TEST_SHELL);
     let fake_gh_bin = write_fake_gh(home.path(), "gh-imported-token");
 
@@ -1082,7 +1084,11 @@ async fn test_shell_setup_yes_installs_skills_and_imports_auth_from_gh() {
     assert_eq!(saved.trim(), "gh-imported-token");
     assert!(
         home.path().join(".codex/skills/stax/SKILL.md").exists(),
-        "expected skills to be installed"
+        "expected skills to be installed for detected codex harness"
+    );
+    assert!(
+        !home.path().join(".cursor/skills/stax/SKILL.md").exists(),
+        "setup --yes should not install skills for undetected harnesses"
     );
 }
 

--- a/tests/skills_selection_tests.rs
+++ b/tests/skills_selection_tests.rs
@@ -1,0 +1,285 @@
+//! Integration tests for per-harness skills selection during setup/update.
+
+use crate::common::stax_bin;
+use std::process::Command;
+use tempfile::{TempDir, tempdir};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_SHELL: &str = "/bin/bash";
+
+fn shell_rc_path(home: &std::path::Path, shell: &str) -> std::path::PathBuf {
+    if shell.ends_with("zsh") {
+        home.join(".zshrc")
+    } else if shell.ends_with("bash") {
+        home.join(".bashrc")
+    } else if shell.ends_with("fish") {
+        home.join(".config").join("fish").join("config.fish")
+    } else {
+        home.join(".profile")
+    }
+}
+
+fn configure_existing_shell_setup(home: &std::path::Path) -> std::path::PathBuf {
+    let config_dir = home.join(".config").join("stax");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    let snippet_path = config_dir.join("shell-setup.sh");
+    let rc_path = shell_rc_path(home, TEST_SHELL);
+    if let Some(parent) = rc_path.parent() {
+        std::fs::create_dir_all(parent).expect("create shell rc dir");
+    }
+    std::fs::write(
+        &rc_path,
+        format!("source \"{}\" # stax shell-setup\n", snippet_path.display()),
+    )
+    .expect("write shell rc");
+    snippet_path
+}
+
+fn write_unavailable_gh(home: &std::path::Path) -> TempDir {
+    let bin_dir = tempdir().expect("bin dir");
+    let gh_path = bin_dir.path().join("gh");
+    std::fs::write(&gh_path, "#!/bin/sh\nexit 127\n").expect("write fake gh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&gh_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let _ = home;
+    bin_dir
+}
+
+fn path_with_bin(bin_dir: &std::path::Path) -> String {
+    let path = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{}", bin_dir.display(), path)
+}
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+#[tokio::test]
+async fn setup_install_skills_flag_with_skills_list_installs_subset() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = tempdir().expect("temp home");
+    let _snippet = configure_existing_shell_setup(home.path());
+    let gh_bin = write_unavailable_gh(home.path());
+
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<!-- stax-skills-version: 0.51.0 -->\n# Stax Skills\n"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let repo = tempdir().expect("repo");
+    let output = Command::new(stax_bin())
+        .args([
+            "setup",
+            "--yes",
+            "--install-skills",
+            "--skills",
+            "codex,cursor",
+        ])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("SHELL", TEST_SHELL)
+        .env("PATH", path_with_bin(gh_bin.path()))
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env(
+            "STAX_SKILLS_URL",
+            format!("{}/skills.md", mock_server.uri()),
+        )
+        .output()
+        .expect("run setup");
+
+    assert!(output.status.success(), "{:?}", output);
+
+    assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
+    assert!(home.path().join(".cursor/skills/stax/SKILL.md").exists());
+    assert!(!home.path().join(".claude/skills/stax/SKILL.md").exists());
+    assert!(!home.path().join(".pi/agent/skills/stax/SKILL.md").exists());
+    assert!(
+        !home
+            .path()
+            .join(".config/opencode/skills/stax/SKILL.md")
+            .exists()
+    );
+
+    let config =
+        std::fs::read_to_string(home.path().join(".config/stax/config.toml")).expect("read config");
+    assert!(config.contains("harnesses"));
+    assert!(config.contains("codex"));
+    assert!(config.contains("cursor"));
+}
+
+#[tokio::test]
+async fn setup_yes_installs_skills_only_for_detected_harnesses() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = tempdir().expect("temp home");
+    let _snippet = configure_existing_shell_setup(home.path());
+    std::fs::create_dir_all(home.path().join(".codex")).expect("create codex dir");
+    let gh_bin = write_unavailable_gh(home.path());
+
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<!-- stax-skills-version: 0.51.0 -->\n# Stax Skills\n"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let repo = tempdir().expect("repo");
+    let output = Command::new(stax_bin())
+        .args(["setup", "--yes"])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("SHELL", TEST_SHELL)
+        .env("PATH", path_with_bin(gh_bin.path()))
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env(
+            "STAX_SKILLS_URL",
+            format!("{}/skills.md", mock_server.uri()),
+        )
+        .output()
+        .expect("run setup --yes");
+
+    assert!(output.status.success(), "{:?}", output);
+    assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
+    assert!(!home.path().join(".cursor/skills/stax/SKILL.md").exists());
+}
+
+#[test]
+fn setup_skills_unknown_harness_fails() {
+    let home = tempdir().expect("temp home");
+    let _snippet = configure_existing_shell_setup(home.path());
+    let repo = tempdir().expect("repo");
+
+    let output = Command::new(stax_bin())
+        .args(["setup", "--skills", "bogus"])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("SHELL", TEST_SHELL)
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .output()
+        .expect("run setup");
+
+    assert!(!output.status.success());
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("bogus"));
+    assert!(combined.contains("codex"));
+}
+
+#[tokio::test]
+async fn setup_skills_none_writes_nothing() {
+    ensure_crypto_provider();
+    let home = tempdir().expect("temp home");
+    let _snippet = configure_existing_shell_setup(home.path());
+    let gh_bin = write_unavailable_gh(home.path());
+    let repo = tempdir().expect("repo");
+
+    let output = Command::new(stax_bin())
+        .args(["setup", "--yes", "--skills", "none"])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("SHELL", TEST_SHELL)
+        .env("PATH", path_with_bin(gh_bin.path()))
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .output()
+        .expect("run setup");
+
+    assert!(output.status.success(), "{:?}", output);
+    assert!(!home.path().join(".codex/skills/stax/SKILL.md").exists());
+}
+
+#[tokio::test]
+async fn skills_update_respects_configured_harnesses() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = tempdir().expect("temp home");
+    let config_dir = home.path().join(".config/stax");
+    std::fs::create_dir_all(&config_dir).expect("config dir");
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "[skills]\nharnesses = [\"codex\"]\n",
+    )
+    .expect("write config");
+
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<!-- stax-skills-version: 0.51.0 -->\n# Stax Skills\n"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let repo = tempdir().expect("repo");
+    let output = Command::new(stax_bin())
+        .args(["skills", "update"])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("STAX_CONFIG_DIR", &config_dir)
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env(
+            "STAX_SKILLS_URL",
+            format!("{}/skills.md", mock_server.uri()),
+        )
+        .output()
+        .expect("skills update");
+
+    assert!(output.status.success(), "{:?}", output);
+    assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
+    assert!(!home.path().join(".cursor/skills/stax/SKILL.md").exists());
+}
+
+#[tokio::test]
+async fn skills_update_all_overrides_configured_selection() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = tempdir().expect("temp home");
+    let config_dir = home.path().join(".config/stax");
+    std::fs::create_dir_all(&config_dir).expect("config dir");
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "[skills]\nharnesses = [\"codex\"]\n",
+    )
+    .expect("write config");
+
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<!-- stax-skills-version: 0.51.0 -->\n# Stax Skills\n"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let repo = tempdir().expect("repo");
+    let output = Command::new(stax_bin())
+        .args(["skills", "update", "--all"])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("STAX_CONFIG_DIR", &config_dir)
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env(
+            "STAX_SKILLS_URL",
+            format!("{}/skills.md", mock_server.uri()),
+        )
+        .output()
+        .expect("skills update --all");
+
+    assert!(output.status.success(), "{:?}", output);
+    assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
+    assert!(home.path().join(".cursor/skills/stax/SKILL.md").exists());
+    assert!(home.path().join(".claude/skills/stax/SKILL.md").exists());
+}


### PR DESCRIPTION
## Summary

Addresses #726: `stax setup` no longer installs the stax skill for every agent harness by default.

- Interactive setup: after the skills yes/no prompt, a multi-select lists Codex, OpenCode, Claude, Cursor, and pi — pre-checked when the harness directory exists on disk.
- Non-interactive: `st setup --skills all|detected|auto|none|claude,codex,...` (composable with `--install-skills`).
- `st setup --yes` now installs skills only for **detected** harnesses (use `--skills all` for the previous behaviour).
- Persists `[skills] harnesses` in `~/.config/stax/config.toml` so `st skills update`, `st skills list`, and `st doctor` respect the selection; `st skills update --all` overrides.

## Test plan

- [x] `make lint` / `make test`
- [x] Unit tests for harness selection parsing
- [x] Integration tests for setup `--skills`, `--yes` detection, config-scoped update, and `--all` override