### PR TITLE
test: cover dirty-working-tree and main-worktree guard rails

### DIFF
--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -78,6 +78,8 @@ mod get_tests;
 mod gh_stack_tests;
 #[path = "github_list_tests.rs"]
 mod github_list_tests;
+#[path = "guard_rail_tests.rs"]
+mod guard_rail_tests;
 #[path = "gui_command_tests.rs"]
 mod gui_command_tests;
 #[path = "integration_tests.rs"]

--- a/tests/guard_rail_tests.rs
+++ b/tests/guard_rail_tests.rs
@@ -1,0 +1,116 @@
+//! Guard-rail regression tests: dirty-working-tree checks in `undo`, `redo`,
+//! and `restack`, `get`'s branch-name validation, and the main-worktree
+//! removal guard.
+
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+
+// =============================================================================
+// Dirty-working-tree guards (`--quiet` branch)
+// =============================================================================
+
+#[test]
+fn undo_quiet_refuses_dirty_working_tree() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["A", "B"]);
+
+    repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
+    repo.run_stax(&["undo", "--yes"]).assert_success();
+
+    repo.create_file("dirty.txt", "uncommitted");
+
+    repo.run_stax(&["undo", "--quiet"])
+        .assert_failure()
+        .assert_stderr_contains("Working tree is dirty");
+}
+
+#[test]
+fn redo_quiet_refuses_dirty_working_tree() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["A", "B"]);
+
+    repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
+    repo.run_stax(&["undo", "--yes"]).assert_success();
+
+    repo.create_file("dirty.txt", "uncommitted");
+
+    repo.run_stax(&["redo", "--quiet"])
+        .assert_failure()
+        .assert_stderr_contains("Working tree is dirty");
+}
+
+#[test]
+fn restack_quiet_refuses_dirty_working_tree() {
+    let repo = TestRepo::new();
+    repo.create_stack(&["A", "B"]);
+
+    repo.run_stax(&["checkout", "A"]).assert_success();
+    repo.create_file("dirty.txt", "uncommitted");
+
+    repo.run_stax(&["restack", "--quiet"])
+        .assert_failure()
+        .assert_stderr_contains("Working tree is dirty");
+}
+
+// =============================================================================
+// `get` branch-name validation
+// =============================================================================
+
+#[test]
+fn get_rejects_empty_branch_name() {
+    let repo = TestRepo::new_with_remote();
+    repo.set_trunk("main");
+
+    repo.run_stax(&["get", ""])
+        .assert_failure()
+        .assert_stderr_contains("Branch name cannot be empty");
+}
+
+#[test]
+fn get_rejects_remote_prefix_with_empty_branch() {
+    let repo = TestRepo::new_with_remote();
+    repo.set_trunk("main");
+
+    repo.run_stax(&["get", "origin/"])
+        .assert_failure()
+        .assert_stderr_contains("Branch name cannot be empty");
+}
+
+#[test]
+fn get_rejects_full_ref_argument() {
+    let repo = TestRepo::new_with_remote();
+    repo.set_trunk("main");
+
+    repo.run_stax(&["get", "refs/heads/foo"])
+        .assert_failure()
+        .assert_stderr_contains("Pass a branch name, not a full ref");
+}
+
+// =============================================================================
+// Main-worktree removal guard
+// =============================================================================
+
+#[test]
+fn worktree_remove_refuses_current_main_worktree() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["worktree", "remove"])
+        .assert_failure()
+        .assert_stderr_contains("Cannot remove the main worktree");
+}
+
+// `run_with_mode` (src/commands/worktree/remove.rs:202-204) checks
+// `worktree.is_main` before ever calling `retire_worktree`, for both the
+// implicit-current and explicit-by-name paths — so `retire_worktree`'s own
+// identical guard at remove.rs:58 is unreachable from `stax worktree remove`.
+// This test therefore exercises the same observable error/site as
+// `worktree_remove_refuses_current_main_worktree`, just via an explicit name.
+#[test]
+fn worktree_remove_by_name_refuses_main_worktree() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["worktree", "remove", "main"])
+        .assert_failure()
+        .assert_stderr_contains("Cannot remove the main worktree");
+}


### PR DESCRIPTION
## Motivation

Second of six PRs closing verified test-coverage gaps.

The dirty-working-tree checks in `undo`, `redo`, and `restack` are the last line of defence against clobbering uncommitted work, and none of the three had a test. Same for the `worktree remove` guard that prevents removing the main worktree. These are the guards that stop a destructive operation before it starts — a regression in any of them costs a user their working tree.

## Description of changes / notes for reviewers

New `tests/guard_rail_tests.rs` (8 tests) covering:

- `undo.rs:60`, `redo.rs:57`, `restack.rs:151` — "Working tree is dirty. Please stash or commit changes first.", reached via the `--quiet` branch
- `get.rs:445` and `get.rs:450` — "Branch name cannot be empty."
- `get.rs:456` — "Pass a branch name, not a full ref"
- `worktree/remove.rs:203` — "Cannot remove the main worktree.", for both the implicit current-worktree and explicit-by-name invocations

**Finding worth a look:** `worktree/remove.rs:58` is unreachable. `retire_worktree` carries its own identical `bail!`, but `run_with_mode` (`remove.rs:202-204`) checks `worktree.is_main` and bails first on both invocation paths. The other caller, `promote.rs:74`, is likewise guarded upstream by `promote.rs:29-31`, which bails with a different message before `retire_worktree` is reached. Both tests here therefore assert against the reachable site at `:203`, with a comment in the test file recording this rather than mislabeling the coverage.

**Deliberately excluded:** `undo.rs:78` and `redo.rs:75` ("Cannot undo/redo with dirty working tree") are reachable only when the user answers *no* to an interactive `dialoguer::Confirm`. Without a TTY, `interact()` errors rather than returning false, so a non-interactive test cannot reach them.

Also excluded as already covered — the trunk guards in `branch/delete.rs`, `branch/rename.rs`, `detach.rs`, `absorb.rs`, `edit.rs`, `branch/create.rs:1497`; the `checkout.rs:694` cycle detector (tested at `checkout.rs:910`); and all six `worktree/promote.rs` guards (`worktree_promote_tests.rs`).

No production behavior changes.
