### PR TITLE
fix ready refresh after PR merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ st config --set-ai
 | `st reviews --stack [--json]` | Stack-wide review/comment inbox, including inline file/line locations on GitHub (`st comments` remains the current-PR view) |
 | `st next` | Move to the next unmerged branch upstack; fork choices are deterministic |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--stack`, `--stack --full`, `--remote`, `--all`) |
-| `st ready` | Interactive PR readiness TUI — CI, review approval, and merge state for all tracked branches; auto-refreshes every 15s and stays open until you quit (`--current`/`--stack` for current stack, `--plain` for a static table, `--json` for machine-readable readiness schema) |
+| `st ready` | Interactive PR readiness TUI — CI, review approval, and merge state for unmerged tracked PRs; auto-refreshes every 15s and drops remotely merged PRs without cleaning up their local branches (`--current`/`--stack` for current stack, `--plain` for a static table, `--json` for machine-readable readiness schema) |
 | `st ci` / `st ci --oneline` | Live CI status for each PR head — full per-check table, or one compact line per branch across the stack (multi-branch defaults to the roll-up) |
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -38,7 +38,7 @@ When `-m` or `--ai` derives a branch name that already exists, Stax stops instea
 | `st draft --stack` | Convert every PR in the current stack to draft |
 | `st undraft [branch]` | Mark the current (or named) branch's PR as ready for review |
 | `st undraft --stack` | Mark every PR in the current stack as ready for review |
-| `st ready` | Interactive PR readiness dashboard — CI, review approval, and merge state for all tracked branches; auto-refreshes every 15s and stays open until you quit (`q`) |
+| `st ready` | Interactive PR readiness dashboard — CI, review approval, and merge state for unmerged tracked PRs; auto-refreshes every 15s, drops remotely merged PRs, and stays open until you quit (`q`) |
 | `st merge` | Cascade-merge from stack bottom up to current branch |
 | `st merge --when-ready` | Wait for CI + approvals, then merge (alias: `st mwr`) |
 | `st merge --downstack-only` / `--ds` | Merge ancestors below current, then rebase current branch |
@@ -107,4 +107,4 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 
 See also: [Navigation](navigation.md) · [Stack health](stack-health.md) · [Full reference](reference.md)
 
-`st ready` and `st pr list --ready` open an interactive TUI showing CI status, review approval (e.g. "1 approval", "missing review"), and recommended next action for each tracked PR. The TUI auto-refreshes every 15s and stays open after CI passes — press `q` to quit. Use `--current` or `--stack` to limit to the current stack. Use `--plain` for a single static table (safe for capture/pipes) and `--json` for the machine-readable readiness schema. Use `--interval <secs>` to change the auto-refresh interval.
+`st ready` and `st pr list --ready` open an interactive TUI showing CI status, review approval (e.g. "1 approval", "missing review"), and recommended next action for each unmerged tracked PR. The TUI auto-refreshes every 15s and stays open after CI passes — press `q` to quit. A PR confirmed remotely merged disappears on initial load or the next refresh; this only updates readiness and cached PR state, and does not delete or reparent local branches (use `st sync` for cleanup). Closed but unmerged PRs remain visible as fix candidates. Use `--current` or `--stack` to limit to the current stack. Use `--plain` for a single static table (safe for capture/pipes) and `--json` for the machine-readable readiness schema. Use `--interval <secs>` to change the auto-refresh interval.

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -149,8 +149,8 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st pr` · `st pr open` | Open current branch PR |
 | `st pr body` · `st pr body --edit` | Print or edit the current branch PR description |
 | `st pr list` | List open PRs (GitHub, GitLab, Gitea) |
-| `st pr list --ready` | Interactive PR readiness TUI for all tracked branches (`--current`/`--stack` limits to the current stack, `--plain` for a static table) |
-| `st ready` | Same as `st pr list --ready` — interactive TUI with CI, review approval, and merge state (`--current`, `--stack`, `--all`, `--plain`, `--json`, `--interval`) |
+| `st pr list --ready` | Interactive PR readiness TUI for unmerged tracked PRs; remotely merged PRs disappear on live refresh (`--current`/`--stack` limits to the current stack, `--plain` for a static table) |
+| `st ready` | Same as `st pr list --ready` — interactive TUI with CI, review approval, and merge state; filtering merged PRs does not clean up local branches (`--current`, `--stack`, `--all`, `--plain`, `--json`, `--interval`) |
 | `st draft [branch]` | Mark the current or named branch's PR as a draft |
 | `st draft --stack` | Mark every PR in the current stack as a draft |
 | `st undraft [branch]` | Mark the current or named branch's PR as ready for review |

--- a/skills.md
+++ b/skills.md
@@ -62,7 +62,7 @@ stax redo [op-id]              # Redo last/specific undone operation
 stax pr                        # Open current branch PR
 stax pr body                   # Print current PR description
 stax pr body --edit            # Edit current PR description in $EDITOR
-stax ready                     # Interactive PR readiness TUI (CI + review approval); auto-refreshes, stays open until q
+stax ready                     # Interactive unmerged-PR readiness TUI; refresh drops remotely merged PRs without local cleanup
 stax ready --current           # PR readiness TUI scoped to current stack only
 stax ready --stack             # Same as --current
 stax ready --plain             # Static readiness table for captured/non-interactive output
@@ -433,7 +433,7 @@ stax range-diff                    # Range-diff branches needing restack
 
 stax pr body                       # Print current PR description
 stax pr body --edit                # Edit current PR description in $EDITOR
-stax ready                         # Interactive PR readiness TUI (CI + review approval); auto-refreshes, stays open until q
+stax ready                         # Interactive unmerged-PR readiness TUI; refresh drops remotely merged PRs without local cleanup
 stax ready --current               # PR readiness TUI scoped to current stack only
 stax ready --plain                 # Static readiness table: action · PR · branch · reviews · CI · title
 stax ready --all                   # Explicit all tracked branches (default)

--- a/src/commands/ready.rs
+++ b/src/commands/ready.rs
@@ -211,6 +211,13 @@ pub struct ReadyScope {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReadyFetchOutcome {
+    Row(Box<PrReadinessRow>),
+    NoPr,
+    Merged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReadyRowState {
     Loading {
         branch: ReadyBranch,
@@ -345,15 +352,20 @@ pub(crate) async fn fetch_row_for_branch(
     remote: &RemoteInfo,
     stack: &Stack,
     branch: &ReadyBranch,
-) -> Result<Option<PrReadinessRow>> {
+) -> Result<ReadyFetchOutcome> {
     let Some(pr_number) = resolve_branch_pr(client, stack, branch).await? else {
-        return Ok(None);
+        return Ok(ReadyFetchOutcome::NoPr);
     };
 
     let status = client
         .get_pr_merge_status(pr_number)
         .await
         .with_context(|| format!("Failed to fetch live readiness for PR #{}", pr_number))?;
+
+    if is_merged_pr_status(&status) {
+        let _ = warm_pr_state_for_ready_status(repo, &branch.name, &status);
+        return Ok(ReadyFetchOutcome::Merged);
+    }
 
     let ci_revision = status.head_sha.clone();
     let check_runs = client
@@ -365,7 +377,11 @@ pub(crate) async fn fetch_row_for_branch(
     let mut row = PrReadinessRow::from_status(&branch.name, status, ci_summary);
     row.pr_url = Some(remote.pr_url(pr_number));
     let _ = warm_caches_for_ready_row(repo, &row, &ci_revision);
-    Ok(Some(row))
+    Ok(ReadyFetchOutcome::Row(Box::new(row)))
+}
+
+fn is_merged_pr_status(status: &PrMergeStatus) -> bool {
+    status.state.eq_ignore_ascii_case("merged")
 }
 
 pub(crate) fn warm_caches_for_ready_row(
@@ -388,15 +404,60 @@ pub(crate) fn warm_caches_for_ready_row(
     }
 
     if let Some(mut meta) = BranchMetadata::read(repo.inner(), &row.branch)? {
-        meta.pr_info = Some(PrInfo {
-            number: row.pr_number,
-            state: row.pr_state.clone(),
-            is_draft: Some(row.is_draft),
-        });
-        meta.write(repo.inner(), &row.branch)?;
+        update_ready_pr_metadata(
+            repo,
+            &row.branch,
+            &mut meta,
+            row.pr_number,
+            &row.pr_state,
+            row.is_draft,
+        )?;
     }
 
     Ok(())
+}
+
+fn warm_pr_state_for_ready_status(
+    repo: &GitRepo,
+    branch: &str,
+    status: &PrMergeStatus,
+) -> Result<()> {
+    let cache_dir = repo.common_git_dir()?;
+    let pr_state = if status.is_draft {
+        "draft".to_string()
+    } else {
+        status.state.clone()
+    };
+    CiCache::update_branch_pr(&cache_dir, branch, Some(pr_state))?;
+
+    if let Some(mut meta) = BranchMetadata::read(repo.inner(), branch)? {
+        update_ready_pr_metadata(
+            repo,
+            branch,
+            &mut meta,
+            status.number,
+            &status.state,
+            status.is_draft,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn update_ready_pr_metadata(
+    repo: &GitRepo,
+    branch: &str,
+    meta: &mut BranchMetadata,
+    number: u64,
+    state: &str,
+    is_draft: bool,
+) -> Result<()> {
+    meta.pr_info = Some(PrInfo {
+        number,
+        state: state.to_string(),
+        is_draft: Some(is_draft),
+    });
+    meta.write(repo.inner(), branch)
 }
 
 fn ready_row_pr_cache_state(row: &PrReadinessRow) -> String {
@@ -428,8 +489,8 @@ async fn fetch_readiness_rows(
 
     while let Some(result) = pending.next().await {
         match result? {
-            Some(row) => rows.push(row),
-            None => skipped += 1,
+            ReadyFetchOutcome::Row(row) => rows.push(*row),
+            ReadyFetchOutcome::NoPr | ReadyFetchOutcome::Merged => skipped += 1,
         }
     }
 
@@ -724,6 +785,19 @@ mod tests {
     }
 
     #[test]
+    fn identifies_only_merged_pr_states_as_merged_outcomes() {
+        assert!(is_merged_pr_status(&status(|s| {
+            s.state = "MeRgEd".to_string()
+        })));
+        assert!(!is_merged_pr_status(&status(|s| {
+            s.state = "OPEN".to_string()
+        })));
+        assert!(!is_merged_pr_status(&status(|s| {
+            s.state = "CLOSED".to_string()
+        })));
+    }
+
+    #[test]
     fn classifies_review_required_pr_as_ping() {
         let row = PrReadinessRow::from_status(
             "feature",
@@ -994,6 +1068,35 @@ mod tests {
         assert_eq!(pr.number, 123);
         assert_eq!(pr.state, "open");
         assert_eq!(pr.is_draft, Some(true));
+    }
+
+    #[test]
+    fn merged_ready_status_warms_pr_cache_and_branch_metadata() {
+        let (_temp, repo) = temp_repo();
+        let branch = "feature/cache-ready";
+        let meta = BranchMetadata {
+            pr_info: None,
+            ..BranchMetadata::new("main", "abc123")
+        };
+        meta.write(repo.inner(), branch).expect("write metadata");
+        let merged = status(|s| {
+            s.number = 123;
+            s.state = "merged".to_string();
+        });
+
+        warm_pr_state_for_ready_status(&repo, branch, &merged).expect("warm merged PR state");
+
+        let cache = CiCache::load(&repo.common_git_dir().expect("common git dir"));
+        let entry = cache.branches.get(branch).expect("cache entry");
+        assert_eq!(entry.pr_state.as_deref(), Some("merged"));
+
+        let updated = BranchMetadata::read(repo.inner(), branch)
+            .expect("read metadata")
+            .expect("metadata");
+        let pr = updated.pr_info.expect("pr info");
+        assert_eq!(pr.number, 123);
+        assert_eq!(pr.state, "merged");
+        assert_eq!(pr.is_draft, Some(false));
     }
 
     #[test]

--- a/src/tui/ready/app.rs
+++ b/src/tui/ready/app.rs
@@ -4,13 +4,14 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub enum ReadyTuiUpdate {
     Loaded {
-        index: usize,
         row: crate::commands::ready::PrReadinessRow,
     },
     Unavailable {
-        index: usize,
         branch: ReadyBranch,
         message: String,
+    },
+    Merged {
+        branch: String,
     },
     Done,
 }
@@ -71,27 +72,24 @@ impl ReadyTuiApp {
 
     pub fn apply_update(&mut self, update: ReadyTuiUpdate) {
         match update {
-            ReadyTuiUpdate::Loaded { index, row } => {
-                if let Some(slot) = self.row_slot_mut(index, &row.branch) {
+            ReadyTuiUpdate::Loaded { row } => {
+                if let Some(slot) = self.row_slot_mut(&row.branch) {
                     *slot = ReadyRowState::Loaded(row);
                 }
                 if self.should_resort_rows() {
                     self.sort_rows_by_updated_at();
                 }
             }
-            ReadyTuiUpdate::Unavailable {
-                index,
-                branch,
-                message,
-            } => {
+            ReadyTuiUpdate::Unavailable { branch, message } => {
                 let branch_name = branch.name.clone();
-                if let Some(slot) = self.row_slot_mut(index, &branch_name) {
+                if let Some(slot) = self.row_slot_mut(&branch_name) {
                     *slot = ReadyRowState::Unavailable { branch, message };
                 }
                 if self.should_resort_rows() {
                     self.sort_rows_by_updated_at();
                 }
             }
+            ReadyTuiUpdate::Merged { branch } => self.remove_row(&branch),
             ReadyTuiUpdate::Done => {
                 self.loading = false;
                 self.sort_rows_by_updated_at();
@@ -107,13 +105,24 @@ impl ReadyTuiApp {
                 .all(|row| matches!(row, ReadyRowState::Loading { .. }))
     }
 
-    fn row_slot_mut(&mut self, fallback_index: usize, branch: &str) -> Option<&mut ReadyRowState> {
-        let index = self
+    fn row_slot_mut(&mut self, branch: &str) -> Option<&mut ReadyRowState> {
+        self.rows.iter_mut().find(|row| row.branch() == branch)
+    }
+
+    fn remove_row(&mut self, branch: &str) {
+        let selected_branch = self
             .rows
-            .iter()
-            .position(|row| row.branch() == branch)
-            .unwrap_or(fallback_index);
-        self.rows.get_mut(index)
+            .get(self.selected_index)
+            .map(|row| row.branch().to_string());
+        let Some(index) = self.rows.iter().position(|row| row.branch() == branch) else {
+            return;
+        };
+
+        self.rows.remove(index);
+        self.selected_index = selected_branch
+            .filter(|selected| selected != branch)
+            .and_then(|selected| self.rows.iter().position(|row| row.branch() == selected))
+            .unwrap_or(index.min(self.rows.len().saturating_sub(1)));
     }
 
     fn sort_rows_by_updated_at(&mut self) {
@@ -296,7 +305,6 @@ mod tests {
         let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
 
         app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 1,
             row: loaded_row("feature/b", 11),
         });
 
@@ -319,14 +327,8 @@ mod tests {
         let mut newer = loaded_row("feature/b", 11);
         newer.updated_at = Some("2026-06-02T10:00:00Z".to_string());
 
-        app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
-            row: older,
-        });
-        app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 1,
-            row: newer,
-        });
+        app.apply_update(ReadyTuiUpdate::Loaded { row: older });
+        app.apply_update(ReadyTuiUpdate::Loaded { row: newer });
         app.apply_update(ReadyTuiUpdate::Done);
 
         assert_eq!(app.rows[0].branch(), "feature/b");
@@ -337,7 +339,6 @@ mod tests {
     fn ready_tui_selected_pr_url_comes_from_selected_loaded_row() {
         let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
         app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
             row: loaded_row("feature/a", 10),
         });
 
@@ -354,7 +355,6 @@ mod tests {
         assert_eq!(app.selected_draft_target(), None);
 
         app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
             row: loaded_row("feature/a", 10),
         });
 
@@ -368,7 +368,6 @@ mod tests {
     fn ready_tui_reconcile_scope_drops_removed_branch_and_keeps_loaded_row() {
         let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
         app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
             row: loaded_row("feature/a", 10),
         });
 
@@ -389,7 +388,6 @@ mod tests {
     fn ready_tui_reconcile_scope_inserts_loading_row_for_new_branch() {
         let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
         app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
             row: loaded_row("feature/a", 10),
         });
 
@@ -416,7 +414,6 @@ mod tests {
     fn ready_tui_refresh_keeps_loaded_rows_visible() {
         let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
         app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
             row: loaded_row("feature/a", 10),
         });
         app.loading = false;
@@ -425,5 +422,88 @@ mod tests {
 
         assert!(app.loading);
         assert!(matches!(app.rows[0], ReadyRowState::Loaded(_)));
+    }
+
+    #[test]
+    fn ready_tui_removes_initial_loading_placeholder_for_merged_pr() {
+        let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
+
+        app.apply_update(ReadyTuiUpdate::Merged {
+            branch: "feature/a".to_string(),
+        });
+
+        assert_eq!(app.rows.len(), 1);
+        assert_eq!(app.rows[0].branch(), "feature/b");
+        assert_eq!(app.selected_index, 0);
+    }
+
+    #[test]
+    fn ready_tui_refresh_removes_previously_loaded_merged_pr() {
+        let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
+        app.apply_update(ReadyTuiUpdate::Loaded {
+            row: loaded_row("feature/a", 10),
+        });
+        app.apply_update(ReadyTuiUpdate::Done);
+        app.begin_refresh();
+
+        app.apply_update(ReadyTuiUpdate::Merged {
+            branch: "feature/a".to_string(),
+        });
+        app.apply_update(ReadyTuiUpdate::Done);
+
+        assert_eq!(app.rows.len(), 1);
+        assert_eq!(app.rows[0].branch(), "feature/b");
+        assert!(!app.loading);
+    }
+
+    #[test]
+    fn ready_tui_out_of_order_updates_use_branch_identity_after_removal() {
+        let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
+
+        app.apply_update(ReadyTuiUpdate::Merged {
+            branch: "feature/a".to_string(),
+        });
+        app.apply_update(ReadyTuiUpdate::Loaded {
+            row: loaded_row("feature/b", 11),
+        });
+
+        assert_eq!(app.rows.len(), 1);
+        assert!(matches!(
+            &app.rows[0],
+            ReadyRowState::Loaded(row) if row.branch == "feature/b"
+        ));
+    }
+
+    #[test]
+    fn ready_tui_removal_preserves_other_selection_and_clamps_selected_last_row() {
+        let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
+        app.selected_index = 1;
+
+        app.apply_update(ReadyTuiUpdate::Merged {
+            branch: "feature/a".to_string(),
+        });
+        assert_eq!(app.selected_index, 0);
+        assert_eq!(app.rows[0].branch(), "feature/b");
+
+        app.apply_update(ReadyTuiUpdate::Merged {
+            branch: "feature/b".to_string(),
+        });
+        assert!(app.rows.is_empty());
+        assert_eq!(app.selected_index, 0);
+    }
+
+    #[test]
+    fn ready_tui_unavailable_update_remains_visible() {
+        let mut app = ReadyTuiApp::new_for_test("owner/repo", "current stack", branches());
+
+        app.apply_update(ReadyTuiUpdate::Unavailable {
+            branch: branches()[0].clone(),
+            message: "forge unavailable".to_string(),
+        });
+
+        assert!(matches!(
+            &app.rows[0],
+            ReadyRowState::Unavailable { message, .. } if message == "forge unavailable"
+        ));
     }
 }

--- a/src/tui/ready/mod.rs
+++ b/src/tui/ready/mod.rs
@@ -16,7 +16,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::commands::open::open_url_in_browser;
-use crate::commands::ready::{ReadyScope, ReadyScopeMode, fetch_row_for_branch, load_ready_scope};
+use crate::commands::ready::{
+    ReadyFetchOutcome, ReadyScope, ReadyScopeMode, fetch_row_for_branch, load_ready_scope,
+};
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
@@ -319,38 +321,37 @@ fn spawn_loader(scope: ReadyScope) -> Receiver<ReadyTuiUpdate> {
         };
 
         runtime.block_on(async {
-            let mut pending =
-                stream::iter(scope.branches.iter().enumerate().map(|(index, branch)| {
-                    let repo = &repo;
-                    let client = &client;
-                    let remote = &scope.remote;
-                    let stack = &stack;
-                    let branch = branch.clone();
-                    async move {
-                        (
-                            index,
-                            branch.clone(),
-                            fetch_row_for_branch(repo, client, remote, stack, &branch).await,
-                        )
-                    }
-                }))
-                .buffer_unordered(crate::parallel::IO_CONCURRENCY_LIMIT);
+            let mut pending = stream::iter(scope.branches.iter().map(|branch| {
+                let repo = &repo;
+                let client = &client;
+                let remote = &scope.remote;
+                let stack = &stack;
+                let branch = branch.clone();
+                async move {
+                    let result = fetch_row_for_branch(repo, client, remote, stack, &branch).await;
+                    (branch, result)
+                }
+            }))
+            .buffer_unordered(crate::parallel::IO_CONCURRENCY_LIMIT);
 
-            while let Some((index, branch, result)) = pending.next().await {
+            while let Some((branch, result)) = pending.next().await {
                 match result {
-                    Ok(Some(row)) => {
-                        let _ = sender.send(ReadyTuiUpdate::Loaded { index, row });
+                    Ok(ReadyFetchOutcome::Row(row)) => {
+                        let _ = sender.send(ReadyTuiUpdate::Loaded { row: *row });
                     }
-                    Ok(None) => {
+                    Ok(ReadyFetchOutcome::NoPr) => {
                         let _ = sender.send(ReadyTuiUpdate::Unavailable {
-                            index,
                             branch,
                             message: "No PR found for branch".to_string(),
                         });
                     }
+                    Ok(ReadyFetchOutcome::Merged) => {
+                        let _ = sender.send(ReadyTuiUpdate::Merged {
+                            branch: branch.name,
+                        });
+                    }
                     Err(error) => {
                         let _ = sender.send(ReadyTuiUpdate::Unavailable {
-                            index,
                             branch,
                             message: error.to_string(),
                         });
@@ -417,9 +418,8 @@ fn send_all_unavailable(
     scope: &ReadyScope,
     message: String,
 ) {
-    for (index, branch) in scope.branches.iter().enumerate() {
+    for branch in &scope.branches {
         let _ = sender.send(ReadyTuiUpdate::Unavailable {
-            index,
             branch: branch.clone(),
             message: message.clone(),
         });

--- a/src/tui/ready/ui.rs
+++ b/src/tui/ready/ui.rs
@@ -584,7 +584,7 @@ mod tests {
         row.review_summary = String::new();
         row.review_decision = None;
         row.approvals = 0;
-        app.apply_update(ReadyTuiUpdate::Loaded { index: 0, row });
+        app.apply_update(ReadyTuiUpdate::Loaded { row });
 
         terminal.draw(|f| render(f, &app)).expect("draw");
         let rendered = format!("{:?}", terminal.backend().buffer());
@@ -604,10 +604,7 @@ mod tests {
                 pr_number: Some(10),
             }],
         );
-        app.apply_update(ReadyTuiUpdate::Loaded {
-            index: 0,
-            row: loaded_row(),
-        });
+        app.apply_update(ReadyTuiUpdate::Loaded { row: loaded_row() });
 
         terminal.draw(|f| render(f, &app)).expect("draw");
         let rendered = format!("{:?}", terminal.backend().buffer());

--- a/tests/ready_tests.rs
+++ b/tests/ready_tests.rs
@@ -1,6 +1,104 @@
 //! Tests for the `stax ready` command
 
-use crate::common::TestRepo;
+use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::PathBuf;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const REMOTE_URL: &str = "https://github.com/test-owner/test-repo.git";
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn setup_github_repo(repo: &TestRepo, api_base_url: &str) {
+    let config_dir = PathBuf::from(repo.clean_home())
+        .join(".config")
+        .join("stax");
+    fs::create_dir_all(&config_dir).expect("config directory");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("[remote]\napi_base_url = \"{api_base_url}\"\n"),
+    )
+    .expect("test config");
+    repo.git(&["remote", "add", "origin", REMOTE_URL])
+        .assert_success();
+}
+
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, parent: &str, pr_number: u64) {
+    let metadata = serde_json::json!({
+        "parentBranchName": parent,
+        "parentBranchRevision": repo.get_commit_sha(parent),
+        "prInfo": { "number": pr_number, "state": "OPEN" }
+    });
+    let file = tempfile::NamedTempFile::new().expect("metadata file");
+    fs::write(file.path(), metadata.to_string()).expect("metadata contents");
+    let hash = repo.git(&["hash-object", "-w", file.path().to_str().unwrap()]);
+    hash.assert_success();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{branch}"),
+        TestRepo::stdout(&hash).trim(),
+    ])
+    .assert_success();
+}
+
+fn merge_status_body(number: u64, title: &str, state: &str, sha: &str) -> serde_json::Value {
+    serde_json::json!({
+        "data": { "repository": { "pullRequest": {
+            "number": number,
+            "title": title,
+            "state": state,
+            "updatedAt": "2026-08-25T10:00:00Z",
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "headRefOid": sha,
+            "statusCheckRollup": { "state": "SUCCESS", "contexts": { "nodes": [] } },
+            "reviews": { "nodes": [
+                { "state": "APPROVED", "author": { "login": "reviewer" } }
+            ] }
+        } } }
+    })
+}
+
+async fn mount_merge_status(server: &MockServer, number: u64, title: &str, state: &str, sha: &str) {
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_string_contains(format!(
+            "pullRequest(number: {number})"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(merge_status_body(number, title, state, sha)),
+        )
+        .mount(server)
+        .await;
+}
+
+async fn mount_empty_checks(server: &MockServer, sha: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/test-owner/test-repo/commits/{sha}/check-runs"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 0,
+            "check_runs": []
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/test-owner/test-repo/commits/{sha}/statuses"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(server)
+        .await;
+}
+
+fn auth_env() -> [(&'static str, &'static str); 1] {
+    [("STAX_GITHUB_TOKEN", "mock-token")]
+}
 
 /// Help text exposes the interactive readiness view and all expected flags.
 #[test]
@@ -134,5 +232,126 @@ fn test_ready_current_and_stack_flags_reach_readiness() {
             || stderr_stack.contains("forge")
             || stderr_stack.contains("auth"),
         "--stack must reach readiness auth guard"
+    );
+}
+
+#[tokio::test]
+async fn test_ready_json_omits_merged_pr_and_skips_its_ci_requests() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["merged-feature", "open-feature"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 10);
+    write_branch_pr_metadata(&repo, &branches[1], &branches[0], 11);
+    let merged_sha = repo.get_commit_sha(&branches[0]);
+    let open_sha = repo.get_commit_sha(&branches[1]);
+
+    mount_merge_status(&server, 10, "Already merged", "MERGED", &merged_sha).await;
+    mount_merge_status(&server, 11, "Still open", "OPEN", &open_sha).await;
+    mount_empty_checks(&server, &open_sha).await;
+
+    let output = repo.run_stax_with_env(&["ready", "--json"], &auth_env());
+    output.assert_success();
+    let rows: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&output)).expect("readiness JSON");
+    let rows = rows.as_array().expect("readiness rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["branch"], branches[1]);
+    assert_eq!(rows[0]["pr_number"], 11);
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let paths = requests
+        .iter()
+        .map(|request| request.url.path())
+        .collect::<Vec<_>>();
+    assert!(
+        paths.contains(
+            &format!("/repos/test-owner/test-repo/commits/{open_sha}/check-runs").as_str()
+        )
+    );
+    assert!(
+        !paths
+            .iter()
+            .any(|request_path| request_path.contains(&merged_sha))
+    );
+
+    let metadata = repo.git(&["show", &format!("refs/branch-metadata/{}", branches[0])]);
+    metadata.assert_success();
+    let metadata: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&metadata)).expect("merged metadata");
+    assert_eq!(metadata["prInfo"]["state"], "merged");
+}
+
+#[tokio::test]
+async fn test_ready_json_keeps_closed_unmerged_pr_as_fix_candidate() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["closed-feature"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 20);
+    let sha = repo.get_commit_sha(&branches[0]);
+
+    mount_merge_status(&server, 20, "Closed without merge", "CLOSED", &sha).await;
+    mount_empty_checks(&server, &sha).await;
+
+    let output = repo.run_stax_with_env(&["ready", "--json"], &auth_env());
+    output.assert_success();
+    let rows: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&output)).expect("readiness JSON");
+    assert_eq!(rows[0]["action"], "fix");
+    assert_eq!(rows[0]["reason"], "closed");
+}
+
+#[tokio::test]
+async fn test_ready_json_status_failure_is_not_treated_as_merged() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["status-error"]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 30);
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["ready", "--json"], &auth_env());
+    assert!(!output.status.success());
+    assert!(
+        TestRepo::stderr(&output).contains("Failed to fetch live readiness for PR #30"),
+        "unexpected error: {}",
+        TestRepo::stderr(&output)
+    );
+}
+
+#[tokio::test]
+async fn test_ready_json_skips_branch_with_no_pr() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    repo.create_stack(&["no-pr-feature"]);
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let output = repo.run_stax_with_env(&["ready", "--json"], &auth_env());
+    output.assert_success();
+    let rows: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&output)).expect("readiness JSON");
+    assert_eq!(rows, serde_json::json!([]));
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.url.path() != "/graphql")
     );
 }


### PR DESCRIPTION
## Motivation

`st ready` kept showing tracked PRs after they were merged remotely, so the readiness view could become stale until local stack cleanup.

## Description of changes / notes for reviewers

- Treat live `MERGED` status as an explicit readiness outcome and omit that PR from plain, JSON, and interactive readiness candidates.
- Remove merged rows during initial load and subsequent manual, draft-triggered, or timed refreshes using stable branch identity.
- Preserve closed, missing-PR, and forge-error behavior; refresh merged metadata without deleting or reparenting local branches.
- Skip CI/check requests once a PR is confirmed merged.
- Update README, command documentation, and the bundled agent skill.

## Verification

- `cargo nextest run ready_tests::` — 10/10 passed
- `cargo nextest run commands::ready::` — 17/17 passed
- `cargo nextest run tui::ready::app::` — 14/14 passed
- `cargo check` — passed
- `make lint-fast` — passed
- `make lint` — passed
- `git diff --check` — passed

The full Docker `make test` suite was not run locally: the host data volume was exhausted and Docker Desktop's content store returned I/O errors. CI is the accepted full-suite gate for this draft PR; this description does not claim the full suite passed locally.

## Performance and residual risk

No benchmark was run because the change adds no new remote request or measurable local hot path. Confirmed merged PRs avoid two existing CI requests. The interactive terminal loop and forge-specific GitLab/Gitea adapters were not exercised end-to-end; shared outcome and TUI state transitions are covered by the focused tests above.