### PR TITLE
fix: remove the last if_same_then_else site and enforce the lint

### DIFF
--- a/scripts/clippy-lint.sh
+++ b/scripts/clippy-lint.sh
@@ -24,7 +24,6 @@ esac
   -A clippy::assertions_on_constants \
   -A clippy::bool_assert_comparison \
   -A clippy::double_comparisons \
-  -A clippy::if_same_then_else \
   -A clippy::items_after_test_module \
   -A clippy::len_zero \
   -A clippy::needless_lifetimes \

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -570,11 +570,14 @@ fn maybe_install_skills(options: &SetupOptions) -> Result<()> {
             SkillInstallMode::Ask => {
                 if options.auto_accept {
                     HarnessSelection::Detected
-                } else if !can_prompt() {
-                    return Ok(());
-                } else if !prompt_for_skill_install()? {
-                    return Ok(());
                 } else {
+                    // A non-interactive shell and an explicit "no" are distinct
+                    // reasons that share one outcome: skip the skills install.
+                    // `&&` short-circuits, so we only prompt when we can prompt.
+                    let opted_in = can_prompt() && prompt_for_skill_install()?;
+                    if !opted_in {
+                        return Ok(());
+                    }
                     prompt_for_harness_selection()?
                 }
             }


### PR DESCRIPTION
## Motivation

`cargo clippy -- -D warnings` has been failing on `main` at `src/commands/shell_setup.rs:573`. CI never caught it because `scripts/lint.sh full` shells out to `scripts/clippy-lint.sh`, which carried `-A clippy::if_same_then_else` in its explicitly-listed legacy lint-debt allowlist.

Green in CI, red for anyone running clippy directly — the worst of both worlds, and a papercut for every contributor who lints locally before pushing. `CLAUDE.md` tells contributors to run `cargo check && cargo clippy -- -D warnings` before committing, so this is the first thing a new contributor hits.

That allowlist documents its own exit criteria: *"Removing an allowance is always safe; adding one requires review."* This was the last site standing, so the allowance can now go.

## Description of changes / notes for reviewers

Restructures the `SkillInstallMode::Ask` arm in `maybe_install_skills`. The two `else if` arms had identical `return Ok(())` bodies but semantically distinct conditions — "we cannot prompt" vs. "the user declined". Rather than suppress the lint, the conditions collapse into a single `opted_in` binding whose name and comment carry the distinction that the duplicated blocks used to carry structurally.

**No behavior change.** `&&` short-circuits, so `prompt_for_skill_install()` is still only invoked when `can_prompt()` is true — a non-interactive shell never prompts, exactly as before. Worth calling out explicitly because the second arm has a side effect (it prompts the user), so the short-circuit is load-bearing rather than incidental.

Drops `-A clippy::if_same_then_else` from `scripts/clippy-lint.sh`. A full `--all-targets --all-features` clippy run over the workspace confirms this was the only occurrence, so removing the allowance keeps CI green while making the lint fatal for new code.

Deliberately **not** using `#[allow]`: the attribute cannot be scoped to a bare `else if` arm, so it would have to blanket the whole 30-line function — suppressing the lint for unrelated future code — and it would leave the repo-wide allowance in place.

### Verification

- `cargo clippy --all-targets --all-features -- -D warnings` exits 0
- `make lint` exits 0
- All 36 `shell_setup` / `skills_selection` tests pass, including `test_shell_setup_interactive_prompt_can_decline_skills_install`, which covers exactly the restructured decline path

### Not changed

None of the other twelve entries in the clippy allowlist. Each needs its own audit and its own PR; this one is removable *today* because the workspace is already clean of it.
