### PR TITLE
fix(github): clarify repository authorization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ export STAX_GITHUB_TOKEN="ghp_xxxx"
 
 By default stax ignores ambient `GITHUB_TOKEN`. Opt in with `auth.allow_github_token_env = true`.
 
+GitHub may report `401 Unauthorized` or `404 Not Found` when a token is expired
+or cannot access a private repository. For repository searches and
+already-resolved review/comment reads, stax adds an auth hint; refresh with
+`st auth --from-gh` or check the token's repository access and scopes. The hint
+is intentionally not attached to every missing PR or failed mutation, where a
+404 can be the expected resource-level error.
+
 </details>
 
 Now ship a two-branch stack end-to-end:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -308,6 +308,15 @@ rejects mismatches before looking up a token or making a request.
 3. `gh auth token` (`auth.use_gh_cli = true`)
 4. `GITHUB_TOKEN` (only when `auth.allow_github_token_env = true`)
 
+GitHub can return `401 Unauthorized` or `404 Not Found` when the selected token
+is expired or cannot see a private repository. Stax adds actionable auth
+guidance to these responses for repository list/search operations and for
+review/comment reads after a PR has already been resolved. Run
+`stax auth --from-gh` to refresh from GitHub CLI, or verify the token's
+repository access and scopes. Direct missing-PR lookups and mutations keep their
+normal errors because their 404 responses commonly describe an absent resource,
+not an authentication problem.
+
 ```bash
 st auth status
 ```

--- a/skills.md
+++ b/skills.md
@@ -564,6 +564,13 @@ stax skills update                 # Download latest skills from GitHub and upda
 stax skills update --dry-run       # Preview what would be updated without writing
 ```
 
+GitHub `401`/`404` errors on repository searches or already-resolved
+review/comment reads can mean the token is expired or lacks private-repository
+access. Follow stax's auth hint: run `stax auth --from-gh`, then verify token
+scopes and repository access. Do not treat every 404 as an auth failure: direct
+missing-PR lookups and mutations deliberately retain their resource-level
+errors.
+
 ## Common Workflows
 
 ### Start a New Feature Stack

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -376,7 +376,12 @@ impl GitHubClient {
             self.owner, self.repo, username
         );
 
-        let response: SearchIssuesResponse = self.octocrab.get(&url, None::<&()>).await?;
+        let response: SearchIssuesResponse = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to get recently merged PRs")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         let merged: Vec<PrActivity> = response
             .items
@@ -413,7 +418,12 @@ impl GitHubClient {
             self.owner, self.repo, username
         );
 
-        let response: SearchIssuesResponse = self.octocrab.get(&url, None::<&()>).await?;
+        let response: SearchIssuesResponse = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to get recently opened PRs")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         let opened: Vec<PrActivity> = response
             .items
@@ -445,7 +455,12 @@ impl GitHubClient {
             self.owner, self.repo, username
         );
         self.record_api_call("search.issues");
-        let response: SearchIssuesResponse = self.octocrab.get(&url, None::<&()>).await?;
+        let response: SearchIssuesResponse = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to search PRs for received reviews")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         let mut reviews = Vec::new();
 
@@ -513,7 +528,8 @@ impl GitHubClient {
             .octocrab
             .get(&url, None::<&()>)
             .await
-            .context("Failed to search PRs")?;
+            .context("Failed to search PRs")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         // For each PR from search, we need to get the branch info
         // Search API doesn't include head/base branch refs, so we fetch each PR
@@ -684,6 +700,125 @@ mod tests {
             .unwrap();
 
         GitHubClient::with_octocrab(octocrab, "test-owner", "test-repo")
+    }
+
+    fn assert_auth_hint(err: anyhow::Error, operation: &str, github_error: &str) {
+        let msg = format!("{:#}", err);
+        assert!(msg.contains(operation), "missing operation context: {msg}");
+        assert!(
+            msg.contains(github_error),
+            "missing original GitHub error: {msg}"
+        );
+        assert!(
+            msg.contains("token is expired"),
+            "missing token hint: {msg}"
+        );
+        assert!(
+            msg.contains("stax auth --from-gh"),
+            "missing remediation: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recent_merged_prs_enriches_unauthorized_search_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Bad credentials"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .get_recent_merged_prs(24, "alice")
+            .await
+            .expect_err("401 search should fail");
+        assert_auth_hint(err, "Failed to get recently merged PRs", "Bad credentials");
+    }
+
+    #[tokio::test]
+    async fn recent_opened_prs_enriches_not_found_search_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .get_recent_opened_prs(24, "alice")
+            .await
+            .expect_err("404 search should fail");
+        assert_auth_hint(err, "Failed to get recently opened PRs", "Not Found");
+    }
+
+    #[tokio::test]
+    async fn reviews_received_enriches_unauthorized_initial_search_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Bad credentials"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .get_reviews_received(24, "alice")
+            .await
+            .expect_err("401 search should fail");
+        assert_auth_hint(
+            err,
+            "Failed to search PRs for received reviews",
+            "Bad credentials",
+        );
+    }
+
+    #[tokio::test]
+    async fn user_open_prs_enriches_not_found_initial_search_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .get_user_open_prs("alice")
+            .await
+            .expect_err("404 search should fail");
+        assert_auth_hint(err, "Failed to search PRs", "Not Found");
+    }
+
+    #[tokio::test]
+    async fn recent_merged_prs_does_not_mislabel_server_error_as_auth() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "message": "temporary failure"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .get_recent_merged_prs(24, "alice")
+            .await
+            .expect_err("500 search should fail");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("Failed to get recently merged PRs"), "{msg}");
+        assert!(msg.contains("temporary failure"), "{msg}");
+        assert!(!msg.contains("stax auth --from-gh"), "{msg}");
     }
 
     /// `get_user_open_prs` reads `number`, `head.ref` and `base.ref` off each

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -1013,7 +1013,8 @@ impl GitHubClient {
         let data: PrReviewData = self
             .graphql_data(serde_json::json!({ "query": query }))
             .await
-            .context("Failed to query PR reviews")?;
+            .context("Failed to query PR reviews")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         let repository = data
             .repository
@@ -1124,7 +1125,8 @@ impl GitHubClient {
             .octocrab
             .get(&url, None::<&()>)
             .await
-            .context("Failed to list issue comments")?;
+            .context("Failed to list issue comments")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         Ok(comments
             .into_iter()
@@ -1161,7 +1163,8 @@ impl GitHubClient {
             .octocrab
             .get(&url, None::<&()>)
             .await
-            .context("Failed to list review comments")?;
+            .context("Failed to list review comments")
+            .map_err(|e| self.enrich_api_error(e))?;
 
         Ok(comments
             .into_iter()
@@ -2170,6 +2173,117 @@ mod tests {
             .unwrap();
 
         GitHubClient::with_octocrab(octocrab, "test-owner", "test-repo")
+    }
+
+    fn assert_auth_hint(err: anyhow::Error, operation: &str) {
+        let msg = format!("{:#}", err);
+        assert!(msg.contains(operation), "missing operation context: {msg}");
+        assert!(msg.contains("Not Found"), "missing GitHub error: {msg}");
+        assert!(
+            msg.contains("token is expired"),
+            "missing token hint: {msg}"
+        );
+        assert!(
+            msg.contains("stax auth --from-gh"),
+            "missing remediation: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pr_review_decision_enriches_not_found_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .get_pr_review_decision(11)
+            .await
+            .expect_err("404 review query should fail");
+        assert_auth_hint(err, "Failed to query PR reviews");
+    }
+
+    #[tokio::test]
+    async fn list_issue_comments_enriches_not_found_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/issues/11/comments"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .list_issue_comments(11)
+            .await
+            .expect_err("404 issue comments should fail");
+        assert_auth_hint(err, "Failed to list issue comments");
+    }
+
+    #[tokio::test]
+    async fn list_review_comments_enriches_not_found_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/11/comments"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .list_review_comments(11)
+            .await
+            .expect_err("404 review comments should fail");
+        assert_auth_hint(err, "Failed to list review comments");
+    }
+
+    #[tokio::test]
+    async fn direct_get_pr_not_found_does_not_gain_auth_hint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/11"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client.get_pr(11).await.expect_err("missing PR should fail");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("Failed to get PR"), "{msg}");
+        assert!(msg.contains("Not Found"), "{msg}");
+        assert!(!msg.contains("stax auth --from-gh"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn merge_pr_not_found_does_not_gain_auth_hint() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/repos/test-owner/test-repo/pulls/11/merge"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let err = client
+            .merge_pr(11, MergeMethod::Squash, None, None, None)
+            .await
+            .expect_err("missing merge target should fail");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("Not Found"), "{msg}");
+        assert!(!msg.contains("stax auth --from-gh"), "{msg}");
     }
 
     fn issue_comment_fixture(id: u64, body: &str) -> serde_json::Value {

--- a/tests/comments_tests.rs
+++ b/tests/comments_tests.rs
@@ -281,3 +281,45 @@ async fn reviews_inbox_reports_comment_api_failures() {
     output.assert_failure();
     output.assert_stderr_contains("Failed to list issue comments");
 }
+
+#[tokio::test]
+async fn reviews_inbox_reports_actionable_auth_hint_for_not_found_comments() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    let home = repo.clean_home();
+    write_test_config(Path::new(&home), &server.uri());
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/test/repo.git",
+    ])
+    .assert_success();
+    let branch = repo.create_stack(&["auth-failed-review-fetch"]).remove(0);
+    write_branch_pr_metadata(&repo, &branch, "main", 45);
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test/repo/issues/45/comments"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "message": "Not Found"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/test/repo/pulls/45/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let output = repo.run_stax_with_env(
+        &["reviews", "--stack", "--json"],
+        &[("STAX_GITHUB_TOKEN", "mock-token")],
+    );
+
+    output.assert_failure();
+    output.assert_stderr_contains("Failed to list issue comments");
+    output.assert_stderr_contains("Not Found");
+    output.assert_stderr_contains("token is expired");
+    output.assert_stderr_contains("stax auth --from-gh");
+}


### PR DESCRIPTION
## Motivation

Some GitHub repository searches and review/comment reads return 404 when the token lacks repository access, producing misleading missing-resource errors without remediation.

## Description of changes / notes for reviewers

- add actionable token-permission context to selected 401/404 repository search and review/comment reads
- preserve the original operation and GitHub error in the error chain
- point users to `stax auth --from-gh` remediation
- avoid auth hints for server errors, direct missing-PR lookups, and mutations where 404 has normal resource semantics
- document the enriched error behavior and its boundaries

## Verification

- `cargo check`
- `make lint-fast`
- focused authorization and boundary tests — 11 passed
- `git diff --check`

Closes #757