### PR TITLE
test: make the CLI-unreachable guards reachable instead of deleting them

### DIFF
--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -1463,6 +1463,16 @@ fn create_branch_with_banner(
     Ok(())
 }
 
+fn validate_placement_flags(from: Option<&str>, insert: bool, below: bool) -> Result<()> {
+    if insert && below {
+        bail!("`--insert` and `--below` cannot be used together");
+    }
+    if below && from.is_some() {
+        bail!("`--below` cannot be used with `--from`");
+    }
+    Ok(())
+}
+
 fn resolve_create_placement(
     repo: &GitRepo,
     current: &str,
@@ -1470,12 +1480,7 @@ fn resolve_create_placement(
     insert: bool,
     below: bool,
 ) -> Result<CreatePlacement> {
-    if insert && below {
-        bail!("`--insert` and `--below` cannot be used together");
-    }
-    if below && from.is_some() {
-        bail!("`--below` cannot be used with `--from`");
-    }
+    validate_placement_flags(from.as_deref(), insert, below)?;
 
     if below {
         let meta = resolve_below_current_metadata(repo, current)?;
@@ -1886,5 +1891,33 @@ mod tests {
         assert!(!prompt.contains("\"branch\" and \"message\""));
         assert!(prompt.contains("The command will stage all changes before committing."));
         assert!(prompt.contains("diff --git"));
+    }
+
+    #[test]
+    fn placement_flags_reject_insert_with_below() {
+        let err = validate_placement_flags(None, true, true).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("`--insert` and `--below` cannot be used together")
+        );
+    }
+
+    #[test]
+    fn placement_flags_reject_below_with_from() {
+        let err = validate_placement_flags(Some("main"), false, true).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("`--below` cannot be used with `--from`")
+        );
+    }
+
+    #[test]
+    fn placement_flags_accept_below_alone() {
+        validate_placement_flags(None, false, true).unwrap();
+    }
+
+    #[test]
+    fn placement_flags_accept_from_alone() {
+        validate_placement_flags(Some("main"), false, false).unwrap();
     }
 }

--- a/src/commands/standup.rs
+++ b/src/commands/standup.rs
@@ -1497,4 +1497,25 @@ Current Sprint: OBX Sprint
         let raw = "Current Sprint: Sprint\n\nNo tickets found in the current sprint.";
         assert!(parse_jit_summary(raw).is_err());
     }
+
+    #[test]
+    fn style_without_ai_is_rejected() {
+        let err = run(
+            false,
+            false,
+            24,
+            false,
+            false,
+            None,
+            None,
+            false,
+            SummaryStyle::Slack,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("--style only applies when used with --ai")
+        );
+    }
 }

--- a/src/commands/worktree/remove.rs
+++ b/src/commands/worktree/remove.rs
@@ -47,13 +47,7 @@ pub(crate) fn remove_worktree_with_hooks(
     Ok(display_name)
 }
 
-pub(crate) fn retire_worktree(
-    repo: &GitRepo,
-    config: &Config,
-    worktree: &WorktreeInfo,
-    force: bool,
-    mode: RemovalMode,
-) -> Result<String> {
+fn ensure_removable_worktree(worktree: &WorktreeInfo) -> Result<()> {
     if worktree.is_main {
         bail!("Cannot remove the main worktree.");
     }
@@ -64,6 +58,18 @@ pub(crate) fn retire_worktree(
             worktree.path.display()
         );
     }
+
+    Ok(())
+}
+
+pub(crate) fn retire_worktree(
+    repo: &GitRepo,
+    config: &Config,
+    worktree: &WorktreeInfo,
+    force: bool,
+    mode: RemovalMode,
+) -> Result<String> {
+    ensure_removable_worktree(worktree)?;
 
     let display_name = worktree
         .branch
@@ -199,16 +205,7 @@ fn run_with_mode(
         None => find_current_worktree(&repo)?,
     };
 
-    if worktree.is_main {
-        bail!("Cannot remove the main worktree.");
-    }
-
-    if !worktree.path.exists() {
-        bail!(
-            "Worktree path '{}' no longer exists. Run `stax worktree prune`.",
-            worktree.path.display()
-        );
-    }
+    ensure_removable_worktree(&worktree)?;
 
     let mut confirmed_dirty_removal = false;
     if !force && repo.is_dirty_at(&worktree.path)? {
@@ -274,7 +271,9 @@ fn run_with_mode(
 
 #[cfg(test)]
 mod tests {
-    use super::effective_remove_force;
+    use super::{effective_remove_force, ensure_removable_worktree};
+    use crate::git::repo::WorktreeInfo;
+    use std::path::PathBuf;
 
     #[test]
     fn confirmed_dirty_removal_upgrades_to_force() {
@@ -289,5 +288,39 @@ mod tests {
     #[test]
     fn clean_non_forced_removal_stays_non_forced() {
         assert!(!effective_remove_force(false, false));
+    }
+
+    fn sample_worktree(is_main: bool, path: PathBuf) -> WorktreeInfo {
+        WorktreeInfo {
+            name: "review-pass".to_string(),
+            path,
+            branch: Some("cesar/review-pass".to_string()),
+            is_main,
+            is_current: false,
+            is_locked: false,
+            lock_reason: None,
+            is_prunable: false,
+            prunable_reason: None,
+        }
+    }
+
+    #[test]
+    fn ensure_removable_rejects_main_worktree() {
+        let worktree = sample_worktree(true, std::env::temp_dir());
+        let err = ensure_removable_worktree(&worktree).unwrap_err();
+        assert!(err.to_string().contains("Cannot remove the main worktree."));
+    }
+
+    #[test]
+    fn ensure_removable_rejects_missing_path() {
+        let worktree = sample_worktree(false, PathBuf::from("/nonexistent/stax-test-path-xyz"));
+        let err = ensure_removable_worktree(&worktree).unwrap_err();
+        assert!(err.to_string().contains("no longer exists"));
+    }
+
+    #[test]
+    fn ensure_removable_accepts_linked_worktree() {
+        let worktree = sample_worktree(false, std::env::temp_dir());
+        ensure_removable_worktree(&worktree).unwrap();
     }
 }

--- a/tests/guard_rail_tests.rs
+++ b/tests/guard_rail_tests.rs
@@ -100,12 +100,23 @@ fn worktree_remove_refuses_current_main_worktree() {
         .assert_stderr_contains("Cannot remove the main worktree");
 }
 
-// `run_with_mode` (src/commands/worktree/remove.rs:202-204) checks
-// `worktree.is_main` before ever calling `retire_worktree`, for both the
-// implicit-current and explicit-by-name paths — so `retire_worktree`'s own
-// identical guard at remove.rs:58 is unreachable from `stax worktree remove`.
-// This test therefore exercises the same observable error/site as
-// `worktree_remove_refuses_current_main_worktree`, just via an explicit name.
+// `run_with_mode` (src/commands/worktree/remove.rs) checks `worktree.is_main`
+// via `ensure_removable_worktree` before ever calling `retire_worktree`, for
+// both the implicit-current and explicit-by-name paths — so
+// `retire_worktree`'s own call to that same guard is unreachable from
+// `stax worktree remove`. This test therefore exercises the same observable
+// error/site as `worktree_remove_refuses_current_main_worktree`, just via an
+// explicit name.
+//
+// `retire_worktree`'s guard IS reachable from the other three callers of
+// `remove_worktree_with_hooks`/`retire_worktree`: the CLI path itself
+// (remove.rs:240), the sync engine (sync.rs:3722), the TUI worktree panel
+// (tui/worktree/app.rs:619), and branch promotion (promote.rs:74). Rather than
+// stand up each of those subsystems in an integration test, `ensure_removable_worktree`
+// is unit-tested directly in src/commands/worktree/remove.rs
+// (`ensure_removable_rejects_main_worktree`,
+// `ensure_removable_rejects_missing_path`,
+// `ensure_removable_accepts_linked_worktree`).
 #[test]
 fn worktree_remove_by_name_refuses_main_worktree() {
     let repo = TestRepo::new();


### PR DESCRIPTION
## Motivation

Four `bail!` arms are unreachable from the CLI because clap rejects the bad combination first:

- `create.rs:1474` / `:1477` — `--insert`+`--below` and `--below`+`--from`, pre-empted by `conflicts_with_all` in `args.rs`
- `standup.rs:165` — `--style` without `--ai`, pre-empted by `requires = "ai"`
- `remove.rs:58` — "Cannot remove the main worktree", pre-empted by every caller

These were surfaced by #743 and #744. The tempting read is "dead code, delete it." **That is the wrong trade.** Each sits inside a plain function taking already-parsed values — a `bool`, an `Option<String>`, a `&WorktreeInfo` — not inside CLI parsing. The clap attribute protects one entry point; the function guard protects every *other* caller, present and future. Deleting them swaps a real safety property for a cosmetic coverage win.

Two of the sites make that concrete rather than hypothetical:

- `branch::create::run` is dispatched from **three** places in `cli/mod.rs` (`:535`, `:731`, `:834`), backed by three separate clap variants that each repeat `conflicts_with_all` by hand (`args.rs:807`, `:1333`, `:1522`). The invariant currently rests on three hand-copied attributes that no test ties together. A fourth alias added without the attribute is a plausible mistake, and the function guard is what catches it.
- `retire_worktree` is `pub(crate)` and reached from **four call paths across three subsystems**: the CLI (`remove.rs:240`), the sync engine (`sync.rs:3722`), the TUI (`tui/worktree/app.rs:619`), and `promote.rs:74` — the latter three via the `remove_worktree_with_hooks` wrapper. Each has its own separate guard in its own file. The TUI's guard runs in `request_delete` (`app.rs:264`) while the removal happens later on a background thread that **re-resolves the worktree by name**, so the check and the use are not atomic. `WorktreeInfo` is `pub` with `pub` fields. This guard is the one place the invariant is actually enforced.

So the fix is to make each guard reachable from a test — turning "unreachable dead code" into "covered defensive depth".

## Description of changes / notes for reviewers

**No behavior changes.** Every guard, message, and check order is preserved.

- **`create.rs`** — extracts the two flag checks into `validate_placement_flags`, called as the first line of `resolve_create_placement`. The guards fired before `&GitRepo` was ever touched, so pulling them into a repo-free function makes them directly unit-testable without standing up a real repository inside a `src/` test.
- **`remove.rs`** — extracts the is_main + path-exists checks into `ensure_removable_worktree`, now called from **both** `retire_worktree` and `run_with_mode`. Those two blocks were byte-identical, so this also removes a copy-paste divergence risk. `run_with_mode`'s early call is kept **deliberately**: it produces the error before the pre-remove hook runs, and dropping it would change observable ordering.
- **`standup.rs`** — no source change needed; the bail is the second statement in `run` and returns before any I/O, so the test calls `run` directly.
- Updates the comment in `guard_rail_tests.rs`, which said the `retire_worktree` guard is "unreachable from `stax worktree remove`". True as scoped, but it read as a broader claim than it should — it now names the sync, TUI, and promote paths and points at the new unit tests.

### Verification

57 targeted tests pass (`flag_validation_tests`, `guard_rail_tests`, and the three new unit-test modules). The `sync_` and `worktree_` suites that reach `remove.rs` transitively are green — worth noting because `sync.rs:4782` already has a test that sets `is_main = true`. `make lint` and `make test` (2353 tests) both pass.

### Deliberately not changed

- **None of the four guards are deleted.** I checked whether any qualified under "exactly one provably-guarded caller, private, unlikely to grow callers". None do: `standup::run` is `pub`, `retire_worktree` has four callers, and the `create` guards back three separate clap variants.
- **No clap attributes are touched.** The CLI-level conflicts are already covered by `tests/flag_validation_tests.rs` and stay exactly as they are; this PR adds the second layer of coverage, it does not move the first.
- **No message strings changed** — `tests/flag_validation_tests.rs` and `tests/guard_rail_tests.rs` assert them and stay green.
