### PR TITLE
test: cover every skills update --all harness

### DIFF
--- a/tests/skills_selection_tests.rs
+++ b/tests/skills_selection_tests.rs
@@ -298,6 +298,12 @@ async fn skills_update_all_overrides_configured_selection() {
 
     assert!(output.status.success(), "{:?}", output);
     assert!(home.path().join(".codex/skills/stax/SKILL.md").exists());
-    assert!(home.path().join(".cursor/skills/stax/SKILL.md").exists());
+    assert!(
+        home.path()
+            .join(".config/opencode/skills/stax/SKILL.md")
+            .exists()
+    );
     assert!(home.path().join(".claude/skills/stax/SKILL.md").exists());
+    assert!(home.path().join(".cursor/skills/stax/SKILL.md").exists());
+    assert!(home.path().join(".pi/agent/skills/stax/SKILL.md").exists());
 }


### PR DESCRIPTION
## Summary
- Extend the existing skills update --all integration contract to assert OpenCode and pi skill files.
- Retain coverage for Codex, Claude Code, and Cursor.

## Validation
- cargo nextest run skills_update_all_overrides_configured_selection --no-fail-fast — passed (1 test)
- make lint — passed
- make test — attempted as a tracked background run; blocked during compilation because the host filesystem reached 100% capacity (No space left on device). No test failure was observed.

## Docs
No user-visible behavior changed; this is test-only coverage.

Fixes #780
