### PR TITLE
fix: surface the token-permissions hint on pr list and issue list

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -553,7 +553,8 @@ impl GitHubClient {
             .octocrab
             .get(&url, None::<&()>)
             .await
-            .context("Failed to list pull requests")?;
+            .context("Failed to list pull requests")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         Ok(response
             .into_iter()
@@ -592,7 +593,8 @@ impl GitHubClient {
                 .octocrab
                 .get(&url, None::<&()>)
                 .await
-                .context("Failed to list issues")?;
+                .context("Failed to list issues")
+                .map_err(|e| self.enrich_api_error(e))?;
 
             let fetched = response.len();
 
@@ -1329,6 +1331,66 @@ mod tests {
         assert!(
             err_msg.contains("token is expired or lacks access"),
             "Expected auth hint in 404 error, got: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_open_pull_requests_404_gives_auth_hint() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found",
+                "documentation_url": "https://docs.github.com/rest"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.list_open_pull_requests(30).await;
+
+        assert!(result.is_err(), "Expected error on 404");
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("token is expired or lacks access"),
+            "Expected auth hint in 404 error, got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("stax auth --from-gh"),
+            "Expected auth remediation hint in 404 error, got: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_open_issues_404_gives_auth_hint() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/issues"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found",
+                "documentation_url": "https://docs.github.com/rest"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.list_open_issues(30).await;
+
+        assert!(result.is_err(), "Expected error on 404");
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("token is expired or lacks access"),
+            "Expected auth hint in 404 error, got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("stax auth --from-gh"),
+            "Expected auth remediation hint in 404 error, got: {}",
             err_msg
         );
     }

--- a/tests/github_failure_tests.rs
+++ b/tests/github_failure_tests.rs
@@ -68,6 +68,12 @@ async fn pr_list_surfaces_rate_limit_error() {
     output
         .assert_failure()
         .assert_stderr_contains("API rate limit exceeded");
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        !stderr.contains("token is expired or lacks access"),
+        "Rate-limit (403) errors should not get the auth hint, got: {}",
+        stderr
+    );
 }
 
 #[tokio::test]
@@ -90,7 +96,34 @@ async fn pr_list_surfaces_missing_repository() {
     output
         .assert_failure()
         .assert_stderr_contains("Failed to list pull requests")
-        .assert_stderr_contains("Not Found");
+        .assert_stderr_contains("Not Found")
+        .assert_stderr_contains("token is expired or lacks access")
+        .assert_stderr_contains("stax auth --from-gh");
+}
+
+#[tokio::test]
+async fn issue_list_surfaces_missing_repository() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = TempDir::new().unwrap();
+    let repo = setup_repo(home.path(), &mock_server.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test/repo/issues"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "message": "Not Found",
+            "documentation_url": "https://docs.github.com/rest"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["issue", "list"], &env_with_auth(&home));
+    output
+        .assert_failure()
+        .assert_stderr_contains("Failed to list issues")
+        .assert_stderr_contains("Not Found")
+        .assert_stderr_contains("token is expired or lacks access")
+        .assert_stderr_contains("stax auth --from-gh");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

GitHub returns **404, not 403**, for a private repository that a token cannot see. That makes a bare "Not Found" one of the most misleading errors we can show: the repo exists, the user can see it in a browser, and nothing in the message points at the token.

`enrich_api_error` (`src/github/client.rs:243`) exists precisely to turn that into an actionable message — "your token is expired or lacks access… run `stax auth --from-gh`". But it was only ever wired into two methods, both in `pr.rs`. `stax pr list` and `stax issue list` each make exactly one API call, propagate it straight to the top-level handler, and so print a bare `Failed to list pull requests: Not Found` and stop. For a user whose token just expired, that is a dead end.

This was surfaced while writing #745, which pinned the (broken) behaviour and flagged the fix as a follow-up. This is that follow-up.

## Description of changes / notes for reviewers

- Routes `GitHubClient::list_open_pull_requests` and `GitHubClient::list_open_issues` through `enrich_api_error`, matching the established `.context(...)`-then-enrich ordering at `pr.rs:418-422`. **The ordering is load-bearing:** `enrich_api_error` takes `anyhow::Error` by value, so the `.context()` conversion has to happen first — applying it to a raw `octocrab::Error` will not type-check.
- Adds wiremock unit tests for both methods alongside the existing `test_find_open_pr_by_head_404_gives_auth_hint`, plus an integration test for `stax issue list`.
- **On the existing `pr_list_surfaces_missing_repository` test:** its two assertions are *extended*, not replaced. Enrichment adds an **outer** context layer and `entrypoint.rs:26` prints the full chain via `{err:#}`, so "Failed to list pull requests" and "Not Found" both still appear — verified empirically against a mock returning 404. If either ever stops appearing, that is a genuine regression in the error chain, not expected churn.
- Adds a negative assertion to the 403 rate-limit test, pinning down that non-auth failures still do **not** get an auth hint. A false "check your token" on a rate-limit error would be its own papercut.

### Scope: what this PR deliberately leaves alone

An audit of the client turned up **~37 methods that hit the network, of which only 2 were enriched** before this change. This PR fixes the 2 that are genuine dead ends and stops there:

- `get_current_user` (`client.rs:355`) is also a first-call dead end for `stax branch track` and `stax standup`, but it has no `.context` at all, so it needs a different fix. Left for a follow-up.
- The ~32 mutating and GraphQL methods are **intentionally** untouched: a 404 from `get_pr` or `merge_pr` usually means the PR really is missing, and a blanket auth hint there would mislead more often than it helps.

There is no single choke point that would have fixed this once — the only shared wrapper (`graphql_data`, `pr.rs:383`) covers 5 GraphQL methods and every REST call bypasses it. `record_api_call` runs *before* the request and returns `()`, so it cannot observe errors either.

### Separate defect found during the audit, not addressed here

`checks.rs:70` (`Err(_) => return Ok((None, Vec::new()))`) and `client.rs:274/277` (`.ok()`, `.ok().flatten()`) **silently swallow** auth failures, so a bad token makes `stax ci` / `stax ready` report "no CI configured" rather than any error. That is arguably worse than this bug — a wrong answer instead of an unhelpful one — but it is a different shape of defect and deserves its own issue.
