### PR TITLE
docs: document refresh --all-stacks workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ st config --set-ai
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` removes merged branches (including tracked merged PRs) and upstream-gone branches with no unique work |
 | `st refresh` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs (`st update` is a back-compat alias) |
+| `st refresh --all-stacks` | Sync trunk once, then restack and submit every independent stack; needs a clean tree unless `--auto-stash-pop` is set and stops at the first conflict |
 | `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |
 | `st refresh --verbose` | Include detailed sync/restack/submit timing |
 | `st restack` | Rebase current stack onto parents locally |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -67,6 +67,7 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 | `st rs --json --force` | Same as `--json` but also auto-confirms branch deletions |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
 | `st refresh` | Sync trunk without merged-branch cleanup, restack, then push and update PRs (`st update` is a back-compat alias); **does not** show the interactive Sync plan prompt (you already chose this workflow) |
+| `st refresh --all-stacks` | Sync trunk once, then restack and submit every independent stack; requires a clean tree unless `--auto-stash-pop` is set, and stops at the first conflict |
 | `st refresh --force --yes --no-prompt` | Full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | Same as `st refresh`, with detailed sync/restack/submit timing |
 

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -139,6 +139,7 @@ The "bottom PR merged, catch me up" command. Prints the plan up front, then sync
 | `st refresh` | sync trunk → restack → push → create/update PRs |
 | `st refresh --no-pr` | sync trunk → restack → push |
 | `st refresh --no-submit` | sync trunk → restack |
+| `st refresh --all-stacks` | sync trunk once → restack and submit every independent stack; needs a clean tree unless `--auto-stash-pop` is set; stops at the first conflict |
 | `st refresh --force` | force the sync step instead of prompting |
 | `st refresh --force --yes --no-prompt` | run the full trunk-sync/restack/submit flow without prompts |
 | `st refresh --verbose` | show detailed sync/restack/submit timing |

--- a/skills.md
+++ b/skills.md
@@ -343,6 +343,8 @@ stax sweep --json                  # Machine-readable branch classification (con
 stax refresh                        # Sync trunk, restack, then submit (no merged cleanup; no Sync plan prompt)
 stax refresh --no-pr                # Push only after trunk sync/restack
 stax refresh --no-submit            # Trunk sync/restack only
+stax refresh --all-stacks           # Sync trunk once, then restack/submit every independent stack; needs a clean tree unless --auto-stash-pop; stops at first conflict
+stax refresh --all-stacks --auto-stash-pop # Stash/pop dirty worktrees while refreshing every stack
 stax refresh --force                # Force sync without prompts first
 stax refresh --force --yes --no-prompt # Full refresh without sync/submit prompts
 stax refresh --verbose              # Show detailed sync/restack/submit timings


### PR DESCRIPTION
## Summary
- Document `st refresh --all-stacks` in the README, command guide, workflow guide, and agent skill map.
- Clarify its one-time trunk sync, clean-tree / `--auto-stash-pop` behavior, and first-conflict stop condition.

Closes #736.

## Verification
- Ad-hoc documentation verification: 4 files checked for required `--all-stacks` guidance.
- `make lint`
- `make test` — 2,289 passed.
