### PR TITLE
feat: add stax watch --iterations to bound the refresh loop

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -938,6 +938,9 @@ pub(crate) enum Commands {
         /// Polling interval in seconds (overrides adaptive default)
         #[arg(long, short)]
         interval: Option<u64>,
+        /// Stop after N refreshes instead of running until interrupted
+        #[arg(long, value_name = "N")]
+        iterations: Option<usize>,
     },
 
     /// tmux integration: status bar string and popup viewer

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -602,7 +602,11 @@ pub fn run() -> Result<()> {
             verbose,
             oneline,
         ),
-        Commands::Watch { current, interval } => commands::watch::run(current, interval),
+        Commands::Watch {
+            current,
+            interval,
+            iterations,
+        } => commands::watch::run(current, interval, iterations),
         Commands::Tmux { command } => commands::tmux::run(command),
         Commands::Split {
             hunk,

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -5,7 +5,7 @@ use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
 use crate::remote::{self, RemoteInfo};
-use anyhow::Result;
+use anyhow::{Result, bail};
 use chrono::Local;
 use colored::Colorize;
 use std::collections::HashSet;
@@ -16,7 +16,11 @@ const DEFAULT_INTERVAL_ACTIVE: u64 = 15;
 const DEFAULT_INTERVAL_IDLE: u64 = 60;
 const DEFAULT_INTERVAL_QUIET: u64 = 120;
 
-pub fn run(current_only: bool, interval: Option<u64>) -> Result<()> {
+pub fn run(current_only: bool, interval: Option<u64>, max_iterations: Option<usize>) -> Result<()> {
+    if max_iterations == Some(0) {
+        bail!("--iterations must be at least 1");
+    }
+
     let repo = GitRepo::open()?;
     let config = Config::load()?;
     let remote_info = RemoteInfo::from_repo(&repo, &config)?;
@@ -99,6 +103,12 @@ pub fn run(current_only: bool, interval: Option<u64>) -> Result<()> {
                 &ci_statuses,
                 &remote_branches,
             );
+        }
+
+        // Bounded mode: stop after the requested number of refreshes. Returns before
+        // the trailing sleep so the final iteration exits immediately.
+        if max_iterations.is_some_and(|max| iteration >= max) {
+            return Ok(());
         }
 
         // Decide next interval

--- a/tests/prev_watch_tmux_tests.rs
+++ b/tests/prev_watch_tmux_tests.rs
@@ -130,3 +130,65 @@ fn watch_rejects_non_numeric_interval() {
     output.assert_failure();
     output.assert_stderr_contains("invalid value 'abc' for '--interval <INTERVAL>'");
 }
+
+// `watch --iterations` needs a resolvable GitHub-shaped remote and a token —
+// `watch::run` calls `RemoteInfo::from_repo` and `ForgeClient::new` before the
+// loop even starts, so a bare `TestRepo::new()` fails with "No git remote
+// 'origin' found" before rendering anything. No tracked branches are created,
+// so the empty-branch-list fast path skips `fetch_ci_statuses` and no network
+// call is made.
+fn watch_ready_repo() -> TestRepo {
+    let repo = TestRepo::new();
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/test/repo.git",
+    ])
+    .assert_success();
+    repo
+}
+
+#[test]
+fn watch_iterations_one_renders_once_and_exits() {
+    let repo = watch_ready_repo();
+
+    let output = repo.run_stax_with_env(
+        &["watch", "--iterations", "1"],
+        &[("STAX_GITHUB_TOKEN", "mock-token")],
+    );
+    output.assert_success();
+    output.assert_stdout_contains("Watching stack");
+}
+
+#[test]
+fn watch_iterations_two_renders_twice() {
+    let repo = watch_ready_repo();
+
+    // With `--interval 1`, both refreshes complete well within a couple of
+    // seconds: the loop returns before the trailing sleep on its final pass.
+    let output = repo.run_stax_with_env(
+        &["watch", "--iterations", "2", "--interval", "1"],
+        &[("STAX_GITHUB_TOKEN", "mock-token")],
+    );
+    output.assert_success();
+    output.assert_stdout_contains("iteration #1");
+}
+
+#[test]
+fn watch_rejects_zero_iterations() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["watch", "--iterations", "0"]);
+    output.assert_failure();
+    output.assert_stderr_contains("--iterations must be at least 1");
+}
+
+#[test]
+fn watch_help_lists_iterations_flag() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["watch", "--help"]);
+    output.assert_success();
+    output.assert_stdout_contains("--iterations");
+}


### PR DESCRIPTION
## Motivation

Last of six PRs closing verified test-coverage gaps, and **the only one that changes production code.**

`stax watch` was the only command in the CLI with no coverage of its actual behaviour, and it was untestable by construction: `watch::run()` is an unbounded `loop { … sleep }` with no exit condition, no single-shot mode, and no non-TTY early exit. #746 could only reach `--help`, argument rejection, and the pure `adaptive_interval` helper.

The flag is useful beyond tests: it makes `stax watch` scriptable — `stax watch --iterations 1` as a one-shot CI snapshot, or bounding a poll inside a wrapper script without having to signal the process.

## Description of changes / notes for reviewers

Adds `--iterations <N>`, which stops the watch loop after N refreshes.

The production diff is four lines of behaviour, no refactoring:

- the clap field on `Commands::Watch` (`args.rs`)
- the dispatch destructure (`cli/mod.rs`)
- `--iterations 0` rejected with "--iterations must be at least 1"
- the bounded-mode early return

The early return sits **after** the table renders but **before** the trailing sleep, so the final iteration exits immediately rather than waiting out a 15–120s interval. That placement is the whole reason the tests finish in ~1s instead of timing out.

Tests cover single-iteration exit, a two-iteration run with `--interval 1` (~1.1s wall clock, verified non-hanging), the zero rejection, and the help text.

**Worth knowing for anyone extending these tests:** `watch::run` resolves `RemoteInfo` and constructs a `ForgeClient` *before* entering the loop, so a test repo needs a GitHub-shaped `origin` and `STAX_GITHUB_TOKEN` set even though no request is ever made — with no tracked branches, `branches_to_watch.is_empty()` short-circuits before `fetch_ci_statuses`. `TestRepo::new_with_remote()` is **not** sufficient here, since it points `origin` at a local bare repo that does not resolve as a GitHub forge.

Full suite green: 2342 tests, 0 failures.
