### PR TITLE
chore: close the gaps in forge API call accounting

### DIFF
--- a/src/github/checks.rs
+++ b/src/github/checks.rs
@@ -59,6 +59,7 @@ impl GitHubClient {
         repo: &GitRepo,
         commit_sha: &str,
     ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+        self.record_api_call("checks.commit_statuses");
         let url = format!(
             "/repos/{}/{}/commits/{}/statuses",
             self.owner, self.repo, commit_sha
@@ -121,6 +122,7 @@ impl GitHubClient {
         repo: &GitRepo,
         commit_sha: &str,
     ) -> Result<(Option<String>, Vec<CheckRunInfo>)> {
+        self.record_api_call("checks.check_runs");
         let url = format!(
             "/repos/{}/{}/commits/{}/check-runs",
             self.owner, self.repo, commit_sha

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -286,6 +286,7 @@ impl GitHubClient {
 
     /// Get status from GitHub Actions check runs
     async fn get_check_runs_status(&self, commit_sha: &str) -> Result<Option<String>> {
+        self.record_api_call("checks.check_runs");
         let url = format!(
             "/repos/{}/{}/commits/{}/check-runs",
             self.owner, self.repo, commit_sha
@@ -350,6 +351,7 @@ impl GitHubClient {
 
     /// Get the authenticated user's login name
     pub async fn get_current_user(&self) -> Result<String> {
+        self.record_api_call("users.current");
         let user = self.octocrab.current().user().await?;
         Ok(user.login)
     }
@@ -362,6 +364,7 @@ impl GitHubClient {
     ) -> Result<Vec<PrActivity>> {
         let since = Utc::now() - chrono::Duration::hours(hours);
         // Use search API to find only user's merged PRs - much faster than listing all
+        self.record_api_call("search.issues");
         let url = format!(
             "/search/issues?q=repo:{}/{}+author:{}+is:pr+is:merged&sort=updated&order=desc&per_page=30",
             self.owner, self.repo, username
@@ -398,6 +401,7 @@ impl GitHubClient {
     ) -> Result<Vec<PrActivity>> {
         let since = Utc::now() - chrono::Duration::hours(hours);
         // Use search API to find only user's created PRs
+        self.record_api_call("search.issues");
         let url = format!(
             "/search/issues?q=repo:{}/{}+author:{}+is:pr&sort=created&order=desc&per_page=30",
             self.owner, self.repo, username
@@ -434,6 +438,7 @@ impl GitHubClient {
             "/search/issues?q=repo:{}/{}+author:{}+is:pr+is:open&per_page=20",
             self.owner, self.repo, username
         );
+        self.record_api_call("search.issues");
         let response: SearchIssuesResponse = self.octocrab.get(&url, None::<&()>).await?;
 
         let mut reviews = Vec::new();
@@ -444,6 +449,7 @@ impl GitHubClient {
                 "/repos/{}/{}/pulls/{}/reviews",
                 self.owner, self.repo, issue.number
             );
+            self.record_api_call("pulls.reviews.list");
             let pr_reviews: Vec<Review> = self
                 .octocrab
                 .get(&reviews_url, None::<&()>)
@@ -496,6 +502,7 @@ impl GitHubClient {
             self.owner, self.repo, username
         );
 
+        self.record_api_call("search.issues");
         let response: SearchIssuesResponse = self
             .octocrab
             .get(&url, None::<&()>)
@@ -507,6 +514,7 @@ impl GitHubClient {
         let mut results = Vec::new();
         for issue in response.items {
             // Fetch full PR details to get branch info
+            self.record_api_call("pulls.get");
             let pr = self
                 .octocrab
                 .pulls(&self.owner, &self.repo)
@@ -575,7 +583,6 @@ impl GitHubClient {
     /// GitHub's issues endpoint includes pull requests, so we filter them client-side and
     /// paginate until we have `limit` real issues or the API has no more pages.
     pub async fn list_open_issues(&self, limit: u8) -> Result<Vec<RepoIssueListItem>> {
-        self.record_api_call("issues.list");
         let want = limit.clamp(1, 100) as usize;
         let mut collected: Vec<RepoIssueListItem> = Vec::with_capacity(want);
         let mut page = 1u32;
@@ -586,6 +593,7 @@ impl GitHubClient {
                 self.owner, self.repo, page
             );
 
+            self.record_api_call("issues.list");
             let response: Vec<RepoListIssue> = self
                 .octocrab
                 .get(&url, None::<&()>)
@@ -1216,6 +1224,65 @@ mod tests {
         assert_eq!(issues.len(), 2);
         assert_eq!(issues[0].number, 10);
         assert_eq!(issues[1].number, 11);
+    }
+
+    #[tokio::test]
+    async fn test_list_open_issues_counts_every_page() {
+        let mock_server = MockServer::start().await;
+
+        // Page 1: 100 items, all PRs — filtered out, so nothing satisfies `want` yet
+        let pr_items: Vec<serde_json::Value> = (1u32..=100)
+            .map(|n| {
+                serde_json::json!({
+                    "number": n,
+                    "title": format!("PR {n}"),
+                    "html_url": format!("https://github.com/test-owner/test-repo/pull/{n}"),
+                    "user": { "login": "u" },
+                    "labels": [],
+                    "updated_at": "2026-03-15T12:00:00Z",
+                    "pull_request": {
+                        "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{n}")
+                    }
+                })
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/issues"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(pr_items)))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/issues"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 10,
+                    "title": "Real issue A",
+                    "html_url": "https://github.com/test-owner/test-repo/issues/10",
+                    "user": { "login": "u" },
+                    "labels": [],
+                    "updated_at": "2026-03-14T10:00:00Z"
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let issues = client.list_open_issues(1).await.unwrap();
+        assert_eq!(issues.len(), 1);
+
+        let stats = client.api_call_stats();
+        assert!(
+            stats
+                .by_operation
+                .iter()
+                .any(|(op, count)| op == "issues.list" && *count == 2),
+            "expected issues.list to be recorded once per page, got: {:?}",
+            stats.by_operation
+        );
     }
 
     #[tokio::test]

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -860,6 +860,7 @@ impl GitHubClient {
         commit_message: Option<String>,
         sha: Option<String>,
     ) -> Result<()> {
+        self.record_api_call("pulls.merge");
         let merge_method = match method {
             MergeMethod::Squash => octocrab::params::pulls::MergeMethod::Squash,
             MergeMethod::Merge => octocrab::params::pulls::MergeMethod::Merge,
@@ -987,6 +988,7 @@ impl GitHubClient {
 
     /// Get PR review information using GraphQL API
     async fn get_pr_reviews(&self, pr_number: u64) -> Result<(Option<String>, usize, bool)> {
+        self.record_api_call("graphql.pr_reviews");
         let query = format!(
             r#"
             query {{
@@ -1029,6 +1031,7 @@ impl GitHubClient {
 
     /// Get the GraphQL node ID for a PR (needed for mutations like enqueuePullRequest).
     async fn get_pr_node_id(&self, pr_number: u64) -> Result<String> {
+        self.record_api_call("graphql.pr_node_id");
         let query = format!(
             r#"
             query {{
@@ -1060,6 +1063,7 @@ impl GitHubClient {
     pub async fn enqueue_pr(&self, pr_number: u64) -> Result<EnqueueResult> {
         let node_id = self.get_pr_node_id(pr_number).await?;
 
+        self.record_api_call("graphql.enqueue_pr");
         let mutation = format!(
             r#"
             mutation {{
@@ -1084,6 +1088,7 @@ impl GitHubClient {
 
     /// Check if a PR is already merged
     pub async fn is_pr_merged(&self, pr_number: u64) -> Result<bool> {
+        self.record_api_call("pulls.is_merged");
         let pr = self
             .octocrab
             .pulls(&self.owner, &self.repo)
@@ -1110,6 +1115,7 @@ impl GitHubClient {
 
     /// List all issue comments (conversation comments) on a PR
     pub async fn list_issue_comments(&self, pr_number: u64) -> Result<Vec<IssueComment>> {
+        self.record_api_call("issues.comments.list");
         let url = format!(
             "/repos/{}/{}/issues/{}/comments",
             self.owner, self.repo, pr_number
@@ -1133,6 +1139,7 @@ impl GitHubClient {
 
     /// List all review comments (inline code comments) on a PR
     pub async fn list_review_comments(&self, pr_number: u64) -> Result<Vec<ReviewComment>> {
+        self.record_api_call("pulls.comments.list");
         let url = format!(
             "/repos/{}/{}/pulls/{}/comments",
             self.owner, self.repo, pr_number
@@ -1391,7 +1398,7 @@ pub fn remove_stack_links_from_body(existing_body: &str) -> String {
 mod tests {
     use super::*;
     use octocrab::Octocrab;
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{body_string_contains, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
@@ -3012,6 +3019,90 @@ mod tests {
                 .by_operation
                 .iter()
                 .any(|(op, count)| op == "pulls.get" && *count == 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_pr_records_api_call() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("PUT"))
+            .and(path("/repos/test-owner/test-repo/pulls/11/merge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "abc123",
+                "merged": true,
+                "message": "Pull Request successfully merged"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        client
+            .merge_pr(11, MergeMethod::Squash, None, None, None)
+            .await
+            .unwrap();
+
+        let stats = client.api_call_stats();
+        assert_eq!(stats.total_requests, 1);
+        assert!(
+            stats
+                .by_operation
+                .iter()
+                .any(|(op, count)| op == "pulls.merge" && *count == 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_pr_records_node_id_and_mutation() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("repository(owner"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pullRequest": { "id": "PR_kwABC" }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("enqueuePullRequest"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "enqueuePullRequest": {
+                        "mergeQueueEntry": { "position": 1 }
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.enqueue_pr(20).await.unwrap();
+
+        assert_eq!(
+            result.merge_queue_entry.and_then(|entry| entry.position),
+            Some(1)
+        );
+
+        let stats = client.api_call_stats();
+        assert_eq!(stats.total_requests, 2);
+        assert!(
+            stats
+                .by_operation
+                .iter()
+                .any(|(op, count)| op == "graphql.pr_node_id" && *count == 1)
+        );
+        assert!(
+            stats
+                .by_operation
+                .iter()
+                .any(|(op, count)| op == "graphql.enqueue_pr" && *count == 1)
         );
     }
 


### PR DESCRIPTION
## Motivation

`record_api_call` feeds the `forge.api.total` and per-operation counters printed by `stax submit --verbose` (`submit.rs:3602`). It was applied opportunistically as methods were added, so roughly half the client's network calls were invisible to it. A user reading that diagnostic to understand why a submit was slow, or to reason about rate-limit headroom, got a number that could be off by a factor of two or more.

**This is a cosmetic undercount in a diagnostic, not a correctness bug** — nothing branches on these counters. The PR is scoped accordingly: add the missing calls, fix one placement bug, stop.

## Description of changes / notes for reviewers

I audited every method in `client.rs`, `pr.rs`, `checks.rs` and `gh_stack.rs` that issues a network request. The gaps:

- **`pr.rs`** — `merge_pr`, `is_pr_merged`, `list_issue_comments`, `list_review_comments`, `get_pr_reviews`, `get_pr_node_id`, `enqueue_pr`
- **`client.rs`** — `get_current_user`, `get_recent_merged_prs`, `get_recent_opened_prs`, `get_reviews_received`, `get_user_open_prs`, `get_check_runs_status`
- **`checks.rs`** — `fetch_commit_statuses`, `fetch_check_runs`

**Two cases where one method makes N requests but recorded 0 or 1:**

- `get_reviews_received` and `get_user_open_prs` each do a search *plus a request per result in a `for` loop*. These now record inside the loop, following the precedent set by `list_open_prs_by_head` (`pr.rs:468`) — the only existing site that got this right.
- `enqueue_pr` makes **two** GraphQL requests: a node-ID lookup and the mutation. Recording `get_pr_node_id` separately fixes this and, as a side effect, also fixes `set_pr_draft`, which shared the same hidden node-ID request.

**One placement bug fixed:** `list_open_issues` recorded once *before* its pagination loop, undercounting by one per extra page. Moved inside the loop.

`checks.rs` needed no refactor to participate — `record_api_call` is `pub(crate)` and `checks.rs` is an `impl GitHubClient` block in the same crate that already reaches `self.octocrab`.

Naming follows the dominant `resource.action` convention with a `graphql.` prefix for GraphQL, matching the existing `graphql.pr_merge_status`.

**Semantics preserved:** `record_api_call` fires *before* the request, so it counts attempts, not successes. That's the existing behaviour at all 22 current sites and is the right one — a failed request still consumes rate limit.

**Tests:** three wiremock unit tests alongside the four that already assert on `api_call_stats`. The counters are readable in-crate via `api_call_stats()` plus the `#[cfg(test)]` `with_octocrab` constructor, so no submit run and no new harness. The two that earn their keep: `test_enqueue_pr_records_node_id_and_mutation` pins the two-requests-one-method case, and `test_list_open_issues_counts_every_page` pins the loop-placement fix. **No new test files.**

**One honest caveat:** instrumenting `get_check_runs_status` is currently *inert*. It makes a real network call, but its only in-crate caller is `combined_status_state`, which is dead code (zero callers repo-wide — see the note in #754). The call is correct and will start counting if that code is ever wired up; it just does nothing today.

### What I deliberately did not change

- **`gh_stack.rs` is scoped out.** It makes zero direct network calls — everything goes through `Command::new("gh")` / `Command::new("git")` subprocesses. Those do hit GitHub, but they're free functions with no `&self` and no tracker access. Counting them needs a different mechanism, and mixing subprocess calls into a counter labelled `forge.api.total` would make the number *less* meaningful, not more.
- **Pure delegators do not record** — `get_pr_review_decision`, `list_all_comments`, `fetch_checks`, and the shared `graphql_data` transport. Recording in any would double-count. `graphql_data` looks like the obvious single choke point, but instrumenting it would double every GraphQL caller that already records.
- **`combined_status_state`** (dead code) and **`get_reviews_given`** (a stub with no network call) are left alone.
- **The legacy inconsistent names stay** — `pulls.convertToDraft` and `pulls.markReadyForReview` are camelCase and `pulls.update-branch` is hyphenated, against the dominant convention. Renaming would change user-visible diagnostic output for no benefit.
- **No test on the printed output** at `submit.rs:3602`. Asserting on formatted diagnostic text is brittle; the counters themselves are pinned at the source.

Checked for stale assertions: the only four `total_requests` assertions are the pre-existing stats tests covering `list_open_prs_by_head`, `find_open_pr_by_head`, `find_pr`, and `get_pr_with_head`. None of those methods were touched, and none asserts on the methods whose totals shift.

Verified: `make lint` clean, `make test` 2361/2361.
