### PR TITLE
fix(restack): drop become-empty commits instead of erroring

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1161,7 +1161,7 @@ impl GitRepo {
     }
 
     fn rebase_in_path(&self, cwd: &Path, onto: &str) -> Result<RebaseResult> {
-        self.rebase_with_args_in_path(cwd, &["rebase", onto])
+        self.rebase_with_args_in_path(cwd, &["rebase", "--empty=drop", onto])
     }
 
     fn rebase_onto_upstream_in_path(
@@ -1170,7 +1170,7 @@ impl GitRepo {
         onto: &str,
         upstream: &str,
     ) -> Result<RebaseResult> {
-        self.rebase_with_args_in_path(cwd, &["rebase", "--onto", onto, upstream])
+        self.rebase_with_args_in_path(cwd, &["rebase", "--empty=drop", "--onto", onto, upstream])
     }
 
     fn reset_hard_in_path(&self, cwd: &Path, target: &str) -> Result<()> {
@@ -1588,22 +1588,54 @@ Use --auto-stash-pop or stash/commit changes first.",
         self.rebase_branch_onto_with_provenance(branch, onto, "", auto_stash_pop)
     }
 
-    /// Continue a rebase after resolving conflicts
+    /// Continue a rebase after resolving conflicts.
+    ///
+    /// If `git rebase --continue` stops again because the next commit became
+    /// empty (not because of real conflicts), automatically `--skip` it and
+    /// keep going, so users aren't stuck on commits stax should have dropped.
     pub fn rebase_continue(&self) -> Result<RebaseResult> {
-        let status = Command::new("git")
-            .args(["rebase", "--continue"])
-            .env("GIT_EDITOR", "true")
-            .current_dir(self.workdir()?)
-            .status()
-            .context("Failed to run git rebase --continue")?;
+        let workdir = self.workdir()?.to_path_buf();
 
-        if status.success() {
-            Ok(RebaseResult::Success)
-        } else if self.rebase_in_progress()? {
-            Ok(RebaseResult::Conflict)
-        } else {
-            anyhow::bail!("git rebase --continue failed")
+        for _ in 0..1000 {
+            let output = Command::new("git")
+                .args(["rebase", "--continue"])
+                .env("GIT_EDITOR", "true")
+                .current_dir(&workdir)
+                .output()
+                .context("Failed to run git rebase --continue")?;
+
+            if output.status.success() {
+                return Ok(RebaseResult::Success);
+            }
+
+            if !self.rebase_in_progress()? {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                anyhow::bail!("git rebase --continue failed: {}", stderr);
+            }
+
+            if self.has_conflicts_in(&workdir)? {
+                return Ok(RebaseResult::Conflict);
+            }
+
+            let skip_output = Command::new("git")
+                .args(["rebase", "--skip"])
+                .env("GIT_EDITOR", "true")
+                .current_dir(&workdir)
+                .output()
+                .context("Failed to run git rebase --skip")?;
+
+            if !skip_output.status.success() && self.rebase_in_progress()? {
+                if self.has_conflicts_in(&workdir)? {
+                    return Ok(RebaseResult::Conflict);
+                }
+                let stderr = String::from_utf8_lossy(&skip_output.stderr)
+                    .trim()
+                    .to_string();
+                anyhow::bail!("git rebase --skip failed: {}", stderr);
+            }
         }
+
+        anyhow::bail!("git rebase --continue did not converge after 1000 iterations")
     }
 
     /// Check if a rebase is in progress

--- a/tests/conflict_handling_tests.rs
+++ b/tests/conflict_handling_tests.rs
@@ -396,3 +396,89 @@ fn test_restack_continue_completes_remaining_branches() {
         stdout
     );
 }
+
+// =============================================================================
+// Bug 4: restack should drop become-empty commits instead of stopping
+// =============================================================================
+
+/// Build a two-commit feature branch off main where the first commit's change
+/// duplicates a change that later lands on main, so it becomes empty on rebase,
+/// while the second commit does not. Returns (feat_branch, upstream_sha, new_main_sha).
+fn create_empty_commit_scenario(repo: &TestRepo) -> (String, String, String) {
+    repo.create_file("fileA.txt", "content X\n");
+    repo.commit("Add fileA");
+
+    repo.run_stax(&["bc", "feat"]);
+    let feat_branch = repo.current_branch();
+    let upstream_sha = {
+        let output = repo.git(&["merge-base", "main", &feat_branch]);
+        TestRepo::stdout(&output).trim().to_string()
+    };
+
+    repo.create_file("fileB.txt", "content Y\n");
+    repo.commit("Add fileB");
+
+    repo.create_file("fileC.txt", "content Z\n");
+    repo.commit("Add fileC");
+
+    repo.run_stax(&["checkout", "main"]);
+    repo.create_file("fileB.txt", "content Y\n");
+    repo.commit("Add fileB on main");
+    let new_main_sha = {
+        let output = repo.git(&["rev-parse", "main"]);
+        TestRepo::stdout(&output).trim().to_string()
+    };
+
+    repo.run_stax(&["checkout", &feat_branch]);
+
+    (feat_branch, upstream_sha, new_main_sha)
+}
+
+#[test]
+fn test_restack_drops_empty_commit_instead_of_stopping() {
+    let repo = TestRepo::new();
+    let (_feat_branch, _upstream_sha, _new_main_sha) = create_empty_commit_scenario(&repo);
+
+    let output = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    output.assert_success();
+
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected no rebase in progress after restack, output: {}",
+        TestRepo::stdout(&output)
+    );
+
+    let file_c = std::fs::read_to_string(repo.path().join("fileC.txt"))
+        .expect("fileC.txt should exist on feat after restack");
+    assert_eq!(file_c, "content Z\n");
+}
+
+#[test]
+fn test_continue_auto_skips_empty_commit() {
+    let repo = TestRepo::new();
+    let (feat_branch, upstream_sha, new_main_sha) = create_empty_commit_scenario(&repo);
+
+    let rebase_output = repo.git(&[
+        "rebase",
+        "--empty=stop",
+        "--onto",
+        &new_main_sha,
+        &upstream_sha,
+        &feat_branch,
+    ]);
+    let _ = rebase_output;
+
+    assert!(
+        repo.has_rebase_in_progress(),
+        "Expected rebase to stop on the become-empty commit"
+    );
+
+    let output = repo.run_stax(&["continue"]);
+
+    assert!(
+        !repo.has_rebase_in_progress(),
+        "Expected `st continue` to auto-skip the empty commit and finish, output: {}",
+        TestRepo::stdout(&output)
+    );
+    output.assert_success();
+}


### PR DESCRIPTION
## Problem

`st restack` failed with:

```
Error: Could not finish rebasing 'cesar/XXX-2943-...'
Inspect the rebase state, then run `st continue` or `st abort`
git rebase stopped for 'cesar/XXX-2943-...' without unresolved file conflicts
```

The rebase hit a commit that became **empty** — its changes were already present in the new base. This happens routinely after a parent PR squash-merges into trunk, or when the same change lands upstream independently. Git stops such a rebase and leaves it in progress **without any file conflict**.

stax misclassified that stopped-but-conflict-free state as a failure and bailed. Worse, the suggested recovery was also broken: `st continue` runs `git rebase --continue`, but git wants `git rebase --skip` for an empty commit — so the user was genuinely stuck with no working stax path forward.

## Fix

Two changes, both in `src/git/repo.rs` at the lowest shared rebase layer so every path (restack, sync, cascade, move, reorder, reparent, fold, upstack, merge-rebase, TUI) benefits:

1. **Prevention** — pass `--empty=drop` to the shared `git rebase` invocations (`rebase_in_path`, `rebase_onto_upstream_in_path`). Commits that become empty are dropped automatically, which is the correct semantic when restacking a stack after a parent has merged. New restacks never hit the spurious stop.
2. **Recovery** — `rebase_continue` (behind `st continue`) now detects a rebase that is stopped-but-conflict-free and auto-runs `git rebase --skip`, looping until the rebase completes or a real conflict appears. This unblocks anyone **already** stuck in this state.

`--empty=drop` only affects commits that *become* empty during the rebase; commits that *start* empty are governed by `--keep-empty` (default keep), so intentional empty commits are preserved. Real file conflicts still stop and report exactly as before.

## Verification

- Added two regression tests in `tests/conflict_handling_tests.rs`:
  - `test_restack_drops_empty_commit_instead_of_stopping` — a two-commit branch where the first commit becomes empty after trunk advances (two commits are required to bypass the whole-branch-integrated squash-merge short-circuit); restack now succeeds and drops the empty commit.
  - `test_continue_auto_skips_empty_commit` — forces the stuck state with `git rebase --empty=stop`, then confirms `st continue` auto-skips and finishes.
- `cargo fmt --check`, `cargo check`, clippy clean on changed files.
- Full `conflict_handling_tests::` + `continue_tests::` suites green (27 tests); both new tests pass.
- Full native suite run: only pre-existing, unrelated `cli_tests::test_shell_setup_*` failures (verified identical on `main`, from #727).

## Risk

Low. The change is additive at the git-invocation layer and does not alter conflict handling, metadata, CLI surface, or the transaction/undo system.
