### PR TITLE
feat(refresh): add --all-stacks to refresh every stack in one pass

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -41,6 +41,7 @@ st --trace status --json >/dev/null
 | `st refresh` | | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack (`st update` is a back-compat alias) |
 | `st refresh --force --yes --no-prompt` | | Run the full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
+| `st refresh --all-stacks` | | Refresh every stack in the repo (fetch/trunk sync once, then restack + submit each stack); stops at the first conflict |
 | `st restack` | | Rebase current stack locally — auto-normalizes missing/merged parents; `--stop-here` limits scope |
 | `st cascade` | | Restack the stack and submit updates, without fetching trunk (offline-friendly) |
 | `st diff` | | Show per-branch diffs vs parent |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -557,6 +557,9 @@ pub(crate) enum Commands {
         /// Auto-stash and auto-pop dirty target worktrees during sync/restack
         #[arg(long)]
         auto_stash_pop: bool,
+        /// Refresh every stack in the repo, not just the current one
+        #[arg(long)]
+        all_stacks: bool,
     },
 
     /// Checkout a branch in the stack

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -447,6 +447,7 @@ pub fn run() -> Result<()> {
             yes,
             no_prompt,
             auto_stash_pop,
+            all_stacks,
         } => commands::refresh::run(
             no_pr,
             no_submit,
@@ -456,6 +457,7 @@ pub fn run() -> Result<()> {
             yes,
             no_prompt,
             auto_stash_pop,
+            all_stacks,
         ),
         Commands::Checkout {
             branch,

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -1,8 +1,11 @@
 use crate::commands;
 use crate::engine::Stack;
+use crate::errors::ConflictStopped;
 use crate::git::{GitRepo, local_branch_exists_in};
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use colored::Colorize;
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use std::io::IsTerminal;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -14,7 +17,21 @@ pub fn run(
     yes: bool,
     no_prompt: bool,
     auto_stash_pop: bool,
+    all_stacks: bool,
 ) -> Result<()> {
+    if all_stacks {
+        return run_all_stacks(
+            no_pr,
+            no_submit,
+            force,
+            safe,
+            verbose,
+            yes,
+            no_prompt,
+            auto_stash_pop,
+        );
+    }
+
     let repo = GitRepo::open()?;
     let original = repo.current_branch()?;
     let workdir = repo.workdir()?.to_path_buf();
@@ -97,4 +114,340 @@ fn restore_original_branch(
     }
 
     Ok(())
+}
+
+struct StackPlan {
+    root: String,
+    branches: Vec<String>,
+}
+
+fn collect_stack_plans(stack: &Stack) -> Vec<StackPlan> {
+    let mut roots = stack.children(&stack.trunk);
+    roots.sort();
+    roots
+        .into_iter()
+        .filter(|root| root != &stack.trunk)
+        .map(|root| {
+            let mut descendants = stack.descendants(&root);
+            descendants.sort();
+            let mut branches = vec![root.clone()];
+            branches.extend(descendants);
+            StackPlan { root, branches }
+        })
+        .collect()
+}
+
+fn root_of(stack: &Stack, branch: &str) -> Option<String> {
+    if branch == stack.trunk || !stack.branches.contains_key(branch) {
+        return None;
+    }
+    let mut ancestors = stack.ancestors(branch);
+    ancestors.retain(|a| a != &stack.trunk);
+    Some(ancestors.pop().unwrap_or_else(|| branch.to_string()))
+}
+
+fn print_all_stacks_header(no_pr: bool, no_submit: bool) {
+    let step3 = if no_submit {
+        "Skip push and PR updates (--no-submit)"
+    } else if no_pr {
+        "Push branches without updating PRs"
+    } else {
+        "Push branches and update PRs"
+    };
+    println!("{} {}", "▸".cyan().bold(), "Updating all stacks".bold());
+    println!("  {} Sync trunk (once)", "├─".dimmed());
+    println!(
+        "  {} Restack every stack onto updated parents",
+        "├─".dimmed()
+    );
+    println!("  {} {}", "└─".dimmed(), step3);
+}
+
+fn print_all_stacks_plan(stack: &Stack, plans: &[StackPlan]) {
+    for (index, plan) in plans.iter().enumerate() {
+        let count = plan.branches.len();
+        let noun = if count == 1 { "branch" } else { "branches" };
+        println!("  {}. {}  ({count} {noun})", index + 1, plan.root);
+        for branch in &plan.branches {
+            let pr = stack
+                .branches
+                .get(branch)
+                .and_then(|b| b.pr_number)
+                .map(|number| format!("#{number}"))
+                .unwrap_or_else(|| "(no PR)".to_string());
+            println!("     {} {}", branch, pr.dimmed());
+        }
+    }
+}
+
+fn confirm_all_stacks(plans: &[StackPlan], yes: bool, force: bool) -> Result<bool> {
+    if yes || force || !std::io::stdin().is_terminal() {
+        return Ok(true);
+    }
+    Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Refresh {} stacks?", plans.len()))
+        .default(true)
+        .interact()
+        .map_err(Into::into)
+}
+
+fn print_all_stacks_progress(plans: &[StackPlan], completed: &[String], stopped_at: &str) {
+    let remaining: Vec<&str> = plans
+        .iter()
+        .map(|plan| plan.root.as_str())
+        .filter(|root| *root != stopped_at && !completed.iter().any(|c| c == root))
+        .collect();
+    println!();
+    println!(
+        "{} {}",
+        "✗".red(),
+        format!("Stopped at '{stopped_at}'").bold()
+    );
+    if completed.is_empty() {
+        println!("  Done: (none)");
+    } else {
+        println!("  Done: {}", completed.join(", "));
+    }
+    if remaining.is_empty() {
+        println!("  Remaining: (none)");
+    } else {
+        println!("  Remaining: {}", remaining.join(", "));
+    }
+    println!(
+        "  Resolve the conflict, run `st continue`, then re-run `st refresh --all-stacks`. \
+         Finished stacks are no-ops on the re-run."
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_all_stacks(
+    no_pr: bool,
+    no_submit: bool,
+    force: bool,
+    safe: bool,
+    verbose: bool,
+    yes: bool,
+    no_prompt: bool,
+    auto_stash_pop: bool,
+) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let original = repo.current_branch()?;
+    let workdir = repo.workdir()?.to_path_buf();
+    let stack = Stack::load(&repo)?;
+
+    let plans = collect_stack_plans(&stack);
+    if plans.is_empty() {
+        println!("{}", "No tracked stacks to refresh.".yellow());
+        return Ok(());
+    }
+
+    if !auto_stash_pop && repo.is_dirty()? {
+        bail!(
+            "Working tree has uncommitted changes.\n\
+             `st refresh --all-stacks` restacks every stack, so it needs a clean tree.\n\
+             Commit or stash your changes, or re-run with --auto-stash-pop."
+        );
+    }
+
+    print_all_stacks_header(no_pr, no_submit);
+    print_all_stacks_plan(&stack, &plans);
+
+    if !confirm_all_stacks(&plans, yes, force)? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    let submit_fetch_refs: Vec<String> = if no_submit {
+        Vec::new()
+    } else {
+        plans
+            .iter()
+            .flat_map(|p| p.branches.iter().cloned())
+            .collect()
+    };
+
+    let sync_root = root_of(&stack, &original);
+    if let Err(error) = commands::sync::run(
+        true,  // restack
+        false, // full
+        false, // delete_merged
+        false, // delete_upstream_gone
+        force,
+        safe,
+        false, // continue
+        false, // quiet
+        verbose,
+        auto_stash_pop,
+        commands::sync::StashPolicy::Prompt,
+        false, // json
+        &submit_fetch_refs,
+        true, // refresh/update is an explicit workflow — no Sync plan prompt
+    ) {
+        if let Some(root) = sync_root.as_deref() {
+            print_all_stacks_progress(&plans, &[], root);
+        }
+        return Err(error);
+    }
+    if repo.rebase_in_progress()? {
+        if let Some(root) = sync_root.as_deref() {
+            print_all_stacks_progress(&plans, &[], root);
+        }
+        return Ok(());
+    }
+
+    let live_stack = Stack::load(&repo)?;
+    let live_plans = collect_stack_plans(&live_stack);
+
+    let mut completed: Vec<String> = Vec::new();
+    for plan in &live_plans {
+        if let Err(error) =
+            commands::restack::run_stack_containing(&repo, &plan.root, false, auto_stash_pop)
+        {
+            print_all_stacks_progress(&live_plans, &completed, &plan.root);
+            return if error.downcast_ref::<ConflictStopped>().is_some() {
+                Err(error)
+            } else {
+                Err(error.context(format!("failed to restack stack '{}'", plan.root)))
+            };
+        }
+        if repo.rebase_in_progress()? {
+            print_all_stacks_progress(&live_plans, &completed, &plan.root);
+            return Ok(());
+        }
+
+        if !no_submit {
+            repo.checkout(&plan.root).with_context(|| {
+                format!(
+                    "could not check out '{}' to submit its stack \
+                     (is it checked out in another worktree?)",
+                    plan.root
+                )
+            })?;
+            commands::submit::run(
+                commands::submit::SubmitScope::Stack,
+                commands::submit::SubmitOptions {
+                    no_pr,
+                    prefetched: true,
+                    yes,
+                    no_prompt,
+                    verbose,
+                    ..Default::default()
+                },
+            )
+            .with_context(|| format!("submit failed for stack '{}'", plan.root))?;
+        }
+        completed.push(plan.root.clone());
+    }
+
+    restore_original_branch(&repo, &workdir, &original)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::stack::StackBranch;
+    use std::collections::HashMap;
+
+    fn create_test_stack() -> Stack {
+        // main (trunk)
+        //  ├── feature-a
+        //  │   └── feature-a-1
+        //  │       └── feature-a-2
+        //  └── feature-b
+        let mut branches = HashMap::new();
+
+        branches.insert(
+            "main".to_string(),
+            StackBranch {
+                name: "main".to_string(),
+                parent: None,
+                parent_revision: None,
+                children: vec!["feature-a".to_string(), "feature-b".to_string()],
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "feature-a".to_string(),
+            StackBranch {
+                name: "feature-a".to_string(),
+                parent: Some("main".to_string()),
+                parent_revision: Some("abc".to_string()),
+                children: vec!["feature-a-1".to_string()],
+                needs_restack: false,
+                pr_number: Some(1),
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "feature-a-1".to_string(),
+            StackBranch {
+                name: "feature-a-1".to_string(),
+                parent: Some("feature-a".to_string()),
+                parent_revision: Some("def".to_string()),
+                children: vec!["feature-a-2".to_string()],
+                needs_restack: false,
+                pr_number: Some(2),
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "feature-a-2".to_string(),
+            StackBranch {
+                name: "feature-a-2".to_string(),
+                parent: Some("feature-a-1".to_string()),
+                parent_revision: Some("ghi".to_string()),
+                children: Vec::new(),
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+        branches.insert(
+            "feature-b".to_string(),
+            StackBranch {
+                name: "feature-b".to_string(),
+                parent: Some("main".to_string()),
+                parent_revision: Some("jkl".to_string()),
+                children: Vec::new(),
+                needs_restack: false,
+                pr_number: Some(3),
+                pr_state: None,
+                pr_is_draft: None,
+            },
+        );
+
+        Stack {
+            branches,
+            trunk: "main".to_string(),
+        }
+    }
+
+    #[test]
+    fn collect_stack_plans_returns_sorted_roots_with_descendants() {
+        let stack = create_test_stack();
+        let plans = collect_stack_plans(&stack);
+        let roots: Vec<&str> = plans.iter().map(|p| p.root.as_str()).collect();
+        assert_eq!(roots, vec!["feature-a", "feature-b"]);
+        assert_eq!(
+            plans[0].branches,
+            vec!["feature-a", "feature-a-1", "feature-a-2"]
+        );
+    }
+
+    #[test]
+    fn root_of_finds_stack_root() {
+        let stack = create_test_stack();
+        assert_eq!(
+            root_of(&stack, "feature-a-2"),
+            Some("feature-a".to_string())
+        );
+        assert_eq!(root_of(&stack, "feature-b"), Some("feature-b".to_string()));
+        assert_eq!(root_of(&stack, "main"), None);
+    }
 }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -101,6 +101,31 @@ pub(crate) fn resume_after_rebase(
     )
 }
 
+pub(crate) fn run_stack_containing(
+    repo: &GitRepo,
+    branch: &str,
+    quiet: bool,
+    auto_stash_pop: bool,
+) -> Result<()> {
+    let session = RepositorySession::open(repo.workdir()?)?;
+    let options = RestackExecutionOptions {
+        scope: RestackScope::StackContaining(branch.to_string()),
+        auto_stash: auto_stash_pop,
+        restore_branch: None,
+        completed_from_receipt: HashSet::new(),
+    };
+    let receipt = match session.restack_with_options(options, &mut NoopOperationReporter) {
+        Ok(receipt) => receipt,
+        Err(error) if error.kind == OperationErrorKind::RebaseConflict => {
+            render_restack_error(repo, &error, quiet);
+            return Err(ConflictStopped.into());
+        }
+        Err(error) => return Err(operation_error(error)),
+    };
+    render_restack_receipt(&receipt, quiet);
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_adapter(
     repo: &GitRepo,

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -92,6 +92,8 @@ mod pr_open_tests;
 mod pr_template_tests;
 #[path = "ready_tests.rs"]
 mod ready_tests;
+#[path = "refresh_all_stacks_tests.rs"]
+mod refresh_all_stacks_tests;
 #[path = "refresh_visual_tests.rs"]
 mod refresh_visual_tests;
 #[path = "reorder_tests.rs"]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -246,6 +246,7 @@ fn test_refresh_help() {
     assert!(stdout.contains("verbose"));
     assert!(stdout.contains("--yes"));
     assert!(stdout.contains("--no-prompt"));
+    assert!(stdout.contains("--all-stacks"));
 }
 
 #[test]

--- a/tests/refresh_all_stacks_tests.rs
+++ b/tests/refresh_all_stacks_tests.rs
@@ -1,0 +1,97 @@
+//! Integration tests for `st refresh --all-stacks`.
+
+use crate::common::{OutputAssertions, TestRepo};
+
+/// Build two independent stacks off trunk: `feat-a -> feat-a1` and `feat-b`.
+/// Returns the actual (possibly-prefixed) branch names for each stack.
+fn build_two_stacks(repo: &TestRepo) -> (Vec<String>, Vec<String>) {
+    let stack_a = repo.create_stack(&["feat-a", "feat-a1"]);
+    repo.git(&["checkout", "main"]).assert_success();
+    let stack_b = repo.create_stack(&["feat-b"]);
+    (stack_a, stack_b)
+}
+
+#[test]
+fn all_stacks_plan_lists_every_root_and_branch() {
+    let repo = TestRepo::new_with_remote();
+    let (stack_a, stack_b) = build_two_stacks(&repo);
+
+    let output = repo.run_stax(&["refresh", "--all-stacks", "--no-submit", "--force", "--yes"]);
+    let stdout = TestRepo::stdout(&output);
+
+    assert!(
+        stdout.contains("Updating all stacks"),
+        "expected header, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(&stack_a[0]),
+        "expected root of stack a, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(&stack_a[1]),
+        "expected descendant of stack a, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(&stack_b[0]),
+        "expected root of stack b, got: {stdout}"
+    );
+}
+
+#[test]
+fn all_stacks_restacks_every_stack() {
+    let repo = TestRepo::new_with_remote();
+    let (stack_a, stack_b) = build_two_stacks(&repo);
+
+    repo.simulate_remote_commit("trunk-update.txt", "updated", "Update trunk");
+
+    repo.run_stax(&["refresh", "--all-stacks", "--no-submit", "--force", "--yes"])
+        .assert_success();
+
+    for branch in stack_a.iter().chain(stack_b.iter()) {
+        repo.git(&["merge-base", "--is-ancestor", "main", branch])
+            .assert_success();
+    }
+}
+
+#[test]
+fn plain_refresh_leaves_other_stacks_untouched() {
+    let repo = TestRepo::new_with_remote();
+    let (stack_a, stack_b) = build_two_stacks(&repo);
+
+    repo.simulate_remote_commit("trunk-update.txt", "updated", "Update trunk");
+
+    repo.git(&["checkout", &stack_a[1]]).assert_success();
+    repo.run_stax(&["refresh", "--no-submit", "--force"])
+        .assert_success();
+
+    for branch in &stack_a {
+        repo.git(&["merge-base", "--is-ancestor", "main", branch])
+            .assert_success();
+    }
+    repo.git(&["merge-base", "--is-ancestor", "main", &stack_b[0]])
+        .assert_failure();
+}
+
+#[test]
+fn all_stacks_restores_original_branch() {
+    let repo = TestRepo::new_with_remote();
+    let (stack_a, _stack_b) = build_two_stacks(&repo);
+
+    repo.git(&["checkout", &stack_a[1]]).assert_success();
+    repo.run_stax(&["refresh", "--all-stacks", "--no-submit", "--force", "--yes"])
+        .assert_success();
+
+    assert_eq!(repo.current_branch(), stack_a[1]);
+}
+
+#[test]
+fn all_stacks_rejects_dirty_tree_without_auto_stash_pop() {
+    let repo = TestRepo::new_with_remote();
+    build_two_stacks(&repo);
+
+    repo.create_file("dirty.txt", "x");
+
+    let output = repo.run_stax(&["refresh", "--all-stacks", "--no-submit", "--force", "--yes"]);
+    output.assert_failure();
+    output.assert_stderr_contains("--auto-stash-pop");
+}


### PR DESCRIPTION
## Problem

`st refresh` is hard-scoped to the stack you happen to be standing on. Both the restack scope (`sync.rs`, `unfrozen_restack_scope`) and the submit fetch refs (`refresh.rs`) derive from `stack.current_stack(&current)`.

Two consequences:

- **N stacks means N cycles.** Keeping three independent stacks current is three `st checkout` + `st refresh` rounds, each re-fetching and re-syncing trunk from scratch.
- **From trunk it does almost nothing.** `current_stack` on trunk resolves to empty, so the restack scope is empty and there is no stack to submit — trunk gets synced and that's it. That's the exact moment you'd most want "bring everything up to date."

## Solution

`st refresh --all-stacks` fetches and syncs trunk **once**, then walks every stack root — tracked branches whose parent is trunk, via `stack.children(&trunk)`, the same set `st restack --all` uses — restacking and submitting each in turn.

```
▸ Updating all stacks
  ├─ Sync trunk (once)
  ├─ Restack every stack onto updated parents
  └─ Push branches and update PRs

  1. feat/parser  (2 branches)
     feat/parser #711
     feat/parser-2 (no PR)
  2. fix/flaky-test  (1 branch)
     fix/flaky-test #718
```

The plan prints before anything is touched; `-y`/`--force` skips the confirmation.

## Design notes for reviewers

Four decisions that aren't obvious from the diff:

**1. `--all-stacks`, not `--all`.** `st restack --all` already means *"all branches in the current stack"*. Reusing the name on a sibling command for *"all stacks"* would put two different scopes behind one flag name.

**2. The sync call keeps `restack = true`.** It looks redundant — we restack each stack ourselves right after — but two fail-closed guards in `SyncContext` are gated on that flag: the bail when the fetch failed, and the bail when local trunk didn't reach the fetched remote trunk. Passing `false` would silently disarm both and let every stack restack onto a stale trunk. Sync therefore restacks whichever stack we started on, and the loop re-visits it as a no-op.

**3. `--all-stacks` requires a clean tree (or `--auto-stash-pop`).** Plain `st refresh` tolerates a dirty tree because sync holds its own stash *across* its restack and pops it in `restore_stash`. The per-stack restacks here run *after* that pop, so they'd hit `DirtyWorktree` partway through the loop. A guard up front turns a confusing mid-loop failure into a clear message naming `--auto-stash-pop`.

**4. Submit checks out each stack's root, not its tip.** `SubmitScope::Stack` resolves to `ancestors + self + descendants`. From a root that covers the whole subtree; from a leaf it would silently miss sibling subtrees in a branching stack.

New `restack::run_stack_containing()` exists because the existing restack entry points infer their scope from the current branch. It takes an explicit `RestackScope::StackContaining(root)`. `restack::run`'s signature is untouched — `cascade.rs` calls it positionally.

## Conflict handling

Stops at the first conflict and reports what got done:

```
✗ Stopped at 'feat/parser'
  Done: fix/flaky-test
  Remaining: chore/deps
  Resolve the conflict, run `st continue`, then re-run `st refresh --all-stacks`. Finished stacks are no-ops on the re-run.
```

No persisted cross-stack resume plan — re-running is idempotent, since completed stacks become no-ops. `ConflictStopped` propagates **unwrapped** (the loop's error branch `downcast_ref`s it before attaching any `.context`) so `entrypoint.rs` still maps it to `exit_codes::CONFLICT` and suppresses the duplicate `Error:` line.

Branches checked out in another worktree fail loudly rather than silently — both the restack call and the pre-submit checkout attach context naming the offending stack. That failure mode is far more likely at N stacks than at one.

Frozen branches needed no new code: `restack_inner` already filters `BranchMetadata::is_frozen` out of the scope and reports them in the receipt.

## Verification

- [x] `cargo check`, `cargo fmt --check`
- [x] 2 unit tests in `src/commands/refresh.rs` — `collect_stack_plans` root ordering/descendants, `root_of` resolution
- [x] 5 integration tests in `tests/refresh_all_stacks_tests.rs` (registered in `all_tests.rs`):
  - plan lists every root and branch
  - every stack actually ends up rebased onto the new trunk
  - **plain `st refresh` leaves other stacks untouched** — regression guard for the unchanged path
  - original branch is restored afterwards
  - dirty tree without `--auto-stash-pop` is rejected, with the flag named in the error
- [x] `test_refresh_help` asserts the flag appears in help
- [x] `make test` — **2285 passed, 0 failed**

`git diff` on `refresh.rs` shows exactly one non-additive line in the whole file (the `use anyhow::...` widening); the non-`--all-stacks` path through `run` is otherwise byte-identical.

## Known limitation

`st undo` rolls back one stack at a time in this mode — sync opens its own transaction and each per-stack restack opens an `OpKind::Restack` one. Unifying them into a single transaction is a larger change; deferring it.

## Risk

Low. Entirely behind a new opt-in flag; the existing code path is unchanged and guarded by a regression test.

## Note on CI

The clippy gate will fail on `src/commands/shell_setup.rs:573` (`clippy::if_same_then_else`). That is **pre-existing on `main`** — reproduced at `09fbfb3` with this branch's changes stashed, and it appears to have come in with #727. Nothing in this diff touches that file; it needs its own fix to unblock the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
