### PR TITLE
fix(gitlab): include head SHA when merging

### DIFF
--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -458,9 +458,21 @@ impl GitLabClient {
         commit_title: Option<&str>,
         sha: Option<&str>,
     ) -> Result<()> {
+        let fetched_sha;
+        let sha = match sha {
+            Some(sha) => sha,
+            None => {
+                fetched_sha = self.get_pr_head_sha(number).await?;
+                fetched_sha.as_str()
+            }
+        };
+        if sha.is_empty() {
+            bail!("GitLab merge request !{} is missing its head SHA", number);
+        }
+
         let request = MergeMrRequest {
             merge_commit_message: commit_title,
-            sha,
+            sha: Some(sha),
             squash: matches!(method, MergeMethod::Squash),
         };
         let _: serde_json::Value = put_json(
@@ -991,7 +1003,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn merge_pr_rebase_retains_non_stack_behavior() {
+    async fn merge_pr_fetches_sha_when_not_supplied() {
+        ensure_crypto_provider();
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/merge_requests/7"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "iid": 7,
+                "title": "Feature",
+                "state": "opened",
+                "draft": false,
+                "source_branch": "feature-a",
+                "target_branch": "main",
+                "sha": "abc123"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/projects/group%2Fsubgroup%2Frepo/merge_requests/7/merge",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        GitLabClient::new(&remote_info(&server))
+            .unwrap()
+            .merge_pr(7, MergeMethod::Merge, None, None)
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method.as_str(), "GET");
+        assert_eq!(requests[1].method.as_str(), "PUT");
+        let payload: serde_json::Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(payload["sha"], "abc123");
+    }
+
+    #[tokio::test]
+    async fn merge_pr_uses_supplied_sha_without_fetch() {
         ensure_crypto_provider();
         unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
         let server = MockServer::start().await;
@@ -1015,6 +1068,38 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
         assert_eq!(payload["sha"], "abc123");
         assert_eq!(payload["squash"], false);
+    }
+
+    #[tokio::test]
+    async fn merge_pr_fails_before_put_when_head_sha_is_missing() {
+        ensure_crypto_provider();
+        unsafe { std::env::set_var("STAX_GITLAB_TOKEN", "test-token") };
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/projects/group%2Fsubgroup%2Frepo/merge_requests/7"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "iid": 7,
+                "title": "Feature",
+                "state": "opened",
+                "draft": false,
+                "source_branch": "feature-a",
+                "target_branch": "main",
+                "sha": null
+            })))
+            .mount(&server)
+            .await;
+
+        let error = GitLabClient::new(&remote_info(&server))
+            .unwrap()
+            .merge_pr(7, MergeMethod::Merge, None, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("missing its head SHA"));
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method.as_str(), "GET");
     }
 
     #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15309,6 +15309,9 @@ exit 1
             "/projects/test%2Frepo/merge_requests/101/merge",
         );
         assert!(retarget_idx > merge_idx);
+        let merge_payload: serde_json::Value =
+            serde_json::from_slice(&requests[merge_idx].body).unwrap();
+        assert_eq!(merge_payload["sha"], "sha-a");
         let retarget = requests
             .iter()
             .find(|request| {
@@ -15512,6 +15515,9 @@ exit 1
             "/projects/test%2Frepo/merge_requests/201/merge",
         );
         assert!(retarget_idx > merge_idx);
+        let merge_payload: serde_json::Value =
+            serde_json::from_slice(&requests[merge_idx].body).unwrap();
+        assert_eq!(merge_payload["sha"], "sha-a");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Some GitLab instances require the merge request head SHA when accepting a merge. Ordinary `st merge` paths omitted that field, causing `400 Bad Request {"message":"SHA must be provided when merging"}`, while `st merge --stack` already supplied it.

Fixes #819.

## Description of changes / notes for reviewers

- Resolve the GitLab MR head SHA once inside `GitLabClient::merge_pr` when the caller did not supply one, then include it in the merge PUT.
- Reuse explicit caller-provided SHAs without an extra lookup, and fail before mutation if GitLab does not report a head SHA.
- Reuse the existing ordinary and `--when-ready` GitLab fixtures to assert the merge request body contains the expected SHA; add focused provider tests for fetched, supplied, and missing SHA paths.

## Verification

Scoped draft gate:

- `cargo check`
- `make lint-fast`
- `git diff --check`
- `cargo nextest run forge::gitlab::tests::merge_pr_` (3 passed)
- focused ordinary, `--when-ready`, and existing stack-merge GitLab integration tests (3 passed)

Hosted CI is the full `make lint` and `make test` gate for the exact PR head.

Documentation is unchanged because this restores the already-documented merge behavior and adds no command, flag, output, concept, or default.
