### PR TITLE
Improve error outside Git repositories

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -262,7 +262,11 @@ struct BranchParentMetadata {
 impl GitRepo {
     /// Open the repository at the current directory or any parent
     pub fn open() -> Result<Self> {
-        let repo = Repository::discover(".").context("Not in a git repository")?;
+        let repo = Repository::discover(".").map_err(|_| {
+            anyhow::anyhow!(
+                "Not in a Git repository. Run this command from inside a Git repository."
+            )
+        })?;
         Ok(Self { repo })
     }
 

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -229,9 +229,7 @@ impl HunkSplitApp {
         let prev_states = self.selected[file_idx].clone();
         let all_selected = prev_states.iter().all(|&s| s);
         let new_val = !all_selected;
-        for s in &mut self.selected[file_idx] {
-            *s = new_val;
-        }
+        self.selected[file_idx].fill(new_val);
         self.undo_stack.push(UndoAction::ToggleFile {
             file_idx,
             prev_states,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -20,6 +20,29 @@ fn stax(args: &[&str]) -> std::process::Output {
         .expect("Failed to execute stax")
 }
 
+#[test]
+fn repository_commands_outside_git_show_actionable_error() {
+    let dir = tempfile::tempdir_in("/tmp").unwrap();
+    let output = Command::new(stax_bin())
+        .current_dir(dir.path())
+        .arg("status")
+        .env("STAX_CONFIG_DIR", dir.path().join("config"))
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .output()
+        .expect("Failed to execute stax");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Not in a Git repository. Run this command from inside a Git repository."),
+        "expected actionable repository error, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("class=Repository"),
+        "expected libgit2 internals to stay hidden, got: {stderr}"
+    );
+}
+
 fn stax_with_home(args: &[&str], home: &std::path::Path) -> std::process::Output {
     Command::new(stax_bin())
         .args(args)


### PR DESCRIPTION
## Summary

- Replace the raw libgit2 error shown outside a Git repository with clear recovery guidance.
- Add an end-to-end regression test that confirms internal libgit2 diagnostics are not shown.
- Use slice fill in the split-hunk toggle path to satisfy the current lint gate without changing behavior.

## Verification

- cargo test --test all_tests cli_tests::repository_commands_outside_git_show_actionable_error -- --exact
- make lint
- make test (2385 tests across 4 binaries)

## Notes

Documentation was not updated because this only improves an undocumented runtime error message.