### PR TITLE
test: cover mutually-exclusive flag validation across 8 commands

### DIFF
--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -669,6 +669,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_harness_selection_rejects_empty_spec() {
+        let err = parse_harness_selection("   ").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("--skills requires a value"));
+    }
+
+    #[test]
+    fn parse_harness_selection_rejects_comma_only_spec() {
+        let err = parse_harness_selection(",,,").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("--skills requires at least one harness id"));
+    }
+
+    #[test]
     fn test_format_update_command_line_shows_flags() {
         assert_eq!(
             format_update_command_line(false, &SkillsUpdateOrigin::AllFlag),

--- a/src/commands/worktree/shared.rs
+++ b/src/commands/worktree/shared.rs
@@ -1784,6 +1784,55 @@ mod tests {
     }
 
     #[test]
+    fn build_launch_spec_rejects_agent_with_run() {
+        let config = Config::default();
+        let err = build_launch_spec(
+            &config,
+            &LaunchOptions {
+                agent: Some("claude".to_string()),
+                run: Some("npm test".to_string()),
+                ..LaunchOptions::default()
+            },
+            "session",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--agent and --run cannot be used together")
+        );
+    }
+
+    #[test]
+    fn build_launch_spec_rejects_model_without_agent() {
+        let config = Config::default();
+        let err = build_launch_spec(
+            &config,
+            &LaunchOptions {
+                model: Some("gpt-5".to_string()),
+                ..LaunchOptions::default()
+            },
+            "session",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--model requires --agent"));
+    }
+
+    #[test]
+    fn build_launch_spec_rejects_tmux_session_without_tmux() {
+        let config = Config::default();
+        let err = build_launch_spec(
+            &config,
+            &LaunchOptions {
+                tmux_session: Some("my-session".to_string()),
+                ..LaunchOptions::default()
+            },
+            "session",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--tmux-session requires --tmux"));
+    }
+
+    #[test]
     fn build_launch_spec_ignores_configured_model_for_worktree_agents() {
         let mut config = Config::default();
         config.ai.model = Some("gpt-5.4".to_string());

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -66,6 +66,8 @@ mod edge_cases_tests;
 mod edit_tests;
 #[path = "fix_tests.rs"]
 mod fix_tests;
+#[path = "flag_validation_tests.rs"]
+mod flag_validation_tests;
 #[path = "fold_tests.rs"]
 mod fold_tests;
 #[path = "freeze_tests.rs"]

--- a/tests/flag_validation_tests.rs
+++ b/tests/flag_validation_tests.rs
@@ -1,0 +1,121 @@
+use crate::common;
+use common::{OutputAssertions, TestRepo};
+
+#[test]
+fn create_insert_and_below_are_mutually_exclusive() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["create", "flag-a", "--insert", "--below"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("'--insert' cannot be used with '--below'");
+}
+
+#[test]
+fn create_below_rejects_from() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["create", "flag-b", "--below", "--from", "main"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("'--below' cannot be used with '--from <FROM>'");
+}
+
+#[test]
+fn standup_plain_text_requires_ai() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["standup", "--plain-text"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("--plain-text only applies when used with --ai");
+}
+
+#[test]
+fn standup_style_requires_ai() {
+    let repo = TestRepo::new();
+
+    // "spoken" is a real StandupSummaryStyle variant (src/cli/args.rs); using it
+    // ensures the test exercises the `--style` requires `--ai` guard rather than
+    // clap rejecting an invalid enum value.
+    let output = repo.run_stax(&["standup", "--style", "spoken"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("required arguments were not provided")
+        .assert_stderr_contains("--ai");
+}
+
+#[test]
+fn resolve_rejects_zero_max_rounds() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["resolve", "--max-rounds", "0"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("--max-rounds must be at least 1");
+}
+
+#[test]
+fn checkout_rejects_explicit_branch_with_trunk_flag() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["checkout", "main", "--trunk"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("Cannot combine explicit branch with --trunk/--parent/--child");
+}
+
+#[test]
+fn checkout_rejects_explicit_branch_with_parent_flag() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["checkout", "main", "--parent"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("Cannot combine explicit branch with --trunk/--parent/--child");
+}
+
+#[test]
+fn changelog_find_rejects_multiple_queries() {
+    let repo = TestRepo::new();
+
+    // After `--`, both tokens are treated as literal positionals, so
+    // `--find=q1` lands in the `from` slot and `q2` in `to`, reaching the
+    // "accepts only one search query" guard in normalize_find_args.
+    let output = repo.run_stax(&["changelog", "--", "--find=q1", "q2"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("`stax changelog --find <query>` accepts only one search query");
+}
+
+#[test]
+fn changelog_find_rejects_empty_query() {
+    let repo = TestRepo::new();
+
+    // Explicit from/to (HEAD HEAD) bypasses tag auto-resolution so the empty
+    // --find guard in run_find_query is reached directly.
+    let output = repo.run_stax(&["changelog", "HEAD", "HEAD", "--find", ""]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("`stax changelog --find <query>` requires a non-empty query");
+}
+
+#[test]
+fn worktree_create_rejects_name_and_pick() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["worktree", "create", "flag-c", "--pick"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("Use either a name or --pick, not both.");
+}
+
+#[test]
+fn lane_tmux_session_requires_explicit_lane_name() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["lane", "--tmux-session", "flag-session"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("--tmux-session requires an explicit lane name");
+}


### PR DESCRIPTION
## Motivation

A test-gap audit of the suite found it heavily skewed toward happy paths: ~2,280 tests against 466 `bail!` sites, with only 80 negative-path assertions in `tests/`. This is the first of six PRs closing the verified-genuine gaps.

CLI-level guards that reject invalid flag combinations had no test coverage at all. Each is a one-line rejection of user-facing argument validation — exactly the kind of code that rots silently when flags are added or renamed, because nothing fails when the guard stops firing.

## Description of changes / notes for reviewers

New `tests/flag_validation_tests.rs` (11 tests) covering:

- `resolve.rs:35` — `--max-rounds 0`
- `checkout.rs:218` — explicit branch combined with `--trunk` / `--parent`
- `changelog.rs:246` — multiple `--find` queries
- `changelog.rs:303` — empty `--find` query
- `worktree/create.rs:33` — branch name passed together with `--pick`
- `worktree/ai.rs:63` — `--tmux-session` without an explicit lane name
- `standup.rs:162` — `--plain-text` without `--ai`

Three more guards are covered as in-source unit tests, where a pure validation function already exists to target directly: `worktree/shared.rs:822/825/828` via `build_launch_spec`, and `skills.rs:106/125` via `parse_harness_selection`.

**Finding worth a look:** three audited `bail!` sites are unreachable dead code. `create.rs:1474` (`--insert` + `--below`), `create.rs:1477` (`--below` + `--from`), and `standup.rs:165` (`--style` without `--ai`) are all pre-empted by clap-level `conflicts_with` / `requires` attributes at `args.rs:804`, `:807`, and `:1129`. Those `bail!` arms can never execute. The tests here assert on the error text the CLI actually produces (clap's) rather than the dead strings, so they pin real observable behaviour. Removing the dead arms is left as a follow-up, since this PR is deliberately tests-only.

Excluded as already covered: `submit.rs:161/164/177` (tested at `submit.rs:4354`, `:4362`), `worktree/shared.rs:831/834` (`shared.rs:1757`, `:1772`), `generate.rs:68` (`cli_tests.rs:1278`).

No production behavior changes. Full suite green (2342 tests).
