### PR TITLE
chore(harness): tier draft PR verification

### DIFF
--- a/.pi/agents/verifier.md
+++ b/.pi/agents/verifier.md
@@ -9,10 +9,11 @@ fallbackModels: claude-bridge/claude-sonnet-4-6
 You are the **Verifier** for the stax Rust CLI. You produce the objective, reproducible verdict on whether the change actually works. You run commands and report exactly what happened — no claims without command output.
 
 ## Core responsibilities
-1. Build & lint: `cargo check` then `make lint-fast` during iteration; run `make lint` for the final full-target/all-features pass.
+1. Build & lint: `cargo check`, `make lint-fast`, and `git diff --check` for the scoped draft gate. Run `make lint` only when the full gate applies.
 2. Tests, following the repo Test Command Policy strictly:
    - Scope to changed areas first for fast feedback: `cargo nextest run <pattern>` or a module prefix (e.g. `status_tests::`).
-   - Run the full suite with `make test` before declaring PASS, or whenever the change touches shared/core code (`engine/`, `git/repo.rs`, `ops/`).
+   - A localized change may receive PASS for draft PR creation from the scoped gate; do not run `make test` merely because the pipeline will open a draft.
+   - Run the full suite with `make test` for shared/core code (`engine/`, `git/repo.rs`, `ops/`), build/test infrastructure, broad cross-cutting behavior, security-critical behavior, or an explicitly requested full gate.
    - Do NOT run the full suite via `cargo test`. On macOS `make test` routes through Docker.
    - If `make test` fails with `failed to connect to the docker API`, do not fall back silently — report that Docker Desktop must be started (`open -a Docker`) and mark the run BLOCKED pending the daemon.
 3. Map every failure to its cause: capture the failing test name, the assertion, and the relevant output lines.
@@ -21,6 +22,7 @@ You are the **Verifier** for the stax Rust CLI. You produce the objective, repro
 - Evidence first. Paste the exact command and the decisive output lines (pass/fail counts, the failing assertion). A green build alone is not a PASS.
 - Never weaken, skip, or delete tests/lint to obtain green. If something is flaky, report it as flaky with evidence — do not mask it.
 - Widen verification when the change touches shared behavior or user-facing flows; narrow it when the change is localized.
+- State whether the verdict covers the scoped draft gate or the full gate, and explain every decision to widen to the full gate.
 - Read-only on source. Your bash runs build/test/lint commands only; you do not edit code.
 
 ## Input / output protocol
@@ -35,7 +37,7 @@ You are the **Verifier** for the stax Rust CLI. You produce the objective, repro
   ## Failures
   - test::name — assertion — cause
   ## Coverage note
-  - happy / error / edge covered? scope run vs full `make test`?
+  - draft or full gate? happy / error / edge covered? scoped run vs full `make test`?
   ```
 
 ## Re-invocation

--- a/.pi/prompts/stax-dev.md
+++ b/.pi/prompts/stax-dev.md
@@ -44,7 +44,7 @@ Flow: **worktree → planner → codex → claude-reviewer → verifier**, then 
 ```
 [ { agent: "codex",           task: "Implement `_workspace/<run_id>/01_plan.md` inside the run worktree. Load /skill:stax-implement. Write source, tests, docs; write `_workspace/<run_id>/02_impl.md`. Do NOT commit. Return changed files + self-verify (cargo check + make lint-fast) results." },
   { agent: "claude-reviewer", task: "Review the implementation against the plan and repo conventions. Load /skill:stax-review. Read 01_plan.md, 02_impl.md, and `git diff`. Write `_workspace/<run_id>/03_review.md`. Return PASS/FAIL + blocker/major counts. Context: {previous}" },
-  { agent: "verifier",        task: "Run the mechanical gate (build/lint/tests) per repo policy. Load /skill:stax-verify. Read 01_plan.md, 02_impl.md. Write `_workspace/<run_id>/04_verify.md`. Return PASS/FAIL/BLOCKED + reason. Context: {previous}" } ]
+  { agent: "verifier",        task: "Run the scoped draft gate (build/lint/focused tests), widening to the full gate only when repo risk criteria require it. Load /skill:stax-verify. Read 01_plan.md, 02_impl.md. Write `_workspace/<run_id>/04_verify.md`. Return PASS/FAIL/BLOCKED + reason. Context: {previous}" } ]
 ```
 > The main agent decides routing from both `03_review.md` and `04_verify.md`.
 
@@ -83,5 +83,6 @@ Read `03_review.md` and `04_verify.md`.
 - **Happy:** standard request → worktree → plan → impl → review PASS → verify PASS → (non-perf: bench skipped) → commit + draft PR. `01–05` present; `manifest.md` shows all stages done, "repair passes used: 0 / 2".
 - **Repair:** verify FAIL (a failing test) → codex fixes only that test → re-review + re-verify PASS → commit + draft PR. `manifest.md` shows "repair passes used: 1 / 2".
 - **Perf-sensitive:** plan marks change in `engine/stack.rs` perf-sensitive → benchmarker runs → REGRESSION → still commits + draft PR, regression flagged in PR body.
-- **Blocked:** `make test` hits Docker-down → verifier BLOCKED → pipeline stops with "start Docker Desktop" remediation, no commit/PR.
+- **Scoped draft:** localized change → `cargo check` + `make lint-fast` + `git diff --check` + focused tests PASS → commit + draft PR without a redundant local full suite.
+- **Blocked full gate:** a high-risk change requires `make test`, Docker is down → verifier BLOCKED → pipeline stops with "start Docker Desktop" remediation, no commit/PR.
 - **Exhausted:** still FAIL after 2 repair passes → stop, report unresolved items, no commit/PR.

--- a/.pi/skills/stax-verify/SKILL.md
+++ b/.pi/skills/stax-verify/SKILL.md
@@ -8,16 +8,17 @@ description: Run the mechanical quality gate for a stax change — build, lint, 
 Produce the objective verdict. No claim without command output.
 
 ## Command policy (repo Test Command Policy — follow exactly)
-- **Build & lint:** `cargo check`, then `make lint-fast` while iterating; `make lint` for the final all-targets/all-features pass.
+- **Build & lint:** `cargo check`, `make lint-fast`, and `git diff --check` form the scoped draft gate. Run `make lint` when the full gate applies.
 - **Tests:**
   - Fast feedback on changed areas: `cargo nextest run <pattern>` or a module prefix (e.g. `status_tests::`, `status_tests::status_json_output`).
-  - Full suite before PASS, and always when the change touches shared/core code (`engine/`, `git/repo.rs`, `ops/`): `make test`.
+  - Localized changes may PASS for draft PR creation after focused tests; a full suite is not required merely because the next step opens a draft.
+  - Run `make test` for shared/core code (`engine/`, `git/repo.rs`, `ops/`), build/test infrastructure, broad cross-cutting behavior, security-critical behavior, or an explicitly requested full gate.
   - Do **NOT** run the full suite via `cargo test`. `cargo test --test <name>` no longer works — scope by module path instead. On macOS, `make test` intentionally routes through Docker.
 - **Docker down:** if `make test` fails with `failed to connect to the docker API`, mark **BLOCKED** and tell the user to start Docker Desktop (`open -a Docker`) and retry. Do not silently fall back to `make test-native`.
 
 ## How to verify
 1. Read `01_plan.md` (intended test matrix) and `02_impl.md` (changed files → scope).
-2. Run scoped tests for changed areas; then the full suite per policy.
+2. Run scoped tests for changed areas. Run the full lint and test suite only when the full-gate risk criteria apply.
 3. For each failure, capture the failing test name, the assertion, and the decisive output lines.
 
 ## Output
@@ -26,7 +27,7 @@ Write `_workspace/<run_id>/04_verify.md`:
 # Verify — verdict: PASS | FAIL | BLOCKED
 ## Commands run (with decisive output)   (`cmd` → result / pass-fail counts)
 ## Failures                              (test::name — assertion — cause)
-## Coverage note                         (happy/error/edge covered? scoped vs full make test?)
+## Coverage note                         (draft/full gate? happy/error/edge covered? scoped vs full make test?)
 ```
 Return **PASS** / **FAIL** / **BLOCKED** + a one-line reason.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 **Goal:** Accelerate stax feature development and bug fixing via a git-native worktree → plan → implement → review → verify → (optional) benchmark → commit → draft-PR pipeline with a bounded repair loop.
 
-**Trigger:** For any code change to the stax CLI (new commands, flags, bugfixes, refactors, behavior changes), run the `/stax-dev` prompt. It orchestrates the `planner`, `codex`, `claude-reviewer`, `verifier`, `benchmarker`, and `release-manager` agents (`.pi/agents/`) via the `subagent` tool. Direct usage/architecture questions don't need the pipeline. Each task runs in its own worktree on a stacked branch; commit + draft PR are automatic on green; **merging to main is never automatic** and promoting a draft to ready-for-review is HITL-gated.
+**Trigger:** For any code change to the stax CLI (new commands, flags, bugfixes, refactors, behavior changes), run the `/stax-dev` prompt. It orchestrates the `planner`, `codex`, `claude-reviewer`, `verifier`, `benchmarker`, and `release-manager` agents (`.pi/agents/`) via the `subagent` tool. Direct usage/architecture questions don't need the pipeline. Each task runs in its own worktree on a stacked branch; commit + draft PR are automatic when the scoped draft gate is green; **merging to main is never automatic** and promoting a draft to ready-for-review is HITL-gated.
 
 **Change History:**
 | Date | Change | Target | Reason |
@@ -12,10 +12,18 @@
 | 2026-07-25 | Initial harness build (5 agents, 5 skills, `/stax-dev` orchestrator) | All | New harness |
 | 2026-07-25 | Git-native evolution: added `benchmarker` (optional perf gate) + `stax-benchmark` skill; worktree-per-task + stacked branch; auto commit-on-green + auto draft PR; hard "never merge to main" rule | benchmarker.md, stax-benchmark/, release-manager.md, codex.md, stax-release/, stax-dev.md | Adopt git-native workflow constraints; keep verifier as mandatory correctness gate |
 | 2026-07-28 | Added `fallbackModels: claude-bridge/claude-sonnet-4-6` to the four `cursor/composer-2.5` agents so a provider outage (quota/auth/timeout) auto-routes instead of stalling the run; codex also falls back to `openai-codex/gpt-5.6-terra`. Extended benchmarker skip rule to cover pure delegation/deletion diffs with no new local hot-path work | codex.md, verifier.md, benchmarker.md, release-manager.md | Cursor was down + OpenAI-Codex usage-limited mid-run (stax-dev-03), forcing manual model overrides; benchmarker also burned time trying to bench a no-local-compute change |
+| 2026-08-26 | Split verification into a fast scoped draft gate and a full CI/ready-for-review gate | AGENTS.md, verifier.md, stax-verify/, stax-dev.md | Avoid repeating the process-heavy full integration suite in every isolated worktree while retaining full validation before review or merge |
+
+## Verification Tiers
+
+- **Draft PR gate (default):** run `cargo check`, `make lint-fast`, `git diff --check`, and focused `cargo nextest run <pattern>` coverage for the changed behavior. Reviewer and verifier must pass, but local `make lint` and `make test` are not required merely to commit and open a draft PR.
+- **Full gate:** CI must run `make lint` and `make test` before a draft is promoted to ready-for-review or merged. If CI is unavailable, run both commands locally on the exact PR head.
+- **High-risk exception:** run the full local gate before opening the draft when the change touches shared/core execution (`engine/`, `git/repo.rs`, `ops/`), build or test infrastructure, broad cross-cutting behavior, or security-critical behavior. The verifier may widen scope when concrete risk warrants it, and must explain why.
+- PR descriptions and verification artifacts must say whether evidence came from the scoped draft gate, the full local gate, or CI.
 
 ## Test Command Policy
 
-- **AI agents:** for full-suite validation always run `make test`. On macOS this routes through Docker, which is the only sane way to run the entire integration suite — `cargo test` natively will be slow, flaky, and may exhaust file handles. Default to `make test` and only fall back to native runners when explicitly told to.
+- **AI agents:** when full-suite validation is required, always run `make test`. On macOS this routes through Docker, which is the only sane way to run the entire integration suite — `cargo test` natively will be slow, flaky, and may exhaust file handles. Do not run a full suite for every localized draft by default; follow the verification tiers above.
 - **Start Docker before running `make test`.** On macOS the Docker daemon is not always running; if `make test` fails with `failed to connect to the docker API at unix:///.../docker.sock`, ask the user to launch Docker Desktop (or run `open -a Docker`) and retry — do not silently fall back to `make test-native`.
 - Do not run the full suite via `cargo test` in this repo.
 - For full-suite validation, always use `make test`.
@@ -24,7 +32,7 @@
   - `make test-native` (guarded nextest path; validates the file-descriptor limit)
   - `make test-local-ramdisk`
   - `make test-local-fast`
-- Targeted single-test runs via `cargo nextest run <pattern>` are fine and encouraged for tight feedback loops; switch to `make test` once changes are ready for verification.
+- Targeted runs via `cargo nextest run <pattern>` are required for the scoped draft gate and encouraged for tight feedback loops. Switch to `make test` when the full gate or high-risk exception applies.
 - Full test runs (`make test`, including native Linux fallback, plus `make test-docker` / `make test-container`) use the `test-container` Cargo profile (no debuginfo) and shared env (`STAX_DISABLE_UPDATE_CHECK`, `RUST_MIN_STACK`, capped/sanitized `NEXTEST_TEST_THREADS`). Container runs also use the pre-baked `stax-test` image (`make test-image`) and mold linker. CI uses the same `test-container` profile and mold on `ubuntu-latest`. For tight iteration, prefer `cargo nextest run --lib --bins` or a module filter before a full run.
 - All integration tests compile into a **single** binary (`tests/all_tests.rs`, with `autotests = false` in `Cargo.toml`) so cargo links one test binary instead of ~50 — this is what keeps test builds fast. Because of this, there is only one `[[test]]` target named `all_tests`: `cargo test --test status_tests` no longer works. To scope a run, filter by module path instead, e.g. `cargo nextest run status_tests::` (one former file) or `cargo nextest run status_tests::status_json_output` (one test). When adding a new `tests/*_tests.rs` file, register it with a `#[path = "..."] mod ...;` entry in `tests/all_tests.rs`.
 
@@ -36,7 +44,7 @@
 ## Lint Command Policy
 
 - During implementation, use `make lint-fast` for formatting plus Clippy on library and binary targets.
-- Before completion or submission, run `make lint` once to cover all targets and features.
+- Before opening a draft PR, `make lint-fast` is sufficient when the scoped draft gate applies. Run `make lint` for the full gate or high-risk exception.
 - Use these Make targets instead of ad hoc `cargo clippy` commands so local and CI lint flags stay aligned.
 
 ## Documentation Policy


### PR DESCRIPTION
## Motivation

Opening a draft PR should not require repeating the full process-heavy integration suite in every isolated worktree. Full validation still belongs before ready-for-review or merge.

## Description of changes / notes for reviewers

- define a scoped draft gate: `cargo check`, `make lint-fast`, `git diff --check`, and focused nextest coverage
- require `make lint` and `make test` in CI before promotion or merge, with a local fallback when CI is unavailable
- retain local full-suite verification for shared-core, build/test infrastructure, cross-cutting, and security-critical changes
- synchronize the verifier agent, verification skill, and `/stax-dev` prompt with `AGENTS.md`

## Verification

- `cargo check`
- `make lint-fast`
- `git diff --check`
- `quick_validate.py .pi/skills/stax-verify`
- static assertion that the old unconditional full-suite wording is absent

Documentation note: this only changes internal development-harness policy, so README, user docs, and `skills.md` do not need updates.