### PR TITLE
Let `st web` open any path inside a Git worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ st web --port 0   # ephemeral port
 st web --no-open  # start without opening browser; prints URL
 ```
 
+Run `st web` from anywhere inside a Git worktree, or pass any path inside one; stax discovers and opens the worktree root automatically.
+
 Binds 127.0.0.1 only with an unguessable session token in the URL, CSRF protection on every mutating POST, and one-mutation-at-a-time enforcement. Requests without an `Origin` remain supported; when present, `Origin` must exactly match `http://127.0.0.1:<actual-bound-port>`. No `--host` flag — it cannot be exposed to the network.
 
 → [Web workspace guide](docs/interface/web.md)

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -426,8 +426,8 @@ Restack the stack and submit updates, without fetching trunk (offline-friendly).
 
 ### `st web`
 
-- `st web` starts the localhost HTMX workspace for the current directory and opens it in the browser.
-- `st web <path>` opens an explicit repository path.
+- `st web` discovers the enclosing Git worktree from the current directory, starts its localhost HTMX workspace, and opens it in the browser.
+- `st web <path>` accepts a repository or any path inside one and opens the enclosing worktree.
 - `st web --port <n>` binds on a specific port (default 8787). `--port 0` picks an ephemeral port. If the requested port is busy, stax warns and uses a free OS-selected port.
 - `st web --no-open` starts the server and prints the URL without opening the browser.
 - Binds **127.0.0.1 only**; no `--host` flag is available.

--- a/docs/interface/web.md
+++ b/docs/interface/web.md
@@ -10,14 +10,16 @@
 st web            # opens port 8787, or warns and uses a free port if busy
 st web --port 0   # ephemeral port (chosen by OS)
 st web --no-open  # start without opening browser; prints URL
-st web /path/to/repo  # open a specific repository
+st web /path/inside/repo  # discover and open a specific worktree
 ```
+
+The current directory or explicit `[PATH]` may be anywhere inside a Git worktree. Stax discovers the enclosing worktree root before starting the server.
 
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `[PATH]` | current directory | Repository to open |
+| `[PATH]` | current directory | Repository or path inside one to open |
 | `--port <N>` | `8787` | Port to bind. `0` picks an ephemeral port. If the port is busy, stax warns and uses a free OS-selected port. |
 | `--no-open` | false | Skip opening the browser; just print the URL. |
 

--- a/skills.md
+++ b/skills.md
@@ -166,10 +166,11 @@ stax web                          # Start on 127.0.0.1:8787 and open browser
 stax web --port 9000              # Custom port (falls back to a free OS port if busy)
 stax web --port 0                 # Ephemeral port
 stax web --no-open                # Print URL only; don't open browser
-stax web /path/to/repo            # Open a specific repository
+stax web /path/inside/repo        # Discover and open a specific worktree
 ```
 
 Key properties:
+- Discovers the enclosing Git worktree root from the current directory or any explicit path inside it
 - GitKraken-inspired layout: grouped toolbar, stack graph table (topology + ahead/behind + PR chips), file-list + patch Changes panel, Details inspector, status bar
 - Binds **127.0.0.1 only** — never reachable from the network; no `--host` flag
 - Unguessable 48-hex session token in every URL: `/s/<token>/…`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -43,7 +43,7 @@ pub(crate) struct Cli {
 
 #[derive(Args, Debug, Clone)]
 pub(crate) struct WebArgs {
-    /// Repository to open; defaults to the current directory
+    /// Repository or path inside one to open; defaults to the current directory
     pub(crate) path: Option<PathBuf>,
     /// Port to bind (default 8787). If the requested port is busy, stax warns and uses a free OS-selected port.
     #[arg(long, default_value_t = 8787)]

--- a/src/commands/web.rs
+++ b/src/commands/web.rs
@@ -13,6 +13,23 @@ fn resolve_repo_root(path: Option<PathBuf>) -> Result<PathBuf> {
         Some(p) => p,
         None => std::env::current_dir().context("Failed to resolve current directory")?,
     };
-    path.canonicalize()
-        .with_context(|| format!("Failed to canonicalize path '{}'", path.display()))
+    let repo = git2::Repository::discover(&path).with_context(|| {
+        format!(
+            "Failed to discover git repository from '{}'",
+            path.display()
+        )
+    })?;
+    let workdir = repo.workdir().with_context(|| {
+        format!(
+            "Git repository discovered from '{}' has no working directory",
+            path.display()
+        )
+    })?;
+    workdir.canonicalize().with_context(|| {
+        format!(
+            "Failed to canonicalize git repository root '{}' discovered from '{}'",
+            workdir.display(),
+            path.display()
+        )
+    })
 }

--- a/tests/web_tests.rs
+++ b/tests/web_tests.rs
@@ -850,10 +850,12 @@ fn web_server_bind_reports_no_fallback_for_ephemeral_port() {
 }
 
 #[test]
-fn web_command_reports_busy_port_fallback_and_startup_progress() {
+fn web_command_discovers_repo_from_nested_directory_and_reports_startup_progress() {
     let repo = common::TestRepo::new();
     let init_out = repo.run_stax(&["init", "--trunk", "main"]);
     assert!(init_out.status.success());
+    let nested_dir = repo.path().join("wayve/frontends/robot-android");
+    std::fs::create_dir_all(&nested_dir).expect("nested directory should be created");
 
     let busy_listener =
         std::net::TcpListener::bind(("127.0.0.1", 0)).expect("busy-port guard should bind");
@@ -862,7 +864,7 @@ fn web_command_reports_busy_port_fallback_and_startup_progress() {
         .expect("busy-port guard should have an address")
         .port();
 
-    let mut child = web_command(&repo.path())
+    let mut child = web_command(&nested_dir)
         .args(["web", "--port", &busy_port.to_string(), "--no-open"])
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -920,6 +922,22 @@ fn web_command_reports_busy_port_fallback_and_startup_progress() {
     assert!(output.contains("skipped (--no-open)"));
     assert!(output.contains("Workspace  http://127.0.0.1:"));
     assert!(output.contains("Press Ctrl-C to stop."));
+}
+
+#[test]
+fn web_command_reports_an_error_outside_a_repository() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = web_command(temp.path())
+        .args(["web", "--no-open"])
+        .output()
+        .expect("st web should exit with an error");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to discover git repository"),
+        "expected repository discovery context: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Discover the enclosing Git worktree when `st web` runs from a nested directory or receives a nested `--path`.
- Preserve a clear error when the starting path is outside a Git repository.
- Update CLI help and user/agent documentation to describe repository-root discovery.

## Tests
- Extend the end-to-end web command test to launch from a nested directory.
- Add error-path coverage for launching outside a Git repository.

## Documentation
- Updated `README.md`, `docs/commands/reference.md`, `docs/interface/web.md`, and `skills.md`.

## Verification
Evidence is from the scoped draft gate:
- `cargo check`
- `make lint-fast`
- `git diff --check`
- `cargo nextest run web_tests::` — 20/20 passed

The full gate is delegated to CI before promotion to ready-for-review or merge.