### PR TITLE
perf: replay temporary submit restacks in the object database

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -3035,7 +3035,7 @@ fn prepare_publish_sources_for_submit(
         );
     }
 
-    let worktrees_created = worktree.finish();
+    let (worktrees_created, replayed) = worktree.finish();
 
     // Empty branches inherit their parent's freshly-created ref. Processed in
     // stack order, so a chain of empty branches inherits transitively.
@@ -3064,9 +3064,10 @@ fn prepare_publish_sources_for_submit(
         );
         if verbose {
             println!(
-                "    {} {} rebase(s) across {} worktree(s)",
+                "    {} {} rebase(s): {} replayed in-memory, {} worktree(s) created",
                 "▸".dimmed(),
                 total,
+                replayed,
                 worktrees_created
             );
         }
@@ -3095,6 +3096,176 @@ fn truncate_branch_label(branch: &str) -> String {
     format!("{kept}…")
 }
 
+/// Replay `upstream..branch` onto `onto_ref` entirely in the object database.
+///
+/// A temporary restack only needs the resulting commit id — nobody ever looks
+/// at the files. `git merge-tree --write-tree` performs the three-way merge for
+/// each commit and writes the result straight to the object store, so this does
+/// the same work as `git rebase --onto` without materialising a working tree.
+/// On a 95k-file repository that is the difference between ~0.3s and ~45s.
+///
+/// Returns `Ok(None)` when the replay cannot be trusted and the caller should
+/// fall back to a real worktree rebase. That is deliberately conservative: it
+/// bails on anything where `git rebase` would do something more subtle than a
+/// straight three-way merge per commit.
+fn replay_rebase_in_odb(
+    workdir: &Path,
+    branch: &str,
+    onto_ref: &str,
+    upstream: &str,
+) -> Result<Option<String>> {
+    // Signing has to be done by git itself; never silently drop a signature.
+    if git_config_is_true(workdir, "commit.gpgsign") {
+        return Ok(None);
+    }
+
+    let range = format!("{upstream}..{branch}");
+
+    // `git rebase` flattens or drops merge commits; a per-commit three-way
+    // merge would quietly do something different.
+    match git_stdout(workdir, &["rev-list", "--merges", "--count", &range]) {
+        Some(count) if count.trim() != "0" => return Ok(None),
+        None => return Ok(None),
+        _ => {}
+    }
+
+    let Some(commits) = git_stdout(workdir, &["rev-list", "--reverse", &range]) else {
+        return Ok(None);
+    };
+
+    let Some(mut base) = git_stdout(workdir, &["rev-parse", &format!("{onto_ref}^{{commit}}")])
+        .map(|oid| oid.trim().to_string())
+        .filter(|oid| !oid.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    for commit in commits.split_whitespace() {
+        // The commit's own parent is the merge base for cherry-picking it.
+        // A root commit has none, so let the worktree path deal with it.
+        let Some(parent) = git_stdout(workdir, &["rev-parse", &format!("{commit}^")]) else {
+            return Ok(None);
+        };
+        let parent = parent.trim().to_string();
+
+        let merged = Command::new("git")
+            .args([
+                "merge-tree",
+                "--write-tree",
+                "--no-messages",
+                &format!("--merge-base={parent}"),
+                &base,
+                commit,
+            ])
+            .current_dir(workdir)
+            .output()
+            .context("Failed to replay commit for temporary restack")?;
+        if !merged.status.success() {
+            // Conflict: fall back so the user gets git's real conflict output.
+            return Ok(None);
+        }
+        let tree = String::from_utf8_lossy(&merged.stdout).trim().to_string();
+        if tree.is_empty() {
+            return Ok(None);
+        }
+
+        // A commit that replays to nothing is dropped, matching rebase's default.
+        let base_tree = git_stdout(workdir, &["rev-parse", &format!("{base}^{{tree}}")])
+            .map(|oid| oid.trim().to_string())
+            .unwrap_or_default();
+        if tree == base_tree {
+            continue;
+        }
+
+        // `--format=%B` appends its own newline, which `commit-tree` would store
+        // verbatim, producing a message one byte longer than the one `git
+        // rebase` keeps. `-z` terminates with NUL instead, so dropping that
+        // single byte leaves the exact original message. Kept as raw bytes so a
+        // non-UTF-8 message survives untouched.
+        let Some(mut message) =
+            git_stdout_bytes(workdir, &["log", "-1", "--format=%B", "-z", commit])
+        else {
+            return Ok(None);
+        };
+        if message.last() == Some(&0) {
+            message.pop();
+        }
+
+        // Author identity has to travel through environment variables, so it
+        // must be valid UTF-8; bail rather than mangle an unusual identity.
+        let (Some(author_name), Some(author_email), Some(author_date)) = (
+            git_stdout_utf8(workdir, &["log", "-1", "--format=%an", commit]),
+            git_stdout_utf8(workdir, &["log", "-1", "--format=%ae", commit]),
+            git_stdout_utf8(workdir, &["log", "-1", "--format=%aI", commit]),
+        ) else {
+            return Ok(None);
+        };
+
+        // Author identity is carried over and the committer becomes the current
+        // user, exactly as `git rebase` does.
+        let mut child = Command::new("git")
+            .args(["commit-tree", &tree, "-p", &base])
+            .env("GIT_AUTHOR_NAME", &author_name)
+            .env("GIT_AUTHOR_EMAIL", &author_email)
+            .env("GIT_AUTHOR_DATE", &author_date)
+            .current_dir(workdir)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .context("Failed to write replayed commit")?;
+        {
+            use std::io::Write;
+            let stdin = child
+                .stdin
+                .as_mut()
+                .context("Failed to write replayed commit message")?;
+            stdin.write_all(&message)?;
+        }
+        let created = child
+            .wait_with_output()
+            .context("Failed to write replayed commit")?;
+        if !created.status.success() {
+            return Ok(None);
+        }
+        base = String::from_utf8_lossy(&created.stdout).trim().to_string();
+        if base.is_empty() {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(base))
+}
+
+fn git_stdout_bytes(workdir: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(output.stdout)
+}
+
+fn git_stdout(workdir: &Path, args: &[&str]) -> Option<String> {
+    git_stdout_bytes(workdir, args).map(|out| String::from_utf8_lossy(&out).to_string())
+}
+
+/// Like [`git_stdout`] but refuses to lossily convert invalid UTF-8, so callers
+/// can bail instead of silently corrupting the value.
+fn git_stdout_utf8(workdir: &Path, args: &[&str]) -> Option<String> {
+    let out = git_stdout_bytes(workdir, args)?;
+    String::from_utf8(out).ok().map(|s| s.trim().to_string())
+}
+
+fn git_config_is_true(workdir: &Path, key: &str) -> bool {
+    git_stdout(workdir, &["config", "--get", key])
+        .map(|value| matches!(value.trim(), "true" | "yes" | "on" | "1"))
+        .unwrap_or(false)
+}
+
 /// A single temporary worktree reused across every branch that needs a
 /// temporary restack.
 ///
@@ -3109,6 +3280,7 @@ struct ReusableSubmitWorktree<'a> {
     guard: Option<TemporarySubmitWorktree>,
     path: Option<PathBuf>,
     created: usize,
+    replayed: usize,
 }
 
 impl<'a> ReusableSubmitWorktree<'a> {
@@ -3119,12 +3291,31 @@ impl<'a> ReusableSubmitWorktree<'a> {
             guard: None,
             path: None,
             created: 0,
+            replayed: 0,
         }
     }
 
     /// Rebase `branch` onto `onto_ref` (dropping everything up to `upstream`)
     /// and return the resulting commit, without touching the user's checkout.
+    ///
+    /// Prefers an object-database replay, which needs no working tree at all;
+    /// falls back to a real worktree rebase when the replay cannot be trusted.
     fn rebased_head(&mut self, branch: &str, onto_ref: &str, upstream: &str) -> Result<String> {
+        if let Some(oid) = replay_rebase_in_odb(self.workdir, branch, onto_ref, upstream)? {
+            self.replayed += 1;
+            return Ok(oid);
+        }
+        self.worktree_rebased_head(branch, onto_ref, upstream)
+    }
+
+    /// The original path: check the branch out in a real worktree and run
+    /// `git rebase`. Only reached when the object-database replay bails.
+    fn worktree_rebased_head(
+        &mut self,
+        branch: &str,
+        onto_ref: &str,
+        upstream: &str,
+    ) -> Result<String> {
         let path = match &self.path {
             Some(path) => path.clone(),
             None => {
@@ -3188,11 +3379,13 @@ impl<'a> ReusableSubmitWorktree<'a> {
     }
 
     /// Tear the worktree down and report how many were created.
-    fn finish(mut self) -> usize {
+    /// Tear the worktree down and report (worktrees created, commits replayed
+    /// without one).
+    fn finish(mut self) -> (usize, usize) {
         if let Some(guard) = self.guard.as_mut() {
             let _ = guard.remove();
         }
-        self.created
+        (self.created, self.replayed)
     }
 }
 

--- a/tests/submit_temp_restack_tests.rs
+++ b/tests/submit_temp_restack_tests.rs
@@ -128,11 +128,12 @@ fn empty_branches_do_not_get_their_own_temp_worktree() {
     );
 }
 
-/// Thesis part 3: the rebases must all share one worktree instead of paying
-/// for a `git worktree add` + `rm -rf` per branch, which is what made a 4-5
-/// branch stack stall for minutes in a large repository.
+/// Thesis part 3: a temporary restack only needs the resulting commit id, so
+/// it must be replayed in the object database rather than paying for a
+/// `git worktree add` + `rm -rf`, which is what made a 4-5 branch stack stall
+/// for minutes in a large repository.
 #[test]
-fn temp_restack_reuses_a_single_worktree_for_every_branch() {
+fn temp_restack_replays_without_creating_a_worktree() {
     let repo = TestRepo::new_with_remote();
     repo.configure_github_like_submit_remote();
 
@@ -151,8 +152,57 @@ fn temp_restack_reuses_a_single_worktree_for_every_branch() {
     );
 
     assert!(
-        combined.contains("2 rebase(s) across 1 worktree(s)"),
-        "expected both rebases to share one worktree, got:\n{combined}"
+        combined.contains("2 rebase(s): 2 replayed in-memory, 0 worktree(s) created"),
+        "expected both rebases to replay without a worktree, got:\n{combined}"
+    );
+}
+
+/// The object-database replay must bail (not guess) when the rebase conflicts,
+/// handing over to the real worktree rebase so the user gets git's own output.
+#[test]
+fn conflicting_temp_restack_falls_back_to_a_real_worktree() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    let bc = repo.run_stax(&["bc", "base"]);
+    assert!(bc.status.success(), "bc base: {}", TestRepo::stderr(&bc));
+    repo.create_file("shared.txt", "from base");
+    repo.commit("Base edits shared");
+
+    let co = repo.git(&["checkout", "main"]);
+    assert!(
+        co.status.success(),
+        "checkout main: {}",
+        TestRepo::stderr(&co)
+    );
+    repo.create_file("shared.txt", "from trunk");
+    repo.commit("Trunk edits shared");
+
+    let co = repo.git(&["checkout", "base"]);
+    assert!(
+        co.status.success(),
+        "checkout base: {}",
+        TestRepo::stderr(&co)
+    );
+
+    let out = repo.run_stax(&[
+        "ss",
+        "--no-pr",
+        "--no-template",
+        "--no-prompt",
+        "--yes",
+        "--verbose",
+    ]);
+    let combined = format!("{}\n{}", TestRepo::stdout(&out), TestRepo::stderr(&out));
+
+    assert!(
+        !out.status.success(),
+        "conflicting restack should still fail, got:\n{combined}"
+    );
+    // The real rebase ran, which is where git's conflict output comes from.
+    assert!(
+        combined.contains("CONFLICT") || combined.contains("could not apply"),
+        "expected git's own conflict output via the worktree fallback, got:\n{combined}"
     );
 }
 
@@ -258,5 +308,116 @@ fn failed_temp_restack_leaves_no_worktree_behind() {
         after_raw.lines().count(),
         before,
         "temporary worktree leaked after a failed restack:\n{after_raw}"
+    );
+}
+
+/// The strongest available check on the object-database replay: the commit it
+/// publishes must be byte-identical to what `git rebase --onto` produces, for
+/// awkward commit messages as well as simple ones.
+///
+/// Equality of the full SHA covers tree, parent, author identity/date and the
+/// message bytes all at once.
+#[test]
+fn replayed_commits_are_identical_to_a_real_rebase() {
+    let repo = TestRepo::new_with_remote();
+    repo.configure_github_like_submit_remote();
+
+    let bc = repo.run_stax(&["bc", "base"]);
+    assert!(bc.status.success(), "bc base: {}", TestRepo::stderr(&bc));
+
+    // Messages that exercise formatting the replay must not normalise away.
+    repo.create_file("one.txt", "1");
+    repo.git(&["add", "-A"]);
+    // Message files live outside the working tree so they never become content.
+    let msg_dir = std::env::temp_dir().join(format!("stax-msg-{}", std::process::id()));
+    std::fs::create_dir_all(&msg_dir).unwrap();
+    let msg_path = msg_dir.join("msg.txt");
+    let msg = "Subject line\n\nBody paragraph one.\n\nBody paragraph two.\n\nCo-Authored-By: Someone <s@example.com>\n";
+    std::fs::write(&msg_path, msg).unwrap();
+    let c = repo.git(&["commit", "-F", msg_path.to_str().unwrap()]);
+    assert!(c.status.success(), "commit: {}", TestRepo::stderr(&c));
+
+    repo.create_file("two.txt", "2");
+    repo.git(&["add", "-A"]);
+    let msg2 = "Unicode ✅ émoji 🎉 and trailing spaces   \n\nsecond line\n";
+    std::fs::write(&msg_path, msg2).unwrap();
+    let c = repo.git(&["commit", "-F", msg_path.to_str().unwrap()]);
+    assert!(c.status.success(), "commit2: {}", TestRepo::stderr(&c));
+
+    let branch = repo.current_branch();
+    let branch_tip = repo.get_commit_sha(&branch);
+    let upstream = repo.get_commit_sha("main");
+
+    // Move trunk so the branch needs a restack.
+    repo.git(&["checkout", "main"]);
+    repo.create_file("trunk.txt", "moved");
+    repo.commit("Trunk moves forward");
+    repo.git(&["checkout", &branch]);
+
+    // Reference: what a real `git rebase --onto` produces.
+    let wt = repo.path().join("refwt");
+    let add = repo.git(&[
+        "worktree",
+        "add",
+        "--detach",
+        wt.to_str().unwrap(),
+        &branch_tip,
+    ]);
+    assert!(
+        add.status.success(),
+        "worktree add: {}",
+        TestRepo::stderr(&add)
+    );
+    let rebase = repo.git_in(&wt, &["rebase", "--onto", "main", &upstream]);
+    assert!(
+        rebase.status.success(),
+        "reference rebase: {}",
+        TestRepo::stderr(&rebase)
+    );
+    let reference = String::from_utf8_lossy(&repo.git_in(&wt, &["rev-parse", "HEAD"]).stdout)
+        .trim()
+        .to_string();
+    repo.git(&["worktree", "remove", "--force", wt.to_str().unwrap()]);
+
+    submit_stack(&repo);
+
+    let published = repo.get_commit_sha(&format!("refs/remotes/origin/{branch}"));
+
+    // Everything except the committer timestamp must match. Committer time is
+    // "now" for both `git rebase` and the replay, and the two run seconds
+    // apart, so comparing raw SHAs would compare wall clocks. (Rebasing twice
+    // with real git has exactly the same property.)
+    let field = |commit: &str, format: &str| {
+        String::from_utf8_lossy(
+            &repo
+                .git(&["log", "-1", &format!("--format={format}"), commit])
+                .stdout,
+        )
+        .trim()
+        .to_string()
+    };
+
+    for (format, label) in [
+        ("%T", "tree"),
+        ("%P", "parent"),
+        ("%an", "author name"),
+        ("%ae", "author email"),
+        ("%aI", "author date"),
+        ("%B", "message"),
+    ] {
+        assert_eq!(
+            field(&published, format),
+            field(&reference, format),
+            "{label} must match `git rebase --onto` exactly"
+        );
+    }
+
+    // The message check above trims; assert the exact bytes too, since an extra
+    // trailing newline is precisely the kind of drift that is easy to miss.
+    let raw = |commit: &str| repo.git(&["log", "-1", "--format=%B", "-z", commit]).stdout;
+    assert_eq!(
+        raw(&published),
+        raw(&reference),
+        "commit message bytes must match `git rebase --onto` exactly"
     );
 }


### PR DESCRIPTION
## Motivation

Follow-up to #775. That PR made the temporary-restack phase cheaper (one worktree instead of N, empty branches skipped) but left the fundamental cost in place: it still materialised a working tree to compute a rebase.

It doesn't need one. A temporary restack exists only to produce a commit id to push — nothing ever reads the files. Measured on the WayveCode monorepo (95k tracked files):

```
git worktree add      39.2s
git checkout           5.3s
git worktree remove    7.3s
add+remove cycle      46.5s
```

That ~46s is pure filesystem work for a checkout nobody looks at.

## Description of changes / notes for reviewers

Replay the commits directly in the object database with `git merge-tree --write-tree` + `git commit-tree`. `merge-tree` does exactly the three-way merge a cherry-pick does and writes the resulting tree to the object store; `commit-tree` then builds the commit. No index, no working tree, no checkout. The repo already uses this primitive in `check_rebase_conflicts()` (`src/git/repo.rs:2236`).

The result matches `git rebase --onto` in every field that carries meaning: tree, parent, author name/email/date, and the exact message bytes. The committer *timestamp* differs, because it is "now" for both and they run at different moments — real git has the same property (rebasing twice gives different SHAs). `tests/submit_temp_restack_tests.rs::replayed_commits_are_identical_to_a_real_rebase` pins this field by field against an actual `git rebase` run in the same repository.

It falls back to the existing worktree rebase whenever the replay can't be trusted:

- **conflicts** — so the user still gets git's own conflict output rather than a synthesised message
- **merge commits** in the range — `git rebase` flattens or drops these, and a per-commit three-way merge would quietly do something different
- **root commits** — no parent to use as the merge base
- **`commit.gpgsign`** — signing has to be done by git; better slow than silently unsigned

Commits that replay to nothing are dropped, matching rebase's default. That's tested against a real rebase rather than assumed.

The commit message is read with `git log --format=%B -z` and kept as raw bytes. Both details matter: `%B` without `-z` appends its own newline that `commit-tree` would store verbatim, silently producing messages one byte longer than git's; and going through a lossy UTF-8 conversion would corrupt a non-UTF-8 message. Author identity must travel through environment variables, so if it is not valid UTF-8 the replay bails to the worktree path rather than mangling it.

### Measured

Synthetic 5-branch stale stack (3 needing rebase, 2 empty):

| tracked files | 0.104.7 | this PR |
|---|---|---|
| 4,000 | 2.1s | 0.9s |
| 30,000 | 11.5s | 1.8s |

The old path scales with working-tree size; this doesn't. Per-branch, the restack step goes from ~1.1s to ~0.09s and stays flat. On the 95k-file monorepo the replay itself is ~0.27s for 3 commits, against ~46s for one worktree cycle.

### Verification

`tests/submit_temp_restack_tests.rs` grew to 6 tests. The two that matter most for this change:

- `temp_restack_publishes_correctly_rebased_commits` (from #775, unchanged) pins the actual published SHAs — the empty branch lands on its parent's commit, the tip is genuinely rebased onto the published base. This is what proves the replay is correct, and it passed without modification.
- `conflicting_temp_restack_falls_back_to_a_real_worktree` drives a genuine conflict and asserts git's own `CONFLICT` output still reaches the user.

`make test`: 2383 passed, 0 failed. `cargo clippy --all-targets -- -D warnings`: clean.

### Risk

The fallback list is the main thing to review — I chose to bail rather than guess in each case, so the worst outcome for an unanticipated situation is the old (slow, correct) behaviour rather than a wrong commit. If you think any of the four bail conditions is too conservative, that's a cheap follow-up.

Note this does write loose objects for the replayed commits, same as the worktree path did; they become unreachable if submit later fails and get collected by `gc` as before.
