### PR TITLE
fix: stop stax ci and stax ready reporting "no CI" when the API call failed

### DIFF
--- a/src/application/ci.rs
+++ b/src/application/ci.rs
@@ -161,7 +161,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use tempfile::TempDir;
-    use wiremock::matchers::method;
+    use wiremock::matchers::{method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     static CONFIG_ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -707,10 +707,17 @@ mod tests {
         let server = runtime.block_on(MockServer::start());
         runtime.block_on(
             Mock::given(method("GET"))
+                .and(path_regex(r"check-runs$"))
                 .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                     "total_count": 0,
                     "check_runs": []
                 })))
+                .mount(&server),
+        );
+        runtime.block_on(
+            Mock::given(method("GET"))
+                .and(path_regex(r"statuses$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
                 .mount(&server),
         );
 

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -7,7 +7,7 @@ use crate::git::GitRepo;
 use crate::github::pr::CiStatus;
 use crate::notifications::{self, BuiltInSound, Sound};
 use crate::remote::RemoteInfo;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use futures_util::{StreamExt, stream};
@@ -342,76 +342,79 @@ pub(crate) async fn fetch_ci_statuses_async(
         })
         .collect();
 
-    let mut statuses = stream::iter(prepared.iter().map(
-        |(branch, local_sha, pr_number)| async move {
-            let pr_merge_status = match (client, pr_number) {
-                (ForgeClient::GitHub(_), Some(n)) => client.get_pr_merge_status(*n).await.ok(),
-                _ => None,
-            };
-            let (pr_live, fallback_head_sha) = match (pr_number, pr_merge_status.is_some()) {
-                (Some(n), false) => {
-                    let (pr, head_sha) =
-                        tokio::join!(client.get_pr_with_head(*n), client.get_pr_head_sha(*n));
-                    (pr.ok(), head_sha.ok())
-                }
-                _ => (None, None),
-            };
-            let pr_head_sha = if let Some(pr_status) = &pr_merge_status {
-                Some(pr_status.head_sha.clone())
-            } else {
-                fallback_head_sha
-            };
-            let sha = pr_head_sha
-                .filter(|head_sha| !head_sha.is_empty())
-                .unwrap_or_else(|| local_sha.clone());
-            let sha_short = sha.chars().take(7).collect::<String>();
-            let check_runs_result = client.fetch_checks(repo, &sha).await;
-            let (overall_status, check_runs) = match check_runs_result {
-                Ok((status, runs)) => (status, runs),
-                Err(_) => (None, Vec::new()),
-            };
-            let pr_is_draft = pr_merge_status
-                .as_ref()
-                .map(|p| p.is_draft)
-                .or_else(|| pr_live.as_ref().map(|p| p.info.is_draft));
-            let pr_title = pr_merge_status
-                .as_ref()
-                .map(|p| p.title.clone())
-                .or_else(|| pr_live.as_ref().map(|p| p.title.clone()));
-
-            // Fetch review decision only for open (non-draft) PRs; failures become None.
-            let pr_review_decision = if let Some(pr_status) = &pr_merge_status {
-                pr_status.review_decision.clone()
-            } else {
-                match (pr_number, pr_is_draft) {
-                    (Some(n), Some(false)) => {
-                        client.get_pr_review_decision(*n).await.unwrap_or(None)
-                    }
+    let statuses = stream::iter(
+        prepared
+            .iter()
+            .map(|(branch, local_sha, pr_number)| async move {
+                let pr_merge_status = match (client, pr_number) {
+                    (ForgeClient::GitHub(_), Some(n)) => client.get_pr_merge_status(*n).await.ok(),
                     _ => None,
-                }
-            };
-            let overall_status = pr_merge_status
-                .as_ref()
-                .filter(|pr_status| pr_status.head_sha == sha)
-                .and_then(|pr_status| ci_status_to_overall_status(&pr_status.ci_status))
-                .or(overall_status);
+                };
+                let (pr_live, fallback_head_sha) = match (pr_number, pr_merge_status.is_some()) {
+                    (Some(n), false) => {
+                        let (pr, head_sha) =
+                            tokio::join!(client.get_pr_with_head(*n), client.get_pr_head_sha(*n));
+                        (pr.ok(), head_sha.ok())
+                    }
+                    _ => (None, None),
+                };
+                let pr_head_sha = if let Some(pr_status) = &pr_merge_status {
+                    Some(pr_status.head_sha.clone())
+                } else {
+                    fallback_head_sha
+                };
+                let sha = pr_head_sha
+                    .filter(|head_sha| !head_sha.is_empty())
+                    .unwrap_or_else(|| local_sha.clone());
+                let sha_short = sha.chars().take(7).collect::<String>();
+                let (overall_status, check_runs) =
+                    client.fetch_checks(repo, &sha).await.with_context(|| {
+                        format!("Failed to fetch CI checks for branch '{}'", branch)
+                    })?;
+                let pr_is_draft = pr_merge_status
+                    .as_ref()
+                    .map(|p| p.is_draft)
+                    .or_else(|| pr_live.as_ref().map(|p| p.info.is_draft));
+                let pr_title = pr_merge_status
+                    .as_ref()
+                    .map(|p| p.title.clone())
+                    .or_else(|| pr_live.as_ref().map(|p| p.title.clone()));
 
-            BranchCiStatus {
-                branch: branch.clone(),
-                sha,
-                sha_short,
-                overall_status,
-                check_runs,
-                pr_number: *pr_number,
-                pr_is_draft,
-                pr_title,
-                pr_review_decision,
-            }
-        },
-    ))
+                // Fetch review decision only for open (non-draft) PRs; failures become None.
+                let pr_review_decision = if let Some(pr_status) = &pr_merge_status {
+                    pr_status.review_decision.clone()
+                } else {
+                    match (pr_number, pr_is_draft) {
+                        (Some(n), Some(false)) => {
+                            client.get_pr_review_decision(*n).await.unwrap_or(None)
+                        }
+                        _ => None,
+                    }
+                };
+                let overall_status = pr_merge_status
+                    .as_ref()
+                    .filter(|pr_status| pr_status.head_sha == sha)
+                    .and_then(|pr_status| ci_status_to_overall_status(&pr_status.ci_status))
+                    .or(overall_status);
+
+                Ok(BranchCiStatus {
+                    branch: branch.clone(),
+                    sha,
+                    sha_short,
+                    overall_status,
+                    check_runs,
+                    pr_number: *pr_number,
+                    pr_is_draft,
+                    pr_title,
+                    pr_review_decision,
+                })
+            }),
+    )
     .buffer_unordered(crate::parallel::IO_CONCURRENCY_LIMIT)
-    .collect::<Vec<_>>()
+    .collect::<Vec<Result<BranchCiStatus>>>()
     .await;
+
+    let mut statuses = statuses.into_iter().collect::<Result<Vec<_>>>()?;
 
     statuses.sort_by(|a, b| a.branch.cmp(&b.branch));
 
@@ -1642,6 +1645,20 @@ mod tests {
         })
     }
 
+    /// Mount an empty (200, `[]`) commit-statuses response for `sha`.
+    ///
+    /// The commit-statuses endpoint is queried by every `fetch_checks` call in
+    /// addition to check-runs; without this mock the request 404s and the now-
+    /// propagated error fails the test instead of hitting the genuine no-CI path.
+    async fn mount_empty_commit_statuses(server: &MockServer, sha: &str) {
+        let path_str = format!("/repos/test-owner/test-repo/commits/{sha}/statuses");
+        Mock::given(method("GET"))
+            .and(path(path_str.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(server)
+            .await;
+    }
+
     async fn mount_github_ci_mocks(server: &MockServer, sha_b1: &str, sha_b2: &str) {
         let path_b1 = format!("/repos/test-owner/test-repo/commits/{sha_b1}/check-runs");
         let path_b2 = format!("/repos/test-owner/test-repo/commits/{sha_b2}/check-runs");
@@ -1656,6 +1673,8 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(check_runs_body("ci-b2")))
             .mount(server)
             .await;
+        mount_empty_commit_statuses(server, sha_b1).await;
+        mount_empty_commit_statuses(server, sha_b2).await;
 
         Mock::given(method("GET"))
             .and(path("/repos/test-owner/test-repo/pulls/201"))
@@ -2184,6 +2203,7 @@ mod tests {
                 .respond_with(ResponseTemplate::new(200).set_body_json(check_runs_body("solo")))
                 .mount(&mock_server)
                 .await;
+            mount_empty_commit_statuses(&mock_server, &sha_b1).await;
 
             let octocrab = Octocrab::builder()
                 .base_uri(mock_server.uri())
@@ -2225,6 +2245,115 @@ mod tests {
     }
 
     #[test]
+    fn fetch_ci_statuses_propagates_check_runs_auth_failure() {
+        ensure_crypto_provider();
+        let (_td, repo, sha_b1, _sha_b2) = git_repo_with_two_branches();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mock_server = MockServer::start().await;
+            let path_b1 = format!("/repos/test-owner/test-repo/commits/{sha_b1}/check-runs");
+            Mock::given(method("GET"))
+                .and(path(path_b1.as_str()))
+                .respond_with(
+                    ResponseTemplate::new(401)
+                        .set_body_json(serde_json::json!({ "message": "Bad credentials" })),
+                )
+                .mount(&mock_server)
+                .await;
+
+            let octocrab = Octocrab::builder()
+                .base_uri(mock_server.uri())
+                .unwrap()
+                .personal_token("test-token".to_string())
+                .build()
+                .unwrap();
+            let gh = GitHubClient::with_octocrab(octocrab, "test-owner", "test-repo");
+            let client = ForgeClient::GitHub(gh);
+
+            let mut branches = HashMap::new();
+            branches.insert(
+                "b1".to_string(),
+                StackBranch {
+                    name: "b1".to_string(),
+                    parent: Some("main".to_string()),
+                    parent_revision: None,
+                    children: Vec::new(),
+                    needs_restack: false,
+                    pr_number: None,
+                    pr_state: None,
+                    pr_is_draft: None,
+                },
+            );
+            let stack = Stack {
+                branches,
+                trunk: "main".to_string(),
+            };
+
+            let err = fetch_ci_statuses_async(&repo, &client, &stack, &["b1".to_string()])
+                .await
+                .unwrap_err();
+            let message = format!("{:#}", err);
+            assert!(message.contains("Failed to fetch CI checks for branch 'b1'"));
+            assert!(message.contains("token is expired or lacks access"));
+        });
+    }
+
+    #[test]
+    fn fetch_ci_statuses_reports_no_ci_when_endpoints_return_empty() {
+        ensure_crypto_provider();
+        let (_td, repo, sha_b1, _sha_b2) = git_repo_with_two_branches();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mock_server = MockServer::start().await;
+            let path_b1 = format!("/repos/test-owner/test-repo/commits/{sha_b1}/check-runs");
+            Mock::given(method("GET"))
+                .and(path(path_b1.as_str()))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({ "total_count": 0, "check_runs": [] })),
+                )
+                .mount(&mock_server)
+                .await;
+            mount_empty_commit_statuses(&mock_server, &sha_b1).await;
+
+            let octocrab = Octocrab::builder()
+                .base_uri(mock_server.uri())
+                .unwrap()
+                .personal_token("test-token".to_string())
+                .build()
+                .unwrap();
+            let gh = GitHubClient::with_octocrab(octocrab, "test-owner", "test-repo");
+            let client = ForgeClient::GitHub(gh);
+
+            let mut branches = HashMap::new();
+            branches.insert(
+                "b1".to_string(),
+                StackBranch {
+                    name: "b1".to_string(),
+                    parent: Some("main".to_string()),
+                    parent_revision: None,
+                    children: Vec::new(),
+                    needs_restack: false,
+                    pr_number: None,
+                    pr_state: None,
+                    pr_is_draft: None,
+                },
+            );
+            let stack = Stack {
+                branches,
+                trunk: "main".to_string(),
+            };
+
+            let statuses = fetch_ci_statuses_async(&repo, &client, &stack, &["b1".to_string()])
+                .await
+                .unwrap();
+            assert_eq!(statuses.len(), 1);
+            assert!(statuses[0].check_runs.is_empty());
+            assert_eq!(statuses[0].overall_status, None);
+        });
+    }
+
+    #[test]
     fn fetch_ci_statuses_uses_github_pr_rollup_over_low_level_checks() {
         ensure_crypto_provider();
         let (_td, repo, sha_b1, _sha_b2) = git_repo_with_two_branches();
@@ -2240,6 +2369,7 @@ mod tests {
                 )
                 .mount(&mock_server)
                 .await;
+            mount_empty_commit_statuses(&mock_server, &sha_b1).await;
             Mock::given(method("GET"))
                 .and(path("/repos/test-owner/test-repo/pulls/201"))
                 .respond_with(ResponseTemplate::new(200).set_body_json(pr_json(201, false)))
@@ -2300,6 +2430,7 @@ mod tests {
                 )
                 .mount(&mock_server)
                 .await;
+            mount_empty_commit_statuses(&mock_server, "different-remote-head").await;
             Mock::given(method("GET"))
                 .and(path("/repos/test-owner/test-repo/pulls/201"))
                 .respond_with(ResponseTemplate::new(200).set_body_json(pr_json(201, false)))
@@ -2354,6 +2485,7 @@ mod tests {
                 .respond_with(ResponseTemplate::new(200).set_body_json(check_runs_body("local-ci")))
                 .mount(&mock_server)
                 .await;
+            mount_empty_commit_statuses(&mock_server, &sha_b1).await;
 
             let octocrab = Octocrab::builder()
                 .base_uri(mock_server.uri())

--- a/src/commands/ready.rs
+++ b/src/commands/ready.rs
@@ -359,8 +359,8 @@ pub(crate) async fn fetch_row_for_branch(
     let check_runs = client
         .fetch_checks(repo, &ci_revision)
         .await
-        .map(|(_, runs)| runs)
-        .unwrap_or_default();
+        .with_context(|| format!("Failed to fetch CI checks for PR #{}", pr_number))
+        .map(|(_, runs)| runs)?;
     let ci_summary = CiSummary::from_checks(status.ci_status.clone(), &check_runs);
     let mut row = PrReadinessRow::from_status(&branch.name, status, ci_summary);
     row.pr_url = Some(remote.pr_url(pr_number));

--- a/src/github/checks.rs
+++ b/src/github/checks.rs
@@ -1,7 +1,7 @@
 use super::client::GitHubClient;
 use crate::ci::{CheckRunInfo, history, normalize};
 use crate::git::GitRepo;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
@@ -64,11 +64,12 @@ impl GitHubClient {
             self.owner, self.repo, commit_sha
         );
 
-        let statuses: Vec<normalize::CommitStatus> =
-            match self.octocrab.get(&url, None::<&()>).await {
-                Ok(s) => s,
-                Err(_) => return Ok((None, Vec::new())),
-            };
+        let statuses: Vec<normalize::CommitStatus> = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to fetch commit statuses")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         if statuses.is_empty() {
             return Ok((None, Vec::new()));
@@ -125,7 +126,12 @@ impl GitHubClient {
             self.owner, self.repo, commit_sha
         );
 
-        let response: CheckRunsResponse = self.octocrab.get(&url, None::<&()>).await?;
+        let response: CheckRunsResponse = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to fetch check runs")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         if response.total_count == 0 {
             return Ok((None, Vec::new()));

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -270,20 +270,17 @@ impl GitHubClient {
             .octocrab
             .repos(&self.owner, &self.repo)
             .combined_status_for_ref(&Reference::Branch(commit_sha.to_string()))
-            .await
-            .ok();
+            .await?;
 
         // Then, check GitHub Actions check runs
-        let check_runs_status = self.get_check_runs_status(commit_sha).await.ok().flatten();
+        let check_runs_status = self.get_check_runs_status(commit_sha).await?;
 
         // Combine results: prioritize check runs (more common), fall back to commit status
-        match (check_runs_status, commit_status) {
+        match check_runs_status {
             // If we have check runs, use that status
-            (Some(cr_status), _) => Ok(Some(cr_status)),
+            Some(cr_status) => Ok(Some(cr_status)),
             // Fall back to commit status
-            (None, Some(status)) => Ok(Some(format!("{:?}", status.state).to_lowercase())),
-            // No CI at all
-            (None, None) => Ok(None),
+            None => Ok(Some(format!("{:?}", commit_status.state).to_lowercase())),
         }
     }
 

--- a/tests/github_failure_tests.rs
+++ b/tests/github_failure_tests.rs
@@ -4,7 +4,7 @@ use common::{OutputAssertions, TestRepo};
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn ensure_crypto_provider() {
@@ -145,6 +145,94 @@ async fn pr_list_surfaces_server_conflict() {
     output
         .assert_failure()
         .assert_stderr_contains("Conflict: repository is empty.");
+}
+
+#[tokio::test]
+async fn ci_surfaces_expired_token_instead_of_no_ci() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = TempDir::new().unwrap();
+    let repo = setup_repo(home.path(), &mock_server.uri());
+
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/repos/test/repo/commits/[0-9a-f]+/check-runs$",
+        ))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "message": "Bad credentials"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["ci"], &env_with_auth(&home));
+    output
+        .assert_failure()
+        .assert_stderr_contains("Failed to fetch CI checks")
+        .assert_stderr_contains("token is expired or lacks access");
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        !stdout.contains("no CI"),
+        "Auth failures must not be reported as 'no CI', got stdout: {}",
+        stdout
+    );
+}
+
+#[tokio::test]
+async fn ci_surfaces_missing_checks_permission_on_statuses_endpoint() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = TempDir::new().unwrap();
+    let repo = setup_repo(home.path(), &mock_server.uri());
+
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/repos/test/repo/commits/[0-9a-f]+/check-runs$",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({ "total_count": 0, "check_runs": [] })),
+        )
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/repos/test/repo/commits/[0-9a-f]+/statuses$"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "message": "Resource not accessible by personal access token"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["ci"], &env_with_auth(&home));
+    output
+        .assert_failure()
+        .assert_stderr_contains("Failed to fetch commit statuses");
+}
+
+#[tokio::test]
+async fn ci_reports_no_ci_when_repo_has_no_checks() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    let home = TempDir::new().unwrap();
+    let repo = setup_repo(home.path(), &mock_server.uri());
+
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/repos/test/repo/commits/[0-9a-f]+/check-runs$",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({ "total_count": 0, "check_runs": [] })),
+        )
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/repos/test/repo/commits/[0-9a-f]+/statuses$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock_server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["ci"], &env_with_auth(&home));
+    output.assert_success().assert_stdout_contains("no CI");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

`stax ci` on a repository with an expired or under-scoped token prints `no CI` and exits 0. That is not an unhelpful answer — it is a **wrong** one. The command whose entire purpose is to report CI state confidently reports that there is none, and the user gets no signal that anything went wrong.

The swallowing happens in three places, and the one that actually bites is not the one you'd guess:

- `commands/ci.rs:369-372` — `Err(_) => (None, Vec::new())` discards every `fetch_checks` failure. **This is the dominant one**; fixing the layer below it alone would change nothing user-visible.
- `commands/ready.rs:361-362` — `.unwrap_or_default()` on the same call.
- `github/checks.rs:70` — `Err(_) => return Ok((None, Vec::new()))`.

`stax ci` compounds it by `.ok()`-ing the PR lookups first (`ci.rs:349`, `:358`), so a dead token produces a fully-populated, fully-fabricated "everything is fine, there's just no CI here".

**The `--watch` case is worse.** `all_checks_complete` (`ci.rs:1151-1162`) treats an empty `check_runs` list as *done*. So one transient 500 during `stax ci --watch` made the loop print the success banner and exit 0 — a long-running watch declaring victory because a request failed.

Found while auditing the client for #751, flagged there as deserving its own issue. This is that issue.

## Description of changes / notes for reviewers

**The design question is "is this intentional graceful degradation?", and the answer is no — there is nothing to degrade.** Every caller of `fetch_checks` wants the error:

| Caller | Command | CI is… |
|---|---|---|
| `commands/ci.rs:368` | `stax ci` | the point |
| `commands/ready.rs:360` | `stax ready` CLI + TUI | the point |
| `application/ci.rs:66` `load_ci` | main TUI pane | decoration — **already propagates** |

The commands that show CI *opportunistically* — `stax status` (`status.rs:164`), `stax log` (`log.rs:144`), `stax tmux` (`tmux.rs:111`) — read the offline `CiCache` and never make a network call. `stax watch` does fetch, but already falls back to cache on `Err` (`watch.rs:60-63`), so it keeps degrading exactly as today.

And the one decorative caller already does the right thing: `load_ci` maps errors through `provider_error()` into `CiUpdate::Unavailable`. **So this design is not new** — it's the pattern already shipped on the only caller that wanted leniency. This makes the other two consistent with it. GitLab (`gitlab.rs:513`) and Gitea (`gitea.rs:430`) already propagate; GitHub was the sole outlier.

**"No CI configured" is fully distinguishable from "auth failed", and the code already proved it.** `GET /commits/{sha}/statuses` returns **HTTP 200 with `[]`** when there are genuinely no statuses — it does not 404 — and that case is handled on the success path at `checks.rs:73-75`. `check-runs` likewise returns 200 with `total_count: 0`. The `Err(_)` arm was therefore *never* reachable by the no-CI case; it could only ever turn a real failure into a fake one.

### Changes

- `checks.rs` — both endpoints use the `.context(...)`-then-`enrich_api_error` idiom from #751. Ordering is load-bearing: `enrich_api_error` takes `anyhow::Error` by value.
- `commands/ci.rs` — propagates with the branch name in context. Required turning the `buffer_unordered` stream's item type into `Result<BranchCiStatus>` and collecting through `Result<Vec<_>>` before the existing sort. **The only non-mechanical hunk in the diff.**
- `commands/ready.rs` — one line. `fetch_readiness_rows` already did `match result?`, and the ready TUI already renders per-branch `Err` as `Unavailable`.
- `client.rs::combined_status_state` — drops its `.ok()` / `.ok().flatten()`.

**Five pre-existing tests were relying on the swallow** to tolerate incomplete mocks — they never mocked the commit-statuses endpoint at all, and the swallowed error hid it. They now mock it properly with the 200-plus-`[]` that a real no-CI repo returns. **No assertion was weakened or removed.**

### Behaviour change to review deliberately

`stax ci --watch` now aborts on a fetch failure instead of continuing. I believe that's correct given the false-success bug above, but it's the one place where "we used to keep going" becomes "we stop" — worth a second opinion.

### What I deliberately did not change

- **`combined_status_state` (`client.rs:267`) is dead code** — zero callers repo-wide, so its `.ok()`s were never producing a wrong answer for anyone. Fixed rather than deleted, because deleting orphans `get_check_runs_status` into a test-only fn, trips `dead_code` under `-D warnings`, and would drop 15 unit tests. Separate decision.
- **The `.ok()`s on the PR lookups (`ci.rs:349-358`).** Those are *real* leniency — `stax ci` can legitimately show check state for a branch whose PR metadata is unavailable — and unlike the CI fetch they aren't what the command is about.
- **`all_checks_complete`'s empty-is-done rule.** Correct for a branch that genuinely has no CI; it was only dangerous because failures were being laundered into that state.
- **`--strict` (`ci.rs:1172`)** is unrelated — it means "exit on CI *failure*", not "exit on API error".

Verified: 15 targeted tests, `make lint` clean, `make test` 2358/2358.
