### PR TITLE
chore: move the toolchain to 1.98.0 everywhere

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.96.1
+          toolchain: 1.98.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo
@@ -94,7 +94,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.96.1
+          toolchain: 1.98.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.96.1
+          toolchain: 1.98.0
           components: rustfmt, clippy
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
@@ -71,7 +71,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.96.1
+          toolchain: 1.98.0
           components: clippy
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -123,7 +123,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.96.1
+          toolchain: 1.98.0
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -148,7 +148,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.96.1
+          toolchain: 1.98.0
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 version = "0.104.8"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.98"
 license = "MIT"
 authors = ["Cesar Ferreira"]
 repository = "https://github.com/cesarferreira/stax"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-trixie
+FROM rust:1.98.0-trixie
 
 ARG CARGO_NEXTEST_VERSION=0.9.114
 


### PR DESCRIPTION
## Motivation

The Dockerfile, all four `rust-tests` jobs, both `release` jobs and the declared `rust-version` were pinned to **1.96.1**, while local development here is on **1.98.0**. On macOS `make test` routes through Docker, so the "run the full suite locally" path compiled against a different toolchain than a plain `cargo test` on the same machine.

## Description of changes / notes for reviewers

Every pin moves to 1.98.0:

| where | from | to |
|---|---|---|
| `Dockerfile` | `rust:1.96.1-trixie` | `rust:1.98.0-trixie` |
| `.github/workflows/rust-tests.yml` (×4) | `1.96.1` | `1.98.0` |
| `.github/workflows/release.yml` (×2) | `1.96.1` | `1.98.0` |
| `Cargo.toml` `rust-version` | `1.96` | `1.98` |

**This raises the MSRV, but only for people building from a clone.** Every advertised install path ships a prebuilt binary and needs no Rust at all:

| install method | needs Rust? | affected |
|---|---|---|
| `brew install cesarferreira/tap/stax` | no — formula downloads the release tarball and does `bin.install` | no |
| `cargo binstall stax` | no — fetches the prebuilt binary | no |
| prebuilt tarball / Windows zip from Releases | no | no |
| `cargo install --path .`, `make install` | yes | **yes** |

So in practice this is a contributor-toolchain requirement rather than a user-facing break: `cargo install --path .` and `make install` now need 1.98.0.

Worth being explicit that nothing in the tree *needs* 1.98 — CI passing on 1.96.1 as recently as #785 proves the code still compiles there. The MSRV bump buys environment parity, not a language feature, so it is a deliberate trade rather than a necessity.

One consequence to be aware of: because CI pinned the exact MSRV, those jobs were also what verified the `rust-version` claim. After this change the three environments agree with each other and with `rust-version`, so that property is preserved — but if you ever want to support an older floor again, it would need its own job rather than being implied by the CI pin.

`CONTRIBUTING.md` defers to `Cargo.toml`'s `rust-version` instead of naming a version, so it stays accurate with no edit.

### Verification

- Confirmed `rust:1.98.0-trixie` exists on Docker Hub (pushed 2026-08-20) before pinning it — Docker is not running here, so the image could not be built locally and the tag was checked against the registry directly.
- `cargo clippy --all-targets -- -D warnings`: clean, for both the root package and `stax-gui` (which CI lints as a separate job).
- Full suite natively: **2384 passed, 7 failed**. The 7 are the same pre-existing macOS-environment failures present on `main` (TTY emulation via `script`, `gh` extension probing, parallel-run recovery, worktree hooks); no new failures. They pass on Linux in CI.

### Stacking

Stacked on `cesar/bump-lib-versions` (#785) to keep the two `Cargo.toml` edits linear — that PR touches the `octocrab` line, this one touches `rust-version`. There is no functional dependency between them.
