### PR TITLE
feat(branch): track all local branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st create <name>` / `st add <name>` | Create a branch stacked on current |
 | `st create --ai -a --yes` | Generate branch name + first commit message |
 | `st create <name> --below` | Insert a new branch below current, carrying tracked/untracked prepared changes with it |
+| `st branch track --all` | Adopt every untracked non-trunk local branch into stacks using its nearest cycle-safe strict local ancestor |
 | `st get [branch|PR]` | Sync the current stack, or fetch a branch/PR stack from remote without overwriting local commits |
 | `st ss` | Submit the full stack, open/update linked PRs; temporary-publishes branches that need restack |
 | `st submit --plan [--json]` | Preview fetch, push, PR, retarget, metadata, and stack-link actions without changing local or remote state |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -85,6 +85,7 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st rename` | | Rename current branch |
 | `st move [target]` | `mv` | Move the current branch and descendants onto a new parent (`st upstack onto` parity alias; picker when omitted) |
 | `st branch track` | | Track an existing branch |
+| `st branch track --all` | | Track every untracked non-trunk local branch under its nearest cycle-safe strict local ancestor |
 | `st branch track --all-prs` | | Track all open PRs (GitHub, GitLab, Gitea); sets upstream on branches it fetches |
 | `st branch untrack` | `ut` | Remove stax metadata |
 | `st branch reparent` | | Change parent |
@@ -95,6 +96,18 @@ See also: [Merge and cascade](../workflows/merge-and-cascade.md)
 | `st detach` | | Remove branch from stack, reparent children |
 | `st reorder` | | Interactively reorder branches in stack |
 | `st absorb` | | Distribute staged changes to the correct stack branches (file-level) |
+
+`st branch track --all` is local and metadata-only: it does not contact a forge,
+fetch or change remotes/upstreams, load remote configuration, or switch branches.
+It snapshots the untracked non-trunk local branches before writing metadata and
+leaves existing tracked metadata and the trunk untouched. For each target, it
+chooses the cycle-safe strict local ancestor with the fewest commits between
+that ancestor and the target, breaking equal-distance ties lexically by branch
+name. Non-trunk branches at the same commit are never selected as one another's
+parent. When no cycle-safe strict local ancestor exists, including for unrelated
+histories, the branch is parented to trunk; trunk remains the fallback root even
+when it points at the same commit. `--all` conflicts with `--parent` and
+`--all-prs`.
 
 ### Up/down scopes
 

--- a/skills.md
+++ b/skills.md
@@ -422,6 +422,7 @@ stax get teammate-branch --no-checkout  # Fetch and track without switching bran
 # Imported PRs still get stack-link comments with relative intro text. GitHub comments keep compact native PR references and mark the rendered PR with 👈.
 # sync --restack refreshes clean imported bases before rebasing descendants; cleanup can remove them locally after merge/gone.
 stax branch track --parent main    # Track existing branch under parent
+stax branch track --all            # Local-only bulk tracking by nearest cycle-safe strict ancestor; equal-tip non-trunk branches never parent each other, otherwise fall back to trunk
 stax branch track --all-prs        # Import your open PRs
 stax branch untrack <branch>       # Remove stax metadata only
 stax branch reparent --parent new  # Change parent branch

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1572,10 +1572,13 @@ pub(crate) enum BranchCommands {
     /// Track an existing branch (set its parent)
     Track {
         /// Parent branch name
-        #[arg(short, long, conflicts_with = "all_prs")]
+        #[arg(short, long, conflicts_with_all = ["all", "all_prs"])]
         parent: Option<String>,
+        /// Track all untracked local branches under their nearest local ancestors
+        #[arg(long, conflicts_with_all = ["parent", "all_prs"])]
+        all: bool,
         /// Track all open PRs authored by you
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["parent", "all"])]
         all_prs: bool,
     },
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -744,9 +744,11 @@ pub fn run() -> Result<()> {
                 child,
                 shell_output,
             } => commands::checkout::run(branch, pr, trunk, parent, child, shell_output),
-            BranchCommands::Track { parent, all_prs } => {
-                commands::branch::track::run(parent, all_prs)
-            }
+            BranchCommands::Track {
+                parent,
+                all,
+                all_prs,
+            } => commands::branch::track::run(parent, all, all_prs),
             BranchCommands::Untrack { branch } => commands::branch::untrack::run(branch),
             BranchCommands::Reparent {
                 branch,

--- a/src/commands/branch/track.rs
+++ b/src/commands/branch/track.rs
@@ -11,11 +11,14 @@ use crate::remote::{self, RemoteInfo};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use dialoguer::{FuzzySelect, theme::ColorfulTheme};
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 
-pub fn run(parent: Option<String>, all_prs: bool) -> Result<()> {
+pub fn run(parent: Option<String>, all: bool, all_prs: bool) -> Result<()> {
+    if all {
+        return run_track_all_local();
+    }
     if all_prs {
         return run_track_all_prs();
     }
@@ -92,17 +95,7 @@ pub fn run(parent: Option<String>, all_prs: bool) -> Result<()> {
         }
     };
 
-    // Use the divergence point (merge-base) rather than the parent's current tip.
-    // This matches freephite's `trackBranch` which stores `getMergeBase(branch, parent)`.
-    // Storing the tip would make the stored revision a non-ancestor of `current`,
-    // which causes `git rebase --onto` to scope the replay incorrectly.
-    let parent_rev = repo
-        .merge_base(&parent_branch, &current)
-        .or_else(|_| repo.branch_commit(&parent_branch))?;
-
-    // Create metadata
-    let meta = BranchMetadata::new(&parent_branch, &parent_rev);
-    meta.write(repo.inner(), &current)?;
+    write_tracking_metadata(&repo, &current, &parent_branch)?;
 
     if let Ok(remote_branches) = remote::get_remote_branches(repo.workdir()?, config.remote_name())
         && !remote_branches.contains(&parent_branch)
@@ -125,6 +118,259 @@ pub fn run(parent: Option<String>, all_prs: bool) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn run_track_all_local() -> Result<()> {
+    let repo = GitRepo::open()?;
+    let trunk = repo.trunk_branch()?;
+    let mut branches = repo.list_branches()?;
+    branches.sort();
+    let workdir = repo.workdir()?;
+
+    let mut tips = HashMap::new();
+    let mut targets = Vec::new();
+    let mut parent_map = HashMap::new();
+    for branch in &branches {
+        tips.insert(branch.clone(), repo.branch_commit(branch)?);
+        match BranchMetadata::read(repo.inner(), branch)? {
+            Some(metadata) => {
+                parent_map.insert(branch.clone(), metadata.parent_branch_name);
+            }
+            None if branch != &trunk => targets.push(branch.clone()),
+            None => {}
+        }
+    }
+
+    if targets.is_empty() {
+        println!("No untracked local branches to track.");
+        return Ok(());
+    }
+
+    let mut reachable_counts = HashMap::new();
+    for branch in &branches {
+        reachable_counts.insert(
+            branch.clone(),
+            reachable_commit_count(workdir, branch)
+                .with_context(|| format!("Failed to count commits reachable from '{}'", branch))?,
+        );
+    }
+
+    let known_branches: HashSet<&str> = branches.iter().map(String::as_str).collect();
+    let mut candidates = HashMap::new();
+    for branch in &targets {
+        let branch_tip = &tips[branch];
+        let target_count = reachable_counts[branch];
+        let mut ranked = Vec::new();
+        for candidate in merged_local_branches(workdir, branch)? {
+            if !known_branches.contains(candidate.as_str())
+                || candidate == branch.as_str()
+                || tips.get(&candidate) == Some(branch_tip)
+            {
+                continue;
+            }
+            let candidate_count = *reachable_counts.get(&candidate).with_context(|| {
+                format!(
+                    "Missing reachable commit count for candidate '{}' of target '{}'",
+                    candidate, branch
+                )
+            })?;
+            let distance = target_count.checked_sub(candidate_count).with_context(|| {
+                format!(
+                    "Reachable commit count underflow for candidate '{}' and target '{}'",
+                    candidate, branch
+                )
+            })?;
+            if distance == 0 {
+                anyhow::bail!(
+                    "Strict ancestor candidate '{}' has zero distance from target '{}'",
+                    candidate,
+                    branch
+                );
+            }
+            ranked.push((distance, candidate));
+        }
+        ranked.sort_by(|(left_ahead, left_name), (right_ahead, right_name)| {
+            left_ahead
+                .cmp(right_ahead)
+                .then_with(|| left_name.cmp(right_name))
+        });
+        candidates.insert(branch.clone(), ranked);
+    }
+
+    let order = topological_target_order(&targets, &candidates)?;
+    let mut plan = Vec::with_capacity(targets.len());
+    for branch in order {
+        let parent = candidates[&branch]
+            .iter()
+            .map(|(_, candidate)| candidate)
+            .find(|candidate| !parent_chain_reaches(&parent_map, candidate, &branch))
+            .cloned()
+            .unwrap_or_else(|| trunk.clone());
+        parent_map.insert(branch.clone(), parent.clone());
+        plan.push((branch, parent));
+    }
+
+    validate_parent_map_acyclic(&parent_map)?;
+
+    for (branch, parent) in &plan {
+        write_tracking_metadata(&repo, branch, parent)?;
+        println!(
+            "{} Tracking '{}' with parent '{}'",
+            "✓".green(),
+            branch.green(),
+            parent.blue()
+        );
+    }
+
+    println!(
+        "Tracked {} local branch(es).",
+        targets.len().to_string().green()
+    );
+    Ok(())
+}
+
+fn reachable_commit_count(workdir: &Path, branch: &str) -> Result<usize> {
+    let branch_ref = format!("refs/heads/{branch}");
+    let output = Command::new("git")
+        .args(["rev-list", "--count", &branch_ref])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to run git rev-list for '{}'", branch))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git rev-list --count '{}' failed: {}",
+            branch,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let count = String::from_utf8(output.stdout)
+        .with_context(|| format!("git rev-list count for '{}' was not UTF-8", branch))?;
+    count.trim().parse().with_context(|| {
+        format!(
+            "Invalid git rev-list count for '{}': {:?}",
+            branch,
+            count.trim()
+        )
+    })
+}
+
+fn merged_local_branches(workdir: &Path, target: &str) -> Result<Vec<String>> {
+    let target_ref = format!("refs/heads/{target}");
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            &format!("--merged={target_ref}"),
+            "--format=%(refname:strip=2)",
+            "refs/heads",
+        ])
+        .current_dir(workdir)
+        .output()
+        .with_context(|| format!("Failed to list local ancestors of target '{}'", target))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git for-each-ref --merged='{}' failed: {}",
+            target,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(output
+        .stdout
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| std::str::from_utf8(line).ok())
+        .filter(|branch| !branch.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn topological_target_order(
+    targets: &[String],
+    candidates: &HashMap<String, Vec<(usize, String)>>,
+) -> Result<Vec<String>> {
+    let target_set: HashSet<&str> = targets.iter().map(String::as_str).collect();
+    let mut indegree: HashMap<String, usize> =
+        targets.iter().cloned().map(|target| (target, 0)).collect();
+    let mut children: HashMap<String, Vec<String>> = HashMap::new();
+
+    for target in targets {
+        for (_, candidate) in &candidates[target] {
+            if target_set.contains(candidate.as_str()) {
+                *indegree
+                    .get_mut(target)
+                    .context("Target missing from topological indegree map")? += 1;
+                children
+                    .entry(candidate.clone())
+                    .or_default()
+                    .push(target.clone());
+            }
+        }
+    }
+    for descendants in children.values_mut() {
+        descendants.sort();
+    }
+
+    let mut ready: BTreeSet<String> = indegree
+        .iter()
+        .filter(|(_, degree)| **degree == 0)
+        .map(|(target, _)| target.clone())
+        .collect();
+    let mut order = Vec::with_capacity(targets.len());
+    while let Some(next) = ready.iter().next().cloned() {
+        ready.remove(&next);
+        order.push(next.clone());
+        for child in children.get(&next).into_iter().flatten() {
+            let degree = indegree
+                .get_mut(child)
+                .context("Target missing from topological indegree map")?;
+            *degree -= 1;
+            if *degree == 0 {
+                ready.insert(child.clone());
+            }
+        }
+    }
+
+    if order.len() != targets.len() {
+        anyhow::bail!("Local branch ancestry contains a cycle");
+    }
+    Ok(order)
+}
+
+fn parent_chain_reaches(parent_map: &HashMap<String, String>, start: &str, target: &str) -> bool {
+    let mut current = start;
+    let mut visited = HashSet::new();
+    loop {
+        if current == target {
+            return true;
+        }
+        if !visited.insert(current.to_string()) {
+            return false;
+        }
+        let Some(parent) = parent_map.get(current) else {
+            return false;
+        };
+        current = parent;
+    }
+}
+
+fn validate_parent_map_acyclic(parent_map: &HashMap<String, String>) -> Result<()> {
+    for branch in parent_map.keys() {
+        let mut current = branch.as_str();
+        let mut path = HashSet::new();
+        while let Some(parent) = parent_map.get(current) {
+            if !path.insert(current.to_string()) {
+                anyhow::bail!("Branch metadata contains a cycle involving '{}'", current);
+            }
+            current = parent;
+        }
+    }
+    Ok(())
+}
+
+fn write_tracking_metadata(repo: &GitRepo, branch: &str, parent: &str) -> Result<()> {
+    let parent_rev = repo
+        .merge_base_refs(parent, branch)
+        .or_else(|_| repo.rev_parse(parent))?;
+    let meta = BranchMetadata::new(parent, &parent_rev);
+    meta.write(repo.inner(), branch)
 }
 
 /// Track all open PRs authored by the current user

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -152,6 +152,8 @@ mod sync_json_tests;
 mod sync_stash_tests;
 #[path = "sync_undo_tests.rs"]
 mod sync_undo_tests;
+#[path = "track_all_local_tests.rs"]
+mod track_all_local_tests;
 #[path = "track_all_prs_tests.rs"]
 mod track_all_prs_tests;
 #[path = "track_merge_base_tests.rs"]

--- a/tests/track_all_local_tests.rs
+++ b/tests/track_all_local_tests.rs
@@ -1,0 +1,231 @@
+//! Integration tests for `stax branch track --all`.
+
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+use serde_json::Value;
+use std::fs;
+
+fn metadata_ref(branch: &str) -> String {
+    format!("refs/branch-metadata/{branch}")
+}
+
+fn metadata_for(repo: &TestRepo, branch: &str) -> Value {
+    let output = repo.git(&["show", &metadata_ref(branch)]);
+    output.assert_success();
+    serde_json::from_str(&TestRepo::stdout(&output)).expect("valid metadata JSON")
+}
+
+fn metadata_oid(repo: &TestRepo, branch: &str) -> String {
+    let output = repo.git(&["rev-parse", "--verify", &metadata_ref(branch)]);
+    output.assert_success();
+    TestRepo::stdout(&output).trim().to_string()
+}
+
+fn rewrite_metadata_parent(repo: &TestRepo, branch: &str, parent: &str) {
+    let mut metadata = metadata_for(repo, branch);
+    metadata["parentBranchName"] = Value::String(parent.to_string());
+    metadata["parentBranchRevision"] = Value::String(repo.get_commit_sha(parent));
+
+    let file = tempfile::NamedTempFile::new().expect("metadata file");
+    fs::write(file.path(), metadata.to_string()).expect("metadata contents");
+    let hash = repo.git(&[
+        "hash-object",
+        "-w",
+        file.path().to_str().expect("metadata path"),
+    ]);
+    hash.assert_success();
+    repo.git(&[
+        "update-ref",
+        &metadata_ref(branch),
+        TestRepo::stdout(&hash).trim(),
+    ])
+    .assert_success();
+}
+
+fn assert_metadata_missing(repo: &TestRepo, branch: &str) {
+    let output = repo.git(&["show-ref", "--verify", &metadata_ref(branch)]);
+    assert!(
+        !output.status.success(),
+        "{branch} should not have branch metadata"
+    );
+}
+
+fn assert_parent(repo: &TestRepo, branch: &str, expected_parent: &str) {
+    let metadata = metadata_for(repo, branch);
+    assert_eq!(
+        metadata["parentBranchName"].as_str(),
+        Some(expected_parent),
+        "unexpected parent metadata for {branch}: {metadata}"
+    );
+}
+
+fn commit_on_new_branch(repo: &TestRepo, branch: &str) {
+    repo.git(&["checkout", "-b", branch]).assert_success();
+    repo.create_file(&format!("{branch}.txt"), branch);
+    repo.commit(&format!("Commit {branch}"));
+}
+
+#[test]
+fn track_all_tracks_raw_git_stack_under_nearest_local_ancestors() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+
+    commit_on_new_branch(&repo, "raw-root");
+    commit_on_new_branch(&repo, "raw-middle");
+    commit_on_new_branch(&repo, "raw-leaf");
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, "raw-root", "main");
+    assert_parent(&repo, "raw-middle", "raw-root");
+    assert_parent(&repo, "raw-leaf", "raw-middle");
+    assert_metadata_missing(&repo, "main");
+}
+
+#[test]
+fn track_all_uses_tracked_parent_without_rewriting_existing_metadata() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+    let tracked_parent = repo.create_stack(&["tracked-parent"]).remove(0);
+    let parent_metadata_before = metadata_for(&repo, &tracked_parent);
+    let parent_oid_before = metadata_oid(&repo, &tracked_parent);
+
+    commit_on_new_branch(&repo, "raw-child");
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, "raw-child", &tracked_parent);
+    assert_eq!(metadata_for(&repo, &tracked_parent), parent_metadata_before);
+    assert_eq!(metadata_oid(&repo, &tracked_parent), parent_oid_before);
+    assert_metadata_missing(&repo, "main");
+}
+
+#[test]
+fn track_all_falls_back_to_trunk_for_unrelated_history() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+
+    repo.git(&["checkout", "--orphan", "isolated"])
+        .assert_success();
+    repo.git(&["rm", "-rf", "."]).assert_success();
+    repo.create_file("isolated.txt", "isolated history");
+    repo.git(&["add", "isolated.txt"]).assert_success();
+    repo.git(&["commit", "-m", "Isolated root commit"])
+        .assert_success();
+    repo.git(&["checkout", "main"]).assert_success();
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, "isolated", "main");
+    assert_metadata_missing(&repo, "main");
+}
+
+#[test]
+fn track_all_does_not_parent_equal_tip_branches_to_each_other() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+
+    commit_on_new_branch(&repo, "same-tip-a");
+    repo.git(&["branch", "same-tip-b", "same-tip-a"])
+        .assert_success();
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, "same-tip-a", "main");
+    assert_parent(&repo, "same-tip-b", "main");
+}
+
+#[test]
+fn track_all_avoids_cycle_through_existing_tracked_metadata() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+    let tracked_ancestor = repo.create_stack(&["tracked-ancestor"]).remove(0);
+    commit_on_new_branch(&repo, "raw-descendant");
+    rewrite_metadata_parent(&repo, &tracked_ancestor, "raw-descendant");
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, &tracked_ancestor, "raw-descendant");
+    assert_parent(&repo, "raw-descendant", "main");
+    repo.run_stax(&["validate"]).assert_success();
+}
+
+#[test]
+fn track_all_breaks_equal_distance_ancestor_ties_lexically() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+
+    commit_on_new_branch(&repo, "z-parent");
+    repo.git(&["checkout", "main"]).assert_success();
+    commit_on_new_branch(&repo, "a-parent");
+    repo.git(&["checkout", "main"]).assert_success();
+    repo.git(&["checkout", "-b", "merge-target"])
+        .assert_success();
+    repo.git(&["merge", "--no-ff", "a-parent", "-m", "Merge a-parent"])
+        .assert_success();
+    repo.git(&["merge", "--no-ff", "z-parent", "-m", "Merge z-parent"])
+        .assert_success();
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, "merge-target", "a-parent");
+}
+
+#[test]
+fn track_all_second_run_is_a_metadata_preserving_noop() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+    commit_on_new_branch(&repo, "raw-branch");
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+    let metadata_before = metadata_for(&repo, "raw-branch");
+    let oid_before = metadata_oid(&repo, "raw-branch");
+
+    let second_run = repo.run_stax(&["branch", "track", "--all"]);
+
+    second_run
+        .assert_success()
+        .assert_stdout_contains("No untracked local branches to track.");
+    assert_eq!(metadata_for(&repo, "raw-branch"), metadata_before);
+    assert_eq!(metadata_oid(&repo, "raw-branch"), oid_before);
+}
+
+#[test]
+fn track_all_handles_branch_names_that_collide_with_tags() {
+    let repo = TestRepo::new();
+    repo.set_trunk("main");
+    commit_on_new_branch(&repo, "shared-name");
+    repo.git(&["tag", "shared-name", "main"]).assert_success();
+    commit_on_new_branch(&repo, "raw-child");
+
+    repo.run_stax(&["branch", "track", "--all"])
+        .assert_success();
+
+    assert_parent(&repo, "shared-name", "main");
+    assert_parent(&repo, "raw-child", "shared-name");
+}
+
+#[test]
+fn track_all_conflicts_with_other_bulk_or_explicit_parent_modes() {
+    let repo = TestRepo::new();
+
+    for conflicting_args in [
+        ["branch", "track", "--all", "--parent", "main"].as_slice(),
+        ["branch", "track", "--all", "--all-prs"].as_slice(),
+    ] {
+        let output = repo.run_stax(conflicting_args);
+        output.assert_failure();
+        assert!(
+            TestRepo::stderr(&output).contains("cannot be used with"),
+            "expected Clap conflict for {conflicting_args:?}, got: {}",
+            TestRepo::stderr(&output)
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

Adopt existing local Git branch stacks into Stax in one local-only command, without requiring PRs or manual parent assignment for every branch.

## Description of changes / notes for reviewers

### Summary

- Add `st branch track --all` to track every untracked non-trunk local branch.
- Infer each parent from the nearest cycle-safe strict local ancestor, with deterministic trunk fallback and equal-tip protection.
- Preserve existing tracked metadata and keep the operation local-only.
- Add happy-path, error-path, edge-case, and regression coverage.
- Update README.md, docs/commands/reference.md, and skills.md for the new user-visible behavior.

### Testing

Scoped draft gate:

- `cargo check` — passed (exit 0)
- `make lint-fast` — passed (exit 0)
- `git diff --check` — passed (exit 0)
- `cargo nextest run track_all_local_tests::` — 9/9 passed
- `cargo nextest run track_all_prs_tests::` — 8/8 passed
- `cargo nextest run track_merge_base_tests::` — 3/3 passed
- Independent review — no Critical or Important findings

The full local gate was not run because this localized branch-tracking change does not meet the high-risk criteria. CI must provide the full gate (`make lint` and `make test`) before this draft is promoted to ready-for-review or merged.

### Benchmark results

- Linear, 50 branches: 1.13s
- Linear, 200 branches: 3.79s (previous implementation: 56.40s)
- Linear, 500 branches: 17.67s
- Wide, 200 branches: 2.97s

Benchmark verdict: PASS.