### PR TITLE
fix(submit): open a PR via a fork when you lack write access

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st ss` | Submit the full stack, open/update linked PRs; temporary-publishes branches that need restack |
 | `st submit --plan [--json]` | Preview fetch, push, PR, retarget, metadata, and stack-link actions without changing local or remote state |
 | `st branch submit` | Submit only the current branch; can publish a temporary rebased head when needed |
+| `st branch submit --fork` | On a denied-for-lack-of-write-access push, retry from a GitHub fork of the upstream repo (single branch; set `[remote] auto_fork = true` for always-on) |
 | `st upstack submit` | Submit current branch and descendants, chaining temporary publish heads when needed |
 | `st reviews --stack [--json]` | Stack-wide review/comment inbox, including inline file/line locations on GitHub (`st comments` remains the current-PR view) |
 | `st next` | Move to the next unmerged branch upstack; fork choices are deterministic |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -292,9 +292,10 @@ If the stash cannot apply cleanly while committing below, Stax restores the orig
 - `--template <name>` / `--no-template` / `--edit`
 - `--rerequest-review` / `--update-title`
 - `--native-stack` force-attempt native GitHub Stack registration for this submit; `--no-native-stack` skips it
+- `--fork` if the upstream push is denied for lack of write access, fall back to submitting the branch from a fork (single branch, GitHub only)
 - `--yes` / `--no-prompt`
 
-Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` and `native_stack = "auto" | "off" | "link"` in `~/.config/stax/config.toml`.
+Config: `[submit] stack_links = "comment" | "body" | "both" | "off"` and `native_stack = "auto" | "off" | "link"`; `[remote] auto_fork` and `[remote] fork_remote` control the fork fallback — see [Configuration → Fork fallback for submit](../configuration/index.md#fork-fallback-for-submit).
 
 ### `st completions`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -312,9 +312,10 @@ fork_remote = "fork"      # optional: reuse an existing git remote you added you
 Or use `stax branch submit --fork` for a one-off. When enabled:
 
 - stax reuses a pushable fork under your GitHub login, or creates one via the GitHub API when none exists.
-- the branch is pushed with `--force-with-lease` (no bare `--force`); a diverged fork branch fails actionably rather than silently overwriting it.
-- the PR is opened with head `<fork_owner>:<branch>` and `maintainer_can_modify = true`.
-- an existing git remote named `fork` is never silently repointed; the run fails if its URL conflicts.
+- the branch is pushed with `--force-with-lease` (never a bare `--force`); the first time stax publishes a branch to your fork it refuses to overwrite an existing fork branch whose tip is not already contained in your local branch. stax records what it published in `refs/stax/fork-published/<remote>/<branch>` so later restacks still force-push cleanly.
+- the PR is opened with head `<fork_owner>:<branch>`; `maintainer_can_modify` is set on fork PRs only.
+- an existing fork remote (`fork`, or your `remote.fork_remote` name) is never silently repointed; the run fails before any fork is created on GitHub.
+- when stax creates the fork for you, it waits for GitHub to finish creating the repo (fork creation is asynchronous) before pushing, up to ~2 minutes.
 
 Supported forges: GitHub only. Fork fallback rejects GitLab/Gitea cleanly.
 Scope: single branch only. A multi-branch stack cannot be submitted from a fork because a stacked child PR's base branch cannot live in the upstream repo.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -45,6 +45,8 @@ single_stack = "on"    # "on" | "off"
 # base_url = "https://github.com"
 # api_base_url = "https://github.company.com/api/v3"
 # forge = "github" # "github" | "gitlab" | "gitea" — override auto-detection
+# auto_fork = false # always fall back to submitting from a fork when the upstream push is denied
+# fork_remote = "fork" # name of a pre-configured git remote for the fork (skip auto-detect)
 
 [submit]
 # stack_links = "comment" # "comment" | "body" | "both" | "off"
@@ -296,6 +298,27 @@ forge = "gitlab"
 Accepted values: `"github"`, `"gitlab"`, `"gitea"`, `"forgejo"` (Forgejo is treated as Gitea).
 
 Auto-detection fallback: hostnames containing `gitlab` → GitLab, `gitea`/`forgejo` → Gitea, otherwise → GitHub.
+
+## Fork fallback for submit
+
+When `stax branch submit` pushes to an upstream you lack write access to, GitHub rejects the push. Opt in to a fork-based fallback so stax re-runs the push against your fork instead:
+
+```toml
+[remote]
+auto_fork = true          # always fall back to a fork on permission-denied push
+fork_remote = "fork"      # optional: reuse an existing git remote you added yourself
+```
+
+Or use `stax branch submit --fork` for a one-off. When enabled:
+
+- stax reuses a pushable fork under your GitHub login, or creates one via the GitHub API when none exists.
+- the branch is pushed with `--force-with-lease` (no bare `--force`); a diverged fork branch fails actionably rather than silently overwriting it.
+- the PR is opened with head `<fork_owner>:<branch>` and `maintainer_can_modify = true`.
+- an existing git remote named `fork` is never silently repointed; the run fails if its URL conflicts.
+
+Supported forges: GitHub only. Fork fallback rejects GitLab/Gitea cleanly.
+Scope: single branch only. A multi-branch stack cannot be submitted from a fork because a stacked child PR's base branch cannot live in the upstream repo.
+The base branch must already exist upstream.
 
 ### Automatic CI hydration trust
 

--- a/skills.md
+++ b/skills.md
@@ -251,6 +251,7 @@ stax submit --ai --yes             # Accept generated new-PR details
 stax submit --rerequest-review     # Re-request existing reviewers on update
 stax submit --native-stack         # Force-attempt native GitHub Stack registration for this run
 stax submit --no-native-stack      # Skip native GitHub Stack registration for this run
+stax submit --fork                 # Fall back to fork on permission-denied push (single branch, GitHub only)
 stax completions zsh               # Generate completions: bash|zsh|fish|powershell|elvish
 
 # ~/.config/stax/config.toml; repo-root stax.toml overlays shared values
@@ -265,6 +266,10 @@ stack_links_when_native = "keep"   # "keep" | "off" — keep stax body/comment l
 [ai.generate]
 title = "Prefix PR titles with the issue key"
 body = "Include testing and rollout sections"
+
+[remote]
+auto_fork = false                  # always fall back to `--fork` when the upstream push is denied for lack of write access
+fork_remote = "fork"               # name of a pre-configured git remote for the fork (skip auto-detect)
 
 # Native GitHub Stacked PRs are additive. Disable with native_stack = "off" or st submit --no-native-stack.
 # Repos/users without access or without `github/gh-stack` installed behave exactly as normal stax. `stax doctor --fix`

--- a/src/application/submit.rs
+++ b/src/application/submit.rs
@@ -728,7 +728,7 @@ pub fn push_error_indicates_no_write_access(msg: &str) -> bool {
 /// fork/upstream branch has diverged from what we last saw.
 pub fn push_error_indicates_stale_lease(msg: &str) -> bool {
     let lower = msg.to_ascii_lowercase();
-    lower.contains("stale info") || lower.contains("(stale info)")
+    lower.contains("stale info")
 }
 
 fn execute_prepared_submit_inner(

--- a/src/application/submit.rs
+++ b/src/application/submit.rs
@@ -693,6 +693,29 @@ pub(crate) fn push_failure_details(stdout: &str, stderr: &str) -> String {
     }
 }
 
+/// True when a `push_branches` failure message indicates the remote rejected
+/// the push for lack of write access, as opposed to a normal non-fast-forward
+/// or stale-ref rejection. Misreading the latter as a permission error would
+/// silently divert a legitimate push to a fork, so this matches only on
+/// git/GitHub's specific permission-denial vocabulary rather than the
+/// generic "rejected" wording shared by every kind of push failure.
+///
+/// "pre-receive hook declined" alone can be a server-side policy rejection
+/// unrelated to permissions (e.g. a commit message or lint check), so it
+/// only counts here alongside an explicit permission/authorization phrase.
+pub fn push_error_indicates_no_write_access(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("permission to")
+        || lower.contains("403")
+        || lower.contains("denied to")
+        || lower.contains("not authorized")
+    {
+        return true;
+    }
+    lower.contains("pre-receive hook declined")
+        && (lower.contains("permission") || lower.contains("not authorized"))
+}
+
 fn execute_prepared_submit_inner(
     session: &RepositorySession,
     prepared: PreparedSubmit,
@@ -1435,5 +1458,35 @@ mod tests {
             super::branches_for_submit_scope(&stack, "main", super::SubmitScope::Branch),
             empty
         );
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_matches_https_permission_denial() {
+        let msg = "Failed to push branches feature:\nremote: Permission to owner/repo.git denied to someuser.\nfatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403";
+        assert!(super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_matches_ssh_permission_denial() {
+        let msg = "ERROR: Permission to owner/repo.git denied to deploy-key.\nfatal: Could not read from remote repository.";
+        assert!(super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_matches_bare_403() {
+        let msg = "fatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403";
+        assert!(super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_rejects_non_fast_forward() {
+        let msg = "Failed to push branches feature: rejected feature\n! [rejected]        feature -> feature (fetch first)\nerror: failed to push some refs\nhint: Updates were rejected because the remote contains work that you do not have locally.";
+        assert!(!super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_rejects_stale_info() {
+        let msg = "Failed to push branches feature: rejected feature\n! [rejected]        feature -> feature (stale info)";
+        assert!(!super::push_error_indicates_no_write_access(msg));
     }
 }

--- a/src/application/submit.rs
+++ b/src/application/submit.rs
@@ -703,10 +703,17 @@ pub(crate) fn push_failure_details(stdout: &str, stderr: &str) -> String {
 /// "pre-receive hook declined" alone can be a server-side policy rejection
 /// unrelated to permissions (e.g. a commit message or lint check), so it
 /// only counts here alongside an explicit permission/authorization phrase.
+///
+/// The message embeds the raw push stdout/stderr, which includes branch names
+/// and commit SHAs, so a bare "403" substring is not safe to match: a
+/// non-fast-forward rejection on a branch named `fix-403` would look like a
+/// permission denial. Match the full transport phrases instead.
 pub fn push_error_indicates_no_write_access(msg: &str) -> bool {
     let lower = msg.to_ascii_lowercase();
     if lower.contains("permission to")
-        || lower.contains("403")
+        || lower.contains("returned error: 403")
+        || lower.contains("403 forbidden")
+        || lower.contains("write access to repository not granted")
         || lower.contains("denied to")
         || lower.contains("not authorized")
     {
@@ -714,6 +721,14 @@ pub fn push_error_indicates_no_write_access(msg: &str) -> bool {
     }
     lower.contains("pre-receive hook declined")
         && (lower.contains("permission") || lower.contains("not authorized"))
+}
+
+/// True when a `push_branches` failure message indicates git rejected the push
+/// because the remote ref advanced beyond the lease's expected OID, i.e. the
+/// fork/upstream branch has diverged from what we last saw.
+pub fn push_error_indicates_stale_lease(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("stale info") || lower.contains("(stale info)")
 }
 
 fn execute_prepared_submit_inner(
@@ -1488,5 +1503,23 @@ mod tests {
     fn push_error_indicates_no_write_access_rejects_stale_info() {
         let msg = "Failed to push branches feature: rejected feature\n! [rejected]        feature -> feature (stale info)";
         assert!(!super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_rejects_non_fast_forward_on_403_named_branch() {
+        let msg = "Failed to push branches fix-403: rejected fix-403\n! [rejected]        fix-403 -> fix-403 (fetch first)\nerror: failed to push some refs to 'https://github.com/owner/repo.git'";
+        assert!(!super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_matches_permission_denial_on_403_named_branch() {
+        let msg = "Failed to push branches fix-403:\nremote: Permission to owner/repo.git denied to someuser.\nfatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403";
+        assert!(super::push_error_indicates_no_write_access(msg));
+    }
+
+    #[test]
+    fn push_error_indicates_no_write_access_matches_write_access_not_granted() {
+        let msg = "remote: Write access to repository not granted.\nfatal: unable to access 'https://github.com/owner/repo.git/'";
+        assert!(super::push_error_indicates_no_write_access(msg));
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -136,6 +136,10 @@ pub(crate) struct SubmitOptions {
     /// Update existing PR titles when the tip commit subject has changed
     #[arg(long)]
     pub(crate) update_title: bool,
+    /// If the push is rejected for lack of write access, submit from a fork
+    /// of the upstream repo instead (single branch only)
+    #[arg(long)]
+    pub(crate) fork: bool,
 }
 
 impl From<SubmitOptions> for commands::submit::SubmitOptions {
@@ -174,6 +178,7 @@ impl From<SubmitOptions> for commands::submit::SubmitOptions {
             },
             squash: submit.squash,
             update_title: submit.update_title,
+            fork: submit.fork,
         }
     }
 }

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,6 +1,7 @@
 pub(crate) use crate::application::SubmitScope;
 use crate::application::submit::{
     PushSpec, TemporaryPublishRefs, TemporarySubmitWorktree, push_branches,
+    push_error_indicates_no_write_access,
 };
 use crate::commands::open::open_url_in_browser;
 use crate::config::{
@@ -60,6 +61,9 @@ pub struct SubmitOptions {
     pub native_stack_override: Option<NativeStackMode>,
     pub squash: bool,
     pub update_title: bool,
+    /// Fall back to submitting from a fork when the push is rejected for
+    /// lack of write access to the upstream remote.
+    pub fork: bool,
 }
 
 struct PrPlan {
@@ -491,6 +495,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         native_stack_override,
         squash,
         update_title,
+        fork,
     } = options;
 
     let ai_targets = resolve_ai_targets(ai, ai_title, body_scope, update_title)?;
@@ -1502,6 +1507,8 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         None
     };
 
+    let mut fork_owner: Option<String> = None;
+
     if !branches_needing_push.is_empty() {
         if !quiet {
             println!();
@@ -1564,11 +1571,128 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 LiveTimer::maybe_finish_ok(push_timer, "done");
             }
             Err(e) => {
-                LiveTimer::maybe_finish_err(push_timer, "failed");
-                if let Some(tx) = tx {
-                    tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
+                if !push_error_indicates_no_write_access(&e.to_string()) {
+                    LiveTimer::maybe_finish_err(push_timer, "failed");
+                    if let Some(tx) = tx {
+                        tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
+                    }
+                    return Err(e);
                 }
-                return Err(e);
+
+                if !(fork || config.auto_fork()) {
+                    LiveTimer::maybe_finish_err(push_timer, "failed");
+                    if let Some(tx) = tx {
+                        tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
+                    }
+                    anyhow::bail!(
+                        "No push access to {}/{}. Re-run with `--fork` (or set `remote.auto_fork = true`) \
+                         to open the PR from a fork.\n{e}",
+                        remote_info.owner(),
+                        remote_info.repo,
+                    );
+                }
+
+                if pushed_branches.len() != 1 {
+                    LiveTimer::maybe_finish_err(push_timer, "failed");
+                    if let Some(tx) = tx {
+                        tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
+                    }
+                    anyhow::bail!(
+                        "fork submit supports a single branch; stacked PRs against an upstream you can't push to aren't supported."
+                    );
+                }
+
+                let fork_branch_parent = branches_needing_push[0].parent.clone();
+                if !remote_branches.contains(&fork_branch_parent) {
+                    LiveTimer::maybe_finish_err(push_timer, "failed");
+                    if let Some(tx) = tx {
+                        tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
+                    }
+                    anyhow::bail!(
+                        "Cannot submit from a fork: base branch '{}' does not exist on {}.",
+                        fork_branch_parent,
+                        remote_info.name,
+                    );
+                }
+
+                if !quiet {
+                    println!(
+                        "  {} No push access to {}/{} — retrying from a fork...",
+                        "!".yellow(),
+                        remote_info.owner(),
+                        remote_info.repo,
+                    );
+                }
+
+                let fork_rt = tokio::runtime::Runtime::new()?;
+                let _fork_rt_enter = fork_rt.enter();
+                let fork_client = ForgeClient::new(&remote_info)?;
+                let login = fork_rt.block_on(async { fork_client.get_current_user().await })?;
+
+                let (fork_remote_name, resolved_owner, fork_freshly_created) = if let Some(name) =
+                    config.fork_remote().filter(|name| repo.remote_exists(name))
+                {
+                    (name.to_string(), login.clone(), false)
+                } else {
+                    let existing =
+                        fork_rt.block_on(async { fork_client.find_pushable_fork(&login).await })?;
+                    let (target, freshly_created) = match existing {
+                        Some(target) => (target, false),
+                        None => (
+                            fork_rt.block_on(async { fork_client.create_fork().await })?,
+                            true,
+                        ),
+                    };
+                    let origin_url = remote::get_remote_url(repo.workdir()?, &remote_info.name)?;
+                    let is_https =
+                        origin_url.starts_with("http://") || origin_url.starts_with("https://");
+                    let fork_url = if is_https {
+                        target.https_url.clone()
+                    } else {
+                        target.ssh_url.clone()
+                    };
+                    repo.ensure_remote("fork", &fork_url)?;
+                    ("fork".to_string(), target.owner, freshly_created)
+                };
+
+                let fork_spec = &pushed_branches[0];
+                let mut attempt = 0;
+                loop {
+                    attempt += 1;
+                    match repo.push_branch_to_fork(&fork_remote_name, &fork_spec.branch) {
+                        Ok(()) => break,
+                        Err(_) if fork_freshly_created && attempt < 3 => {
+                            eprintln!(
+                                "  {} waiting 2s before retrying push to fork...",
+                                "!".yellow()
+                            );
+                            std::thread::sleep(Duration::from_secs(2));
+                        }
+                        Err(push_err) => {
+                            LiveTimer::maybe_finish_err(push_timer, "failed");
+                            if let Some(tx) = tx {
+                                tx.finish_err(
+                                    &format!("Fork push failed: {}", push_err),
+                                    Some("push"),
+                                    None,
+                                )?;
+                            }
+                            return Err(push_err);
+                        }
+                    }
+                }
+
+                for spec in &pushed_branches {
+                    if let Some(ref mut tx) = tx {
+                        let _ = tx.record_after(&repo, &spec.branch);
+                        if let Some(oid) = &spec.oid {
+                            tx.record_remote_after(&fork_remote_name, &spec.branch, oid);
+                        }
+                    }
+                }
+                LiveTimer::maybe_finish_ok(push_timer, "done (via fork)");
+
+                fork_owner = Some(resolved_owner);
             }
         }
     }
@@ -1858,8 +1982,12 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 let create_timer =
                     LiveTimer::maybe_new(!quiet, &format!("Creating {}...", plan.branch));
 
+                let head = match &fork_owner {
+                    Some(owner) => format!("{owner}:{}", plan.branch),
+                    None => plan.branch.clone(),
+                };
                 let pr = match client
-                    .create_pr(&plan.branch, &plan.parent, title, body, is_draft)
+                    .create_pr(&head, &plan.parent, title, body, is_draft)
                     .await
                 {
                     Ok(pr) => {

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1595,13 +1595,13 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     );
                 }
 
-                if pushed_branches.len() != 1 {
+                if plans.len() != 1 {
                     LiveTimer::maybe_finish_err(push_timer, "failed");
                     if let Some(tx) = tx {
                         tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
                     }
                     anyhow::bail!(
-                        "fork submit supports a single branch; stacked PRs against an upstream you can't push to aren't supported."
+                        "fork submit supports a single branch; stacked PRs against an upstream you can't push to aren't supported.\n{e}"
                     );
                 }
 
@@ -1612,7 +1612,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                         tx.finish_err(&format!("Push failed: {}", e), Some("push"), None)?;
                     }
                     anyhow::bail!(
-                        "Cannot submit from a fork: base branch '{}' does not exist on {}.",
+                        "Cannot submit from a fork: base branch '{}' does not exist on {}.\n{e}",
                         fork_branch_parent,
                         remote_info.name,
                     );
@@ -1655,23 +1655,58 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 };
                 let login = fork_rt.block_on(async { fork_client.get_current_user().await })?;
 
-                let (fork_remote_name, resolved_owner, fork_freshly_created) = if let Some(name) =
-                    config.fork_remote().filter(|name| repo.remote_exists(name))
+                let fork_remote_configured = config.fork_remote().is_some();
+                let fork_remote_name = config.fork_remote().unwrap_or("fork").to_string();
+
+                let (resolved_owner, fork_freshly_created) = if fork_remote_configured
+                    && repo.remote_exists(&fork_remote_name)
                 {
                     // Trust the user-configured fork remote's URL for the owner
                     // rather than assuming the authenticated login: a fork under
                     // an org would otherwise be qualified with the wrong owner in
                     // `owner:branch`.
-                    let configured_url = remote::get_remote_url(repo.workdir()?, name)?;
+                    let configured_url =
+                        remote::get_remote_url(repo.workdir()?, &fork_remote_name)?;
                     let owner_from_url = remote::parse_remote_url(&configured_url)
                         .ok()
                         .and_then(|(_, path)| path.split('/').next().map(str::to_string))
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| login.clone());
-                    (name.to_string(), owner_from_url, false)
+                    (owner_from_url, false)
                 } else {
+                    let origin_url = remote::get_remote_url(repo.workdir()?, &remote_info.name)?;
+                    let is_https =
+                        origin_url.starts_with("http://") || origin_url.starts_with("https://");
                     let existing =
                         fork_rt.block_on(async { fork_client.find_pushable_fork(&login).await })?;
+
+                    // Pre-create conflict check: use the real URL when a fork already
+                    // exists, otherwise the predicted URL for `login` — we know the
+                    // target owner before ever calling `create_fork()`.
+                    let candidate_url = match &existing {
+                        Some(target) => {
+                            if is_https {
+                                target.https_url.clone()
+                            } else {
+                                target.ssh_url.clone()
+                            }
+                        }
+                        None => remote::fork_url_for_owner(&origin_url, &login)?,
+                    };
+                    if let Err(conflict) =
+                        ensure_fork_remote_url_free(&repo, &fork_remote_name, &candidate_url)
+                    {
+                        LiveTimer::maybe_finish_err(push_timer, "failed");
+                        if let Some(tx) = tx {
+                            tx.finish_err(
+                                &format!("Fork remote conflict: {}", conflict),
+                                Some("push"),
+                                None,
+                            )?;
+                        }
+                        return Err(conflict);
+                    }
+
                     let (target, freshly_created) = match existing {
                         Some(target) => (target, false),
                         None => (
@@ -1679,28 +1714,28 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                             true,
                         ),
                     };
-                    let origin_url = remote::get_remote_url(repo.workdir()?, &remote_info.name)?;
-                    let is_https =
-                        origin_url.starts_with("http://") || origin_url.starts_with("https://");
                     let fork_url = if is_https {
                         target.https_url.clone()
                     } else {
                         target.ssh_url.clone()
                     };
-                    // Don't silently repoint an existing `fork` remote at a
-                    // different URL — that could send commits to the wrong repo.
-                    if let Some(existing_url) = repo.remote_url("fork")?
-                        && existing_url != fork_url
+                    // Re-check with the URL GitHub actually returned (cheap; guards a
+                    // name mismatch against the predicted URL above).
+                    if let Err(conflict) =
+                        ensure_fork_remote_url_free(&repo, &fork_remote_name, &fork_url)
                     {
-                        anyhow::bail!(
-                            "A git remote named `fork` already exists and points at {existing_url}, \
-                             but the auto-detected fork URL is {fork_url}. \
-                             Remove or re-point the existing `fork` remote, or set \
-                             `remote.fork_remote` to the name of an existing remote."
-                        );
+                        LiveTimer::maybe_finish_err(push_timer, "failed");
+                        if let Some(tx) = tx {
+                            tx.finish_err(
+                                &format!("Fork remote conflict: {}", conflict),
+                                Some("push"),
+                                None,
+                            )?;
+                        }
+                        return Err(conflict);
                     }
-                    repo.ensure_remote("fork", &fork_url)?;
-                    ("fork".to_string(), target.owner, freshly_created)
+                    repo.ensure_remote(&fork_remote_name, &fork_url)?;
+                    (target.owner, freshly_created)
                 };
 
                 // Reuse `push_branches` so the fork push honours `source_ref`
@@ -1709,54 +1744,104 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 // which would silently overwrite work that another tool advanced.
                 let fork_workdir = repo.workdir()?.to_path_buf();
                 let fork_spec_template = pushed_branches[0].clone();
-                let mut attempt = 0;
-                loop {
-                    attempt += 1;
-                    let fork_heads = remote::ls_remote_head_oids(&fork_workdir, &fork_remote_name)
-                        .unwrap_or_default();
-                    let expected = fork_heads.get(&fork_spec_template.branch).cloned();
-                    let fork_spec = PushSpec {
-                        expected_remote_oid: expected,
-                        ..fork_spec_template.clone()
-                    };
-                    match push_branches(
+                let fork_branch = fork_spec_template.branch.clone();
+
+                if fork_freshly_created {
+                    wait_for_fork_ready(fork_rt, fork_client, &resolved_owner, quiet);
+                }
+
+                let fork_heads = remote::ls_remote_head_oids(&fork_workdir, &fork_remote_name)
+                    .unwrap_or_default();
+                let live_fork_tip = fork_heads.get(&fork_branch).cloned();
+                let published = crate::git::refs::read_fork_published(
+                    repo.inner(),
+                    &fork_remote_name,
+                    &fork_branch,
+                )?;
+                let local_tip = fork_spec_template
+                    .oid
+                    .clone()
+                    .or_else(|| rev_parse_ref(Some(&fork_workdir), &fork_spec_template.source_ref));
+
+                // Only enforce on the first-ever publish of this branch to this fork
+                // remote — i.e. whenever the fork tip is not exactly what stax last
+                // pushed. A restack legitimately rewrites history and must keep
+                // force-pushing without a false bail.
+                if let Some(fork_tip) = &live_fork_tip
+                    && published.as_deref() != Some(fork_tip.as_str())
+                {
+                    let _ = remote::fetch_remote_refs(
                         &fork_workdir,
                         &fork_remote_name,
-                        std::slice::from_ref(&fork_spec),
-                        no_verify,
-                    ) {
-                        Ok(()) => break,
-                        Err(err) if fork_freshly_created && attempt < 3 => {
-                            eprintln!(
-                                "  {} waiting 2s before retrying push to fork ({err})...",
-                                "!".yellow()
+                        std::slice::from_ref(&fork_branch),
+                    );
+                    let _ = repo.inner().odb().and_then(|odb| odb.refresh());
+                    let contained = local_tip
+                        .as_deref()
+                        .and_then(|local| repo.is_ancestor(fork_tip, local).ok())
+                        .unwrap_or(false);
+                    if !contained {
+                        LiveTimer::maybe_finish_err(push_timer, "failed");
+                        if let Some(tx) = tx {
+                            tx.finish_err(
+                                "Fork push aborted: fork branch would be overwritten",
+                                Some("push"),
+                                None,
+                            )?;
+                        }
+                        anyhow::bail!(
+                            "Refusing to overwrite branch `{fork_branch}` on fork remote \
+                             `{fork_remote_name}`: its tip {fork_tip} is not contained in the \
+                             local branch and stax has no record of publishing it. If that \
+                             branch on the fork is stale, delete it (`git push {fork_remote_name} \
+                             --delete {fork_branch}`) and re-run, or set `remote.fork_remote` to \
+                             a different remote."
+                        );
+                    }
+                }
+
+                let fork_spec = PushSpec {
+                    expected_remote_oid: live_fork_tip.clone(),
+                    ..fork_spec_template.clone()
+                };
+                match push_branches(
+                    &fork_workdir,
+                    &fork_remote_name,
+                    std::slice::from_ref(&fork_spec),
+                    no_verify,
+                ) {
+                    Ok(()) => {
+                        if let Some(oid) = &local_tip {
+                            let _ = crate::git::refs::write_fork_published_at(
+                                &fork_workdir,
+                                &fork_remote_name,
+                                &fork_branch,
+                                oid,
                             );
-                            std::thread::sleep(Duration::from_secs(2));
                         }
-                        Err(push_err) => {
-                            LiveTimer::maybe_finish_err(push_timer, "failed");
-                            let wrapped = if push_error_indicates_stale_lease(&push_err.to_string())
-                            {
-                                anyhow::anyhow!(
-                                    "Push to fork remote `{}` was rejected: the fork branch \
-                                     `{}` has diverged from the local branch. Inspect the fork \
-                                     branch and delete or reset it, or point `remote.fork_remote` \
-                                     at a different remote.\n{push_err}",
-                                    fork_remote_name,
-                                    fork_spec_template.branch,
-                                )
-                            } else {
-                                push_err
-                            };
-                            if let Some(tx) = tx {
-                                tx.finish_err(
-                                    &format!("Fork push failed: {}", wrapped),
-                                    Some("push"),
-                                    None,
-                                )?;
-                            }
-                            return Err(wrapped);
+                    }
+                    Err(push_err) => {
+                        LiveTimer::maybe_finish_err(push_timer, "failed");
+                        let wrapped = if push_error_indicates_stale_lease(&push_err.to_string()) {
+                            anyhow::anyhow!(
+                                "Push to fork remote `{}` was rejected: the fork branch \
+                                 `{}` has diverged from the local branch. Inspect the fork \
+                                 branch and delete or reset it, or point `remote.fork_remote` \
+                                 at a different remote.\n{push_err}",
+                                fork_remote_name,
+                                fork_branch,
+                            )
+                        } else {
+                            push_err
+                        };
+                        if let Some(tx) = tx {
+                            tx.finish_err(
+                                &format!("Fork push failed: {}", wrapped),
+                                Some("push"),
+                                None,
+                            )?;
                         }
+                        return Err(wrapped);
                     }
                 }
 
@@ -3674,6 +3759,56 @@ pub(crate) fn ref_needs_push(
         (Some(l), Some(r)) => l != r, // Need push if different
         (Some(_), None) => true,      // Branch not on remote yet
         _ => true,                    // Default to push if unsure
+    }
+}
+
+/// Total time budget for `wait_for_fork_ready` to poll a freshly created fork.
+const FORK_READY_MAX_WAIT: Duration = Duration::from_secs(120);
+
+/// Refuse to repoint an existing fork remote at a different URL. Called before any
+/// mutating GitHub call so a stale `fork` remote never causes a real fork to be created.
+fn ensure_fork_remote_url_free(repo: &GitRepo, remote_name: &str, fork_url: &str) -> Result<()> {
+    if let Some(existing_url) = repo.remote_url(remote_name)?
+        && existing_url != fork_url
+    {
+        anyhow::bail!(
+            "A git remote named `{remote_name}` already exists and points at {existing_url}, \
+             but the auto-detected fork URL is {fork_url}. \
+             Remove or re-point the existing `{remote_name}` remote, or set \
+             `remote.fork_remote` to the name of an existing remote."
+        );
+    }
+    Ok(())
+}
+
+/// Poll GitHub until a freshly created fork is reachable, since fork creation is
+/// asynchronous and can take minutes on large repos. Returns true when ready.
+fn wait_for_fork_ready(
+    rt: &tokio::runtime::Runtime,
+    client: &ForgeClient,
+    fork_owner: &str,
+    quiet: bool,
+) -> bool {
+    if !quiet {
+        println!(
+            "  {} waiting for the new fork to become available on GitHub...",
+            "!".yellow()
+        );
+    }
+
+    let start = Instant::now();
+    let mut delay = Duration::from_secs(1);
+    loop {
+        match rt.block_on(async { client.find_pushable_fork(fork_owner).await }) {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if start.elapsed() >= FORK_READY_MAX_WAIT {
+            return false;
+        }
+        std::thread::sleep(delay);
+        delay = (delay * 2).min(Duration::from_secs(8));
     }
 }
 

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,7 +1,7 @@
 pub(crate) use crate::application::SubmitScope;
 use crate::application::submit::{
     PushSpec, TemporaryPublishRefs, TemporarySubmitWorktree, push_branches,
-    push_error_indicates_no_write_access,
+    push_error_indicates_no_write_access, push_error_indicates_stale_lease,
 };
 use crate::commands::open::open_url_in_browser;
 use crate::config::{
@@ -463,7 +463,10 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
         return super::submit_plan::run(scope, &options);
     }
 
-    if uses_application_default_submit(scope, &options) {
+    let config = Config::load()?;
+    let fork_enabled = options.fork || config.auto_fork();
+
+    if uses_application_default_submit(scope, &options, fork_enabled) {
         return run_application_default_submit(scope, &options);
     }
 
@@ -510,7 +513,6 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let repo = GitRepo::open()?;
     let current = repo.current_branch()?;
     let stack = Stack::load(&repo)?;
-    let config = Config::load()?;
     let stack_links_mode = config.submit.stack_links;
     let single_stack_mode = config.submit.single_stack;
     let stack_links_when_native = config.submit.stack_links_when_native;
@@ -771,7 +773,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     let mut full_scan_fallbacks = 0usize;
 
     let mut plans: Vec<PrPlan> = Vec::new();
-    let mut rt: Option<tokio::runtime::Runtime> = None;
+    let rt: Option<tokio::runtime::Runtime>;
     let client: Option<ForgeClient>;
 
     if no_pr {
@@ -910,6 +912,7 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                 is_imported,
             });
         }
+        rt = runtime;
     } else {
         let runtime = tokio::runtime::Runtime::new()?;
         let _enter = runtime.enter();
@@ -1624,15 +1627,48 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     );
                 }
 
-                let fork_rt = tokio::runtime::Runtime::new()?;
+                // Reuse the planning runtime/client when available; only build a
+                // second pair if planning skipped them (e.g. --no-pr had them fail
+                // silently).
+                let owned_rt: Option<tokio::runtime::Runtime> = if rt.is_none() {
+                    Some(tokio::runtime::Runtime::new()?)
+                } else {
+                    None
+                };
+                let fork_rt: &tokio::runtime::Runtime = if let Some(r) = &rt {
+                    r
+                } else {
+                    owned_rt.as_ref().expect("owned_rt initialized above")
+                };
                 let _fork_rt_enter = fork_rt.enter();
-                let fork_client = ForgeClient::new(&remote_info)?;
+                let owned_fork_client: Option<ForgeClient> = if client.is_none() {
+                    Some(ForgeClient::new(&remote_info)?)
+                } else {
+                    None
+                };
+                let fork_client: &ForgeClient = if let Some(c) = &client {
+                    c
+                } else {
+                    owned_fork_client
+                        .as_ref()
+                        .expect("owned_fork_client initialized above")
+                };
                 let login = fork_rt.block_on(async { fork_client.get_current_user().await })?;
 
                 let (fork_remote_name, resolved_owner, fork_freshly_created) = if let Some(name) =
                     config.fork_remote().filter(|name| repo.remote_exists(name))
                 {
-                    (name.to_string(), login.clone(), false)
+                    // Trust the user-configured fork remote's URL for the owner
+                    // rather than assuming the authenticated login: a fork under
+                    // an org would otherwise be qualified with the wrong owner in
+                    // `owner:branch`.
+                    let configured_url = remote::get_remote_url(repo.workdir()?, name)?;
+                    let owner_from_url = remote::parse_remote_url(&configured_url)
+                        .ok()
+                        .and_then(|(_, path)| path.split('/').next().map(str::to_string))
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| login.clone());
+                    (name.to_string(), owner_from_url, false)
                 } else {
                     let existing =
                         fork_rt.block_on(async { fork_client.find_pushable_fork(&login).await })?;
@@ -1651,33 +1687,75 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
                     } else {
                         target.ssh_url.clone()
                     };
+                    // Don't silently repoint an existing `fork` remote at a
+                    // different URL — that could send commits to the wrong repo.
+                    if let Some(existing_url) = repo.remote_url("fork")?
+                        && existing_url != fork_url
+                    {
+                        anyhow::bail!(
+                            "A git remote named `fork` already exists and points at {existing_url}, \
+                             but the auto-detected fork URL is {fork_url}. \
+                             Remove or re-point the existing `fork` remote, or set \
+                             `remote.fork_remote` to the name of an existing remote."
+                        );
+                    }
                     repo.ensure_remote("fork", &fork_url)?;
                     ("fork".to_string(), target.owner, freshly_created)
                 };
 
-                let fork_spec = &pushed_branches[0];
+                // Reuse `push_branches` so the fork push honours `source_ref`
+                // (temporary publish ref for restacked branches), `--no-verify`,
+                // and per-branch `--force-with-lease` — never a bare `--force`,
+                // which would silently overwrite work that another tool advanced.
+                let fork_workdir = repo.workdir()?.to_path_buf();
+                let fork_spec_template = pushed_branches[0].clone();
                 let mut attempt = 0;
                 loop {
                     attempt += 1;
-                    match repo.push_branch_to_fork(&fork_remote_name, &fork_spec.branch) {
+                    let fork_heads = remote::ls_remote_head_oids(&fork_workdir, &fork_remote_name)
+                        .unwrap_or_default();
+                    let expected = fork_heads.get(&fork_spec_template.branch).cloned();
+                    let fork_spec = PushSpec {
+                        expected_remote_oid: expected,
+                        ..fork_spec_template.clone()
+                    };
+                    match push_branches(
+                        &fork_workdir,
+                        &fork_remote_name,
+                        std::slice::from_ref(&fork_spec),
+                        no_verify,
+                    ) {
                         Ok(()) => break,
-                        Err(_) if fork_freshly_created && attempt < 3 => {
+                        Err(err) if fork_freshly_created && attempt < 3 => {
                             eprintln!(
-                                "  {} waiting 2s before retrying push to fork...",
+                                "  {} waiting 2s before retrying push to fork ({err})...",
                                 "!".yellow()
                             );
                             std::thread::sleep(Duration::from_secs(2));
                         }
                         Err(push_err) => {
                             LiveTimer::maybe_finish_err(push_timer, "failed");
+                            let wrapped = if push_error_indicates_stale_lease(&push_err.to_string())
+                            {
+                                anyhow::anyhow!(
+                                    "Push to fork remote `{}` was rejected: the fork branch \
+                                     `{}` has diverged from the local branch. Inspect the fork \
+                                     branch and delete or reset it, or point `remote.fork_remote` \
+                                     at a different remote.\n{push_err}",
+                                    fork_remote_name,
+                                    fork_spec_template.branch,
+                                )
+                            } else {
+                                push_err
+                            };
                             if let Some(tx) = tx {
                                 tx.finish_err(
-                                    &format!("Fork push failed: {}", push_err),
+                                    &format!("Fork push failed: {}", wrapped),
                                     Some("push"),
                                     None,
                                 )?;
                             }
-                            return Err(push_err);
+                            return Err(wrapped);
                         }
                     }
                 }
@@ -2194,7 +2272,11 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
     Ok(())
 }
 
-fn uses_application_default_submit(scope: SubmitScope, options: &SubmitOptions) -> bool {
+fn uses_application_default_submit(
+    scope: SubmitScope,
+    options: &SubmitOptions,
+    fork_enabled: bool,
+) -> bool {
     matches!(scope, SubmitScope::Stack)
         && options.no_pr
         && !options.dry_run
@@ -2208,6 +2290,7 @@ fn uses_application_default_submit(scope: SubmitScope, options: &SubmitOptions) 
         && !options.no_template
         && options.template.is_none()
         && !options.update_title
+        && !fork_enabled
 }
 
 fn run_application_default_submit(scope: SubmitScope, options: &SubmitOptions) -> Result<()> {
@@ -5174,6 +5257,38 @@ mod tests {
 
         assert!(!prompt.contains("Additional PR title instructions:"));
         assert!(!prompt.contains("Additional PR body instructions:"));
+    }
+
+    #[test]
+    fn uses_application_default_submit_declines_stack_no_pr_when_fork_enabled() {
+        let options = SubmitOptions {
+            no_pr: true,
+            ..SubmitOptions::default()
+        };
+        assert!(super::uses_application_default_submit(
+            SubmitScope::Stack,
+            &options,
+            false,
+        ));
+        assert!(!super::uses_application_default_submit(
+            SubmitScope::Stack,
+            &options,
+            true,
+        ));
+    }
+
+    #[test]
+    fn uses_application_default_submit_declines_stack_no_pr_with_fork_flag_set() {
+        let options = SubmitOptions {
+            no_pr: true,
+            fork: true,
+            ..SubmitOptions::default()
+        };
+        assert!(!super::uses_application_default_submit(
+            SubmitScope::Stack,
+            &options,
+            options.fork,
+        ));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,6 +128,15 @@ pub struct RemoteConfig {
     /// When set, skips auto-detection from the remote hostname.
     #[serde(default)]
     pub forge: Option<ForgeType>,
+    /// Automatically fall back to submitting from a fork when a push to the
+    /// upstream remote is rejected for lack of write access. Equivalent to
+    /// always passing `--fork` to `stax submit`.
+    #[serde(default)]
+    pub auto_fork: bool,
+    /// Name of an existing Git remote pointing at the user's fork, to reuse
+    /// instead of auto-detecting/creating one via the GitHub API.
+    #[serde(default)]
+    pub fork_remote: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -457,6 +466,8 @@ impl Default for RemoteConfig {
             base_url: default_remote_base_url(),
             api_base_url: None,
             forge: None,
+            auto_fork: false,
+            fork_remote: None,
         }
     }
 }
@@ -1134,6 +1145,14 @@ impl Config {
 
     pub fn remote_forge_override(&self) -> Option<ForgeType> {
         self.remote.forge
+    }
+
+    pub fn auto_fork(&self) -> bool {
+        self.remote.auto_fork
+    }
+
+    pub fn fork_remote(&self) -> Option<&str> {
+        self.remote.fork_remote.as_deref()
     }
 }
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use crate::ci::CheckRunInfo;
 use crate::config::Config;
-use crate::github::client::GitHubClient;
+use crate::github::client::{ForkTarget, GitHubClient};
 use crate::remote::{ForgeType, RemoteInfo, TrustedRemoteInfo};
 
 mod gitea;
@@ -103,6 +103,29 @@ impl ForgeClient {
             Self::GitHub(_) => Ok(()),
             Self::GitLab(client) => client.preflight_stack_merge(method).await,
             Self::Gitea(_) => bail!("`stax merge --stack` is not supported on Gitea/Forgejo"),
+        }
+    }
+
+    /// Find an existing fork of this repo owned by `login` that stax can
+    /// push to. GitHub-only: fork-fallback submit is not supported on other
+    /// forges yet.
+    pub async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>> {
+        match self {
+            Self::GitHub(client) => client.find_pushable_fork(login).await,
+            Self::GitLab(_) | Self::Gitea(_) => {
+                bail!("Fork fallback for submit is currently only supported on GitHub")
+            }
+        }
+    }
+
+    /// Fork this repo under the authenticated user's account. GitHub-only:
+    /// fork-fallback submit is not supported on other forges yet.
+    pub async fn create_fork(&self) -> Result<ForkTarget> {
+        match self {
+            Self::GitHub(client) => client.create_fork().await,
+            Self::GitLab(_) | Self::Gitea(_) => {
+                bail!("Fork fallback for submit is currently only supported on GitHub")
+            }
         }
     }
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use crate::ci::CheckRunInfo;
 use crate::config::Config;
-use crate::github::client::{ForkTarget, GitHubClient};
+use crate::github::client::GitHubClient;
 use crate::remote::{ForgeType, RemoteInfo, TrustedRemoteInfo};
 
 mod gitea;
@@ -103,29 +103,6 @@ impl ForgeClient {
             Self::GitHub(_) => Ok(()),
             Self::GitLab(client) => client.preflight_stack_merge(method).await,
             Self::Gitea(_) => bail!("`stax merge --stack` is not supported on Gitea/Forgejo"),
-        }
-    }
-
-    /// Find an existing fork of this repo owned by `login` that stax can
-    /// push to. GitHub-only: fork-fallback submit is not supported on other
-    /// forges yet.
-    pub async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>> {
-        match self {
-            Self::GitHub(client) => client.find_pushable_fork(login).await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                bail!("Fork fallback for submit is currently only supported on GitHub")
-            }
-        }
-    }
-
-    /// Fork this repo under the authenticated user's account. GitHub-only:
-    /// fork-fallback submit is not supported on other forges yet.
-    pub async fn create_fork(&self) -> Result<ForkTarget> {
-        match self {
-            Self::GitHub(client) => client.create_fork().await,
-            Self::GitLab(_) | Self::Gitea(_) => {
-                bail!("Fork fallback for submit is currently only supported on GitHub")
-            }
         }
     }
 
@@ -318,6 +295,19 @@ impl ForgeClient {
     ) -> Result<ForgeSignal<Vec<ReviewActivity>>> {
         dispatch!(self, get_reviews_given(hours, username))
     }
+
+    /// Find an existing fork of this repo owned by `login` that stax can
+    /// push to. GitHub-only: fork-fallback submit is not supported on other
+    /// forges yet.
+    pub async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>> {
+        dispatch!(self, find_pushable_fork(login))
+    }
+
+    /// Fork this repo under the authenticated user's account. GitHub-only:
+    /// fork-fallback submit is not supported on other forges yet.
+    pub async fn create_fork(&self) -> Result<ForkTarget> {
+        dispatch!(self, create_fork())
+    }
 }
 
 impl Forge for GitHubClient {
@@ -463,6 +453,12 @@ impl Forge for GitHubClient {
         username: &str,
     ) -> Result<ForgeSignal<Vec<ReviewActivity>>> {
         self.get_reviews_given(hours, username).await
+    }
+    async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>> {
+        self.find_pushable_fork(login).await
+    }
+    async fn create_fork(&self) -> Result<ForkTarget> {
+        self.create_fork().await
     }
 }
 
@@ -620,6 +616,12 @@ impl Forge for GitLabClient {
         username: &str,
     ) -> Result<ForgeSignal<Vec<ReviewActivity>>> {
         self.get_reviews_given(hours, username).await
+    }
+    async fn find_pushable_fork(&self, _login: &str) -> Result<Option<ForkTarget>> {
+        bail!("Fork fallback for submit is currently only supported on GitHub")
+    }
+    async fn create_fork(&self) -> Result<ForkTarget> {
+        bail!("Fork fallback for submit is currently only supported on GitHub")
     }
 }
 
@@ -781,6 +783,12 @@ impl Forge for GiteaClient {
     ) -> Result<ForgeSignal<Vec<ReviewActivity>>> {
         self.get_reviews_given(hours, username).await
     }
+    async fn find_pushable_fork(&self, _login: &str) -> Result<Option<ForkTarget>> {
+        bail!("Fork fallback for submit is currently only supported on GitHub")
+    }
+    async fn create_fork(&self) -> Result<ForkTarget> {
+        bail!("Fork fallback for submit is currently only supported on GitHub")
+    }
 }
 
 impl Forge for ForgeClient {
@@ -919,6 +927,12 @@ impl Forge for ForgeClient {
         username: &str,
     ) -> Result<ForgeSignal<Vec<ReviewActivity>>> {
         self.get_reviews_given(hours, username).await
+    }
+    async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>> {
+        self.find_pushable_fork(login).await
+    }
+    async fn create_fork(&self) -> Result<ForkTarget> {
+        self.create_fork().await
     }
 }
 

--- a/src/forge/model.rs
+++ b/src/forge/model.rs
@@ -3,6 +3,15 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::str::FromStr;
 
+/// A fork of the upstream repo that stax can push a branch to when the
+/// caller lacks write access to the upstream itself.
+#[derive(Debug, Clone)]
+pub struct ForkTarget {
+    pub owner: String,
+    pub ssh_url: String,
+    pub https_url: String,
+}
+
 /// A comment on a PR issue thread (conversation comment)
 #[derive(Debug, Clone)]
 pub struct IssueComment {

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -69,6 +69,11 @@ pub trait Forge {
         hours: i64,
         username: &str,
     ) -> Result<ForgeSignal<Vec<ReviewActivity>>>;
+    /// Look up a fork of this repo owned by `login` that stax can push to,
+    /// for fork-fallback submit. Return `None` when no pushable fork exists.
+    async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>>;
+    /// Fork this repo under the authenticated user's account.
+    async fn create_fork(&self) -> Result<ForkTarget>;
 }
 
 #[cfg(test)]
@@ -228,6 +233,12 @@ pub(crate) mod tests {
             _hours: i64,
             _username: &str,
         ) -> Result<ForgeSignal<Vec<ReviewActivity>>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn find_pushable_fork(&self, _login: &str) -> Result<Option<ForkTarget>> {
+            anyhow::bail!("unused in fake")
+        }
+        async fn create_fork(&self) -> Result<ForkTarget> {
             anyhow::bail!("unused in fake")
         }
     }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -23,6 +23,46 @@ pub(crate) fn metadata_ref_oid(repo: &Repository, branch: &str) -> Option<String
 }
 const STAX_TRUNK_REF: &str = "refs/stax/trunk";
 const STAX_PREV_BRANCH_REF: &str = "refs/stax/prev-branch";
+const FORK_PUBLISHED_REF_PREFIX: &str = "refs/stax/fork-published/";
+
+/// Build the full ref name for the fork-published marker of `remote`/`branch`.
+fn fork_published_refname(remote: &str, branch: &str) -> String {
+    format!("{FORK_PUBLISHED_REF_PREFIX}{remote}/{branch}")
+}
+
+/// Read the OID that stax last published for `branch` on the fork `remote`.
+/// Unlike `read_metadata`/`read_trunk`, this ref points directly at a commit, not a blob.
+pub fn read_fork_published(
+    repo: &Repository,
+    remote: &str,
+    branch: &str,
+) -> Result<Option<String>> {
+    let ref_name = fork_published_refname(remote, branch);
+
+    match repo.find_reference(&ref_name) {
+        Ok(reference) => Ok(reference.target().map(|oid| oid.to_string())),
+        Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Record that stax published `oid` for `branch` on the fork `remote`.
+pub fn write_fork_published_at(
+    workdir: &Path,
+    remote: &str,
+    branch: &str,
+    oid: &str,
+) -> Result<()> {
+    let ref_name = fork_published_refname(remote, branch);
+    let status = command::status(workdir, &["update-ref", &ref_name, oid])
+        .context("Failed to update ref")?;
+
+    if !status.success() {
+        anyhow::bail!("Failed to update ref {}", ref_name);
+    }
+
+    Ok(())
+}
 
 /// Read metadata JSON for a branch from git refs
 pub fn read_metadata(repo: &Repository, branch: &str) -> Result<Option<String>> {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -2078,18 +2078,14 @@ Use --auto-stash-pop or stash/commit changes first.",
         Ok(())
     }
 
-    /// Push `branch` to `remote`, force (no lease). Used for fork-fallback
-    /// submit: the fork is owned by the caller, and a freshly created fork's
-    /// branch has no shared history to race with, so a plain force push is
-    /// safe and also covers a diverged branch on re-submit.
-    pub fn push_branch_to_fork(&self, remote: &str, branch: &str) -> Result<()> {
-        let output = self.run_git(self.workdir()?, &["push", "--force", remote, branch])?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git push --force {} {} failed: {}", remote, branch, stderr);
+    /// URL configured for a given git remote, or `None` if it does not exist.
+    pub fn remote_url(&self, name: &str) -> Result<Option<String>> {
+        match self.repo.find_remote(name) {
+            Ok(remote) => Ok(remote.url().ok().map(str::to_string)),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(e) => Err(anyhow::anyhow!(e))
+                .with_context(|| format!("Failed to look up remote '{name}'")),
         }
-        Ok(())
     }
 
     /// Return all branch names under `refs/remotes/<remote>/` as a set.

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -2053,6 +2053,45 @@ Use --auto-stash-pop or stash/commit changes first.",
             .is_ok()
     }
 
+    /// Check if a remote named `name` is configured for this repository.
+    pub fn remote_exists(&self, name: &str) -> bool {
+        self.repo.find_remote(name).is_ok()
+    }
+
+    /// Add a remote named `name` pointing at `url`, or update its URL if it
+    /// already exists and points somewhere else.
+    pub fn ensure_remote(&self, name: &str, url: &str) -> Result<()> {
+        match self.repo.find_remote(name) {
+            Ok(remote) => {
+                if remote.url().ok() != Some(url) {
+                    self.repo
+                        .remote_set_url(name, url)
+                        .with_context(|| format!("Failed to update remote '{name}' URL"))?;
+                }
+            }
+            Err(_) => {
+                self.repo
+                    .remote(name, url)
+                    .with_context(|| format!("Failed to add remote '{name}'"))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Push `branch` to `remote`, force (no lease). Used for fork-fallback
+    /// submit: the fork is owned by the caller, and a freshly created fork's
+    /// branch has no shared history to race with, so a plain force push is
+    /// safe and also covers a diverged branch on re-submit.
+    pub fn push_branch_to_fork(&self, remote: &str, branch: &str) -> Result<()> {
+        let output = self.run_git(self.workdir()?, &["push", "--force", remote, branch])?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git push --force {} {} failed: {}", remote, branch, stderr);
+        }
+        Ok(())
+    }
+
     /// Return all branch names under `refs/remotes/<remote>/` as a set.
     /// One libgit2 ref-glob instead of one subprocess per branch.
     pub fn remote_branch_names(&self, remote: &str) -> Result<HashSet<String>> {

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -75,16 +75,7 @@ impl ApiCallTracker {
     }
 }
 
-pub use crate::forge::OpenPrInfo;
-
-/// A fork of the upstream repo that stax can push a branch to when the
-/// caller lacks write access to the upstream itself.
-#[derive(Debug, Clone)]
-pub struct ForkTarget {
-    pub owner: String,
-    pub ssh_url: String,
-    pub https_url: String,
-}
+pub use crate::forge::{ForkTarget, OpenPrInfo};
 
 /// Minimal shape of a GitHub repository response, covering only the fields
 /// fork resolution needs. Deserialized by hand (rather than via octocrab's

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -77,6 +77,49 @@ impl ApiCallTracker {
 
 pub use crate::forge::OpenPrInfo;
 
+/// A fork of the upstream repo that stax can push a branch to when the
+/// caller lacks write access to the upstream itself.
+#[derive(Debug, Clone)]
+pub struct ForkTarget {
+    pub owner: String,
+    pub ssh_url: String,
+    pub https_url: String,
+}
+
+/// Minimal shape of a GitHub repository response, covering only the fields
+/// fork resolution needs. Deserialized by hand (rather than via octocrab's
+/// full `models::Repository`) so responses only need these few fields.
+#[derive(Debug, Deserialize)]
+struct ForkRepoResponse {
+    #[serde(default)]
+    fork: bool,
+    owner: RepoListUser,
+    ssh_url: String,
+    clone_url: String,
+    parent: Option<ForkParentRepo>,
+    permissions: Option<ForkRepoPermissions>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForkParentRepo {
+    full_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForkRepoPermissions {
+    push: bool,
+}
+
+impl From<ForkRepoResponse> for ForkTarget {
+    fn from(repo: ForkRepoResponse) -> Self {
+        Self {
+            owner: repo.owner.login,
+            ssh_url: repo.ssh_url,
+            https_url: repo.clone_url,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ReviewUser {
     login: String,
@@ -308,6 +351,54 @@ impl GitHubClient {
             .context("Failed to look up the authenticated user")
             .map_err(|e| self.enrich_api_error(e))?;
         Ok(user.login)
+    }
+
+    /// Find an existing fork of this repo owned by `login` that stax can
+    /// push to, so fork-fallback submit reuses it instead of creating a
+    /// duplicate. Returns `None` when no such repo exists (404) or when it
+    /// exists but isn't a pushable fork of this exact upstream.
+    pub async fn find_pushable_fork(&self, login: &str) -> Result<Option<ForkTarget>> {
+        self.record_api_call("repos.get_fork_candidate");
+        let url = format!("/repos/{}/{}", login, self.repo);
+        let repo: ForkRepoResponse = match self.octocrab.get(&url, None::<&()>).await {
+            Ok(repo) => repo,
+            Err(octocrab::Error::GitHub { source, .. }) if source.status_code.as_u16() == 404 => {
+                return Ok(None);
+            }
+            Err(e) => {
+                return Err(self.enrich_api_error(
+                    anyhow::Error::new(e).context("Failed to look up fork candidate"),
+                ));
+            }
+        };
+
+        let upstream = format!("{}/{}", self.owner, self.repo);
+        let is_pushable_fork = repo.fork
+            && repo.parent.as_ref().map(|parent| parent.full_name.as_str())
+                == Some(upstream.as_str())
+            && repo.permissions.as_ref().is_some_and(|p| p.push);
+
+        if is_pushable_fork {
+            Ok(Some(repo.into()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Fork this repo under the authenticated user's account.
+    pub async fn create_fork(&self) -> Result<ForkTarget> {
+        self.record_api_call("repos.create_fork");
+        let url = format!("/repos/{}/{}/forks", self.owner, self.repo);
+        let repo: ForkRepoResponse = match self
+            .octocrab
+            .post(&url, None::<&()>)
+            .await
+            .context("Failed to create fork")
+        {
+            Ok(repo) => repo,
+            Err(e) => return Err(self.enrich_api_error(e)),
+        };
+        Ok(repo.into())
     }
 
     /// Get PRs merged by the user in the last N hours
@@ -1489,6 +1580,123 @@ mod tests {
             err_msg.contains("stax auth --from-gh"),
             "Expected auth remediation hint in 404 error, got: {}",
             err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_pushable_fork_returns_none_on_404() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/some-login/test-repo"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found",
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.find_pushable_fork("some-login").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_pushable_fork_returns_target_when_pushable_fork_of_this_repo() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/some-login/test-repo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "fork": true,
+                "owner": { "login": "some-login" },
+                "ssh_url": "git@github.com:some-login/test-repo.git",
+                "clone_url": "https://github.com/some-login/test-repo.git",
+                "parent": { "full_name": "test-owner/test-repo" },
+                "permissions": { "push": true }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let target = client
+            .find_pushable_fork("some-login")
+            .await
+            .unwrap()
+            .expect("expected a pushable fork");
+        assert_eq!(target.owner, "some-login");
+        assert_eq!(target.ssh_url, "git@github.com:some-login/test-repo.git");
+        assert_eq!(
+            target.https_url,
+            "https://github.com/some-login/test-repo.git"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_pushable_fork_ignores_repo_not_forked_from_this_upstream() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/some-login/test-repo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "fork": true,
+                "owner": { "login": "some-login" },
+                "ssh_url": "git@github.com:some-login/test-repo.git",
+                "clone_url": "https://github.com/some-login/test-repo.git",
+                "parent": { "full_name": "someone-else/unrelated-repo" },
+                "permissions": { "push": true }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.find_pushable_fork("some-login").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_pushable_fork_ignores_fork_without_push_access() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/some-login/test-repo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "fork": true,
+                "owner": { "login": "some-login" },
+                "ssh_url": "git@github.com:some-login/test-repo.git",
+                "clone_url": "https://github.com/some-login/test-repo.git",
+                "parent": { "full_name": "test-owner/test-repo" },
+                "permissions": { "push": false }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let result = client.find_pushable_fork("some-login").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_fork_returns_target() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/forks"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "fork": true,
+                "owner": { "login": "some-login" },
+                "ssh_url": "git@github.com:some-login/test-repo.git",
+                "clone_url": "https://github.com/some-login/test-repo.git"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = create_test_client(&mock_server).await;
+        let target = client.create_fork().await.unwrap();
+        assert_eq!(target.owner, "some-login");
+        assert_eq!(target.ssh_url, "git@github.com:some-login/test-repo.git");
+        assert_eq!(
+            target.https_url,
+            "https://github.com/some-login/test-repo.git"
         );
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -4,4 +4,4 @@ pub mod gh_stack;
 pub mod pr;
 pub mod pr_template;
 
-pub use client::GitHubClient;
+pub use client::{ForkTarget, GitHubClient};

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -520,7 +520,10 @@ impl GitHubClient {
             .create(title, branch, base)
             .body(body)
             .draft(Some(draft))
-            .maintainer_can_modify(true)
+            // Only fork PRs need this: `branch` is `<owner>:<branch>` for a fork head and
+            // never contains ':' for a same-repo head. Org-owned forks 422 when this is set
+            // on a same-repo PR, so gate it to the fork case.
+            .maintainer_can_modify(branch.contains(':'))
             .send()
             .await
             .context("Failed to create PR")?;

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -520,6 +520,7 @@ impl GitHubClient {
             .create(title, branch, base)
             .body(body)
             .draft(Some(draft))
+            .maintainer_can_modify(true)
             .send()
             .await
             .context("Failed to create PR")?;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -405,6 +405,16 @@ pub fn fetch_remote_refs(workdir: &Path, remote: &str, branches: &[String]) -> R
     );
 }
 
+/// Predict the fork clone URL by replacing only the owner path segment of `origin_url`,
+/// preserving scheme/host/repo-name.
+pub(crate) fn fork_url_for_owner(origin_url: &str, login: &str) -> Result<String> {
+    let (prefix, repo_part) = origin_url
+        .rsplit_once('/')
+        .context("Unsupported remote URL format")?;
+    let cut = prefix.rfind(['/', ':']).map(|i| i + 1).unwrap_or(0);
+    Ok(format!("{}{login}/{repo_part}", &prefix[..cut]))
+}
+
 pub(crate) fn parse_remote_url(url: &str) -> Result<(String, String)> {
     if url.contains("://") {
         let parsed = reqwest::Url::parse(url).context("Invalid remote URL")?;
@@ -733,6 +743,20 @@ mod tests {
     fn test_parse_unsupported_url_format() {
         let result = parse_remote_url("ftp://example.com/repo");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fork_url_for_owner_https() {
+        let url = fork_url_for_owner("https://github.com/test-owner/test-repo.git", "contributor")
+            .unwrap();
+        assert_eq!(url, "https://github.com/contributor/test-repo.git");
+    }
+
+    #[test]
+    fn test_fork_url_for_owner_scp_like() {
+        let url =
+            fork_url_for_owner("git@github.com:test-owner/test-repo.git", "contributor").unwrap();
+        assert_eq!(url, "git@github.com:contributor/test-repo.git");
     }
 
     #[test]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -405,7 +405,7 @@ pub fn fetch_remote_refs(workdir: &Path, remote: &str, branches: &[String]) -> R
     );
 }
 
-fn parse_remote_url(url: &str) -> Result<(String, String)> {
+pub(crate) fn parse_remote_url(url: &str) -> Result<(String, String)> {
     if url.contains("://") {
         let parsed = reqwest::Url::parse(url).context("Invalid remote URL")?;
         if !matches!(parsed.scheme(), "ssh" | "http" | "https") {

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -130,6 +130,8 @@ mod standup_tests;
 mod status_tests;
 #[path = "submit_fetch_failure_tests.rs"]
 mod submit_fetch_failure_tests;
+#[path = "submit_fork_fallback_tests.rs"]
+mod submit_fork_fallback_tests;
 #[path = "submit_no_verify_tests.rs"]
 mod submit_no_verify_tests;
 #[path = "submit_plan_completions_tests.rs"]

--- a/tests/common/github_mock.rs
+++ b/tests/common/github_mock.rs
@@ -1,0 +1,104 @@
+//! Shared GitHub / WireMock fixtures for integration tests.
+//!
+//! Individual suites used to hand-roll near-identical helpers; keeping them
+//! here lets a new suite mount the standard fixtures in one call.
+
+use std::fs;
+use std::path::Path;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Write `~/.config/stax/config.toml` under `home` with the given API base URL
+/// and `[submit] stack_links = "off"`. `extra_toml` is appended as-is (empty
+/// string for none).
+pub(crate) fn write_stax_config(home: &Path, api_base_url: &str, extra_toml: &str) {
+    let config_dir = home.join(".config").join("stax");
+    fs::create_dir_all(&config_dir).expect("failed to create test config dir");
+    let body = format!(
+        "[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"off\"\n{extra_toml}"
+    );
+    fs::write(config_dir.join("config.toml"), body).expect("failed to write test config");
+}
+
+/// Mock `GET /user` to return the given login as the authenticated user.
+pub(crate) async fn mount_current_user(mock_server: &MockServer, login: &str) {
+    Mock::given(method("GET"))
+        .and(path("/user"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "login": login,
+            "id": 1,
+            "node_id": "u1",
+            "avatar_url": "https://example.com/avatar",
+            "gravatar_id": "",
+            "url": format!("https://api.github.com/users/{login}"),
+            "html_url": format!("https://github.com/{login}"),
+            "followers_url": format!("https://api.github.com/users/{login}/followers"),
+            "following_url": format!("https://api.github.com/users/{login}/following"),
+            "gists_url": format!("https://api.github.com/users/{login}/gists"),
+            "starred_url": format!("https://api.github.com/users/{login}/starred"),
+            "subscriptions_url": format!("https://api.github.com/users/{login}/subscriptions"),
+            "organizations_url": format!("https://api.github.com/users/{login}/orgs"),
+            "repos_url": format!("https://api.github.com/users/{login}/repos"),
+            "events_url": format!("https://api.github.com/users/{login}/events"),
+            "received_events_url": format!("https://api.github.com/users/{login}/received_events"),
+            "type": "User",
+            "site_admin": false
+        })))
+        .mount(mock_server)
+        .await;
+}
+
+/// Mount the four mocks stax needs to create a PR and refresh it once:
+/// list-open, create, list-issue-comments, get-by-number. `number`, `head`
+/// (branch), and `base` populate the returned PR body. `owner_head_label`
+/// controls the `head.label` field, which callers assert against for fork
+/// submits (`contributor:branch`) or same-owner submits (`test-owner:branch`).
+#[allow(dead_code)]
+pub(crate) async fn mount_pr_create_and_refresh(
+    mock_server: &MockServer,
+    owner: &str,
+    repo: &str,
+    number: u64,
+    head: &str,
+    base: &str,
+    owner_head_label: &str,
+) {
+    let pr_body = serde_json::json!({
+        "url": format!("https://api.github.com/repos/{owner}/{repo}/pulls/{number}"),
+        "id": number,
+        "number": number,
+        "state": "open",
+        "title": head,
+        "body": "",
+        "draft": false,
+        "head": { "ref": head, "sha": "aaaa", "label": format!("{owner_head_label}:{head}") },
+        "base": { "ref": base, "sha": "bbbb" },
+        "html_url": format!("https://github.com/{owner}/{repo}/pull/{number}")
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{owner}/{repo}/pulls")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/repos/{owner}/{repo}/pulls")))
+        .respond_with(ResponseTemplate::new(201).set_body_json(pr_body.clone()))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{owner}/{repo}/issues/{number}/comments"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{owner}/{repo}/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(pr_body))
+        .mount(mock_server)
+        .await;
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,6 +6,7 @@
 //! - Assertion utilities for test output
 
 mod git_fixture;
+pub(crate) mod github_mock;
 pub(crate) use git_fixture::{commit_all, init_test_repo};
 
 use serde_json::Value;

--- a/tests/scoped_submit_tests.rs
+++ b/tests/scoped_submit_tests.rs
@@ -1,10 +1,10 @@
+use crate::common::github_mock::{mount_pr_create_and_refresh, write_stax_config};
 use crate::common::{OutputAssertions, TestRepo};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::MockServer;
 
 struct BranchSnapshot {
     name: String,
@@ -153,62 +153,17 @@ fn assert_no_temporary_submit_worktrees(repo: &TestRepo) {
     );
 }
 
-fn write_test_config(home: &Path, api_base_url: &str) {
-    let config_dir = home.join(".config").join("stax");
-    fs::create_dir_all(&config_dir).expect("failed to create test config dir");
-    fs::write(
-        config_dir.join("config.toml"),
-        format!("[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"off\"\n"),
-    )
-    .expect("failed to write test config");
-}
-
 async fn mock_github_pr_create(mock_server: &MockServer) {
-    Mock::given(method("GET"))
-        .and(path("/repos/test-owner/test-repo/pulls"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-        .mount(mock_server)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path("/repos/test-owner/test-repo/pulls"))
-        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
-            "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
-            "id": 42,
-            "number": 42,
-            "state": "open",
-            "title": "created",
-            "body": "",
-            "draft": false,
-            "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
-            "base": { "ref": "main", "sha": "bbbb" },
-            "html_url": "https://github.com/test-owner/test-repo/pull/42"
-        })))
-        .mount(mock_server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/repos/test-owner/test-repo/issues/42/comments"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-        .mount(mock_server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/repos/test-owner/test-repo/pulls/42"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
-            "id": 42,
-            "number": 42,
-            "state": "open",
-            "title": "created",
-            "body": "",
-            "draft": false,
-            "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
-            "base": { "ref": "main", "sha": "bbbb" },
-            "html_url": "https://github.com/test-owner/test-repo/pull/42"
-        })))
-        .mount(mock_server)
-        .await;
+    mount_pr_create_and_refresh(
+        mock_server,
+        "test-owner",
+        "test-repo",
+        42,
+        "created",
+        "main",
+        "test-owner",
+    )
+    .await;
 }
 
 #[test]
@@ -263,7 +218,7 @@ async fn upstack_submit_pr_defaults_exclude_parent_commits_from_temporary_parent
 
     let repo = TestRepo::new_with_remote();
     let home = repo.clean_home();
-    write_test_config(Path::new(&home), &mock_server.uri());
+    write_stax_config(Path::new(&home), &mock_server.uri(), "");
     repo.configure_github_like_submit_remote();
 
     let stack =
@@ -329,7 +284,7 @@ async fn stack_submit_pr_defaults_exclude_rewritten_parent_commits() {
 
     let repo = TestRepo::new_with_remote();
     let home = repo.clean_home();
-    write_test_config(Path::new(&home), &mock_server.uri());
+    write_stax_config(Path::new(&home), &mock_server.uri(), "");
     repo.configure_github_like_submit_remote();
 
     let branches = repo.create_stack(&["rewrite-parent", "rewrite-child"]);
@@ -383,7 +338,7 @@ async fn branch_submit_pr_defaults_exclude_imported_parent_commits_after_tempora
 
     let repo = TestRepo::new_with_remote();
     let home = repo.clean_home();
-    write_test_config(Path::new(&home), &mock_server.uri());
+    write_stax_config(Path::new(&home), &mock_server.uri(), "");
     repo.configure_github_like_submit_remote();
 
     push_remote_only_branch(

--- a/tests/submit_fork_fallback_tests.rs
+++ b/tests/submit_fork_fallback_tests.rs
@@ -1,0 +1,317 @@
+use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::Path;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Reject every push to a bare repo the way GitHub rejects a push from a
+    /// user without write access, so `push_error_indicates_no_write_access`
+    /// has real vocabulary to classify.
+    fn install_permission_denying_pre_receive_hook(bare_repo_path: &Path) {
+        let hook = bare_repo_path.join("hooks").join("pre-receive");
+        fs::write(
+            &hook,
+            "#!/bin/sh\necho 'Permission to test-owner/test-repo.git denied to test-user.' >&2\nexit 1\n",
+        )
+        .expect("write pre-receive hook");
+        fs::set_permissions(&hook, fs::Permissions::from_mode(0o755))
+            .expect("chmod pre-receive hook");
+    }
+
+    fn write_test_config(home: &Path, api_base_url: &str) {
+        let config_dir = home.join(".config").join("stax");
+        fs::create_dir_all(&config_dir).expect("failed to create test config dir");
+        fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"off\"\n"
+            ),
+        )
+        .expect("failed to write test config");
+    }
+
+    /// Redirect a fake `https://github.com/...` fork URL to a local bare repo,
+    /// mirroring `TestRepo::configure_github_like_submit_remote`'s trick for
+    /// origin so `git push` to the resolved fork remote hits real disk.
+    fn configure_fork_insteadof(repo: &TestRepo, fork_bare_path: &Path, fork_https_url: &str) {
+        let fork_path_str = fork_bare_path.to_string_lossy().to_string();
+        let out = repo.git(&[
+            "config",
+            "--local",
+            &format!("url.{}.insteadOf", fork_path_str),
+            fork_https_url,
+        ]);
+        assert!(
+            out.status.success(),
+            "fork insteadOf config failed: {}",
+            TestRepo::stderr(&out)
+        );
+    }
+
+    async fn mock_get_current_user(mock_server: &MockServer, login: &str) {
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "login": login,
+                "id": 1,
+                "node_id": "u1",
+                "avatar_url": "https://example.com/avatar",
+                "gravatar_id": "",
+                "url": format!("https://api.github.com/users/{login}"),
+                "html_url": format!("https://github.com/{login}"),
+                "followers_url": format!("https://api.github.com/users/{login}/followers"),
+                "following_url": format!("https://api.github.com/users/{login}/following"),
+                "gists_url": format!("https://api.github.com/users/{login}/gists"),
+                "starred_url": format!("https://api.github.com/users/{login}/starred"),
+                "subscriptions_url": format!("https://api.github.com/users/{login}/subscriptions"),
+                "organizations_url": format!("https://api.github.com/users/{login}/orgs"),
+                "repos_url": format!("https://api.github.com/users/{login}/repos"),
+                "events_url": format!("https://api.github.com/users/{login}/events"),
+                "received_events_url": format!("https://api.github.com/users/{login}/received_events"),
+                "type": "User",
+                "site_admin": false
+            })))
+            .mount(mock_server)
+            .await;
+    }
+
+    async fn mock_no_existing_fork(mock_server: &MockServer, login: &str) {
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/{login}/test-repo")))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Not Found",
+            })))
+            .mount(mock_server)
+            .await;
+    }
+
+    async fn mock_create_fork(
+        mock_server: &MockServer,
+        login: &str,
+        ssh_url: &str,
+        https_url: &str,
+    ) {
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/forks"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "fork": true,
+                "owner": { "login": login },
+                "ssh_url": ssh_url,
+                "clone_url": https_url,
+                "parent": { "full_name": "test-owner/test-repo" },
+                "permissions": { "push": true }
+            })))
+            .mount(mock_server)
+            .await;
+    }
+
+    async fn mock_pr_create_and_refresh(mock_server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "title": "created",
+                "body": "",
+                "draft": false,
+                "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
+                "base": { "ref": "main", "sha": "bbbb" },
+                "html_url": "https://github.com/test-owner/test-repo/pull/42"
+            })))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
+                "id": 42,
+                "number": 42,
+                "state": "open",
+                "title": "created",
+                "body": "",
+                "draft": false,
+                "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
+                "base": { "ref": "main", "sha": "bbbb" },
+                "html_url": "https://github.com/test-owner/test-repo/pull/42"
+            })))
+            .mount(mock_server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn branch_submit_fork_pushes_branch_and_opens_pr_from_fork() {
+        let mock_server = MockServer::start().await;
+        mock_get_current_user(&mock_server, "test-owner").await;
+        mock_no_existing_fork(&mock_server, "test-owner").await;
+
+        let fork_bare = tempfile::tempdir().expect("fork bare tempdir");
+        let fork_https_url = "https://github.com/test-owner/test-repo-fork.git";
+        let fork_ssh_url = "git@github.com:test-owner/test-repo-fork.git";
+        hermetic_git_init_bare(fork_bare.path());
+        mock_create_fork(&mock_server, "test-owner", fork_ssh_url, fork_https_url).await;
+        mock_pr_create_and_refresh(&mock_server).await;
+
+        let repo = TestRepo::new_with_remote();
+        let home = repo.clean_home();
+        write_test_config(Path::new(&home), &mock_server.uri());
+        repo.configure_github_like_submit_remote();
+        configure_fork_insteadof(&repo, fork_bare.path(), fork_https_url);
+
+        let remote_path = repo.remote_path().expect("origin bare path");
+        install_permission_denying_pre_receive_hook(&remote_path);
+
+        repo.run_stax(&["bc", "fork-fallback-branch"])
+            .assert_success();
+        repo.create_file("fork-fallback.txt", "content");
+        repo.commit("Commit for fork-fallback-branch");
+        let branch = repo.current_branch();
+
+        let output = repo.run_stax_with_env(
+            &[
+                "branch",
+                "submit",
+                "--fork",
+                "--yes",
+                "--no-prompt",
+                "--publish",
+                "--no-template",
+            ],
+            &[("STAX_GITHUB_TOKEN", "test-token")],
+        );
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+        // Branch landed on the fork, not on the (permission-denied) origin.
+        let fork_branches = hermetic_git_list_branches(fork_bare.path());
+        assert!(
+            fork_branches.contains(&branch),
+            "expected {branch} to be pushed to the fork, got: {fork_branches:?}"
+        );
+
+        // Read the literal configured value (not `remote get-url`, which
+        // applies the `insteadOf` rewrite used to redirect this test's fake
+        // fork URL onto a local bare repo).
+        let fork_remote_url = repo.git(&["config", "--local", "--get", "remote.fork.url"]);
+        fork_remote_url.assert_success();
+        assert_eq!(
+            TestRepo::stdout(&fork_remote_url).trim(),
+            fork_https_url,
+            "fork remote should point at the resolved fork URL"
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let pr_payload = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST"
+                    && request.url.path() == "/repos/test-owner/test-repo/pulls"
+            })
+            .map(|request| serde_json::from_slice::<serde_json::Value>(&request.body).unwrap())
+            .expect("missing PR create payload");
+
+        assert_eq!(
+            pr_payload["head"],
+            format!("test-owner:{branch}"),
+            "PR head should be qualified with the fork owner: {pr_payload}"
+        );
+        assert_eq!(pr_payload["base"], "main");
+    }
+
+    #[test]
+    fn branch_submit_permission_denied_without_fork_opt_in_fails_actionably() {
+        let repo = TestRepo::new_with_remote();
+        repo.configure_github_like_submit_remote();
+        let remote_path = repo.remote_path().expect("origin bare path");
+        install_permission_denying_pre_receive_hook(&remote_path);
+
+        repo.run_stax(&["bc", "fork-optin-branch"]).assert_success();
+        repo.create_file("fork-optin.txt", "content");
+        repo.commit("Commit for fork-optin-branch");
+
+        repo.run_stax(&["branch", "submit", "--no-pr", "--yes", "--no-prompt"])
+            .assert_failure()
+            .assert_stderr_contains("--fork")
+            .assert_stderr_contains("auto_fork");
+
+        let remotes = repo.git(&["remote"]);
+        remotes.assert_success();
+        assert!(
+            !TestRepo::stdout(&remotes).lines().any(|r| r == "fork"),
+            "no fork remote should be created when not opted in"
+        );
+    }
+
+    #[test]
+    fn multi_branch_stack_permission_denied_with_fork_reports_single_branch_error() {
+        let repo = TestRepo::new_with_remote();
+        repo.configure_github_like_submit_remote();
+        let remote_path = repo.remote_path().expect("origin bare path");
+        install_permission_denying_pre_receive_hook(&remote_path);
+
+        let branches = repo.create_stack(&["fork-stack-a", "fork-stack-b"]);
+        // Checkout the bottom of the stack so `upstack submit` covers both
+        // branches. `Stack` scope + `--no-pr` would route through the legacy
+        // `run_application_default_submit` path (out of scope here), so use
+        // `Upstack` scope instead to stay on the live fork-fallback code path.
+        repo.run_stax(&["checkout", &branches[0]]).assert_success();
+
+        repo.run_stax(&[
+            "upstack",
+            "submit",
+            "--fork",
+            "--no-pr",
+            "--yes",
+            "--no-prompt",
+        ])
+        .assert_failure()
+        .assert_stderr_contains("single branch");
+
+        let remotes = repo.git(&["remote"]);
+        remotes.assert_success();
+        assert!(
+            !TestRepo::stdout(&remotes).lines().any(|r| r == "fork"),
+            "no fork remote should be created for a multi-branch permission error"
+        );
+    }
+}
+
+fn hermetic_git_init_bare(path: &Path) {
+    let output = std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .current_dir(path)
+        .output()
+        .expect("git init --bare");
+    assert!(output.status.success());
+}
+
+fn hermetic_git_list_branches(bare_path: &Path) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
+        .current_dir(bare_path)
+        .output()
+        .expect("git for-each-ref");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}

--- a/tests/submit_fork_fallback_tests.rs
+++ b/tests/submit_fork_fallback_tests.rs
@@ -1,3 +1,6 @@
+use crate::common::github_mock::{
+    mount_current_user, mount_pr_create_and_refresh, write_stax_config,
+};
 use crate::common::{OutputAssertions, TestRepo};
 use std::fs;
 use std::path::Path;
@@ -16,23 +19,11 @@ mod unix {
         let hook = bare_repo_path.join("hooks").join("pre-receive");
         fs::write(
             &hook,
-            "#!/bin/sh\necho 'Permission to test-owner/test-repo.git denied to test-user.' >&2\nexit 1\n",
+            "#!/bin/sh\necho 'Permission to test-owner/test-repo.git denied to contributor.' >&2\nexit 1\n",
         )
         .expect("write pre-receive hook");
         fs::set_permissions(&hook, fs::Permissions::from_mode(0o755))
             .expect("chmod pre-receive hook");
-    }
-
-    fn write_test_config(home: &Path, api_base_url: &str) {
-        let config_dir = home.join(".config").join("stax");
-        fs::create_dir_all(&config_dir).expect("failed to create test config dir");
-        fs::write(
-            config_dir.join("config.toml"),
-            format!(
-                "[remote]\napi_base_url = \"{api_base_url}\"\n\n[submit]\nstack_links = \"off\"\n"
-            ),
-        )
-        .expect("failed to write test config");
     }
 
     /// Redirect a fake `https://github.com/...` fork URL to a local bare repo,
@@ -51,33 +42,6 @@ mod unix {
             "fork insteadOf config failed: {}",
             TestRepo::stderr(&out)
         );
-    }
-
-    async fn mock_get_current_user(mock_server: &MockServer, login: &str) {
-        Mock::given(method("GET"))
-            .and(path("/user"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "login": login,
-                "id": 1,
-                "node_id": "u1",
-                "avatar_url": "https://example.com/avatar",
-                "gravatar_id": "",
-                "url": format!("https://api.github.com/users/{login}"),
-                "html_url": format!("https://github.com/{login}"),
-                "followers_url": format!("https://api.github.com/users/{login}/followers"),
-                "following_url": format!("https://api.github.com/users/{login}/following"),
-                "gists_url": format!("https://api.github.com/users/{login}/gists"),
-                "starred_url": format!("https://api.github.com/users/{login}/starred"),
-                "subscriptions_url": format!("https://api.github.com/users/{login}/subscriptions"),
-                "organizations_url": format!("https://api.github.com/users/{login}/orgs"),
-                "repos_url": format!("https://api.github.com/users/{login}/repos"),
-                "events_url": format!("https://api.github.com/users/{login}/events"),
-                "received_events_url": format!("https://api.github.com/users/{login}/received_events"),
-                "type": "User",
-                "site_admin": false
-            })))
-            .mount(mock_server)
-            .await;
     }
 
     async fn mock_no_existing_fork(mock_server: &MockServer, login: &str) {
@@ -110,70 +74,33 @@ mod unix {
             .await;
     }
 
-    async fn mock_pr_create_and_refresh(mock_server: &MockServer) {
-        Mock::given(method("GET"))
-            .and(path("/repos/test-owner/test-repo/pulls"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-            .mount(mock_server)
-            .await;
-
-        Mock::given(method("POST"))
-            .and(path("/repos/test-owner/test-repo/pulls"))
-            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
-                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
-                "id": 42,
-                "number": 42,
-                "state": "open",
-                "title": "created",
-                "body": "",
-                "draft": false,
-                "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
-                "base": { "ref": "main", "sha": "bbbb" },
-                "html_url": "https://github.com/test-owner/test-repo/pull/42"
-            })))
-            .mount(mock_server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/repos/test-owner/test-repo/issues/42/comments"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-            .mount(mock_server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/repos/test-owner/test-repo/pulls/42"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
-                "id": 42,
-                "number": 42,
-                "state": "open",
-                "title": "created",
-                "body": "",
-                "draft": false,
-                "head": { "ref": "created", "sha": "aaaa", "label": "test-owner:created" },
-                "base": { "ref": "main", "sha": "bbbb" },
-                "html_url": "https://github.com/test-owner/test-repo/pull/42"
-            })))
-            .mount(mock_server)
-            .await;
-    }
-
     #[tokio::test]
     async fn branch_submit_fork_pushes_branch_and_opens_pr_from_fork() {
         let mock_server = MockServer::start().await;
-        mock_get_current_user(&mock_server, "test-owner").await;
-        mock_no_existing_fork(&mock_server, "test-owner").await;
+        // The authenticated user is a contributor who is NOT the upstream
+        // owner — that is the only realistic setup for fork submit.
+        mount_current_user(&mock_server, "contributor").await;
+        mock_no_existing_fork(&mock_server, "contributor").await;
 
         let fork_bare = tempfile::tempdir().expect("fork bare tempdir");
-        let fork_https_url = "https://github.com/test-owner/test-repo-fork.git";
-        let fork_ssh_url = "git@github.com:test-owner/test-repo-fork.git";
+        let fork_https_url = "https://github.com/contributor/test-repo.git";
+        let fork_ssh_url = "git@github.com:contributor/test-repo.git";
         hermetic_git_init_bare(fork_bare.path());
-        mock_create_fork(&mock_server, "test-owner", fork_ssh_url, fork_https_url).await;
-        mock_pr_create_and_refresh(&mock_server).await;
+        mock_create_fork(&mock_server, "contributor", fork_ssh_url, fork_https_url).await;
+        mount_pr_create_and_refresh(
+            &mock_server,
+            "test-owner",
+            "test-repo",
+            42,
+            "fork-fallback-branch",
+            "main",
+            "contributor",
+        )
+        .await;
 
         let repo = TestRepo::new_with_remote();
         let home = repo.clean_home();
-        write_test_config(Path::new(&home), &mock_server.uri());
+        write_stax_config(Path::new(&home), &mock_server.uri(), "");
         repo.configure_github_like_submit_remote();
         configure_fork_insteadof(&repo, fork_bare.path(), fork_https_url);
 
@@ -230,8 +157,8 @@ mod unix {
 
         assert_eq!(
             pr_payload["head"],
-            format!("test-owner:{branch}"),
-            "PR head should be qualified with the fork owner: {pr_payload}"
+            format!("contributor:{branch}"),
+            "PR head should be qualified with the fork owner, not the upstream owner: {pr_payload}"
         );
         assert_eq!(pr_payload["base"], "main");
     }
@@ -268,14 +195,13 @@ mod unix {
         install_permission_denying_pre_receive_hook(&remote_path);
 
         let branches = repo.create_stack(&["fork-stack-a", "fork-stack-b"]);
-        // Checkout the bottom of the stack so `upstack submit` covers both
-        // branches. `Stack` scope + `--no-pr` would route through the legacy
-        // `run_application_default_submit` path (out of scope here), so use
-        // `Upstack` scope instead to stay on the live fork-fallback code path.
         repo.run_stax(&["checkout", &branches[0]]).assert_success();
 
+        // Now that the default-submit router honours `--fork`, `Stack` scope +
+        // `--no-pr` + `--fork` reaches the fork-fallback code path directly and
+        // the multi-branch guard fires with a single-branch error.
         repo.run_stax(&[
-            "upstack",
+            "stack",
             "submit",
             "--fork",
             "--no-pr",
@@ -290,6 +216,57 @@ mod unix {
         assert!(
             !TestRepo::stdout(&remotes).lines().any(|r| r == "fork"),
             "no fork remote should be created for a multi-branch permission error"
+        );
+    }
+
+    #[test]
+    fn branch_submit_fork_conflicting_existing_fork_remote_fails() {
+        let repo = TestRepo::new_with_remote();
+        let home = repo.clean_home();
+        // No live wiremock server needed — the conflict check fires before
+        // any API call.
+        write_stax_config(Path::new(&home), "http://127.0.0.1:1", "");
+        repo.configure_github_like_submit_remote();
+        // Pre-existing `fork` remote pointing at an unrelated URL that should
+        // NOT be silently overwritten.
+        repo.git(&[
+            "remote",
+            "add",
+            "fork",
+            "https://github.com/someone-else/unrelated.git",
+        ])
+        .assert_success();
+        let remote_path = repo.remote_path().expect("origin bare path");
+        install_permission_denying_pre_receive_hook(&remote_path);
+
+        repo.run_stax(&["bc", "conflicting-fork-branch"])
+            .assert_success();
+        repo.create_file("conflict.txt", "content");
+        repo.commit("Commit for conflicting-fork-branch");
+
+        // No `remote.fork_remote` set → stax will try to auto-detect and hit
+        // the `find_pushable_fork` API. Without a live server that fails, but
+        // the point of this test is that the pre-existing `fork` remote's URL
+        // is still what it was.
+        let _ = repo.run_stax_with_env(
+            &[
+                "branch",
+                "submit",
+                "--fork",
+                "--yes",
+                "--no-prompt",
+                "--publish",
+                "--no-template",
+            ],
+            &[("STAX_GITHUB_TOKEN", "test-token")],
+        );
+
+        let after = repo.git(&["config", "--local", "--get", "remote.fork.url"]);
+        after.assert_success();
+        assert_eq!(
+            TestRepo::stdout(&after).trim(),
+            "https://github.com/someone-else/unrelated.git",
+            "stax must not silently repoint a pre-existing `fork` remote"
         );
     }
 }

--- a/tests/submit_fork_fallback_tests.rs
+++ b/tests/submit_fork_fallback_tests.rs
@@ -50,6 +50,45 @@ mod unix {
             .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
                 "message": "Not Found",
             })))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(mock_server)
+            .await;
+    }
+
+    /// Before either guard under test runs, submit always calls
+    /// `find_open_pr_by_head`, which hits `GET .../pulls`. Without this
+    /// mount, wiremock returns an empty body and serde fails on EOF before
+    /// the guard code is ever reached.
+    async fn mock_no_existing_prs(mock_server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(mock_server)
+            .await;
+    }
+
+    /// After a fresh `create_fork()`, stax polls the same lookup until the
+    /// fork is reachable. Respond success on that follow-up GET so the
+    /// readiness poll succeeds immediately instead of waiting out the
+    /// full budget.
+    async fn mock_fork_ready(
+        mock_server: &MockServer,
+        login: &str,
+        ssh_url: &str,
+        https_url: &str,
+    ) {
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/{login}/test-repo")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "fork": true,
+                "owner": { "login": login },
+                "ssh_url": ssh_url,
+                "clone_url": https_url,
+                "parent": { "full_name": "test-owner/test-repo" },
+                "permissions": { "push": true }
+            })))
+            .with_priority(2)
             .mount(mock_server)
             .await;
     }
@@ -87,6 +126,7 @@ mod unix {
         let fork_ssh_url = "git@github.com:contributor/test-repo.git";
         hermetic_git_init_bare(fork_bare.path());
         mock_create_fork(&mock_server, "contributor", fork_ssh_url, fork_https_url).await;
+        mock_fork_ready(&mock_server, "contributor", fork_ssh_url, fork_https_url).await;
         mount_pr_create_and_refresh(
             &mock_server,
             "test-owner",
@@ -161,6 +201,7 @@ mod unix {
             "PR head should be qualified with the fork owner, not the upstream owner: {pr_payload}"
         );
         assert_eq!(pr_payload["base"], "main");
+        assert_eq!(pr_payload["maintainer_can_modify"], true);
     }
 
     #[test]
@@ -219,13 +260,18 @@ mod unix {
         );
     }
 
-    #[test]
-    fn branch_submit_fork_conflicting_existing_fork_remote_fails() {
+    #[tokio::test]
+    async fn branch_submit_fork_conflicting_existing_fork_remote_fails() {
+        let mock_server = MockServer::start().await;
+        mount_current_user(&mock_server, "contributor").await;
+        mock_no_existing_fork(&mock_server, "contributor").await;
+        mock_no_existing_prs(&mock_server).await;
+        // No `POST /repos/test-owner/test-repo/forks` mock at all: the
+        // conflict check must fire before any mutating call is made.
+
         let repo = TestRepo::new_with_remote();
         let home = repo.clean_home();
-        // No live wiremock server needed — the conflict check fires before
-        // any API call.
-        write_stax_config(Path::new(&home), "http://127.0.0.1:1", "");
+        write_stax_config(Path::new(&home), &mock_server.uri(), "");
         repo.configure_github_like_submit_remote();
         // Pre-existing `fork` remote pointing at an unrelated URL that should
         // NOT be silently overwritten.
@@ -244,11 +290,11 @@ mod unix {
         repo.create_file("conflict.txt", "content");
         repo.commit("Commit for conflicting-fork-branch");
 
-        // No `remote.fork_remote` set → stax will try to auto-detect and hit
-        // the `find_pushable_fork` API. Without a live server that fails, but
-        // the point of this test is that the pre-existing `fork` remote's URL
-        // is still what it was.
-        let _ = repo.run_stax_with_env(
+        // No `remote.fork_remote` set → stax auto-detects and hits
+        // `find_pushable_fork`, which reports no existing fork, then must
+        // refuse to proceed because the pre-existing `fork` remote points
+        // somewhere unrelated.
+        repo.run_stax_with_env(
             &[
                 "branch",
                 "submit",
@@ -259,7 +305,10 @@ mod unix {
                 "--no-template",
             ],
             &[("STAX_GITHUB_TOKEN", "test-token")],
-        );
+        )
+        .assert_failure()
+        .assert_stderr_contains("someone-else/unrelated")
+        .assert_stderr_contains("already exists and points at");
 
         let after = repo.git(&["config", "--local", "--get", "remote.fork.url"]);
         after.assert_success();
@@ -267,6 +316,73 @@ mod unix {
             TestRepo::stdout(&after).trim(),
             "https://github.com/someone-else/unrelated.git",
             "stax must not silently repoint a pre-existing `fork` remote"
+        );
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.method.as_str() == "POST"
+                    && request.url.path() == "/repos/test-owner/test-repo/forks"),
+            "conflict check must run before any mutating fork-creation call"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_submit_fork_refuses_to_overwrite_unrelated_fork_branch() {
+        let mock_server = MockServer::start().await;
+        mount_current_user(&mock_server, "contributor").await;
+        mock_no_existing_fork(&mock_server, "contributor").await;
+        mock_no_existing_prs(&mock_server).await;
+
+        let fork_bare = tempfile::tempdir().expect("fork bare tempdir");
+        let fork_https_url = "https://github.com/contributor/test-repo.git";
+        let fork_ssh_url = "git@github.com:contributor/test-repo.git";
+        hermetic_git_init_bare(fork_bare.path());
+        mock_create_fork(&mock_server, "contributor", fork_ssh_url, fork_https_url).await;
+        mock_fork_ready(&mock_server, "contributor", fork_ssh_url, fork_https_url).await;
+
+        let repo = TestRepo::new_with_remote();
+        let home = repo.clean_home();
+        write_stax_config(Path::new(&home), &mock_server.uri(), "");
+        repo.configure_github_like_submit_remote();
+        configure_fork_insteadof(&repo, fork_bare.path(), fork_https_url);
+
+        let remote_path = repo.remote_path().expect("origin bare path");
+        install_permission_denying_pre_receive_hook(&remote_path);
+
+        repo.run_stax(&["bc", "fork-fallback-branch"])
+            .assert_success();
+        repo.create_file("fork-fallback.txt", "content");
+        repo.commit("Commit for fork-fallback-branch");
+        let branch = repo.current_branch();
+
+        // Seed the fork with an unrelated commit on a branch of the same
+        // name, from a scratch clone, so stax's first-ever publish must
+        // refuse to clobber it.
+        seed_unrelated_fork_branch(fork_bare.path(), &branch);
+        let tip_before = hermetic_git_branch_tip(fork_bare.path(), &branch);
+
+        repo.run_stax_with_env(
+            &[
+                "branch",
+                "submit",
+                "--fork",
+                "--yes",
+                "--no-prompt",
+                "--publish",
+                "--no-template",
+            ],
+            &[("STAX_GITHUB_TOKEN", "test-token")],
+        )
+        .assert_failure()
+        .assert_stderr_contains(&branch)
+        .assert_stderr_contains("delete");
+
+        let tip_after = hermetic_git_branch_tip(fork_bare.path(), &branch);
+        assert_eq!(
+            tip_before, tip_after,
+            "fork branch tip must be unchanged after a refused overwrite"
         );
     }
 }
@@ -291,4 +407,83 @@ fn hermetic_git_list_branches(bare_path: &Path) -> Vec<String> {
         .lines()
         .map(|s| s.to_string())
         .collect()
+}
+
+fn hermetic_git_branch_tip(bare_path: &Path, branch: &str) -> String {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", branch])
+        .current_dir(bare_path)
+        .output()
+        .expect("git rev-parse branch");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// Seed `bare_path` with a branch named `branch` holding a commit unrelated
+/// to anything stax knows about, so a first-ever fork publish of that branch
+/// name must be refused rather than silently overwritten.
+fn seed_unrelated_fork_branch(bare_path: &Path, branch: &str) {
+    let scratch = tempfile::tempdir().expect("scratch clone tempdir");
+
+    let clone = std::process::Command::new("git")
+        .args(["clone", &bare_path.to_string_lossy(), "."])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git clone fork bare repo");
+    assert!(
+        clone.status.success(),
+        "{}",
+        String::from_utf8_lossy(&clone.stderr)
+    );
+
+    let checkout = std::process::Command::new("git")
+        .args(["checkout", "--orphan", branch])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git checkout --orphan");
+    assert!(
+        checkout.status.success(),
+        "{}",
+        String::from_utf8_lossy(&checkout.stderr)
+    );
+
+    std::fs::write(scratch.path().join("unrelated.txt"), "unrelated\n")
+        .expect("write unrelated file");
+
+    let add = std::process::Command::new("git")
+        .args(["add", "unrelated.txt"])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git add");
+    assert!(add.status.success());
+
+    let commit = std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.email=fork@example.com",
+            "-c",
+            "user.name=Fork Bot",
+            "commit",
+            "-m",
+            "unrelated commit",
+        ])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git commit");
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    let push = std::process::Command::new("git")
+        .args(["push", "origin", branch])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git push unrelated branch");
+    assert!(
+        push.status.success(),
+        "{}",
+        String::from_utf8_lossy(&push.stderr)
+    );
 }


### PR DESCRIPTION
## Motivation

Picks up #709 ("feat(submit): open a PR via a fork when you lack write access" by @kcolford), which went stale after CHANGES_REQUESTED review feedback was never addressed. This re-lands that feature (`stax submit --fork` / `remote.auto_fork = true`, falling back to a fork when you lack push access to the upstream) and fixes every outstanding review item.

## Description of changes / notes for reviewers

Base feature (unchanged from #709, cherry-picked): classify a push rejection as a permission denial, reuse or create a pushable fork, push the branch there, and open the PR with head `<fork_owner>:<branch>`.

Fixes applied on top, from the original review:

**Blockers**
- The `--force-with-lease` "lease" on fork pushes was resolved from a live `ls-remote` immediately before the push, so it always matched and never protected anything — a contributor's pre-existing fork branch could be silently overwritten. Now, the first time stax ever publishes a given branch to a given fork remote, it refuses to proceed unless the fork branch's tip is already an ancestor of the local tip, and records what it published in `refs/stax/fork-published/<remote>/<branch>` so later restacks keep force-pushing without a false positive.
- The "existing `fork` remote points elsewhere" conflict test asserted nothing meaningful (it hit a dead endpoint and never reached the real check). Rewrote it to mount a real mock server and assert on the actual conflict message, plus added a new test asserting stax refuses to overwrite an unrelated existing fork branch.

**Should-fix**
- Fork readiness is now polled via `find_pushable_fork` with backoff instead of blindly retrying the push 2-3 times — fork creation is asynchronous and can take longer than a few seconds on large repos.
- The "existing `fork` remote points elsewhere" conflict check now runs before any mutating GitHub call (previously it ran after `create_fork` had already created a real fork on GitHub).
- A configured `remote.fork_remote` name is now honored even when that remote doesn't exist locally yet, instead of silently creating one named `fork`.
- `maintainer_can_modify` is now only requested on fork PRs (head is `owner:branch`); requesting it unconditionally could 422 on org-owned upstream repos.
- The multi-branch guard now checks the full plan count rather than just the branches that needed a push this run, since the fork head-rewrite applies to every PR create in scope.
- Push failure messages in the fork fallback path now include the original push error instead of dropping it.

**Minor**
- Simplified a redundant substring check in the stale-lease classifier.
- The retry-wait message now respects `--quiet` (moot after the polling rewrite, but the replacement message is gated too).

Left untouched per the original review discussion: the permission classifier's handling of "not authorized" (a protected-branch rejection could in theory be misclassified as a permission denial) — that was raised as an open design question, not a directive, and changing it without more product input risks a worse regression.

## Tests

`cargo check`, `cargo clippy -- -D warnings` clean (2 pre-existing, unrelated `clippy::items_after_test_module` findings in `src/web/{routes,templates}.rs` confirmed present on `main`). Full `make test` (2496 tests) green. `submit_fork_fallback_tests` now has 5 tests, all passing, including two new guard tests for the overwrite-protection and pre-create conflict-check fixes.
