### PR TITLE
fix(merge): enforce queue timeout deadline

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -56,7 +56,7 @@ st --trace status --json >/dev/null
 - `st merge --stack` — GitHub/GitLab stack merge: target every selected PR/MR to trunk, merge only the selected tip with SHA-preserving `merge`, and poll lower items for authoritative merged state; timed-out items stay open. Multi-PR GitHub `rebase`/`squash` fails before mutation because rewritten SHAs prevent genuine lower-PR merged state; a single selected GitHub PR may still use them. GitLab first verifies project merge settings, sends `squash: false`, and rejects explicit `rebase`/`squash`. Gitea/Forgejo is unsupported
 - `st merge --stack --full` — include descendants above the current branch and land the full stack through the actual stack tip
 - `st merge --remote` — merge entirely via GitHub API, no local git operations (GitHub only)
-- `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains
+- `st merge --queue` — enqueue PRs into GitHub merge queue / GitLab merge trains, polling only within the configured timeout deadline
 
 See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 
@@ -313,7 +313,11 @@ st completions elvish
 - `--when-ready` · `--when-ready --interval 10`
 - `--remote` · `--remote --all` · `--remote --timeout 60 --interval 10`
 - `--queue` · `--queue --all --yes`
-- `--no-wait` / `--no-sync` / `--no-delete` / `--timeout 60` / `--quiet`
+- `--timeout <minutes>` — positive whole minutes (default: 30); zero is rejected
+- `--interval <seconds>` — positive whole seconds (default: 15) for `--when-ready`, `--remote`, `--queue`, and `--stack --when-ready`; zero is rejected
+- `--no-wait` / `--no-sync` / `--no-delete` / `--quiet`
+
+For `--queue`, the timeout is a real deadline: stax caps the final sleep to the remaining budget and does not start another forge status poll once the deadline is reached.
 
 ### `st sync` / `st rs`
 

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -111,9 +111,12 @@ Enqueue the stack into your forge's merge queue (GitHub) or merge trains (GitLab
 ```bash
 st merge --queue
 st merge --queue --all --yes
+st merge --queue --timeout 60 --interval 10
 ```
 
 Flow: retarget all PRs to trunk → enqueue each → poll until merged (respects `--timeout` and `--interval`) → auto `st rs` unless `--no-sync` → desktop notification.
+
+`--timeout` accepts positive whole minutes (default: 30), and `--interval` accepts positive whole seconds (default: 15); zero is rejected for either flag. The queue timeout is a hard polling deadline: the final sleep is capped to the remaining time, and stax does not begin another forge status poll once that deadline is reached.
 
 | Forge | Requirement |
 |---|---|

--- a/skills.md
+++ b/skills.md
@@ -313,12 +313,15 @@ stax merge --stack --when-ready    # Wait only for selected tip PR/MR readiness 
 stax merge --when-ready            # Wait for CI + approval before each merge
 stax merge --remote                # Merge via GitHub API only — no local checkout/rebase/push
 stax merge --remote --all          # Include full stack (GitHub only)
-stax merge --interval 30           # Poll interval in seconds for --when-ready / --remote / --stack --when-ready
+stax merge --interval 30           # Positive poll seconds for --when-ready / --remote / --queue / --stack --when-ready
 stax merge --no-wait               # Fail fast if CI is pending
-stax merge --timeout 60            # Max wait minutes per PR
+stax merge --timeout 60            # Positive max-wait minutes (default 30; zero is rejected)
 stax merge --no-delete             # Keep branches after merge
 stax merge --no-sync               # Skip post-merge sync
 stax merge-when-ready              # Backward-compatible alias
+
+# For merge --queue, timeout is a hard polling deadline: cap the final sleep to
+# the remaining budget and never poll the forge at or after the deadline.
 
 stax rs                            # Sync trunk + clean merged branches
 stax rs --restack                  # Sync then restack

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -376,7 +376,7 @@ pub(crate) enum Commands {
         #[arg(long)]
         no_wait: bool,
         /// Max wait time for CI per PR in minutes
-        #[arg(long, default_value = "30")]
+        #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..))]
         timeout: u64,
         /// Wait for each PR to be ready (CI + approval) before merging
         #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "remote", "queue"])]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -499,3 +499,17 @@ fn merge_accepts_interval_of_one() {
         Some(Commands::Merge { interval: 1, .. })
     ));
 }
+
+#[test]
+fn merge_rejects_zero_timeout() {
+    assert!(try_parse_cli(&["stax", "merge", "--timeout", "0"]).is_err());
+}
+
+#[test]
+fn merge_accepts_timeout_of_one() {
+    let cli = parse_cli(&["stax", "merge", "--timeout", "1"]);
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Merge { timeout: 1, .. })
+    ));
+}

--- a/src/commands/merge_queue.rs
+++ b/src/commands/merge_queue.rs
@@ -29,6 +29,17 @@ struct QueueBranchInfo {
     original_base: String,
 }
 
+fn duration_from_seconds(seconds: u64) -> Duration {
+    #[cfg(debug_assertions)]
+    if let Some(milliseconds_per_second) = std::env::var_os("STAX_TEST_MILLIS_PER_SECOND")
+        .and_then(|value| value.to_str().and_then(|value| value.parse::<u64>().ok()))
+    {
+        return Duration::from_millis(seconds.saturating_mul(milliseconds_per_second));
+    }
+
+    Duration::from_secs(seconds)
+}
+
 pub fn run(
     all: bool,
     timeout: u64,
@@ -385,24 +396,35 @@ pub fn run(
         println!();
     }
 
-    let timeout_duration = Duration::from_secs(timeout * 60);
-    let poll_interval = Duration::from_secs(interval);
+    let timeout_duration = duration_from_seconds(timeout * 60);
+    let poll_interval = duration_from_seconds(interval);
     let start = Instant::now();
     let mut pending: Vec<(String, u64)> =
         enqueued.iter().map(|(b, pr, _)| (b.clone(), *pr)).collect();
     let mut timed_out = false;
 
-    while !pending.is_empty() {
-        std::thread::sleep(poll_interval);
+    'pending: while !pending.is_empty() {
+        let elapsed = start.elapsed();
+        if elapsed >= timeout_duration {
+            timed_out = true;
+            break;
+        }
+
+        std::thread::sleep(poll_interval.min(timeout_duration - elapsed));
 
         let elapsed = start.elapsed();
-        if elapsed > timeout_duration {
+        if elapsed >= timeout_duration {
             timed_out = true;
             break;
         }
 
         let mut still_pending = Vec::new();
         for (branch, pr) in &pending {
+            if start.elapsed() >= timeout_duration {
+                timed_out = true;
+                break 'pending;
+            }
+
             match rt.block_on(async { client.is_pr_merged(*pr).await }) {
                 Ok(true) => {
                     if !quiet {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -36,6 +36,10 @@ fn sanitized_stax_command() -> Command {
         .env_remove("STAX_GITHUB_TOKEN")
         .env_remove("STAX_SHELL_INTEGRATION")
         .env_remove("GH_TOKEN")
+        .env_remove("GIT_AUTHOR_NAME")
+        .env_remove("GIT_AUTHOR_EMAIL")
+        .env_remove("GIT_COMMITTER_NAME")
+        .env_remove("GIT_COMMITTER_EMAIL")
         .env("GIT_CONFIG_GLOBAL", null_path)
         .env("GIT_CONFIG_SYSTEM", null_path)
         .env("STAX_DISABLE_UPDATE_CHECK", "1")
@@ -8836,6 +8840,16 @@ mod forge_mock_tests {
         token_env: &str,
         args: &[&str],
     ) -> Output {
+        run_stax_with_token_env_and_extra_env(repo, home, token_env, &[], args)
+    }
+
+    fn run_stax_with_token_env_and_extra_env(
+        repo: &TestRepo,
+        home: &Path,
+        token_env: &str,
+        extra_env: &[(&str, &str)],
+        args: &[&str],
+    ) -> Output {
         let gitconfig = ensure_empty_gitconfig(home);
         let mut command = Command::new(stax_bin());
         command
@@ -8848,6 +8862,9 @@ mod forge_mock_tests {
             .env("STAX_DISABLE_UPDATE_CHECK", "1")
             .env("STAX_TEST_DISABLE_HEAD_SYNC", "1")
             .env("STAX_STACK_MERGE_INDIRECT_WAIT_SECS", "0");
+        for (key, value) in extra_env {
+            command.env(key, value);
+        }
         command.output().expect("Failed to execute stax")
     }
 
@@ -14375,6 +14392,244 @@ exit 1
             })
             .count();
         assert_eq!(patch_count, 2, "Expected retarget and rollback PATCHes");
+    }
+
+    async fn setup_single_pr_merge_queue(
+        mock_server: &MockServer,
+        branch_name: &str,
+        pr_number: u64,
+    ) -> (TempDir, TestRepo, TempDir, String) {
+        let home = super::test_tempdir();
+        let repo = TestRepo::new();
+        let remote_root = setup_fake_github_remote(&repo, home.path());
+        write_test_config(home.path(), &mock_server.uri());
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", branch_name]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+        let branch = repo.current_branch();
+        repo.create_file("queue.txt", "queue\n");
+        repo.commit("Add queue fixture");
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch]);
+        assert!(push.status.success(), "{}", TestRepo::stderr(&push));
+        write_branch_pr_metadata(&repo, &branch, "main", pr_number, Some(false));
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                github_pull_fixture(pr_number, &branch, "main", "queue-sha")
+            ])))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains(format!(
+                "pullRequest(number: {})",
+                pr_number
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pullRequest": { "id": format!("PR_node_{}", pr_number) }
+                    }
+                }
+            })))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("enqueuePullRequest"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "enqueuePullRequest": {
+                        "mergeQueueEntry": { "position": 1 }
+                    }
+                }
+            })))
+            .mount(mock_server)
+            .await;
+
+        (home, repo, remote_root, branch)
+    }
+
+    #[tokio::test]
+    async fn test_merge_queue_observes_pr_merged_before_deadline() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let pr_number = 771;
+        let (home, repo, _remote_root, branch) =
+            setup_single_pr_merge_queue(&mock_server, "queue-success", pr_number).await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/pulls/{}", pr_number)))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                    pr_number,
+                    &branch,
+                    "main",
+                    "queue-sha",
+                )),
+            )
+            .with_priority(1)
+            .up_to_n_times(3)
+            .mount(&mock_server)
+            .await;
+
+        let mut merged = github_pull_fixture(pr_number, &branch, "main", "queue-sha");
+        merged["merged_at"] = serde_json::json!("2026-08-25T00:00:00Z");
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/pulls/{}", pr_number)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(merged))
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        let output = run_stax_with_token_env_and_extra_env(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &[("STAX_TEST_MILLIS_PER_SECOND", "50")],
+            &[
+                "merge",
+                "--queue",
+                "--yes",
+                "--timeout",
+                "1",
+                "--interval",
+                "5",
+                "--no-sync",
+            ],
+        );
+
+        assert!(
+            output.status.success(),
+            "merge --queue failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+        let stdout = TestRepo::stdout(&output);
+        assert!(
+            stdout.contains("Stack Merged") && stdout.contains("Merged 1 PR"),
+            "expected successful queue completion, got:\n{}",
+            stdout
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let enqueue_index = requests
+            .iter()
+            .position(|request| {
+                request.method.as_str() == "POST"
+                    && request.url.path() == "/graphql"
+                    && String::from_utf8_lossy(&request.body).contains("enqueuePullRequest")
+            })
+            .expect("missing enqueue mutation");
+        let polls_after_enqueue = requests
+            .iter()
+            .skip(enqueue_index + 1)
+            .filter(|request| {
+                request.method.as_str() == "GET"
+                    && request.url.path() == format!("/repos/test/repo/pulls/{}", pr_number)
+            })
+            .count();
+        assert_eq!(polls_after_enqueue, 2, "expected two queue status polls");
+    }
+
+    #[tokio::test]
+    async fn test_merge_queue_timeout_shorter_than_interval_stops_at_deadline() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let pr_number = 772;
+        let (home, repo, _remote_root, branch) =
+            setup_single_pr_merge_queue(&mock_server, "queue-timeout", pr_number).await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/test/repo/pulls/{}", pr_number)))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(github_pull_fixture(
+                    pr_number,
+                    &branch,
+                    "main",
+                    "queue-sha",
+                )),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let started = std::time::Instant::now();
+        let output = run_stax_with_token_env_and_extra_env(
+            &repo,
+            home.path(),
+            "STAX_GITHUB_TOKEN",
+            &[("STAX_TEST_MILLIS_PER_SECOND", "50")],
+            &[
+                "merge",
+                "--queue",
+                "--yes",
+                "--timeout",
+                "1",
+                "--interval",
+                "200",
+                "--no-sync",
+            ],
+        );
+        let elapsed = started.elapsed();
+
+        assert!(
+            output.status.success(),
+            "merge --queue failed\nstdout: {}\nstderr: {}",
+            TestRepo::stdout(&output),
+            TestRepo::stderr(&output)
+        );
+        let stdout = TestRepo::stdout(&output);
+        assert!(
+            stdout.contains("Timed out after 1 min waiting for merge queue to finish."),
+            "expected timeout warning, got:\n{}",
+            stdout
+        );
+        // 1 minute × 60 simulated seconds × 50 ms is a 3-second deadline.
+        // Keep 500 ms of tolerance while still rejecting an immediate timeout.
+        let scaled_deadline = std::time::Duration::from_secs(3);
+        let lower_bound_tolerance = std::time::Duration::from_millis(500);
+        assert!(
+            elapsed >= scaled_deadline - lower_bound_tolerance,
+            "queue wait returned before the scaled deadline margin: {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(8),
+            "queue wait exceeded the scaled deadline margin: {:?}",
+            elapsed
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let enqueue_index = requests
+            .iter()
+            .position(|request| {
+                request.method.as_str() == "POST"
+                    && request.url.path() == "/graphql"
+                    && String::from_utf8_lossy(&request.body).contains("enqueuePullRequest")
+            })
+            .expect("missing enqueue mutation");
+        let status_requests: Vec<_> = requests
+            .iter()
+            .enumerate()
+            .filter(|(_, request)| {
+                request.method.as_str() == "GET"
+                    && request.url.path() == format!("/repos/test/repo/pulls/{}", pr_number)
+            })
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(
+            status_requests.len(),
+            2,
+            "expected only pre-enqueue merge/base checks"
+        );
+        assert!(
+            status_requests.iter().all(|index| *index < enqueue_index),
+            "deadline must prevent a post-enqueue status poll: {:?}",
+            status_requests
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

`st merge --queue` could wait past its configured timeout because the deadline was not enforced before the first poll or before a full polling sleep.

## Description of changes / notes for reviewers

- establish the queue deadline before polling begins
- reject zero-second timeouts and cap every sleep at the remaining deadline
- stop without an extra post-deadline poll while preserving successful multi-poll behavior
- document timeout semantics in command, workflow, and agent guidance
- add parser and end-to-end timing coverage

## Verification

- `cargo check`
- `make lint-fast`
- focused merge parser and queue tests — 10 passed
- `git diff --check`

Closes #771