### PR TITLE
fix: report installed skills correctly

### DIFF
--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -497,6 +497,7 @@ pub fn run_update_with(
         }
 
         let action = if file_exists { "update" } else { "install" };
+        let result = if file_exists { "updated" } else { "installed" };
         let content = build_content(&remote_body, loc);
 
         if dry_run {
@@ -518,7 +519,7 @@ pub fn run_update_with(
                 "{}  {} {}",
                 "✓".green(),
                 loc.name.cyan(),
-                format!("{action}d: {}", path.display()).dimmed(),
+                format!("{result}: {}", path.display()).dimmed(),
             );
             updated += 1;
         }

--- a/tests/skills_selection_tests.rs
+++ b/tests/skills_selection_tests.rs
@@ -97,6 +97,11 @@ async fn setup_install_skills_flag_with_skills_list_installs_subset() {
         .expect("run setup");
 
     assert!(output.status.success(), "{:?}", output);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("installed:"),
+        "stdout was: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
 
     assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
     assert!(home.path().join(".cursor/skills/stax/SKILL.md").exists());
@@ -213,6 +218,14 @@ async fn skills_update_respects_configured_harnesses() {
         "[skills]\nharnesses = [\"codex\"]\n",
     )
     .expect("write config");
+    let installed_skill = home.path().join(".codex/skills/stax/SKILL.md");
+    std::fs::create_dir_all(installed_skill.parent().expect("skill parent"))
+        .expect("create skill dir");
+    std::fs::write(
+        &installed_skill,
+        "<!-- stax-skills-version: 0.50.0 -->\n# Old Stax Skills\n",
+    )
+    .expect("write outdated skill");
 
     Mock::given(method("GET"))
         .and(path("/skills.md"))
@@ -238,6 +251,11 @@ async fn skills_update_respects_configured_harnesses() {
         .expect("skills update");
 
     assert!(output.status.success(), "{:?}", output);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("updated:"),
+        "stdout was: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
     assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
     assert!(!home.path().join(".cursor/skills/stax/SKILL.md").exists());
 }


### PR DESCRIPTION
Fixes #773

## What changed
- Render explicit past-tense status text for skill writes, so new files report `installed:` rather than `installd:`.
- Preserve `would install` / `would update` dry-run wording.
- Cover both a new install and an outdated existing skill update in integration tests.

## Verification
- `cargo nextest run --cargo-profile test-container skills_selection_tests::` (6 passed)
- `make lint-fast`
- `make lint`
- `make test` (2,384 passed)

Docs not updated: this is a correction to a success-message typo; no command, flag, or documented behavior changed.