### PR TITLE
fix: stop submit stalling silently on temporary restacks

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -26,7 +26,7 @@ use futures_util::future::join_all;
 use serde::Deserialize;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -750,8 +750,14 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         )?;
     }
 
-    let (publish_sources, _temporary_publish_refs) =
-        prepare_publish_sources_for_submit(&repo, &stack, &branches_to_submit, quiet)?;
+    let (publish_sources, _temporary_publish_refs) = prepare_publish_sources_for_submit(
+        &repo,
+        &stack,
+        &branches_to_submit,
+        &empty_set,
+        quiet,
+        verbose,
+    )?;
 
     // Build plan - determine which PRs need create vs update
     let planning_timer = LiveTimer::maybe_new(!quiet, "Planning PR operations...");
@@ -2894,10 +2900,12 @@ fn prepare_publish_sources_for_submit(
     repo: &GitRepo,
     stack: &Stack,
     branches_to_submit: &[String],
+    empty_set: &HashSet<&String>,
     quiet: bool,
+    verbose: bool,
 ) -> Result<(HashMap<String, PublishSource>, TemporaryPublishRefs)> {
     let workdir = repo.workdir()?;
-    let mut sources = HashMap::new();
+    let mut sources: HashMap<String, PublishSource> = HashMap::new();
     let temp_root = std::env::temp_dir().join(format!(
         "stax-submit-{}-{}",
         std::process::id(),
@@ -2905,49 +2913,114 @@ fn prepare_publish_sources_for_submit(
     ));
     let mut temporary_refs = TemporaryPublishRefs::empty(workdir);
 
-    for branch in branches_to_submit {
-        let meta = BranchMetadata::read(repo.inner(), branch)?
-            .with_context(|| format!("No metadata for branch {}", branch))?;
-        if is_imported_branch(&meta) {
-            continue;
+    // Work out up-front which branches actually need a rebase, so progress can
+    // be reported as "(i/N)" rather than leaving the user staring at nothing.
+    // (branch, upstream revision to rebase from, ref to rebase onto, temp ref)
+    let mut planned: Vec<(String, String, String, String)> = Vec::new();
+    // (empty branch, the parent whose prepared ref it inherits)
+    let mut reused_parent_sources: Vec<(String, String)> = Vec::new();
+    {
+        // Mirrors `sources` while planning, since the real refs don't exist yet.
+        let mut planned_sources: HashMap<String, PublishSource> = HashMap::new();
+        for branch in branches_to_submit {
+            let meta = BranchMetadata::read(repo.inner(), branch)?
+                .with_context(|| format!("No metadata for branch {}", branch))?;
+            if is_imported_branch(&meta) {
+                continue;
+            }
+
+            let parent_source = planned_sources.get(&meta.parent_branch_name).cloned();
+            let parent_will_publish_from_temp = parent_source.is_some();
+            let branch_needs_temp = stack
+                .branches
+                .get(branch)
+                .map(|br| br.needs_restack)
+                .unwrap_or(false)
+                || parent_will_publish_from_temp;
+
+            if !branch_needs_temp {
+                continue;
+            }
+
+            // An empty branch has, by definition, the same tip commit as its
+            // parent, so its rebased tip is exactly the parent's rebased tip.
+            // Reuse the parent's prepared ref instead of paying for a whole
+            // worktree checkout + rebase + teardown that cannot change anything.
+            if empty_set.contains(branch) {
+                if let Some(parent_source) = parent_source {
+                    planned_sources.insert(
+                        branch.clone(),
+                        PublishSource {
+                            commit_range_base: parent_source.source_ref.clone(),
+                            source_ref: parent_source.source_ref,
+                            oid: None,
+                            is_temporary: true,
+                        },
+                    );
+                    reused_parent_sources.push((branch.clone(), meta.parent_branch_name.clone()));
+                }
+                // With no parent temp ref, the branch already points at its
+                // parent's tip, so `refs/heads/<branch>` is already correct.
+                continue;
+            }
+
+            let onto_ref = parent_source
+                .map(|source| source.source_ref)
+                .unwrap_or_else(|| meta.parent_branch_name.clone());
+
+            // Placeholder: only `source_ref` is read while planning, and the
+            // real ref name is computed here so children chain onto it.
+            let temp_ref = format!(
+                "refs/stax/submit/{}/{}",
+                chrono_like_timestamp(),
+                hex_ref_component(branch)
+            );
+            planned_sources.insert(
+                branch.clone(),
+                PublishSource {
+                    source_ref: temp_ref.clone(),
+                    commit_range_base: onto_ref.clone(),
+                    oid: None,
+                    is_temporary: true,
+                },
+            );
+            planned.push((
+                branch.clone(),
+                meta.parent_branch_revision.clone(),
+                onto_ref,
+                temp_ref,
+            ));
         }
+    }
 
-        let parent_source_ref = sources
-            .get(&meta.parent_branch_name)
-            .map(|source: &PublishSource| source.source_ref.clone());
-        let parent_will_publish_from_temp = parent_source_ref.is_some();
-        let branch_needs_temp = stack
-            .branches
-            .get(branch)
-            .map(|br| br.needs_restack)
-            .unwrap_or(false)
-            || parent_will_publish_from_temp;
+    let total = planned.len();
+    let mut worktree = ReusableSubmitWorktree::new(workdir, &temp_root);
 
-        if !branch_needs_temp {
-            continue;
-        }
-
-        let onto_ref = parent_source_ref.unwrap_or_else(|| meta.parent_branch_name.clone());
-        let temp_ref = format!(
-            "refs/stax/submit/{}/{}",
-            chrono_like_timestamp(),
-            hex_ref_component(branch)
+    for (index, (branch, upstream, onto_ref, temp_ref)) in planned.into_iter().enumerate() {
+        let timer = LiveTimer::maybe_new(
+            !quiet,
+            &format!(
+                "Preparing restack {}/{}: {}...",
+                index + 1,
+                total,
+                truncate_branch_label(&branch)
+            ),
         );
-        let temp_worktree = temp_root.join(hex_ref_component(branch));
-        let oid = temporary_rebased_head(
-            workdir,
-            &temp_worktree,
-            branch,
-            &onto_ref,
-            &meta.parent_branch_revision,
-        )
-        .with_context(|| {
-            format!(
-                "Could not prepare temporary restack for submit of '{}'.\n\
-                 Run `stax restack` to resolve it locally, then retry submit.",
-                branch
-            )
-        })?;
+
+        let oid = match worktree.rebased_head(&branch, &onto_ref, &upstream) {
+            Ok(oid) => oid,
+            Err(err) => {
+                LiveTimer::maybe_finish_warn(timer, "FAILED");
+                return Err(err).with_context(|| {
+                    format!(
+                        "Could not prepare temporary restack for submit of '{}'.\n\
+                         Run `stax restack` to resolve it locally, then retry submit.",
+                        branch
+                    )
+                });
+            }
+        };
+        LiveTimer::maybe_finish_ok(timer, "done");
 
         update_ref(workdir, &temp_ref, &oid)?;
         temporary_refs.refs.push(temp_ref.clone());
@@ -2962,13 +3035,41 @@ fn prepare_publish_sources_for_submit(
         );
     }
 
-    if !sources.is_empty() && !quiet {
+    let worktrees_created = worktree.finish();
+
+    // Empty branches inherit their parent's freshly-created ref. Processed in
+    // stack order, so a chain of empty branches inherits transitively.
+    for (branch, parent) in reused_parent_sources {
+        let Some(parent_source) = sources.get(&parent).cloned() else {
+            continue;
+        };
+        sources.insert(
+            branch,
+            PublishSource {
+                commit_range_base: parent_source.source_ref.clone(),
+                source_ref: parent_source.source_ref,
+                oid: parent_source.oid,
+                is_temporary: true,
+            },
+        );
+    }
+
+    let prepared_refs = temporary_refs.refs.len();
+    if prepared_refs > 0 && !quiet {
         println!(
             "  {} Prepared {} temporary restack {} for submit",
             "▸".dimmed(),
-            sources.len().to_string().cyan(),
-            if sources.len() == 1 { "ref" } else { "refs" }
+            prepared_refs.to_string().cyan(),
+            if prepared_refs == 1 { "ref" } else { "refs" }
         );
+        if verbose {
+            println!(
+                "    {} {} rebase(s) across {} worktree(s)",
+                "▸".dimmed(),
+                total,
+                worktrees_created
+            );
+        }
     }
 
     if let Err(err) = remove_path_if_exists(&temp_root)
@@ -2985,57 +3086,114 @@ fn prepare_publish_sources_for_submit(
     Ok((sources, temporary_refs))
 }
 
-fn temporary_rebased_head(
-    workdir: &Path,
-    temp_worktree: &Path,
-    branch: &str,
-    onto_ref: &str,
-    upstream: &str,
-) -> Result<String> {
-    if let Some(parent) = temp_worktree.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!("Failed to create temporary directory {}", parent.display())
-        })?;
+fn truncate_branch_label(branch: &str) -> String {
+    const MAX: usize = 40;
+    if branch.chars().count() <= MAX {
+        return branch.to_string();
+    }
+    let kept: String = branch.chars().take(MAX - 1).collect();
+    format!("{kept}…")
+}
+
+/// A single temporary worktree reused across every branch that needs a
+/// temporary restack.
+///
+/// Creating and tearing down one worktree per branch means a full working-tree
+/// checkout plus an `rm -rf` per branch, which in a large repository is tens of
+/// seconds each and dominates submit time for anything but a trivial stack.
+/// Checking out successive branches in one worktree only touches the files that
+/// actually differ between them.
+struct ReusableSubmitWorktree<'a> {
+    workdir: &'a Path,
+    root: PathBuf,
+    guard: Option<TemporarySubmitWorktree>,
+    path: Option<PathBuf>,
+    created: usize,
+}
+
+impl<'a> ReusableSubmitWorktree<'a> {
+    fn new(workdir: &'a Path, root: &Path) -> Self {
+        Self {
+            workdir,
+            root: root.to_path_buf(),
+            guard: None,
+            path: None,
+            created: 0,
+        }
     }
 
-    let add = Command::new("git")
-        .args(["worktree", "add", "--detach"])
-        .arg(temp_worktree)
-        .arg(branch)
-        .current_dir(workdir)
-        .output()
-        .context("Failed to create temporary submit worktree")?;
-    if !add.status.success() {
-        anyhow::bail!("{}", command_output_details("git worktree add", &add));
+    /// Rebase `branch` onto `onto_ref` (dropping everything up to `upstream`)
+    /// and return the resulting commit, without touching the user's checkout.
+    fn rebased_head(&mut self, branch: &str, onto_ref: &str, upstream: &str) -> Result<String> {
+        let path = match &self.path {
+            Some(path) => path.clone(),
+            None => {
+                let path = self.root.join("worktree");
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("Failed to create temporary directory {}", parent.display())
+                    })?;
+                }
+                let add = Command::new("git")
+                    .args(["worktree", "add", "--detach"])
+                    .arg(&path)
+                    .arg(branch)
+                    .current_dir(self.workdir)
+                    .output()
+                    .context("Failed to create temporary submit worktree")?;
+                if !add.status.success() {
+                    anyhow::bail!("{}", command_output_details("git worktree add", &add));
+                }
+                self.guard = Some(TemporarySubmitWorktree::new(self.workdir, &path));
+                self.path = Some(path.clone());
+                self.created += 1;
+                path
+            }
+        };
+
+        // The worktree is already detached at `branch` on the very first use;
+        // afterwards it is parked on the previous branch's rebase result.
+        let checkout = Command::new("git")
+            .args(["checkout", "--force", "--detach", branch])
+            .current_dir(&path)
+            .output()
+            .context("Failed to check out branch in temporary submit worktree")?;
+        if !checkout.status.success() {
+            anyhow::bail!("{}", command_output_details("git checkout", &checkout));
+        }
+
+        let rebase = Command::new("git")
+            .args(["rebase", "--onto", onto_ref, upstream])
+            .current_dir(&path)
+            .output()
+            .context("Failed to run temporary submit rebase")?;
+        if !rebase.status.success() {
+            let _ = Command::new("git")
+                .args(["rebase", "--abort"])
+                .current_dir(&path)
+                .output();
+            anyhow::bail!("{}", command_output_details("git rebase", &rebase));
+        }
+
+        let rev = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&path)
+            .output()
+            .context("Failed to read temporary submit head")?;
+        if !rev.status.success() {
+            anyhow::bail!("{}", command_output_details("git rev-parse", &rev));
+        }
+
+        Ok(String::from_utf8_lossy(&rev.stdout).trim().to_string())
     }
-    let mut temp_worktree_guard = TemporarySubmitWorktree::new(workdir, temp_worktree);
 
-    let rebase = Command::new("git")
-        .args(["rebase", "--onto", onto_ref, upstream])
-        .current_dir(temp_worktree)
-        .output()
-        .context("Failed to run temporary submit rebase")?;
-    if !rebase.status.success() {
-        let _ = Command::new("git")
-            .args(["rebase", "--abort"])
-            .current_dir(temp_worktree)
-            .output();
-        anyhow::bail!("{}", command_output_details("git rebase", &rebase));
+    /// Tear the worktree down and report how many were created.
+    fn finish(mut self) -> usize {
+        if let Some(guard) = self.guard.as_mut() {
+            let _ = guard.remove();
+        }
+        self.created
     }
-
-    let rev = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(temp_worktree)
-        .output()
-        .context("Failed to read temporary submit head")?;
-    if !rev.status.success() {
-        anyhow::bail!("{}", command_output_details("git rev-parse", &rev));
-    }
-    let oid = String::from_utf8_lossy(&rev.stdout).trim().to_string();
-
-    temp_worktree_guard.remove()?;
-
-    Ok(oid)
 }
 
 fn update_ref(workdir: &Path, refname: &str, oid: &str) -> Result<()> {

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -138,6 +138,8 @@ mod submit_no_verify_tests;
 mod submit_plan_completions_tests;
 #[path = "submit_pr_base_tests.rs"]
 mod submit_pr_base_tests;
+#[path = "submit_temp_restack_tests.rs"]
+mod submit_temp_restack_tests;
 #[path = "sweep_tests.rs"]
 mod sweep_tests;
 #[path = "sync_confirm_tests.rs"]

--- a/tests/submit_temp_restack_tests.rs
+++ b/tests/submit_temp_restack_tests.rs
@@ -1,0 +1,262 @@
+//! Tests for the temporary-restack preparation phase of `stax submit`.
+//!
+//! Background: when a branch in the stack needs a restack, submit does not
+//! refuse to publish — it prepares a *temporary* rebased ref per branch so the
+//! pushed content is what the PR should contain. That preparation used to be:
+//!
+//!   * completely silent (no progress output at all), and
+//!   * one full `git worktree add` + `git rebase` + `git worktree remove`
+//!     per branch, including for empty branches that need no rebase at all.
+//!
+//! In a large repository with a 4-5 branch stack that is several minutes of
+//! dead air after "Fetching from origin... done". These tests pin the fixed
+//! contract: visible per-branch progress, no worktree for empty branches, and
+//! byte-identical rebase results.
+
+use crate::common;
+
+use common::TestRepo;
+
+/// Build `main -> base -> empty -> tip`, then move `main` forward so the whole
+/// stack needs a restack. `empty` deliberately carries no commits of its own.
+///
+/// Returns (base, empty, tip) branch names.
+fn stale_stack_with_empty_branch(repo: &TestRepo) -> (String, String, String) {
+    let bc = repo.run_stax(&["bc", "base"]);
+    assert!(bc.status.success(), "bc base: {}", TestRepo::stderr(&bc));
+    repo.create_file("base.txt", "base");
+    repo.commit("Commit for base");
+    let base = repo.current_branch();
+
+    // Empty branch: created on top of `base` but never committed to.
+    let bc = repo.run_stax(&["bc", "empty"]);
+    assert!(bc.status.success(), "bc empty: {}", TestRepo::stderr(&bc));
+    let empty = repo.current_branch();
+
+    let bc = repo.run_stax(&["bc", "tip"]);
+    assert!(bc.status.success(), "bc tip: {}", TestRepo::stderr(&bc));
+    repo.create_file("tip.txt", "tip");
+    repo.commit("Commit for tip");
+    let tip = repo.current_branch();
+
+    // Move trunk forward so `base` (and therefore the whole stack) is stale.
+    let co = repo.git(&["checkout", "main"]);
+    assert!(
+        co.status.success(),
+        "checkout main: {}",
+        TestRepo::stderr(&co)
+    );
+    repo.create_file("trunk.txt", "moved");
+    repo.commit("Trunk moves forward");
+
+    let co = repo.git(&["checkout", &tip]);
+    assert!(
+        co.status.success(),
+        "checkout tip: {}",
+        TestRepo::stderr(&co)
+    );
+
+    (base, empty, tip)
+}
+
+/// Run a stack submit on the PR-creating (legacy) submit path.
+///
+/// `--no-pr` alone routes to the newer application backend, which does not do
+/// temporary-restack preparation. `--no-template` keeps us on the same code
+/// path a real `stax ss` takes while `--no-pr` keeps the test offline.
+fn submit_stack(repo: &TestRepo) -> String {
+    submit_stack_with(
+        repo,
+        &["ss", "--no-pr", "--no-template", "--no-prompt", "--yes"],
+    )
+}
+
+fn submit_stack_with(repo: &TestRepo, args: &[&str]) -> String {
+    let out = repo.run_stax(args);
+    let stdout = TestRepo::stdout(&out);
+    let stderr = TestRepo::stderr(&out);
+    assert!(
+        out.status.success(),
+        "submit failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    format!("{stdout}\n{stderr}")
+}
+
+/// Thesis part 1: the preparation phase must not be silent.
+///
+/// Before the fix the only output was a single summary line printed *after*
+/// every worktree had been created, rebased and torn down — i.e. after the
+/// entire stall. There must be per-branch progress while the work happens.
+#[test]
+fn temp_restack_preparation_reports_per_branch_progress() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    let (base, _empty, tip) = stale_stack_with_empty_branch(&repo);
+
+    let combined = submit_stack(&repo);
+
+    assert!(
+        combined.contains("Preparing restack"),
+        "expected per-branch restack progress output, got:\n{combined}"
+    );
+    for branch in [&base, &tip] {
+        assert!(
+            combined.contains(branch.as_str()),
+            "expected branch '{branch}' named in preparation progress, got:\n{combined}"
+        );
+    }
+}
+
+/// Thesis part 2: an empty branch has the same tip commit as its parent by
+/// definition, so its rebased tip is exactly the parent's rebased tip. It must
+/// reuse the parent's prepared ref instead of paying for its own worktree
+/// checkout + rebase + teardown.
+#[test]
+fn empty_branches_do_not_get_their_own_temp_worktree() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    let (_base, _empty, _tip) = stale_stack_with_empty_branch(&repo);
+
+    let combined = submit_stack(&repo);
+
+    // Only `base` and `tip` genuinely need a rebase; `empty` must not.
+    assert!(
+        combined.contains("Prepared 2 temporary restack refs"),
+        "expected exactly 2 prepared refs (empty branch skipped), got:\n{combined}"
+    );
+}
+
+/// Thesis part 3: the rebases must all share one worktree instead of paying
+/// for a `git worktree add` + `rm -rf` per branch, which is what made a 4-5
+/// branch stack stall for minutes in a large repository.
+#[test]
+fn temp_restack_reuses_a_single_worktree_for_every_branch() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    let (_base, _empty, _tip) = stale_stack_with_empty_branch(&repo);
+
+    let combined = submit_stack_with(
+        &repo,
+        &[
+            "ss",
+            "--no-pr",
+            "--no-template",
+            "--no-prompt",
+            "--yes",
+            "--verbose",
+        ],
+    );
+
+    assert!(
+        combined.contains("2 rebase(s) across 1 worktree(s)"),
+        "expected both rebases to share one worktree, got:\n{combined}"
+    );
+}
+
+/// Regression guard for the worktree-reuse optimisation: reusing a single
+/// worktree across branches must produce exactly the same published commits as
+/// one-worktree-per-branch did.
+///
+/// `empty` must land on the remote at the same commit as `base` (that is what
+/// "empty" means), and `tip` must sit one commit above it with both the trunk
+/// commit and the base commit in its history.
+#[test]
+fn temp_restack_publishes_correctly_rebased_commits() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    let (base, empty, tip) = stale_stack_with_empty_branch(&repo);
+
+    submit_stack(&repo);
+
+    let remote_sha = |branch: &str| repo.get_commit_sha(&format!("refs/remotes/origin/{branch}"));
+
+    let trunk_sha = repo.get_commit_sha("main");
+    let base_sha = remote_sha(&base);
+    let empty_sha = remote_sha(&empty);
+    let tip_sha = remote_sha(&tip);
+
+    assert_eq!(
+        base_sha, empty_sha,
+        "empty branch must be published at the same commit as its parent"
+    );
+    assert_ne!(base_sha, tip_sha, "tip must be published above its parent");
+
+    // The rebase actually happened: the published base contains the new trunk
+    // commit, and the published tip contains the published base.
+    let contains = |ancestor: &str, descendant: &str| {
+        repo.git(&["merge-base", "--is-ancestor", ancestor, descendant])
+            .status
+            .success()
+    };
+    assert!(
+        contains(&trunk_sha, &base_sha),
+        "published base must be rebased onto the moved trunk"
+    );
+    assert!(
+        contains(&base_sha, &tip_sha),
+        "published tip must be rebased onto the published base"
+    );
+}
+
+/// The reused worktree must not survive a failed rebase.
+///
+/// With one worktree per branch a conflict left at most that branch's worktree
+/// behind; now a single worktree is held across the whole phase, so its cleanup
+/// on the error path is worth pinning rather than assuming.
+#[test]
+fn failed_temp_restack_leaves_no_worktree_behind() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    // `base` edits a file that trunk then edits differently, so replaying
+    // `base` onto the moved trunk conflicts.
+    let bc = repo.run_stax(&["bc", "base"]);
+    assert!(bc.status.success(), "bc base: {}", TestRepo::stderr(&bc));
+    repo.create_file("shared.txt", "from base");
+    repo.commit("Base edits shared");
+
+    let co = repo.git(&["checkout", "main"]);
+    assert!(
+        co.status.success(),
+        "checkout main: {}",
+        TestRepo::stderr(&co)
+    );
+    repo.create_file("shared.txt", "from trunk");
+    repo.commit("Trunk edits shared");
+
+    let co = repo.git(&["checkout", "base"]);
+    assert!(
+        co.status.success(),
+        "checkout base: {}",
+        TestRepo::stderr(&co)
+    );
+
+    let worktrees_before = repo.git(&["worktree", "list"]);
+    let before = String::from_utf8_lossy(&worktrees_before.stdout)
+        .lines()
+        .count();
+
+    let out = repo.run_stax(&["ss", "--no-pr", "--no-template", "--no-prompt", "--yes"]);
+    let combined = format!("{}\n{}", TestRepo::stdout(&out), TestRepo::stderr(&out));
+
+    assert!(
+        !out.status.success(),
+        "submit should fail when the temporary restack conflicts, got:\n{combined}"
+    );
+    assert!(
+        combined.contains("stax restack"),
+        "failure should point at `stax restack`, got:\n{combined}"
+    );
+
+    let worktrees_after = repo.git(&["worktree", "list"]);
+    let after_raw = String::from_utf8_lossy(&worktrees_after.stdout).to_string();
+    assert_eq!(
+        after_raw.lines().count(),
+        before,
+        "temporary worktree leaked after a failed restack:\n{after_raw}"
+    );
+}


### PR DESCRIPTION
## Motivation

Reported by Sean Rennie on 0.104.6: `stax ss` stalls for multiple minutes with no output at all once a stack has more than ~3 branches. The last thing printed is `✓ Fetching from origin... done 4.393s`, then nothing.

The stall is the temporary-restack preparation phase in `submit.rs`, which runs between the fetch timer and the `Planning PR operations...` timer and prints nothing while it works. For every branch it did a full `git worktree add --detach` (whole-tree checkout), a `git rebase --onto`, and a `git worktree remove` (`rm -rf`) — sequentially.

Two things make that blow up on a real stack:

- The temp-worktree condition cascades. A single branch needing a restack forces *every* branch above it through the same worktree cycle, because a child publishing on top of a temp ref must itself publish from a temp ref.
- Empty branches were not exempt, so push-only/no-PR branches each paid for a full worktree too.

In a large repo each cycle is tens of seconds, so a 4-5 branch stack is several minutes of dead air. Sean's screenshot shows exactly this shape: one branch `needs restack` plus two empty branches.

## Description of changes / notes for reviewers

- **Visible progress.** Each rebase now runs under a `LiveTimer` (`Preparing restack 1/2: <branch>...`), so the phase reports itself while it happens rather than only via one summary line printed after it finishes.
- **Empty branches no longer get a worktree.** `empty` is defined in submit as `branch_commit == parent_commit`, so an empty branch's rebased tip is *exactly* its parent's rebased tip. It now inherits the parent's prepared ref. When the parent has no temp ref, `refs/heads/<branch>` is already correct and nothing is prepared at all.
- **One worktree, reused.** `ReusableSubmitWorktree` creates a single detached worktree on first use and `git checkout --force --detach <branch>`es between branches. Checking out between adjacent stack branches only touches the files that actually differ, instead of a full checkout plus `rm -rf` per branch.
- The summary line now counts refs actually created rather than branches publishing from them (an inheriting empty branch is not a new ref).
- `--verbose` additionally prints `N rebase(s) across M worktree(s)`.

Rebase targets are now resolved during a planning pass rather than recomputed mid-loop. That pass is what makes the empty-branch inheritance correct: a branch stacked *above* an empty branch must rebase onto the empty branch's inherited temp ref, not onto the stale `refs/heads/<empty>`. Getting this wrong published unrebased commits, and the correctness test below caught it.

### Verification

New `tests/submit_temp_restack_tests.rs` (4 tests), written against the current code first and confirmed failing before the fix:

- `temp_restack_preparation_reports_per_branch_progress` — the phase is not silent.
- `empty_branches_do_not_get_their_own_temp_worktree` — reproduced the bug as `Prepared 3 temporary restack refs` for a `base → empty → tip` stack; now 2.
- `temp_restack_reuses_a_single_worktree_for_every_branch` — asserts `2 rebase(s) across 1 worktree(s)`.
- `temp_restack_publishes_correctly_rebased_commits` — pins the published SHAs: the empty branch lands on the same commit as its parent, and the tip is genuinely rebased onto the published base.

The tests drive the same code path a real `stax ss` takes. `--no-pr` alone routes to the newer application backend (which has no temp-restack phase), so they pass `--no-template` to stay on the PR-creating path while remaining offline.

`make test`: 2381 passed, 0 failed. `cargo clippy --all-targets -- -D warnings`: clean.

### Risk

Behaviour-preserving by intent; the published commits are pinned by test. The reuse path does mean a `git checkout --force` between branches inside the temporary worktree — that worktree is stax-created and detached, never the user's checkout, and is torn down at the end of the phase as before.
