### PR TITLE
fix: reject non-positive standup hours

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -12,6 +12,14 @@ fn parse_positive_usize(value: &str) -> Result<usize, String> {
         .ok_or_else(|| "value must be greater than zero".to_string())
 }
 
+fn parse_positive_i64(value: &str) -> Result<i64, String> {
+    value
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| "value must be greater than zero".to_string())
+}
+
 #[derive(Parser)]
 #[command(name = "stax")]
 #[command(version)]
@@ -1127,7 +1135,7 @@ pub(crate) enum Commands {
         #[arg(long)]
         all: bool,
         /// Time window in hours (default: 24)
-        #[arg(long, default_value = "24")]
+        #[arg(long, default_value = "24", value_parser = parse_positive_i64)]
         hours: i64,
         /// Summarize standup using AI
         #[arg(long)]

--- a/tests/standup_tests.rs
+++ b/tests/standup_tests.rs
@@ -40,6 +40,22 @@ fn setup_repo(home: &TempDir, api_base_url: &str) -> TestRepo {
     repo
 }
 
+#[test]
+fn standup_rejects_non_positive_hours() {
+    let repo = TestRepo::new();
+
+    for hours in ["--hours=-1", "--hours=0"] {
+        let output = repo.run_stax(&["standup", "--json", hours]);
+        output.assert_failure();
+
+        let stderr = TestRepo::stderr(&output);
+        assert!(
+            stderr.contains("value must be greater than zero"),
+            "expected positive-hours validation for {hours}, got: {stderr}"
+        );
+    }
+}
+
 fn env_with_auth(home: &TempDir) -> [(&str, &str); 2] {
     [
         ("HOME", home.path().to_str().expect("UTF-8 home path")),


### PR DESCRIPTION
## Summary
- reject zero and negative `stax standup --hours` values during CLI parsing
- cover both invalid boundaries in the standup integration suite

Fixes #763

## Validation
- `cargo nextest run standup_tests::`
- `make lint-fast`
- `make lint`
- `make test` (2,372 passed)
- CLI smoke for `--hours=0` and `--hours=-1`

Docs: not updated; this is a validation-only bug fix and the documented time-window behavior is unchanged.