### PR TITLE
docs(watch): clarify iteration semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ st config --set-ai
 | `st ls` / `st ll` | Show stack health and PR status (`st ll` adds PR URLs/details) |
 | `st watch` | Live auto-refreshing stack status with CI and PR state (adaptive polling: 15s active CI → 60s open PRs → 120s idle) |
 | `st watch --current` | Watch only the current stack |
+| `st watch --iterations <N>` | Run exactly `N` total refreshes (`1` renders exactly once; `0` is invalid), then exit without sleeping; for `N > 1`, use `--interval <seconds>` to set the delay between refreshes |
 | `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -164,7 +164,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st changelog --find [query]` | Flag form of commit fuzzy-find |
 | `st generate` · `st gen` | AI generation: interactive picker, or `--pr-body` / `--pr-title` / `--commit-msg` |
 | `st ss --ai` | Submit with AI-generated PR title/body suggestions |
-| `st watch` | Live auto-refreshing stack status with CI and PR state (`--current`, `--interval <seconds>`) |
+| `st watch` | Live auto-refreshing stack status with CI and PR state (`--current`, `--interval <seconds>`); `--iterations <N>` performs exactly `N` total refreshes (`1` renders exactly once; `0` is rejected), then returns without a final sleep. For `N > 1`, use `--interval <seconds>` to control the delay between refreshes. |
 
 ## Utilities
 

--- a/skills.md
+++ b/skills.md
@@ -461,9 +461,14 @@ stax ci --refresh                  # Force refresh (bypass cache)
 stax ci --json                     # Machine-readable output
 stax ci --verbose                  # Compact summary cards (grouped failed/running/passed per branch)
 
+stax watch --iterations 1          # Render exactly one refresh, then exit
+stax watch --iterations N --interval <seconds>  # Run N total refreshes with a delay between them
+
 # Oneline roll-up: status icon · branch · #PR · draft/ready · title · check-count + timing.
 # Single branch shows the full per-check table; any multi-branch view defaults to oneline;
 # --verbose forces the grouped cards. --oneline conflicts with --verbose.
+
+`--iterations` counts total refreshes: `1` renders exactly once, `0` is invalid, and a bounded run never sleeps after its final refresh. For `N > 1`, use `--interval <seconds>` to set the delay between refreshes.
 
 # ~/.config/stax/config.toml
 [ci]


### PR DESCRIPTION
## Motivation

The command reference and agent guide did not explain how `st watch --iterations` counts refreshes or interacts with the initial render.

## Description of changes / notes for reviewers

- document `--iterations` in the command reference
- clarify that the initial render is not counted as a polling iteration
- add a concise bounded-watch example to README and `skills.md`

## Verification

- `cargo check`
- `make lint-fast`
- `git diff --check`

Documentation note: no runtime behavior changed, so no focused runtime test was required.

Closes #761