### PR TITLE
refactor(cli): remove the now-redundant `st cli upgrade` subcommand

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -177,8 +177,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st --default-config` | Print annotated config template (all options and allowed values) |
 | `st --skill` | Print bundled AI agent skill document (SKILL.md format with frontmatter) |
 | `st init` | Initialize stax or reconfigure trunk (`--trunk <branch>`) |
-| `st cli upgrade` | Detect install method and run the matching upgrade |
-| `st update` | Upgrade the stax CLI (same as `st cli upgrade`), then check installed AI agent skill files and offer to refresh them. Skips the CLI upgrade if already on the latest version — pass `--force` to upgrade anyway |
+| `st update` | Detect install method and run the matching upgrade, then check installed AI agent skill files and offer to refresh them. Skips the CLI upgrade if already on the latest version — pass `--force` to upgrade anyway |
 | `st doctor` | Check repo health |
 | `st doctor --fix` | Apply safe local repairs after one confirmation (recommended Git config, stale AI skills for selected harnesses, and optional `gh-stack` install) |
 | `st skills` | Manage installed AI agent skill files (`list`, `update`, `update --all`, `update --skills <list>`, `update --dry-run`) |

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -62,7 +62,7 @@ cargo install --path . --locked --features vendored-openssl
 stax --version
 st setup --yes       # shell integration; skills for detected agents only; auth from gh (if available)
 st setup --yes --skills all   # install skills for every known harness (previous default)
-st cli upgrade       # later, upgrade via the install method you used
+st update            # later, upgrade via the install method you used
 ```
 
 For native shell completion, evaluate or install the generated script. For example:

--- a/docs/reference/windows.md
+++ b/docs/reference/windows.md
@@ -6,7 +6,7 @@ stax ships prebuilt Windows binaries (`x86_64-pc-windows-msvc`). Unit tests run 
 
 Download `stax-x86_64-pc-windows-msvc.zip` from [GitHub Releases](https://github.com/cesarferreira/stax/releases/latest), extract `stax.exe` and `st.exe`, and place them on your `PATH`.
 
-If you install with `cargo install` or `cargo binstall`, update notifications and `st cli upgrade` detect the Windows `.cargo\bin` path and show the matching cargo upgrade command.
+If you install with `cargo install` or `cargo binstall`, update notifications and `st update` detect the Windows `.cargo\bin` path and show the matching cargo upgrade command.
 
 ## What works
 

--- a/skills.md
+++ b/skills.md
@@ -95,8 +95,7 @@ stax gen --commit-msg          # Non-interactive: amend HEAD commit message from
 
 stax auth [status]             # GitHub auth setup/status
 stax config                    # Print config path + contents
-stax cli upgrade               # Detect the install method and run the matching upgrade flow
-stax update                    # Upgrade the CLI, then offer to refresh installed AI agent skill files
+stax update                    # Detect the install method and run the matching upgrade flow, then offer to refresh installed AI agent skill files
 stax doctor                    # Health checks (also reports stale skill files)
 stax doctor --fix              # Show one repair plan, then apply safe local fixes after confirmation
 stax validate                  # Validate stack metadata
@@ -378,7 +377,7 @@ stax refresh --force                # Force sync without prompts first
 stax refresh --force --yes --no-prompt # Full refresh without sync/submit prompts
 stax refresh --verbose              # Show detailed sync/restack/submit timings
 # refresh inherits sync's fetch/trunk guard and exits before its submit phase, so it does not push or update PRs after that failure.
-# `stax update` is a separate top-level command: it upgrades the CLI (see `stax cli upgrade`), then offers to refresh installed AI agent skill files.
+# `stax update` is a separate top-level command: it upgrades the CLI, then offers to refresh installed AI agent skill files.
 
 stax restack                       # Restack current branch onto parent
 stax restack --all                 # Restack whole stack
@@ -583,8 +582,7 @@ stax auth --token <token>          # Save GitHub PAT
 stax auth --from-gh                # Import from gh auth token
 stax auth status                   # Show active auth source
 stax config                        # Print config location + values
-stax cli upgrade                   # Upgrade using the detected install method, then refresh shell setup
-stax update                        # Upgrade the CLI, then offer to refresh installed AI agent skill files
+stax update                        # Upgrade using the detected install method (refreshing shell setup), then offer to refresh installed AI agent skill files
 stax doctor                        # Repo/config health checks (also reports stale skill files)
 stax doctor --fix                  # Confirm once to set recommended git config and update stale installed skills
 stax demo                          # Interactive tutorial

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -687,12 +687,6 @@ pub(crate) enum Commands {
         command: Option<AuthSubcommand>,
     },
 
-    /// Manage the installed stax CLI
-    Cli {
-        #[command(subcommand)]
-        command: CliSubcommand,
-    },
-
     /// Upgrade the stax CLI and check for skill updates
     Update {
         /// Run the upgrade even if already on the latest version
@@ -1466,12 +1460,6 @@ pub(crate) enum Commands {
 pub(crate) enum AuthSubcommand {
     /// Show which auth source is currently active
     Status,
-}
-
-#[derive(Subcommand, Clone)]
-pub(crate) enum CliSubcommand {
-    /// Upgrade stax using the current installation method
-    Upgrade,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -157,12 +157,6 @@ pub fn run() -> Result<()> {
             update::show_update_notification();
             return result;
         }
-        Commands::Cli { command } => {
-            let result = match command {
-                CliSubcommand::Upgrade => commands::cli::run_upgrade(),
-            };
-            return result;
-        }
         Commands::Update { force } => {
             commands::cli::run_update(*force)?;
             commands::skills::propose_skills_update()?;
@@ -510,7 +504,6 @@ pub fn run() -> Result<()> {
             restack,
         } => commands::modify::run(message, all, quiet, no_verify, restack),
         Commands::Auth { .. } => unreachable!(), // Handled above
-        Commands::Cli { .. } => unreachable!(),  // Handled above
         Commands::Update { .. } => unreachable!(), // Handled above
         Commands::Config { .. } => unreachable!(), // Handled above
         Commands::Init { .. } => unreachable!(), // Handled above

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::{
-    BranchCommands, Cli, CliSubcommand, CommandPolicy, Commands, RestackSubmitAfter, StackCommands,
+    BranchCommands, Cli, CommandPolicy, Commands, RestackSubmitAfter, StackCommands,
     WorktreeCommands,
 };
 use crate::cli::interactive::{
@@ -373,14 +373,17 @@ fn restack_backward_compat() {
 }
 
 #[test]
-fn cli_upgrade_parses() {
-    let cli = parse_cli(&["stax", "cli", "upgrade"]);
+fn update_force_parses() {
+    let cli = parse_cli(&["stax", "update", "--force"]);
     assert!(matches!(
         cli.command,
-        Some(Commands::Cli {
-            command: CliSubcommand::Upgrade
-        })
+        Some(Commands::Update { force: true })
     ));
+}
+
+#[test]
+fn cli_subcommand_no_longer_parses() {
+    assert!(try_parse_cli(&["stax", "cli", "upgrade"]).is_err());
 }
 
 #[test]

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 use std::process::Command;
 
 /// Run the CLI upgrade for `stax update`, skipping it when already on the latest
-/// published version (pass `force` to upgrade unconditionally, as `stax cli upgrade` does).
+/// published version (pass `force` to upgrade unconditionally).
 pub fn run_update(force: bool) -> Result<()> {
     if !force && already_up_to_date(&update::check_latest_version()) {
         println!(

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -182,10 +182,10 @@ fn write_binstall_record(home: &Path) {
     .expect("write binstall metadata");
 }
 
-fn run_upgrade(binary: &Path, home: &Path, extra_path: &Path) -> std::process::Output {
+fn run_update_cli(binary: &Path, home: &Path, extra_path: &Path) -> std::process::Output {
     let null_path = if cfg!(windows) { "NUL" } else { "/dev/null" };
     Command::new(binary)
-        .args(["cli", "upgrade"])
+        .args(["update", "--force"])
         .current_dir(home)
         .env("HOME", home)
         .env("PATH", path_with_bin(extra_path))
@@ -193,7 +193,7 @@ fn run_upgrade(binary: &Path, home: &Path, extra_path: &Path) -> std::process::O
         .env("GIT_CONFIG_SYSTEM", null_path)
         .env("STAX_DISABLE_UPDATE_CHECK", "1")
         .output()
-        .expect("run stax cli upgrade")
+        .expect("run stax update --force")
 }
 
 #[test]
@@ -437,7 +437,7 @@ fn test_bd_shortcut() {
 }
 
 #[test]
-fn cli_upgrade_uses_cargo_for_cargo_installs_and_refreshes_shell_setup() {
+fn update_uses_cargo_for_cargo_installs_and_refreshes_shell_setup() {
     let home = tempdir().expect("temp home");
     let installer_bin_dir = home.path().join("bin");
     let cargo_log = home.path().join("cargo.log");
@@ -451,7 +451,7 @@ fn cli_upgrade_uses_cargo_for_cargo_installs_and_refreshes_shell_setup() {
     .expect("seed stale shell setup");
 
     let binary = install_test_binary(&home.path().join(".cargo/bin/stax"));
-    let output = run_upgrade(&binary, home.path(), &installer_bin_dir);
+    let output = run_update_cli(&binary, home.path(), &installer_bin_dir);
 
     assert!(output.status.success(), "{:?}", output);
     assert_eq!(
@@ -465,7 +465,7 @@ fn cli_upgrade_uses_cargo_for_cargo_installs_and_refreshes_shell_setup() {
 }
 
 #[test]
-fn cli_upgrade_uses_cargo_binstall_for_binstall_installs() {
+fn update_uses_cargo_binstall_for_binstall_installs() {
     let home = tempdir().expect("temp home");
     let installer_bin_dir = home.path().join("bin");
     let cargo_log = home.path().join("cargo-binstall.log");
@@ -473,7 +473,7 @@ fn cli_upgrade_uses_cargo_binstall_for_binstall_installs() {
     write_binstall_record(home.path());
 
     let binary = install_test_binary(&home.path().join(".cargo/bin/stax"));
-    let output = run_upgrade(&binary, home.path(), &installer_bin_dir);
+    let output = run_update_cli(&binary, home.path(), &installer_bin_dir);
 
     assert!(output.status.success(), "{:?}", output);
     assert_eq!(
@@ -483,14 +483,14 @@ fn cli_upgrade_uses_cargo_binstall_for_binstall_installs() {
 }
 
 #[test]
-fn cli_upgrade_uses_homebrew_for_homebrew_installs() {
+fn update_uses_homebrew_for_homebrew_installs() {
     let home = tempdir().expect("temp home");
     let installer_bin_dir = home.path().join("bin");
     let brew_log = home.path().join("brew.log");
     write_fake_installer(&installer_bin_dir, "brew", &brew_log, 0);
 
     let binary = install_test_binary(&home.path().join("opt/homebrew/bin/stax"));
-    let output = run_upgrade(&binary, home.path(), &installer_bin_dir);
+    let output = run_update_cli(&binary, home.path(), &installer_bin_dir);
 
     assert!(output.status.success(), "{:?}", output);
     assert_eq!(
@@ -500,14 +500,14 @@ fn cli_upgrade_uses_homebrew_for_homebrew_installs() {
 }
 
 #[test]
-fn cli_upgrade_explains_unknown_install_method() {
+fn update_explains_unknown_install_method() {
     let home = tempdir().expect("temp home");
     let installer_bin_dir = home.path().join("bin");
     let upgrade_log = home.path().join("upgrade.log");
     write_fake_installer(&installer_bin_dir, "upgrade", &upgrade_log, 0);
 
     let binary = install_test_binary(&home.path().join("custom/bin/stax"));
-    let output = run_upgrade(&binary, home.path(), &installer_bin_dir);
+    let output = run_update_cli(&binary, home.path(), &installer_bin_dir);
 
     assert!(
         !output.status.success(),
@@ -525,14 +525,14 @@ fn cli_upgrade_explains_unknown_install_method() {
 }
 
 #[test]
-fn cli_upgrade_surfaces_installer_failures() {
+fn update_surfaces_installer_failures() {
     let home = tempdir().expect("temp home");
     let installer_bin_dir = home.path().join("bin");
     let cargo_log = home.path().join("cargo-fail.log");
     write_fake_installer(&installer_bin_dir, "cargo", &cargo_log, 23);
 
     let binary = install_test_binary(&home.path().join(".cargo/bin/stax"));
-    let output = run_upgrade(&binary, home.path(), &installer_bin_dir);
+    let output = run_update_cli(&binary, home.path(), &installer_bin_dir);
 
     assert!(!output.status.success(), "upgrade should fail");
     assert_eq!(


### PR DESCRIPTION
Stacked on #812.

## Summary
- `st update` (added in #812) supersedes `st cli upgrade` — `st update --force` does the exact same upgrade, plus proposes a skills update.
- Removes the `Commands::Cli { command: CliSubcommand }` variant and the `CliSubcommand` enum entirely.
- `commands::cli::run_upgrade()` / `run_upgrade_command()` are **kept** — `st update`'s `run_update()` still calls them internally.
- Retargeted the installer integration tests (`cli_upgrade_*` in `tests/cli_tests.rs`) at `st update --force` and renamed them accordingly.
- Updated docs (`docs/commands/reference.md`, `skills.md`, `docs/getting-started/install.md`, `docs/reference/windows.md`) to drop `st cli upgrade` mentions.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check && cargo clippy -- -D warnings`
- [x] Targeted `cargo nextest run` on `cli::tests::`, `cli_tests::`, `command_coverage_tests::`, `commands::cli::tests::`
- [x] Full `make test` (2546 tests, shared CLI dispatch change)