### PR TITLE
fix(web): validate origins on session routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ st web --port 0   # ephemeral port
 st web --no-open  # start without opening browser; prints URL
 ```
 
-Binds 127.0.0.1 only with an unguessable session token in the URL, CSRF protection on every mutating POST, and one-mutation-at-a-time enforcement. No `--host` flag — it cannot be exposed to the network.
+Binds 127.0.0.1 only with an unguessable session token in the URL, CSRF protection on every mutating POST, and one-mutation-at-a-time enforcement. Requests without an `Origin` remain supported; when present, `Origin` must exactly match `http://127.0.0.1:<actual-bound-port>`. No `--host` flag — it cannot be exposed to the network.
 
 → [Web workspace guide](docs/interface/web.md)
 

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -426,7 +426,7 @@ Restack the stack and submit updates, without fetching trunk (offline-friendly).
 - Binds **127.0.0.1 only**; no `--host` flag is available.
 - Each session URL embeds an unguessable 48-hex session token: `/s/<token>/`. Requests with a wrong or missing token return 404.
 - Every mutating POST requires a matching CSRF token field; mismatches return 403.
-- Non-local `Host` / `Origin` headers are rejected with 403.
+- `Host` must be local. Requests without `Origin` are allowed, but a present `Origin` must exactly equal `http://127.0.0.1:<actual-bound-port>` (including an ephemeral or busy-port fallback port); cross-site, malformed, duplicate, and wrong-port values return 403. This check is independent of the session token and CSRF protections.
 - Only one mutation runs at a time; mutating controls are disabled while an operation is in flight.
 - All git operations run in `spawn_blocking` to avoid blocking the async Tokio runtime.
 - Session state is in-memory; restarting the server generates a new token and URL.

--- a/docs/interface/web.md
+++ b/docs/interface/web.md
@@ -101,7 +101,7 @@ The preference is stored per repository in `.git/stax/web-state.json`.
 - Binds **127.0.0.1 only** — not accessible on the network.
 - Every URL contains an **unguessable 48-hex session token**: `/s/<token>/…`.
 - Every mutating POST requires a matching **CSRF token** (`csrf` form field). Requests with wrong CSRF return `403 Forbidden`.
-- Non-local `Host` / `Origin` headers are rejected with `403 Forbidden`.
+- `Host` must be `127.0.0.1` or `localhost`. An absent `Origin` is allowed for navigation and non-browser clients; when present, exactly one `Origin` header must equal `http://127.0.0.1:<actual-bound-port>`. Cross-site, malformed, duplicate, and wrong-port Origins return `403 Forbidden`.
 - Only **one mutation at a time** — mutating controls are disabled while an operation is in flight.
 - `--host` flag is intentionally absent — you cannot expose this server to the network.
 

--- a/skills.md
+++ b/skills.md
@@ -172,7 +172,7 @@ Key properties:
 - Binds **127.0.0.1 only** — never reachable from the network; no `--host` flag
 - Unguessable 48-hex session token in every URL: `/s/<token>/…`
 - CSRF token required on all mutating POSTs; wrong token → 403
-- Non-local `Host`/`Origin` headers → 403
+- `Host` must be local. Originless requests are allowed; if sending `Origin`, use exactly `http://127.0.0.1:<actual-bound-port>` from the printed URL. Cross-site, malformed, duplicate, and wrong-port Origins → 403; this does not replace the session token or CSRF requirement.
 - One mutation at a time; mutating controls disabled while op is in flight
 - Session state is in-memory; server restart generates a new URL
 

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -14,21 +14,17 @@ use crate::web::templates::{
 };
 use axum::Router;
 use axum::body::Body;
-use axum::extract::{Form, Path, Query, State};
+use axum::extract::{Form, Path, Query, Request, State};
 use axum::http::{HeaderMap, Response, StatusCode, header};
+use axum::middleware::{self, Next};
 use axum::response::{Html, IntoResponse};
 use axum::routing::{get, post};
 use serde::Deserialize;
 
 type AppState = SharedSession;
 
-pub fn build_router(session: SharedSession) -> Router {
-    Router::new()
-        // Static assets (no token needed)
-        .route("/assets/app.css", get(serve_css))
-        .route("/assets/htmx.min.js", get(serve_htmx))
-        .route("/assets/app.js", get(serve_appjs))
-        // Session routes
+pub fn build_router(session: SharedSession, allowed_origin: String) -> Router {
+    let token_routes = Router::new()
         .route("/s/{token}/", get(workspace_handler))
         .route("/s/{token}/stack", get(stack_partial))
         .route("/s/{token}/select", post(select_branch))
@@ -51,6 +47,17 @@ pub fn build_router(session: SharedSession) -> Router {
         .route("/s/{token}/op/reorder", post(op_reorder))
         .route("/s/{token}/op/open-pr", get(op_open_pr))
         .route("/s/{token}/project", post(switch_project))
+        .route_layer(middleware::from_fn_with_state(
+            allowed_origin,
+            token_route_guard,
+        ));
+
+    Router::new()
+        // Static assets (no token needed)
+        .route("/assets/app.css", get(serve_css))
+        .route("/assets/htmx.min.js", get(serve_htmx))
+        .route("/assets/app.js", get(serve_appjs))
+        .merge(token_routes)
         .with_state(session)
 }
 
@@ -97,16 +104,33 @@ fn log_action(action: &str, detail: &str) {
     }
 }
 
-fn check_local_host(headers: &HeaderMap) -> Option<Response<Body>> {
+fn is_local_host(headers: &HeaderMap) -> bool {
     let host = headers
         .get(header::HOST)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     let host_part = host.split(':').next().unwrap_or(host);
-    if host_part != "127.0.0.1" && host_part != "localhost" {
-        return Some((StatusCode::FORBIDDEN, Html("<h1>Forbidden</h1>")).into_response());
+    host_part == "127.0.0.1" || host_part == "localhost"
+}
+
+fn has_allowed_origin(headers: &HeaderMap, allowed_origin: &str) -> bool {
+    let mut origins = headers.get_all(header::ORIGIN).iter();
+    match origins.next() {
+        None => true,
+        Some(origin) => origins.next().is_none() && origin.to_str().ok() == Some(allowed_origin),
     }
-    None
+}
+
+async fn token_route_guard(
+    State(allowed_origin): State<String>,
+    request: Request,
+    next: Next,
+) -> axum::response::Response {
+    if !is_local_host(request.headers()) || !has_allowed_origin(request.headers(), &allowed_origin)
+    {
+        return (StatusCode::FORBIDDEN, Html("<h1>Forbidden</h1>")).into_response();
+    }
+    next.run(request).await
 }
 
 fn compute_stack_row_meta(
@@ -174,11 +198,8 @@ async fn serve_appjs() -> impl IntoResponse {
 async fn workspace_handler(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -221,12 +242,9 @@ struct BranchQuery {
 async fn stack_partial(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Query(q): Query<BranchQuery>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -256,12 +274,9 @@ struct SelectForm {
 async fn select_branch(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<SelectForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -283,11 +298,8 @@ async fn select_branch(
 async fn branch_details(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -363,11 +375,8 @@ async fn branch_details(
 async fn branch_diff(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -418,11 +427,8 @@ async fn branch_diff(
 async fn ci_summary(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -440,12 +446,9 @@ struct SearchForm {
 async fn search_branches(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<SearchForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -477,12 +480,9 @@ struct PanesForm {
 async fn toggle_panes(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<PanesForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -516,12 +516,9 @@ struct ThemeForm {
 async fn set_theme(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<ThemeForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -553,12 +550,9 @@ struct CsrfForm {
 async fn refresh_handler(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<CsrfForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -580,12 +574,9 @@ struct CheckoutForm {
 async fn op_checkout(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<CheckoutForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -612,12 +603,9 @@ struct CreateForm {
 async fn op_create(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<CreateForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -648,12 +636,9 @@ struct RenameForm {
 async fn op_rename(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<RenameForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -681,12 +666,9 @@ struct DeleteForm {
 async fn op_delete(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<DeleteForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -714,12 +696,9 @@ struct RestackForm {
 async fn op_restack(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<RestackForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -752,12 +731,9 @@ async fn op_restack(
 async fn op_submit(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<CsrfForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -777,12 +753,9 @@ async fn op_submit(
 async fn op_undo(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<CsrfForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -803,12 +776,9 @@ async fn op_undo(
 async fn op_redo(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<CsrfForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -837,12 +807,9 @@ struct MoveForm {
 async fn op_move(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<MoveForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -875,12 +842,9 @@ struct ReorderForm {
 async fn op_reorder(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<ReorderForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -923,12 +887,9 @@ struct ProjectForm {
 async fn switch_project(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Form(form): Form<ProjectForm>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }
@@ -1010,12 +971,9 @@ where
 async fn op_open_pr(
     State(state): State<AppState>,
     Path(token): Path<String>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Query(q): Query<BranchQuery>,
 ) -> impl IntoResponse {
-    if let Some(r) = check_local_host(&headers) {
-        return r;
-    }
     if let Some(r) = check_token(&state, &token) {
         return r;
     }

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -32,10 +32,10 @@ pub struct BoundServer {
 /// the returned `BoundServer`. All other bind failures are returned as errors.
 pub async fn bind(port: u16, session: SharedSession) -> Result<BoundServer> {
     let token = session.lock().unwrap().session_token.clone();
-    let router = build_router(session);
-
     let (listener, fell_back) = bind_listener(port).await?;
     let bound_addr = listener.local_addr()?;
+    let allowed_origin = format!("http://127.0.0.1:{}", bound_addr.port());
+    let router = build_router(session, allowed_origin);
     let url = format!("http://127.0.0.1:{}/s/{}/", bound_addr.port(), token);
 
     let join_handle = tokio::spawn(async move {

--- a/tests/web_tests.rs
+++ b/tests/web_tests.rs
@@ -23,6 +23,23 @@ fn web_command(cwd: &Path) -> Command {
     command
 }
 
+fn session_origin(base_url: &str) -> String {
+    base_url
+        .split("/s/")
+        .next()
+        .expect("test server URL should contain a session path")
+        .to_owned()
+}
+
+fn csrf_from_workspace(html: &str) -> String {
+    html.split(r#"id="workspace-csrf""#)
+        .nth(1)
+        .and_then(|s| s.split(r#"value=""#).nth(1))
+        .and_then(|s| s.split('"').next())
+        .expect("csrf token in workspace HTML")
+        .to_owned()
+}
+
 // ── CLI shape tests ──────────────────────────────────────────────────────────
 
 #[test]
@@ -201,6 +218,257 @@ fn web_server_serves_static_assets() {
             .await
             .unwrap();
         assert_eq!(js.status().as_u16(), 200, "htmx.min.js should return 200");
+    });
+}
+
+#[test]
+fn web_token_routes_allow_absent_and_exact_bound_origin() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new();
+        let init_out = repo.run_stax(&["init", "--trunk", "main"]);
+        assert!(init_out.status.success());
+
+        let server = stax::web::start_test_server(repo.path().to_path_buf())
+            .await
+            .expect("server should start");
+        let client = reqwest::Client::new();
+        let origin = session_origin(&server.base_url);
+
+        let absent_origin = client
+            .get(format!("{}stack", server.base_url))
+            .send()
+            .await
+            .expect("originless token route should respond");
+        assert_eq!(absent_origin.status(), 200);
+
+        let exact_origin = client
+            .get(format!("{}stack", server.base_url))
+            .header("origin", &origin)
+            .send()
+            .await
+            .expect("exact-origin token route should respond");
+        assert_eq!(exact_origin.status(), 200);
+    });
+}
+
+#[test]
+fn web_token_routes_reject_cross_site_origin_before_every_handler() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new();
+        let server = stax::web::start_test_server(repo.path().to_path_buf())
+            .await
+            .expect("server should start");
+        let client = reqwest::Client::new();
+
+        // Removing the shared token-route Origin guard must make every one of
+        // these requests reach a handler instead of returning 403.
+        for (method, path) in [
+            ("GET", ""),
+            ("GET", "stack"),
+            ("POST", "select"),
+            ("GET", "details"),
+            ("GET", "diff"),
+            ("GET", "ci"),
+            ("POST", "search"),
+            ("POST", "panes"),
+            ("POST", "theme"),
+            ("POST", "refresh"),
+            ("POST", "op/checkout"),
+            ("POST", "op/create"),
+            ("POST", "op/rename"),
+            ("POST", "op/delete"),
+            ("POST", "op/restack"),
+            ("POST", "op/submit"),
+            ("POST", "op/undo"),
+            ("POST", "op/redo"),
+            ("POST", "op/move"),
+            ("POST", "op/reorder"),
+            ("GET", "op/open-pr"),
+            ("POST", "project"),
+        ] {
+            let request = match method {
+                "GET" => client.get(format!("{}{}", server.base_url, path)),
+                "POST" => client
+                    .post(format!("{}{}", server.base_url, path))
+                    .header("content-type", "application/x-www-form-urlencoded"),
+                _ => unreachable!("test route method"),
+            };
+            let response = request
+                .header("origin", "https://attacker.example")
+                .send()
+                .await
+                .expect("cross-site request should receive a response");
+            assert_eq!(
+                response.status(),
+                403,
+                "{method} /s/{{token}}/{path} must reject a cross-site Origin before its handler"
+            );
+        }
+    });
+}
+
+#[test]
+fn web_token_routes_reject_malformed_duplicate_and_wrong_port_origins() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new();
+        let init_out = repo.run_stax(&["init", "--trunk", "main"]);
+        assert!(init_out.status.success());
+        let server = stax::web::start_test_server(repo.path().to_path_buf())
+            .await
+            .expect("server should start");
+        let client = reqwest::Client::new();
+        let origin = session_origin(&server.base_url);
+        let port = origin
+            .rsplit_once(':')
+            .expect("bound origin should include a port")
+            .1
+            .parse::<u16>()
+            .expect("bound origin port should be numeric");
+        let wrong_port = format!("http://127.0.0.1:{}", port.saturating_add(1));
+        let wrong_scheme = origin.replacen("http://", "https://", 1);
+        let wrong_host = format!("http://localhost:{port}");
+
+        for malformed in [
+            "null",
+            "not an origin",
+            "http://127.0.0.1:1/path",
+            "http://127.0.0.1:1, https://attacker.example",
+            &wrong_port,
+        ] {
+            let response = client
+                .get(format!("{}stack", server.base_url))
+                .header("origin", malformed)
+                .send()
+                .await
+                .expect("malformed Origin should receive a response");
+            assert_eq!(
+                response.status(),
+                403,
+                "Origin {malformed:?} must be rejected"
+            );
+        }
+
+        for (description, invalid_origin) in [
+            ("wrong scheme with the actual host and port", wrong_scheme),
+            ("wrong host with the actual scheme and port", wrong_host),
+        ] {
+            let response = client
+                .get(format!("{}stack", server.base_url))
+                .header("origin", invalid_origin)
+                .send()
+                .await
+                .expect("wrong canonical Origin component should receive a response");
+            assert_eq!(response.status(), 403, "{description} must be rejected");
+        }
+
+        let non_utf8 = reqwest::header::HeaderValue::from_bytes(b"http://127.0.0.1:\xff")
+            .expect("non-UTF-8 Origin bytes should form an HTTP header value");
+        let non_utf8_response = client
+            .get(format!("{}stack", server.base_url))
+            .header("origin", non_utf8)
+            .send()
+            .await
+            .expect("non-UTF-8 Origin should receive a response");
+        assert_eq!(
+            non_utf8_response.status(),
+            403,
+            "non-UTF-8 Origin bytes must be rejected"
+        );
+
+        let duplicate = client
+            .get(format!("{}stack", server.base_url))
+            .header("origin", &origin)
+            .header("origin", &origin)
+            .send()
+            .await
+            .expect("duplicate Origin should receive a response");
+        assert_eq!(
+            duplicate.status(),
+            403,
+            "duplicate Origin headers must be rejected"
+        );
+    });
+}
+
+#[test]
+fn web_origin_guard_preserves_host_csrf_and_static_asset_defenses() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new();
+        let init_out = repo.run_stax(&["init", "--trunk", "main"]);
+        assert!(init_out.status.success());
+        let server = stax::web::start_test_server(repo.path().to_path_buf())
+            .await
+            .expect("server should start");
+        let client = reqwest::Client::new();
+        let origin = session_origin(&server.base_url);
+
+        let non_local_host = client
+            .get(format!("{}stack", server.base_url))
+            .header("host", "attacker.example")
+            .send()
+            .await
+            .expect("non-local Host should receive a response");
+        assert_eq!(non_local_host.status(), 403);
+
+        let invalid_csrf = client
+            .post(format!("{}select", server.base_url))
+            .header("origin", &origin)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body("branch=main&csrf=wrong")
+            .send()
+            .await
+            .expect("invalid CSRF should receive a response");
+        assert_eq!(invalid_csrf.status(), 403);
+
+        let asset = client
+            .get(format!("{origin}/assets/app.css"))
+            .header("origin", "https://attacker.example")
+            .send()
+            .await
+            .expect("public asset should receive a response");
+        assert_eq!(
+            asset.status(),
+            200,
+            "assets must remain outside token guard"
+        );
+    });
+}
+
+#[test]
+fn web_exact_origin_and_valid_csrf_allow_select_branch() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new();
+        let init_out = repo.run_stax(&["init", "--trunk", "main"]);
+        assert!(init_out.status.success());
+        let server = stax::web::start_test_server(repo.path().to_path_buf())
+            .await
+            .expect("server should start");
+        let client = reqwest::Client::new();
+        let origin = session_origin(&server.base_url);
+        let workspace = client
+            .get(&server.base_url)
+            .send()
+            .await
+            .expect("workspace should respond")
+            .text()
+            .await
+            .expect("workspace HTML should be readable");
+        let csrf = csrf_from_workspace(&workspace);
+
+        let response = client
+            .post(format!("{}select", server.base_url))
+            .header("origin", &origin)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(format!("branch=main&csrf={csrf}"))
+            .send()
+            .await
+            .expect("valid CSRF request should respond");
+        assert_eq!(response.status(), 200);
     });
 }
 
@@ -526,12 +794,24 @@ fn web_server_bind_falls_back_when_requested_port_is_busy() {
         assert_ne!(bound.addr.port(), busy_port);
         assert_ne!(bound.addr.port(), 0);
 
-        let response = reqwest::Client::new()
+        let client = reqwest::Client::new();
+        let actual_origin = session_origin(&bound.url);
+        let response = client
             .get(&bound.url)
+            .header("origin", &actual_origin)
             .send()
             .await
             .expect("fallback server should be reachable");
         assert_eq!(response.status().as_u16(), 200);
+
+        let requested_port_origin = format!("http://127.0.0.1:{busy_port}");
+        let wrong_port = client
+            .get(&bound.url)
+            .header("origin", requested_port_origin)
+            .send()
+            .await
+            .expect("wrong-port Origin should receive a response");
+        assert_eq!(wrong_port.status(), 403);
 
         bound.join_handle.abort();
         drop(busy_listener);
@@ -556,6 +836,14 @@ fn web_server_bind_reports_no_fallback_for_ephemeral_port() {
         assert_eq!(bound.requested_port, 0);
         assert!(!bound.fell_back);
         assert_ne!(bound.addr.port(), 0);
+
+        let requested_ephemeral_origin = reqwest::Client::new()
+            .get(&bound.url)
+            .header("origin", "http://127.0.0.1:0")
+            .send()
+            .await
+            .expect("requested ephemeral-port Origin should receive a response");
+        assert_eq!(requested_ephemeral_origin.status(), 403);
 
         bound.join_handle.abort();
     });


### PR DESCRIPTION
## Motivation

Token-scoped `st web` session routes need explicit browser Origin validation so a cross-site page cannot drive an authenticated local session.

## Description of changes / notes for reviewers

- validate Origin before every token-scoped route handler against the server's exact bound origin
- reject malformed, duplicate, wrong-scheme, wrong-host, and wrong-port origins while preserving non-browser requests without Origin
- keep Host, session-token, CSRF, and static-asset defenses independent
- document the browser-origin contract in README, command docs, web docs, and `skills.md`
- add end-to-end coverage for accepted and rejected origin variants

## Verification

- `cargo check`
- `make lint-fast`
- `cargo nextest run web_tests::` — 19 passed
- `git diff --check`
- full local gate attempted: 2,170 tests passed; seven unrelated interactive `split_hunk_tests` remained alive beyond eight minutes and the run was interrupted. CI remains the authoritative full gate before merge.

Closes #795