### PR TITLE
feat(cli): add r alias for refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` removes merged branches (including tracked merged PRs) and upstream-gone branches with no unique work |
-| `st refresh` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs |
+| `st refresh` / `st r` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs |
 | `st refresh --all-stacks` | Sync trunk once, then restack and submit every independent stack; needs a clean tree unless `--auto-stash-pop` is set and stops at the first conflict |
 | `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |
 | `st refresh --verbose` | Include detailed sync/restack/submit timing |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -38,7 +38,7 @@ st --trace status --json >/dev/null
 | `st sweep --delete --force` | | Skip confirmation prompt |
 | `st sweep --stale-days <N>` | | Override stale threshold in days (default: 30) |
 | `st sweep --json` | | Machine-readable branch classification (conflicts with `--delete`) |
-| `st refresh` | | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack |
+| `st refresh` | `r` | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack |
 | `st refresh --force --yes --no-prompt` | | Run the full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
 | `st refresh --all-stacks` | | Refresh every stack in the repo (fetch/trunk sync once, then restack + submit each stack); stops at the first conflict |

--- a/skills.md
+++ b/skills.md
@@ -369,7 +369,7 @@ stax sweep --delete --force        # Skip confirmation prompt
 stax sweep --stale-days 60         # Override stale threshold in days (default 30, or branch.stale_days config)
 stax sweep --json                  # Machine-readable branch classification (conflicts with --delete)
 
-stax refresh                        # Sync trunk, restack, then submit (no merged cleanup; no Sync plan prompt)
+stax refresh|r                      # Sync trunk, restack, then submit (no merged cleanup; no Sync plan prompt)
 stax refresh --no-pr                # Push only after trunk sync/restack
 stax refresh --no-submit            # Trunk sync/restack only
 stax refresh --all-stacks           # Sync trunk once, then restack/submit every independent stack; needs a clean tree unless --auto-stash-pop; stops at first conflict

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -554,6 +554,7 @@ pub(crate) enum Commands {
     },
 
     /// Sync trunk, restack current stack, then submit updates
+    #[command(visible_alias = "r")]
     Refresh {
         /// Push branches to remote but skip PR creation/updates
         #[arg(long)]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -274,6 +274,16 @@ fn test_refresh_help() {
 }
 
 #[test]
+fn test_refresh_alias_r() {
+    let output = stax(&["r", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Sync trunk"));
+    assert!(stdout.contains("--no-submit"));
+    assert!(stdout.contains("--all-stacks"));
+}
+
+#[test]
 fn test_update_help_describes_cli_and_skills_upgrade() {
     let output = stax(&["update", "--help"]);
     assert!(output.status.success());


### PR DESCRIPTION
## Motivation

Make the common refresh workflow faster to invoke by supporting `st r` as a short alias for `st refresh`.

## Description of changes / notes for reviewers

- Register `r` as a visible Clap alias for the top-level `refresh` command.
- Add an end-to-end CLI regression test covering refresh-specific help through the alias.
- Document the alias in the README, command reference, and agent-facing skills guide.

## Verification

Scoped draft PR gate:

- `cargo nextest run cli_tests::test_refresh_alias_r command_coverage_tests::documented_cli_commands_and_aliases_resolve_from_help`
- `cargo check`
- `make lint-fast`
- `git diff --check`

All passed locally. The full gate (`make lint` and `make test`) is deferred to CI before promotion from draft.