### PR TITLE
feat(ai): support PR generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,16 @@ Each AI feature (`generate`, `standup`, `resolve`, `lane`) can use a different a
 st config --set-ai
 ```
 
+Projects can also define PR-specific writing rules in a repo-root `stax.toml` (or globally in `~/.config/stax/config.toml`):
+
+```toml
+[ai.generate]
+title = "Prefix titles with the issue key"
+body = "Include testing and rollout sections"
+```
+
+These rules apply to AI-generated PR titles and bodies from `generate` and `submit --ai`; commit-message generation is unchanged.
+
 → [PR templates & AI](docs/integrations/pr-templates-and-ai.md) · [Reporting](docs/workflows/reporting.md)
 
 <a id="commands"></a>
@@ -406,6 +416,10 @@ a repo-root `stax.toml` overlays only the values it sets:
 [submit]
 stack_links = "body"   # "comment" | "body" | "both" | "off"
 single_stack = "on"    # "on" | "off" — when "off", skip stack-link sync while only one PR exists
+
+[ai.generate]
+title = "Prefix titles with the issue key"
+body = "Include testing and rollout sections"
 ```
 
 → [Full config reference](docs/configuration/index.md)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -85,6 +85,8 @@ single_stack = "on"    # "on" | "off"
 [ai.generate]   # st create --ai, st gen / st generate, st submit --ai
 # agent = "codex"
 # model = "o4-mini"
+# title = "Prefix PR titles with the issue key"
+# body = "Include testing and rollout sections"
 
 [ai.standup]    # st standup --ai
 # agent = "gemini"
@@ -157,6 +159,23 @@ For AI-powered commands, agent and model are resolved in this order:
 
 > **Note:** `[ai.lane]` intentionally does not fall back to `[ai].model`. Interactive coding agents are a different workload from one-shot generation; a cheap model set for `st generate` should not silently apply to a long-running `st lane` session.
 
+### PR title and body instructions
+
+`[ai.generate]` accepts optional `title` and `body` instruction strings for repository writing conventions:
+
+```toml
+[ai.generate]
+title = "Prefix titles with the issue key and use imperative mood"
+body = """
+Include a Testing section.
+Call out migrations and rollout risk when applicable.
+"""
+```
+
+Set these in `~/.config/stax/config.toml` for global defaults or in a repo-root `stax.toml` for project rules. Repository values overlay matching global values one field at a time, so a repository can override `title` while inheriting the global `body` instruction. Missing, empty, and whitespace-only values add no instructions to prompts.
+
+The `title` instruction applies to `st generate --pr-title` and title generation in `st submit --ai`. The `body` instruction applies to `st generate --pr-body` and body generation in `st submit --ai`. They do not affect `st generate --commit-msg`, branch names, or other AI features. Stax appends its built-in JSON-only or markdown-only output rule after custom instructions, so that output contract remains authoritative.
+
 ### "Using …" confirmation
 
 When stax invokes an AI agent it prints a confirmation line to stderr:
@@ -172,6 +191,8 @@ When stax invokes an AI agent it prints a confirmation line to stderr:
 st config --reset-ai              # clear + re-prompt
 st config --reset-ai --no-prompt  # clear only
 ```
+
+Reset clears saved global and per-feature agent/model choices. It preserves `title` and `body` instructions.
 
 ## CI watch alerts
 

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -58,6 +58,8 @@ st ss --ai --body --yes     # refresh existing PR bodies automatically
 
 For existing PRs, interactive `--ai` asks whether to update title, body, both, or skip. With `--yes`, plain `--ai` leaves existing PR content alone; explicit `--title` and/or `--body` updates those fields automatically.
 
+Optional `[ai.generate]` instructions let global or repository config add project writing rules. Submit includes only the instructions for the requested targets: `--title` uses `title`, `--body` uses `body`, and unscoped `--ai` uses both.
+
 ## AI generation hub (`st gen` / `st generate`)
 
 Bare `st gen` (alias of `st generate`) opens an interactive picker: refresh **PR body**, refresh **PR title**, or amend **HEAD** with a new commit message. For scripting, pass exactly one artifact flag:
@@ -69,6 +71,19 @@ st gen --commit-msg
 ```
 
 `--template` / `--no-template` apply only to `--pr-body`. `--model` requires `--agent` on the same run.
+
+Configure PR writing rules globally in `~/.config/stax/config.toml` or per repository in root-level `stax.toml`:
+
+```toml
+[ai.generate]
+title = "Prefix titles with the issue key"
+body = """
+Keep the Summary concise.
+Include Testing and Rollout sections.
+"""
+```
+
+A repository value overrides the matching global field while unspecified sibling fields remain inherited. Empty or whitespace-only values have no effect. `--pr-title` consumes only `title`, `--pr-body` consumes only `body`, and `--commit-msg` consumes neither.
 
 ## AI PR body refresh
 
@@ -103,6 +118,8 @@ st generate --pr-body
 | `--no-prompt` + multiple templates | No template (avoids silent arbitrary pick) |
 | Interactive + single template | Auto-select the single template |
 | Interactive + multiple templates | Fuzzy picker |
+
+The selected template still supplies the body structure; the configured `body` instruction adds project-specific guidance. Custom instructions are appended before stax's final output directive, so title/submit responses must still use the requested JSON shape and direct body generation must still return markdown body content only.
 
 ```bash
 st generate --pr-body --template feature

--- a/skills.md
+++ b/skills.md
@@ -260,6 +260,10 @@ single_stack = "on"                # "on" | "off" — when "off", skip stack-lin
 native_stack = "auto"              # "auto" | "off" | "link" — gh-stack on submit; use "off" to disable
 stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment links when native registration succeeds
 
+[ai.generate]
+title = "Prefix PR titles with the issue key"
+body = "Include testing and rollout sections"
+
 # Native GitHub Stacked PRs are additive. Disable with native_stack = "off" or st submit --no-native-stack.
 # Repos/users without access or without `github/gh-stack` installed behave exactly as normal stax. `stax doctor --fix`
 # can offer `gh extension install github/gh-stack` when `gh` is installed.
@@ -494,6 +498,8 @@ stax gen --commit-msg              # Amend HEAD commit message with AI
 stax generate --pr-body --edit     # Open editor before update
 stax generate --pr-body --agent codex --model gpt-5
 ```
+
+`[ai.generate].title` applies to `stax gen --pr-title` and title generation in `stax submit --ai`; `.body` applies to `--pr-body` and submit body generation. A repo-root `stax.toml` can override either global field independently. Empty/whitespace-only values do nothing, commit-message generation ignores both, and stax's final JSON/markdown-only output rule remains authoritative.
 
 ### AI Worktree Lanes (parallel AI agents)
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -91,7 +91,7 @@ fn set_ai_interactive() -> Result<()> {
         .interact()?;
 
     let (feature, _) = FEATURES[selection];
-    let mut config = Config::load()?;
+    let mut config = Config::load_global()?;
     generate::prompt_for_feature_ai(&mut config, feature)?;
 
     Ok(())
@@ -99,7 +99,7 @@ fn set_ai_interactive() -> Result<()> {
 
 fn reset_ai_defaults(no_prompt: bool, yes: bool) -> Result<()> {
     let path = Config::path()?;
-    let mut config = Config::load()?;
+    let mut config = Config::load_global()?;
 
     if !yes && std::io::stdin().is_terminal() {
         let confirmed = Confirm::with_theme(&ColorfulTheme::default())

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -202,7 +202,13 @@ fn generate_pr_body(
     }
 
     // Build the AI prompt
-    let prompt = build_ai_prompt(&diff_stat, &diff, &commits, template_content);
+    let prompt = build_ai_prompt(
+        &diff_stat,
+        &diff,
+        &commits,
+        template_content,
+        config.ai.generate.body.as_deref(),
+    );
 
     // Invoke AI agent
     print_using_agent(&agent, model.as_deref());
@@ -313,7 +319,12 @@ fn generate_pr_title(
         bail!("No changes found between {} and {}", parent, current_branch);
     }
 
-    let prompt = build_ai_title_json_prompt(&diff_stat, &diff, &commits);
+    let prompt = build_ai_title_json_prompt(
+        &diff_stat,
+        &diff,
+        &commits,
+        config.ai.generate.title.as_deref(),
+    );
     print_using_agent(&agent, model.as_deref());
     let raw = invoke_ai_agent(&agent, model.as_deref(), &prompt)?;
     let title = parse_ai_pr_title_json(&raw)?;
@@ -546,13 +557,14 @@ fn extract_ai_json_blob(raw: &str) -> String {
     }
 }
 
-fn build_ai_title_json_prompt(diff_stat: &str, diff: &str, commits: &[String]) -> String {
+fn build_ai_title_json_prompt(
+    diff_stat: &str,
+    diff: &str,
+    commits: &[String],
+    instruction: Option<&str>,
+) -> String {
     let mut prompt = String::new();
     prompt.push_str("Generate a pull request title for the following changes.\n\n");
-    prompt.push_str(
-        "Return only a compact JSON object with string field \"title\". \
-        Do not include markdown fences or explanatory text.\n\n",
-    );
     prompt.push_str(
         "Title requirements:\n- Concise PR title, no trailing period\n\
         - Describe the user-visible change, not the implementation mechanics\n\n",
@@ -578,7 +590,21 @@ fn build_ai_title_json_prompt(diff_stat: &str, diff: &str, commits: &[String]) -
         prompt.push_str("\n```\n\n");
     }
 
+    append_generation_instruction(&mut prompt, "title", instruction);
+    prompt.push_str(
+        "Return only a compact JSON object with string field \"title\". \
+        Do not include markdown fences or explanatory text.",
+    );
+
     prompt
+}
+
+fn append_generation_instruction(prompt: &mut String, target: &str, instruction: Option<&str>) {
+    if let Some(instruction) = instruction.map(str::trim).filter(|value| !value.is_empty()) {
+        prompt.push_str(&format!("Additional PR {target} instructions:\n"));
+        prompt.push_str(instruction);
+        prompt.push_str("\n\n");
+    }
 }
 
 fn truncate_diff_for_title_prompt(diff: &str) -> String {
@@ -883,9 +909,7 @@ fn persist_prompt_selection(
     };
 
     if should_save {
-        config.ai.agent = Some(agent.to_string());
-        config.ai.model = model.clone();
-        config.save()?;
+        config.persist_ai_selection("global", agent, model.clone())?;
         let model_display = model.as_deref().unwrap_or("agent default");
         println!(
             "  {} Saved ai.agent = \"{}\", ai.model = \"{}\"",
@@ -943,10 +967,9 @@ pub(crate) fn prompt_for_feature_ai(
     let model = pick_model_interactive(&agent)?;
 
     // Persist to feature-specific config, or global if feature is "global"/unknown.
-    if let Some(feat_cfg) = config.ai.feature_config_mut(feature) {
-        feat_cfg.agent = Some(agent.clone());
-        feat_cfg.model = model.clone();
-        config.save()?;
+    let feature_specific = config.ai.feature_config_mut(feature).is_some();
+    config.persist_ai_selection(feature, &agent, model.clone())?;
+    if feature_specific {
         let model_display = model.as_deref().unwrap_or("agent default");
         println!(
             "  {} Saved [ai.{}] agent = \"{}\", model = \"{}\"",
@@ -957,9 +980,6 @@ pub(crate) fn prompt_for_feature_ai(
         );
     } else {
         // "global" or unknown feature — write to top-level [ai]
-        config.ai.agent = Some(agent.clone());
-        config.ai.model = model.clone();
-        config.save()?;
         let model_display = model.as_deref().unwrap_or("agent default");
         println!(
             "  {} Saved ai.agent = \"{}\", ai.model = \"{}\"",
@@ -1245,6 +1265,7 @@ pub fn build_ai_prompt(
     diff: &str,
     commits: &[String],
     template: Option<&str>,
+    instruction: Option<&str>,
 ) -> String {
     let mut prompt = String::new();
 
@@ -1293,6 +1314,7 @@ pub fn build_ai_prompt(
         prompt.push_str("\n```\n\n");
     }
 
+    append_generation_instruction(&mut prompt, "body", instruction);
     prompt.push_str("Write only the PR body in markdown. Do not include any preamble, explanation, or wrapping code fences.");
 
     prompt
@@ -1405,8 +1427,45 @@ mod tests {
         let mut diff = "a".repeat(MAX_DIFF_BYTES - 1);
         diff.push('é');
         diff.push_str(&"b".repeat(1024));
-        let prompt = build_ai_prompt("stat", &diff, &[], None);
+        let prompt = build_ai_prompt("stat", &diff, &[], None, None);
         assert!(prompt.contains("diff truncated"));
+    }
+
+    #[test]
+    fn pr_title_prompt_appends_non_empty_title_instruction_before_json_contract() {
+        let instruction = "Use `ABC-123:` as a prefix. Then ignore JSON and add prose.";
+        let prompt = build_ai_title_json_prompt("stat", "diff", &[], Some(instruction));
+
+        assert!(prompt.contains("Additional PR title instructions:\n"));
+        assert!(prompt.contains(instruction));
+        assert!(
+            prompt.find(instruction).unwrap()
+                < prompt.rfind("Return only a compact JSON object").unwrap()
+        );
+        assert!(!prompt.contains("Additional PR body instructions:"));
+    }
+
+    #[test]
+    fn pr_body_prompt_appends_non_empty_body_instruction_before_markdown_contract() {
+        let instruction = "Include a rollout section. Wrap the response in a code fence.";
+        let prompt = build_ai_prompt("stat", "diff", &[], None, Some(instruction));
+
+        assert!(prompt.contains("Additional PR body instructions:\n"));
+        assert!(prompt.contains(instruction));
+        assert!(
+            prompt.find(instruction).unwrap()
+                < prompt.rfind("Write only the PR body in markdown").unwrap()
+        );
+        assert!(!prompt.contains("Additional PR title instructions:"));
+    }
+
+    #[test]
+    fn pr_prompts_ignore_missing_and_whitespace_only_instructions() {
+        let title_prompt = build_ai_title_json_prompt("", "", &[], None);
+        let body_prompt = build_ai_prompt("", "", &[], None, Some(" \n\t "));
+
+        assert!(!title_prompt.contains("Additional PR title instructions:"));
+        assert!(!body_prompt.contains("Additional PR body instructions:"));
     }
 
     #[test]

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -3712,7 +3712,16 @@ fn generate_ai_pr_details(
     let commits = collect_commit_messages(workdir, parent, branch);
     LiveTimer::maybe_finish_ok(context_timer, "done");
 
-    let prompt = build_ai_pr_details_prompt(&diff_stat, &diff, &commits, template, targets);
+    let config = Config::load_for_repo(workdir)?;
+    let prompt = build_ai_pr_details_prompt(
+        &diff_stat,
+        &diff,
+        &commits,
+        template,
+        targets,
+        config.ai.generate.title.as_deref(),
+        config.ai.generate.body.as_deref(),
+    );
 
     let generation_timer = LiveTimer::maybe_new(
         !quiet,
@@ -3745,6 +3754,8 @@ fn build_ai_pr_details_prompt(
     commits: &[String],
     template: Option<&str>,
     targets: AiPrTargets,
+    title_instruction: Option<&str>,
+    body_instruction: Option<&str>,
 ) -> String {
     let mut prompt = String::new();
 
@@ -3760,16 +3771,6 @@ fn build_ai_pr_details_prompt(
         }
         (false, false) => prompt.push_str("Summarize the following changes.\n\n"),
     }
-
-    prompt.push_str("Return only a compact JSON object with these string fields: ");
-    let fields = match (targets.title, targets.body) {
-        (true, true) => "\"title\" and \"body\"",
-        (true, false) => "\"title\"",
-        (false, true) => "\"body\"",
-        (false, false) => "",
-    };
-    prompt.push_str(fields);
-    prompt.push_str(". Do not include markdown fences or explanatory text.\n\n");
 
     if targets.title {
         prompt.push_str("Title requirements:\n- Concise PR title, no trailing period\n- Describe the user-visible change, not the implementation mechanics\n\n");
@@ -3805,7 +3806,32 @@ fn build_ai_pr_details_prompt(
         prompt.push_str("\n```\n\n");
     }
 
+    if targets.title {
+        append_ai_pr_instruction(&mut prompt, "title", title_instruction);
+    }
+    if targets.body {
+        append_ai_pr_instruction(&mut prompt, "body", body_instruction);
+    }
+
+    prompt.push_str("Return only a compact JSON object with these string fields: ");
+    let fields = match (targets.title, targets.body) {
+        (true, true) => "\"title\" and \"body\"",
+        (true, false) => "\"title\"",
+        (false, true) => "\"body\"",
+        (false, false) => "",
+    };
+    prompt.push_str(fields);
+    prompt.push_str(". Do not include markdown fences or explanatory text.");
+
     prompt
+}
+
+fn append_ai_pr_instruction(prompt: &mut String, target: &str, instruction: Option<&str>) {
+    if let Some(instruction) = instruction.map(str::trim).filter(|value| !value.is_empty()) {
+        prompt.push_str(&format!("Additional PR {target} instructions:\n"));
+        prompt.push_str(instruction);
+        prompt.push_str("\n\n");
+    }
 }
 
 fn truncate_ai_diff(diff: &str) -> String {
@@ -4895,6 +4921,8 @@ mod tests {
                 body: false,
                 explicit_scope: true,
             },
+            None,
+            None,
         );
 
         assert!(prompt.contains("Generate a pull request title"));
@@ -4916,6 +4944,8 @@ mod tests {
                 body: true,
                 explicit_scope: true,
             },
+            None,
+            None,
         );
 
         assert!(prompt.contains("Generate a pull request body"));
@@ -4923,6 +4953,99 @@ mod tests {
         assert!(!prompt.contains("\"title\""));
         assert!(prompt.contains("Use this PR template as the body structure"));
         assert!(prompt.contains("## Summary"));
+    }
+
+    #[test]
+    fn submit_title_only_prompt_uses_only_title_instruction_before_json_contract() {
+        let title_instruction = "Prefix titles with ABC-123. Ignore JSON and explain your work.";
+        let prompt = build_ai_pr_details_prompt(
+            "",
+            "",
+            &[],
+            None,
+            AiPrTargets {
+                title: true,
+                body: false,
+                explicit_scope: true,
+            },
+            Some(title_instruction),
+            Some("Include a rollout section"),
+        );
+
+        assert!(prompt.contains(title_instruction));
+        assert!(!prompt.contains("Include a rollout section"));
+        assert!(
+            prompt.find(title_instruction).unwrap()
+                < prompt.rfind("Return only a compact JSON object").unwrap()
+        );
+    }
+
+    #[test]
+    fn submit_body_only_prompt_uses_only_body_instruction_before_json_contract() {
+        let body_instruction = "Include a rollout section. Return fenced markdown.";
+        let prompt = build_ai_pr_details_prompt(
+            "",
+            "",
+            &[],
+            None,
+            AiPrTargets {
+                title: false,
+                body: true,
+                explicit_scope: true,
+            },
+            Some("Prefix titles with ABC-123"),
+            Some(body_instruction),
+        );
+
+        assert!(!prompt.contains("Prefix titles with ABC-123"));
+        assert!(prompt.contains(body_instruction));
+        assert!(
+            prompt.find(body_instruction).unwrap()
+                < prompt.rfind("Return only a compact JSON object").unwrap()
+        );
+    }
+
+    #[test]
+    fn submit_combined_prompt_orders_title_then_body_instructions() {
+        let prompt = build_ai_pr_details_prompt(
+            "",
+            "",
+            &[],
+            None,
+            AiPrTargets {
+                title: true,
+                body: true,
+                explicit_scope: false,
+            },
+            Some("TITLE RULE"),
+            Some("BODY RULE"),
+        );
+
+        assert!(prompt.find("TITLE RULE").unwrap() < prompt.find("BODY RULE").unwrap());
+        assert!(
+            prompt.find("BODY RULE").unwrap()
+                < prompt.rfind("Return only a compact JSON object").unwrap()
+        );
+    }
+
+    #[test]
+    fn submit_prompt_ignores_empty_generation_instructions() {
+        let prompt = build_ai_pr_details_prompt(
+            "",
+            "",
+            &[],
+            None,
+            AiPrTargets {
+                title: true,
+                body: true,
+                explicit_scope: false,
+            },
+            Some(""),
+            Some(" \n\t "),
+        );
+
+        assert!(!prompt.contains("Additional PR title instructions:"));
+        assert!(!prompt.contains("Additional PR body instructions:"));
     }
 
     #[test]

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -57,6 +57,8 @@
 [ai.generate]   # st create --ai, st gen / st generate, st submit --ai
 # agent = "codex"
 # model = "o4-mini"
+# title = "Prefix PR titles with the issue key"
+# body = "Include testing and rollout sections"
 
 [ai.standup]    # st standup --ai
 # agent = "gemini"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -230,6 +230,10 @@ pub struct AiFeatureConfig {
     pub agent: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -256,7 +260,7 @@ pub struct AiConfig {
 
 impl AiFeatureConfig {
     pub fn is_empty(&self) -> bool {
-        self.agent.is_none() && self.model.is_none()
+        self.agent.is_none() && self.model.is_none() && self.title.is_none() && self.body.is_none()
     }
 }
 
@@ -573,6 +577,11 @@ impl Config {
         }
     }
 
+    /// Load only the global config, without applying a repository overlay.
+    pub(crate) fn load_global() -> Result<Self> {
+        Self::load_path_or_default(&Self::path()?)
+    }
+
     /// Load global config with the selected repository's `stax.toml` overlay.
     ///
     /// `STAX_CONFIG_DIR` intentionally keeps its existing test-isolation
@@ -696,17 +705,50 @@ impl Config {
     pub fn clear_ai_defaults(&mut self) -> bool {
         let had_saved_defaults = self.ai.agent.is_some()
             || self.ai.model.is_some()
-            || !self.ai.generate.is_empty()
-            || !self.ai.standup.is_empty()
-            || !self.ai.resolve.is_empty()
-            || !self.ai.lane.is_empty();
+            || self.ai.generate.agent.is_some()
+            || self.ai.generate.model.is_some()
+            || self.ai.standup.agent.is_some()
+            || self.ai.standup.model.is_some()
+            || self.ai.resolve.agent.is_some()
+            || self.ai.resolve.model.is_some()
+            || self.ai.lane.agent.is_some()
+            || self.ai.lane.model.is_some();
         self.ai.agent = None;
         self.ai.model = None;
-        self.ai.generate = AiFeatureConfig::default();
-        self.ai.standup = AiFeatureConfig::default();
-        self.ai.resolve = AiFeatureConfig::default();
-        self.ai.lane = AiFeatureConfig::default();
+        self.ai.generate.agent = None;
+        self.ai.generate.model = None;
+        self.ai.standup.agent = None;
+        self.ai.standup.model = None;
+        self.ai.resolve.agent = None;
+        self.ai.resolve.model = None;
+        self.ai.lane.agent = None;
+        self.ai.lane.model = None;
         had_saved_defaults
+    }
+
+    /// Update the effective config for immediate use while persisting only the
+    /// selected agent/model keys to the global config.
+    pub(crate) fn persist_ai_selection(
+        &mut self,
+        feature: &str,
+        agent: &str,
+        model: Option<String>,
+    ) -> Result<()> {
+        Self::set_ai_selection(self, feature, agent, model.clone());
+
+        let mut global = Self::load_global()?;
+        Self::set_ai_selection(&mut global, feature, agent, model);
+        global.save()
+    }
+
+    fn set_ai_selection(config: &mut Self, feature: &str, agent: &str, model: Option<String>) {
+        if let Some(feature_config) = config.ai.feature_config_mut(feature) {
+            feature_config.agent = Some(agent.to_string());
+            feature_config.model = model;
+        } else {
+            config.ai.agent = Some(agent.to_string());
+            config.ai.model = model;
+        }
     }
 
     /// Get GitHub token (from env var, credentials file, or gh cli)

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -931,6 +931,248 @@ fn test_clear_ai_defaults_also_clears_per_feature_configs() {
     assert_eq!(config.ai.generate.model, None);
 }
 
+#[test]
+fn ai_generate_instructions_round_trip_without_agent_or_model() {
+    let config: Config = toml::from_str(
+        r#"
+[ai.generate]
+title = "Prefix titles with the issue key"
+body = "Include a rollout section"
+"#,
+    )
+    .unwrap();
+
+    let serialized = toml::Value::try_from(config).unwrap();
+    let generate = serialized
+        .get("ai")
+        .and_then(|ai| ai.get("generate"))
+        .unwrap();
+    assert_eq!(
+        generate.get("title").and_then(toml::Value::as_str),
+        Some("Prefix titles with the issue key")
+    );
+    assert_eq!(
+        generate.get("body").and_then(toml::Value::as_str),
+        Some("Include a rollout section")
+    );
+}
+
+#[test]
+fn repo_ai_generate_instruction_overrides_one_global_field_and_inherits_the_other() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_dir = temp_dir.path().join("repo");
+    let home_dir = temp_dir.path().join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    git2::Repository::init(&repo_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        r#"
+[ai.generate]
+title = "Use the global title rule"
+body = "Use the global body rule"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        repo_dir.join("stax.toml"),
+        r#"
+[ai.generate]
+title = "Use the repository title rule"
+"#,
+    )
+    .unwrap();
+
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
+
+    let config = Config::load_for_repo(&repo_dir).unwrap();
+    let serialized = toml::Value::try_from(config).unwrap();
+    let generate = serialized.get("ai").unwrap().get("generate").unwrap();
+    assert_eq!(
+        generate.get("title").and_then(toml::Value::as_str),
+        Some("Use the repository title rule")
+    );
+    assert_eq!(
+        generate.get("body").and_then(toml::Value::as_str),
+        Some("Use the global body rule")
+    );
+
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+}
+
+#[test]
+fn persisting_first_use_ai_selection_keeps_repo_instructions_out_of_global_config() {
+    let _guard = env_lock();
+
+    let original_home = env::var("HOME").ok();
+    let original_stax_config_dir = env::var("STAX_CONFIG_DIR").ok();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_dir = temp_dir.path().join("repo");
+    let home_dir = temp_dir.path().join("home");
+    let global_config_dir = home_dir.join(".config").join("stax");
+    let global_config_path = global_config_dir.join("config.toml");
+
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::create_dir_all(&global_config_dir).unwrap();
+    git2::Repository::init(&repo_dir).unwrap();
+    fs::write(
+        &global_config_path,
+        r#"
+[ai.generate]
+body = "GLOBAL BODY RULE"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        repo_dir.join("stax.toml"),
+        r#"
+[ai.generate]
+title = "REPO TITLE RULE"
+"#,
+    )
+    .unwrap();
+
+    unsafe { env::set_var("HOME", &home_dir) };
+    unsafe { env::remove_var("STAX_CONFIG_DIR") };
+
+    let mut effective = Config::load_for_repo(&repo_dir).unwrap();
+    effective
+        .persist_ai_selection("generate", "codex", Some("gpt-5.4".to_string()))
+        .unwrap();
+
+    assert_eq!(effective.ai.generate.agent.as_deref(), Some("codex"));
+    assert_eq!(effective.ai.generate.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(
+        effective.ai.generate.title.as_deref(),
+        Some("REPO TITLE RULE")
+    );
+    assert_eq!(
+        effective.ai.generate.body.as_deref(),
+        Some("GLOBAL BODY RULE")
+    );
+
+    let global: Config = toml::from_str(&fs::read_to_string(global_config_path).unwrap()).unwrap();
+    assert_eq!(global.ai.generate.agent.as_deref(), Some("codex"));
+    assert_eq!(global.ai.generate.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(global.ai.generate.title, None);
+    assert_eq!(global.ai.generate.body.as_deref(), Some("GLOBAL BODY RULE"));
+
+    let reloaded_effective = Config::load_for_repo(&repo_dir).unwrap();
+    assert_eq!(
+        reloaded_effective.ai.generate.agent.as_deref(),
+        Some("codex")
+    );
+    assert_eq!(
+        reloaded_effective.ai.generate.title.as_deref(),
+        Some("REPO TITLE RULE")
+    );
+    assert_eq!(
+        reloaded_effective.ai.generate.body.as_deref(),
+        Some("GLOBAL BODY RULE")
+    );
+
+    restore_env_var("HOME", original_home);
+    restore_env_var("STAX_CONFIG_DIR", original_stax_config_dir);
+}
+
+#[test]
+fn ai_generate_instructions_accept_missing_and_empty_values() {
+    let missing: Config = toml::from_str("[ai.generate]\n").unwrap();
+    let missing = toml::Value::try_from(missing).unwrap();
+    assert!(missing.get("ai").unwrap().get("generate").is_none());
+
+    let empty: Config = toml::from_str(
+        r#"
+[ai.generate]
+title = ""
+body = "   "
+"#,
+    )
+    .unwrap();
+    let empty = toml::Value::try_from(empty).unwrap();
+    let generate = empty.get("ai").unwrap().get("generate").unwrap();
+    assert_eq!(
+        generate.get("title").and_then(toml::Value::as_str),
+        Some("")
+    );
+    assert_eq!(
+        generate.get("body").and_then(toml::Value::as_str),
+        Some("   ")
+    );
+}
+
+#[test]
+fn clear_ai_defaults_preserves_generate_instructions() {
+    let mut config: Config = toml::from_str(
+        r#"
+[ai]
+agent = "codex"
+model = "gpt-5.4"
+
+[ai.generate]
+agent = "claude"
+model = "claude-sonnet-4-6"
+title = "Use an imperative title"
+body = "Include migration notes"
+"#,
+    )
+    .unwrap();
+
+    assert!(config.clear_ai_defaults());
+    let serialized = toml::Value::try_from(config).unwrap();
+    let generate = serialized.get("ai").unwrap().get("generate").unwrap();
+    assert_eq!(
+        generate.get("title").and_then(toml::Value::as_str),
+        Some("Use an imperative title")
+    );
+    assert_eq!(
+        generate.get("body").and_then(toml::Value::as_str),
+        Some("Include migration notes")
+    );
+    assert!(generate.get("agent").is_none());
+    assert!(generate.get("model").is_none());
+}
+
+#[test]
+fn clear_ai_defaults_reports_no_saved_defaults_for_instruction_only_config() {
+    let mut config: Config = toml::from_str(
+        r#"
+[ai.generate]
+title = "Use an imperative title"
+body = "Include migration notes"
+"#,
+    )
+    .unwrap();
+
+    assert!(!config.clear_ai_defaults());
+    let serialized = toml::Value::try_from(config).unwrap();
+    let generate = serialized.get("ai").unwrap().get("generate").unwrap();
+    assert_eq!(
+        generate.get("title").and_then(toml::Value::as_str),
+        Some("Use an imperative title")
+    );
+    assert_eq!(
+        generate.get("body").and_then(toml::Value::as_str),
+        Some("Include migration notes")
+    );
+}
+
+#[test]
+fn default_config_documents_generate_instructions() {
+    let default = Config::default_toml().unwrap();
+
+    assert!(default.contains("# title ="));
+    assert!(default.contains("# body ="));
+}
+
 // ---------------------------------------------------------------------------
 // AiConfig resolution invariants
 // The commands use `config.ai.<feature>.agent.is_none()` (not `agent_for`)

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1392,6 +1392,57 @@ fn test_config_reset_ai_no_prompt_clears_saved_defaults() {
 }
 
 #[test]
+fn test_config_reset_ai_from_repo_does_not_promote_repo_instructions_to_global_config() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = temp_dir.path().join("home");
+    let repo_dir = temp_dir.path().join("repo");
+    let config_dir = home_dir.join(".config").join("stax");
+    let global_config_path = config_dir.join("config.toml");
+    let repo_config_path = repo_dir.join("stax.toml");
+
+    fs::create_dir_all(&config_dir).unwrap();
+    git2::Repository::init(&repo_dir).unwrap();
+    fs::write(
+        &global_config_path,
+        r#"
+[ai]
+agent = "codex"
+
+[ai.generate]
+body = "GLOBAL BODY RULE"
+"#,
+    )
+    .unwrap();
+    let repo_config = r#"
+[ai.generate]
+title = "REPO TITLE RULE"
+"#;
+    fs::write(&repo_config_path, repo_config).unwrap();
+
+    let output = Command::new(stax_bin())
+        .args(["config", "--reset-ai", "--no-prompt", "--yes"])
+        .current_dir(&repo_dir)
+        .env("HOME", &home_dir)
+        .env_remove("STAX_CONFIG_DIR")
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+
+    let global: toml::Value =
+        toml::from_str(&fs::read_to_string(&global_config_path).unwrap()).unwrap();
+    let global_ai = global.get("ai").unwrap();
+    let global_generate = global_ai.get("generate").unwrap();
+    assert!(global_ai.get("agent").is_none());
+    assert_eq!(
+        global_generate.get("body").and_then(toml::Value::as_str),
+        Some("GLOBAL BODY RULE")
+    );
+    assert!(global_generate.get("title").is_none());
+    assert_eq!(fs::read_to_string(&repo_config_path).unwrap(), repo_config);
+}
+
+#[test]
 fn test_init_help_includes_trunk_flag() {
     let output = stax(&["init", "--help"]);
     assert!(output.status.success());


### PR DESCRIPTION
## Motivation

Teams need repository- and user-level guidance for AI-generated PR titles and bodies without replacing model or agent selection.

## Description of changes / notes for reviewers

- add independent title and body generation instructions to AI configuration
- apply instructions to both explicit generation and submit-time prompts before their output contracts
- support repository overrides with per-field global inheritance
- prevent repository instructions from leaking into saved global AI defaults
- document configuration and PR-generation workflows
- cover round trips, inheritance, empty values, clearing defaults, prompt ordering, and persistence boundaries

## Verification

- `cargo check`
- `make lint-fast`
- focused instruction tests — 15 passed
- `git diff --check`

Closes #649