### PR TITLE
test: cover stax prev, tmux popup guard, and watch interval selection

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -287,3 +287,98 @@ fn adaptive_interval(ci_statuses: &[BranchCiStatus], stack: &Stack, branches: &[
     // Nothing active — back off
     DEFAULT_INTERVAL_QUIET
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ci::CheckRunInfo;
+    use crate::engine::stack::StackBranch;
+    use std::collections::HashMap;
+
+    fn empty_stack() -> Stack {
+        Stack {
+            branches: HashMap::new(),
+            trunk: "main".to_string(),
+        }
+    }
+
+    fn ci_status_with_check(branch: &str, status: &str) -> BranchCiStatus {
+        BranchCiStatus {
+            branch: branch.to_string(),
+            sha: "abc123".to_string(),
+            sha_short: "abc123".to_string(),
+            overall_status: None,
+            check_runs: vec![CheckRunInfo {
+                name: "build".to_string(),
+                status: status.to_string(),
+                conclusion: None,
+                url: None,
+                started_at: None,
+                completed_at: None,
+                elapsed_secs: None,
+                average_secs: None,
+                completion_percent: None,
+            }],
+            pr_number: None,
+            pr_is_draft: None,
+            pr_title: None,
+            pr_review_decision: None,
+        }
+    }
+
+    fn branch_with_pr_state(name: &str, pr_state: Option<&str>) -> StackBranch {
+        StackBranch {
+            name: name.to_string(),
+            parent: Some("main".to_string()),
+            parent_revision: Some("abc123".to_string()),
+            children: Vec::new(),
+            needs_restack: false,
+            pr_number: Some(1),
+            pr_state: pr_state.map(|s| s.to_string()),
+            pr_is_draft: None,
+        }
+    }
+
+    #[test]
+    fn adaptive_interval_polls_fast_when_checks_running() {
+        let stack = empty_stack();
+        let ci_statuses = vec![ci_status_with_check("feature", "in_progress")];
+        let branches = vec!["feature".to_string()];
+
+        assert_eq!(
+            adaptive_interval(&ci_statuses, &stack, &branches),
+            DEFAULT_INTERVAL_ACTIVE
+        );
+    }
+
+    #[test]
+    fn adaptive_interval_uses_idle_interval_with_open_prs() {
+        let mut stack = empty_stack();
+        stack.branches.insert(
+            "feature".to_string(),
+            branch_with_pr_state("feature", Some("open")),
+        );
+        let ci_statuses: Vec<BranchCiStatus> = vec![];
+        let branches = vec!["feature".to_string()];
+
+        assert_eq!(
+            adaptive_interval(&ci_statuses, &stack, &branches),
+            DEFAULT_INTERVAL_IDLE
+        );
+    }
+
+    #[test]
+    fn adaptive_interval_backs_off_when_nothing_is_active() {
+        let mut stack = empty_stack();
+        stack
+            .branches
+            .insert("feature".to_string(), branch_with_pr_state("feature", None));
+        let ci_statuses: Vec<BranchCiStatus> = vec![];
+        let branches = vec!["feature".to_string()];
+
+        assert_eq!(
+            adaptive_interval(&ci_statuses, &stack, &branches),
+            DEFAULT_INTERVAL_QUIET
+        );
+    }
+}

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -96,6 +96,8 @@ mod pr_body_tests;
 mod pr_open_tests;
 #[path = "pr_template_tests.rs"]
 mod pr_template_tests;
+#[path = "prev_watch_tmux_tests.rs"]
+mod prev_watch_tmux_tests;
 #[path = "ready_tests.rs"]
 mod ready_tests;
 #[path = "refresh_all_stacks_tests.rs"]

--- a/tests/prev_watch_tmux_tests.rs
+++ b/tests/prev_watch_tmux_tests.rs
@@ -1,0 +1,132 @@
+//! Coverage for `stax prev`, the `tmux popup` guard rail, and `stax watch`
+//! flag validation.
+
+use crate::common;
+
+use common::{IsolatedProcessEnv, OutputAssertions, TestRepo};
+
+// =============================================================================
+// prev
+// =============================================================================
+
+#[test]
+fn prev_returns_to_previously_checked_out_branch() {
+    let repo = TestRepo::new();
+    repo.git(&["branch", "a"]).assert_success();
+    repo.git(&["branch", "b"]).assert_success();
+    repo.run_stax(&["checkout", "a"]).assert_success();
+    repo.run_stax(&["checkout", "b"]).assert_success();
+
+    let output = repo.run_stax(&["prev"]);
+    output.assert_success();
+    output.assert_stdout_contains("Switched to branch 'a'");
+    assert_eq!(repo.current_branch(), "a");
+}
+
+#[test]
+fn prev_reports_no_previous_branch_on_fresh_repo() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["prev"]);
+    output.assert_success();
+    output.assert_stdout_contains("No previous branch recorded");
+    assert_eq!(repo.current_branch(), "main");
+}
+
+#[test]
+fn prev_is_a_no_op_when_previous_equals_current() {
+    let repo = TestRepo::new();
+    let current = repo.current_branch();
+
+    // Point refs/stax/prev-branch at the branch we're already on, via a temp
+    // file (git hash-object --stdin needs a piped child; a file is simpler).
+    let file = tempfile::NamedTempFile::new().expect("temp file for prev-branch blob");
+    std::fs::write(file.path(), &current).expect("write prev-branch contents");
+    let hash = repo.git(&["hash-object", "-w", file.path().to_str().unwrap()]);
+    hash.assert_success();
+    repo.git(&[
+        "update-ref",
+        "refs/stax/prev-branch",
+        TestRepo::stdout(&hash).trim(),
+    ])
+    .assert_success();
+
+    let output = repo.run_stax(&["prev"]);
+    output.assert_success();
+    output.assert_stdout_contains("Previous branch is the same as current branch");
+    assert_eq!(repo.current_branch(), current);
+}
+
+#[test]
+fn prev_fails_when_previous_branch_was_deleted() {
+    let repo = TestRepo::new();
+    repo.git(&["branch", "a"]).assert_success();
+    repo.git(&["branch", "b"]).assert_success();
+    repo.run_stax(&["checkout", "a"]).assert_success();
+    repo.run_stax(&["checkout", "b"]).assert_success();
+    repo.git(&["branch", "-D", "a"]).assert_success();
+
+    let output = repo.run_stax(&["prev"]);
+    output.assert_failure();
+    output.assert_stderr_contains("Previous branch 'a' no longer exists.");
+}
+
+#[test]
+fn prev_alias_p_matches_prev() {
+    let repo = TestRepo::new();
+    repo.git(&["branch", "a"]).assert_success();
+    repo.git(&["branch", "b"]).assert_success();
+    repo.run_stax(&["checkout", "a"]).assert_success();
+    repo.run_stax(&["checkout", "b"]).assert_success();
+
+    let output = repo.run_stax(&["p"]);
+    output.assert_success();
+    output.assert_stdout_contains("Switched to branch 'a'");
+    assert_eq!(repo.current_branch(), "a");
+}
+
+// =============================================================================
+// tmux popup
+// =============================================================================
+
+#[test]
+fn tmux_popup_requires_tmux_session() {
+    let repo = TestRepo::new();
+    let env = IsolatedProcessEnv::with_config("");
+
+    // `run_stax_with_env` only sets env vars; it cannot unset the ambient TMUX
+    // var a test happens to inherit from a real tmux session. Build the
+    // Command directly and explicitly remove TMUX instead.
+    let output = env
+        .command(&repo.path())
+        .env_remove("TMUX")
+        .args(["tmux", "popup"])
+        .output()
+        .expect("run stax tmux popup");
+
+    output.assert_failure();
+    output.assert_stderr_contains("Not inside a tmux session");
+}
+
+// =============================================================================
+// watch (flag validation only — the main loop has no exit condition)
+// =============================================================================
+
+#[test]
+fn watch_help_lists_current_and_interval_flags() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["watch", "--help"]);
+    output.assert_success();
+    output.assert_stdout_contains("--current");
+    output.assert_stdout_contains("--interval");
+}
+
+#[test]
+fn watch_rejects_non_numeric_interval() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["watch", "--interval", "abc"]);
+    output.assert_failure();
+    output.assert_stderr_contains("invalid value 'abc' for '--interval <INTERVAL>'");
+}


### PR DESCRIPTION
## Motivation

Fourth of six PRs closing verified test-coverage gaps.

`stax prev` had zero tests, despite `navigation_tests.rs` covering next/up/down/top/bottom. The "go back to where I was" command — the one most likely to be used reflexively — was entirely unverified, including its failure path when the recorded branch has since been deleted.

## Description of changes / notes for reviewers

New `tests/prev_watch_tmux_tests.rs` (8 tests) plus an in-source test module in `watch.rs` (3 tests):

- the `prev` happy path, round-tripping between two checked-out branches
- the no-previous-branch message on a fresh repo
- the previous-equals-current no-op
- the `p` alias
- `navigate.rs:216` — "Previous branch '<x>' no longer exists." after the recorded branch is deleted out from under it
- `tmux.rs:162` — "Not inside a tmux session."
- `watch --help` and clap rejection of a non-numeric `--interval`
- `watch.rs:260` `adaptive_interval`, pinning the 15s/60s/120s polling tiers against the `DEFAULT_INTERVAL_ACTIVE/IDLE/QUIET` constants

**Note on the tmux test —** it removes `TMUX` from the child environment rather than setting it empty. `tmux.rs:161` uses `std::env::var("TMUX").is_err()`, which treats an empty value as *present*, so a naive `TMUX=""` test would pass without ever reaching the guard, and would shell out to a real `tmux display-popup` for anyone running the suite inside tmux. It therefore uses `IsolatedProcessEnv::command()` plus `.env_remove("TMUX")`.

Every asserted string was confirmed against the built binary rather than read off the source — earlier PRs in this stack turned up `bail!` sites whose text never actually reaches the user. Both target sites here are live and their wording matches.

**Deliberately excluded:** `stax watch`'s main loop is an unbounded `loop { … sleep }` with no exit condition, no single-shot mode, and no non-TTY early exit, so only `--help`, argument rejection, and the pure `adaptive_interval` helper are reachable without a production seam. #748 adds that seam. Also excluded: `tmux popup`'s success path (spawns real tmux), and the tmux status-bar formatter, which already has 11 tests at `tmux.rs:180-299`.

No production behavior changes.
