### PR TITLE
Add resizable stack pane and safe web sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 |---|---|
 | `st` | Launch interactive TUI |
 | `st web [path]` | Start a localhost web workspace in the browser |
+| Web stack pane | Automatically fits branch names and topology; drag or use Arrow keys to resize. Manual width persists per repository in browser localStorage; double-click resets automatic sizing. |
+| Web Sync | Confirmed browser action: fetches, updates trunk, and cleans merged local branches; requires a clean tree and never stashes or restacks. Refresh only reloads the current snapshot. |
 | `st ls` / `st ll` | Show stack health and PR status (`st ll` adds PR URLs/details) |
 | `st watch` | Live auto-refreshing stack status with CI and PR state (adaptive polling: 15s active CI → 60s open PRs → 120s idle) |
 | `st watch --current` | Watch only the current stack |

--- a/docs/interface/web.md
+++ b/docs/interface/web.md
@@ -93,6 +93,7 @@ The preference is stored per repository in `.git/stax/web-state.json`.
 - **Submit** — push the stack and create/update PRs (draft mode)
 - **Undo / Redo** — restore local transaction state (top-bar utility buttons)
 - **Refresh** — reload the repository snapshot (top-bar `↺` button)
+- **Sync** — after confirmation, fetch updates, fast-forward trunk, and delete merged local branches. It requires a clean worktree, never stashes, and does not restack. Refresh remains read-only.
 - **Rename** — rename a branch (inspector Actions → Rename overlay)
 - **Create** — create a new branch stacked on the selected one (inspector or quick action `N`)
 - **Delete** — delete a non-current branch (inspector Actions)
@@ -105,6 +106,7 @@ The preference is stored per repository in `.git/stax/web-state.json`.
 - Every mutating POST requires a matching **CSRF token** (`csrf` form field). Requests with wrong CSRF return `403 Forbidden`.
 - `Host` must be `127.0.0.1` or `localhost`. An absent `Origin` is allowed for navigation and non-browser clients; when present, exactly one `Origin` header must equal `http://127.0.0.1:<actual-bound-port>`. Cross-site, malformed, duplicate, and wrong-port Origins return `403 Forbidden`.
 - Only **one mutation at a time** — mutating controls are disabled while an operation is in flight.
+- The stack pane automatically fits branch names and topology. Drag its accessible divider or use Arrow keys to resize; the width is stored in browser localStorage per canonical repository. Double-click the divider to return to automatic sizing. Narrow layouts stack panes and wrap long names.
 - `--host` flag is intentionally absent — you cannot expose this server to the network.
 
 ## Routes reference
@@ -129,6 +131,7 @@ The preference is stored per repository in `.git/stax/web-state.json`.
 | `POST` | `/s/:token/op/rename` | Rename a branch |
 | `POST` | `/s/:token/op/delete` | Delete a branch |
 | `POST` | `/s/:token/op/restack` | Restack |
+| `POST` | `/s/:token/op/sync` | Confirmed safe sync (clean worktree, no stash or restack) |
 | `POST` | `/s/:token/op/submit` | Submit (draft PRs) |
 | `POST` | `/s/:token/op/undo` | Undo last transaction |
 | `POST` | `/s/:token/op/redo` | Redo last transaction |

--- a/skills.md
+++ b/skills.md
@@ -336,6 +336,10 @@ stax merge-when-ready              # Backward-compatible alias
 # the remaining budget and never poll the forge at or after the deadline.
 
 stax rs                            # Sync trunk + clean merged branches
+# In st web, Sync is confirmed and uses the active repository (not server cwd):
+# fetch + trunk update + merged-local cleanup; clean tree required, no stash/restack.
+# Refresh remains read-only. The stack pane auto-fits long names; drag/Arrow-resize
+# persists per repository in browser localStorage, and double-click resets it.
 stax rs --restack                  # Sync then restack
 stax sync --dry-run                # Preview sync plan (read-only — no fetch, no stash, no ref writes); alias: --plan
 stax sync --dry-run --json         # Same as --dry-run but emits a single JSON doc (kind:"sync_plan", schema_version:1, dry_run:true); always exits 0; no receipt written

--- a/src/application/interaction.rs
+++ b/src/application/interaction.rs
@@ -2,7 +2,7 @@
 //!
 //! Shared by the `st web` workspace.
 
-use super::{OperationReceipt, RepositorySnapshot};
+use super::{OperationReceipt, RepositorySnapshot, TransactionSummary};
 
 /// Whether a specific user action is currently available.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +58,25 @@ pub fn interaction_state(
     active_mutating: bool,
     last_receipt: Option<&OperationReceipt>,
 ) -> InteractionState {
+    interaction_state_from_transaction(
+        snapshot,
+        selected,
+        active_mutating,
+        last_receipt.and_then(|receipt| receipt.transaction.as_ref()),
+    )
+}
+
+/// Returns interaction state from the latest persisted local transaction.
+///
+/// Application operations normally provide an [`OperationReceipt`], while
+/// clients that invoke a legacy transactional command can reload its
+/// [`TransactionSummary`] directly from disk and use this entry point.
+pub fn interaction_state_from_transaction(
+    snapshot: &RepositorySnapshot,
+    selected: Option<&str>,
+    active_mutating: bool,
+    last_transaction: Option<&TransactionSummary>,
+) -> InteractionState {
     if active_mutating {
         let reason = "A repository operation is running.";
         let disabled = ActionAvailability::disabled(reason);
@@ -86,10 +105,7 @@ pub fn interaction_state(
         .map(|b| b.name.as_str())
         .unwrap_or("the selected branch");
     let has_non_trunk = snapshot.branches.iter().any(|b| !b.is_trunk);
-    let local_transaction = last_receipt
-        .as_ref()
-        .and_then(|r| r.transaction.as_ref())
-        .filter(|tx| !tx.changed_remote_refs);
+    let local_transaction = last_transaction.filter(|tx| !tx.changed_remote_refs);
     let reorder_len = selected_summary
         .and_then(|b| linear_stack_order(snapshot, &b.name))
         .map(|v| v.len())

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use branch_name::{
     BranchNameContext, BranchNameError, BranchNameResult, format_branch_name,
 };
 pub use interaction::{
-    ActionAvailability, InteractionState, descendants_of, interaction_state, linear_stack_order,
-    move_parent_candidates,
+    ActionAvailability, InteractionState, descendants_of, interaction_state,
+    interaction_state_from_transaction, linear_stack_order, move_parent_candidates,
 };
 pub use model::{
     BranchDetails, BranchDiff, BranchSummary, CiSummary, DetailRequestToken, DiffLine,

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -17,7 +17,7 @@ use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
 use crate::remote::{self, RemoteInfo};
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use dialoguer::{Confirm, Select, theme::ColorfulTheme};
 use futures_util::stream::{self, StreamExt};
@@ -334,6 +334,9 @@ struct PlannedMergedDetection {
 impl SyncContext {
     #[allow(clippy::too_many_arguments)]
     fn new(
+        repo: GitRepo,
+        config: Config,
+        auto_confirm: bool,
         sync_started_at: Instant,
         restack: bool,
         full: bool,
@@ -349,11 +352,9 @@ impl SyncContext {
         extra_fetch_refs: &[String],
         skip_interactive_plan: bool,
     ) -> Result<(Self, GitRepo)> {
-        let repo = GitRepo::open()?;
         let stack = Stack::load(&repo)?;
         let current = repo.current_branch()?;
         let workdir = repo.workdir()?.to_path_buf();
-        let config = Config::load()?;
         let remote_name = config.remote_name().to_string();
         let remote_trunk_ref = format!("{}/{}", remote_name, stack.trunk);
         let imported_branches = imported_branches_for_remote(&repo, &stack, &remote_name)?;
@@ -364,7 +365,6 @@ impl SyncContext {
                 sync_extra_fetch_refs.push(branch.clone());
             }
         }
-        let auto_confirm = force;
         let current_after_deletions = current.clone();
         let effective_quiet = quiet || json;
         Ok((
@@ -2598,8 +2598,103 @@ pub fn run(
     extra_fetch_refs: &[String],
     skip_interactive_plan: bool,
 ) -> Result<()> {
+    run_with_repo(
+        GitRepo::open()?,
+        Config::load()?,
+        force,
+        restack,
+        full,
+        delete_merged,
+        delete_upstream_gone,
+        force,
+        safe,
+        r#continue,
+        quiet,
+        verbose,
+        auto_stash_pop,
+        stash_policy,
+        json,
+        extra_fetch_refs,
+        skip_interactive_plan,
+    )
+}
+
+/// Run sync against an explicit repository instead of the process working
+/// directory. This is the web-server boundary; CLI callers keep using `run`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_at(
+    repository: &Path,
+    auto_confirm: bool,
+    restack: bool,
+    full: bool,
+    delete_merged: bool,
+    delete_upstream_gone: bool,
+    force: bool,
+    safe: bool,
+    r#continue: bool,
+    quiet: bool,
+    verbose: bool,
+    auto_stash_pop: bool,
+    stash_policy: StashPolicy,
+    json: bool,
+    extra_fetch_refs: &[String],
+    skip_interactive_plan: bool,
+) -> Result<()> {
+    let repo = GitRepo::open_from_path(repository)?;
+    for worktree in repo.list_worktrees()? {
+        if repo.is_dirty_at(&worktree.path)? {
+            bail!(
+                "Working tree '{}' has uncommitted changes; Sync made no changes",
+                worktree.path.display()
+            );
+        }
+    }
+    run_with_repo(
+        repo,
+        Config::load_for_trusted_network(repository)?,
+        auto_confirm,
+        restack,
+        full,
+        delete_merged,
+        delete_upstream_gone,
+        force,
+        safe,
+        r#continue,
+        quiet,
+        verbose,
+        auto_stash_pop,
+        stash_policy,
+        json,
+        extra_fetch_refs,
+        skip_interactive_plan,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_with_repo(
+    repo: GitRepo,
+    config: Config,
+    auto_confirm: bool,
+    restack: bool,
+    full: bool,
+    delete_merged: bool,
+    delete_upstream_gone: bool,
+    force: bool,
+    safe: bool,
+    r#continue: bool,
+    quiet: bool,
+    verbose: bool,
+    auto_stash_pop: bool,
+    stash_policy: StashPolicy,
+    json: bool,
+    extra_fetch_refs: &[String],
+    skip_interactive_plan: bool,
+) -> Result<()> {
     let sync_started_at = Instant::now();
     let (mut ctx, repo) = SyncContext::new(
+        repo,
+        config,
+        auto_confirm,
         sync_started_at,
         restack,
         full,

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -4,7 +4,8 @@
 
 use crate::application::{
     NoopOperationReporter, OperationOutcome, OperationRequest, PullRequestMode, RepositorySnapshot,
-    RestackScope, execute_repository_operation, interaction_state,
+    RestackScope, TransactionSummary, execute_repository_operation,
+    interaction_state_from_transaction,
 };
 use crate::web::session::{SharedSession, ThemePreference};
 use crate::web::static_assets::{APP_CSS, APP_JS, HTMX_JS};
@@ -40,6 +41,7 @@ pub fn build_router(session: SharedSession, allowed_origin: String) -> Router {
         .route("/s/{token}/op/rename", post(op_rename))
         .route("/s/{token}/op/delete", post(op_delete))
         .route("/s/{token}/op/restack", post(op_restack))
+        .route("/s/{token}/op/sync", post(op_sync))
         .route("/s/{token}/op/submit", post(op_submit))
         .route("/s/{token}/op/undo", post(op_undo))
         .route("/s/{token}/op/redo", post(op_redo))
@@ -214,8 +216,12 @@ async fn workspace_handler(
             let selected = session.selected_branch.as_deref();
             let active_op = session.active_operation;
             let last_receipt = session.last_receipt.clone();
-            let interaction =
-                interaction_state(&snapshot, selected, active_op, last_receipt.as_ref());
+            let interaction = interaction_state_from_transaction(
+                &snapshot,
+                selected,
+                active_op,
+                last_receipt.as_ref(),
+            );
             let html = workspace_page(&session, &snapshot, &interaction, &row_meta);
             Html(html.into_string()).into_response()
         }
@@ -329,7 +335,7 @@ async fn branch_details(
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Branch not found: {branch_name}"))?;
         let details = repo_session.branch_details(&branch_summary)?;
-        let interaction = interaction_state(
+        let interaction = interaction_state_from_transaction(
             &snapshot,
             Some(branch_summary.name.as_str()),
             active,
@@ -748,6 +754,152 @@ async fn op_submit(
     run_mutation(state, token, request).await
 }
 
+/// Run the conservative browser Sync preset against the session repository.
+/// This deliberately uses an explicit path, never the server process cwd.
+async fn op_sync(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+    _headers: HeaderMap,
+    Form(form): Form<CsrfForm>,
+) -> impl IntoResponse {
+    if let Some(r) = check_token(&state, &token) {
+        return r;
+    }
+    if let Some(r) = check_csrf(&state, &form.csrf) {
+        return r;
+    }
+    log_action("sync", "");
+
+    let repo_root = {
+        let mut session = state.lock().unwrap();
+        if session.active_operation {
+            return Html(
+                error_fragment("Another operation is already in progress. Please wait.")
+                    .into_string(),
+            )
+            .into_response();
+        }
+        session.active_operation = true;
+        session.repository_root.clone()
+    };
+    let worker_state = state.clone();
+    let result = spawn_off_runtime(move || {
+        run_sync_worker(worker_state, repo_root, |repository| {
+            crate::commands::sync::run_at(
+                repository,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                crate::commands::sync::StashPolicy::Never,
+                false,
+                &[],
+                true,
+            )
+        })
+    })
+    .await;
+    let (success, message) = match result {
+        Ok(Ok(())) => (true, "✓ Sync complete".to_string()),
+        Ok(Err(e)) => (false, format!("✗ Sync failed: {e}")),
+        Err(e) => (false, format!("✗ Spawn error: {e}")),
+    };
+    with_pane_refresh(render_stack_pane_with_banner(&state, &token, &message, success).await)
+}
+
+fn reload_after_sync(
+    repo_root: &std::path::Path,
+) -> anyhow::Result<(RepositorySnapshot, Option<TransactionSummary>)> {
+    let repository = crate::application::RepositorySession::open(repo_root)?;
+    let snapshot = repository.snapshot()?;
+    let repo = crate::git::GitRepo::open_from_path(repo_root)?;
+    let latest = crate::ops::receipt::OpReceipt::load_latest(repo.git_dir()?)?
+        .as_ref()
+        .map(TransactionSummary::from);
+    Ok((snapshot, latest))
+}
+
+/// Publish repository state from the same detached worker that owns Sync.
+/// Keeping this after `run_at` in the worker means request cancellation cannot
+/// release `active_operation` while the git process is still mutating refs.
+fn finish_sync_worker(
+    state: &SharedSession,
+    repo_root: &std::path::Path,
+    sync_result: anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let refreshed = reload_after_sync(repo_root);
+    let mut session = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    session.active_operation = false;
+
+    if session.repository_root == repo_root
+        && let Ok((snapshot, latest_receipt)) = &refreshed
+    {
+        if session.selected_branch.as_ref().is_some_and(|selected| {
+            !snapshot
+                .branches
+                .iter()
+                .any(|branch| &branch.name == selected)
+        }) {
+            session.selected_branch = Some(snapshot.current_branch.clone());
+        }
+        session.last_receipt = latest_receipt.clone();
+    }
+    drop(session);
+
+    match sync_result {
+        Err(sync_error) => Err(sync_error),
+        Ok(()) => refreshed
+            .map(|_| ())
+            .map_err(|error| error.context("Sync completed but repository refresh failed")),
+    }
+}
+
+/// Own the operation lock for the entire lifetime of the detached Sync worker.
+/// A panic in Sync or post-Sync publication is converted into an error while
+/// the guard guarantees that the browser session is unlocked.
+fn run_sync_worker<F>(
+    state: SharedSession,
+    repo_root: std::path::PathBuf,
+    operation: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(&std::path::Path) -> anyhow::Result<()>,
+{
+    let guard = ActiveOpGuard {
+        state: state.clone(),
+        disarmed: false,
+    };
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let sync_result = operation(&repo_root);
+        finish_sync_worker(&state, &repo_root, sync_result)
+    }));
+
+    match result {
+        Ok(result) => {
+            // `finish_sync_worker` cleared the flag while publishing state.
+            guard.disarm();
+            result
+        }
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<&str>()
+                .map(|message| (*message).to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            Err(anyhow::anyhow!("Sync worker panicked: {message}"))
+        }
+    }
+}
+
 // ── Op: undo ─────────────────────────────────────────────────────────────────
 
 async fn op_undo(
@@ -896,6 +1048,22 @@ async fn switch_project(
     if let Some(r) = check_csrf(&state, &form.csrf) {
         return r;
     }
+    let expected_repository = {
+        let session = state.lock().unwrap();
+        if session.active_operation {
+            return (
+                StatusCode::CONFLICT,
+                Html(
+                    error_fragment(
+                        "Another operation is already in progress. Wait for it to finish before switching projects.",
+                    )
+                    .into_string(),
+                ),
+            )
+                .into_response();
+        }
+        session.repository_root.clone()
+    };
     log_action("switch project", form.path.trim());
 
     let path = std::path::PathBuf::from(form.path.trim());
@@ -919,6 +1087,18 @@ async fn switch_project(
                 .map(|snap| snap.current_branch);
             {
                 let mut s = state.lock().unwrap();
+                if s.active_operation || s.repository_root != expected_repository {
+                    return (
+                        StatusCode::CONFLICT,
+                        Html(
+                            error_fragment(
+                                "The active repository changed while this project was opening. Try switching again.",
+                            )
+                            .into_string(),
+                        ),
+                    )
+                        .into_response();
+                }
                 s.switch_repository(root, selected);
             }
             // Full page reload for the new workspace.
@@ -1035,9 +1215,11 @@ impl ActiveOpGuard {
 
 impl Drop for ActiveOpGuard {
     fn drop(&mut self) {
-        if !self.disarmed
-            && let Ok(mut s) = self.state.lock()
-        {
+        if !self.disarmed {
+            let mut s = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             s.active_operation = false;
         }
     }
@@ -1092,7 +1274,7 @@ async fn run_mutation(
         let mut s = state.lock().unwrap();
         s.active_operation = false;
         if let Some(r) = receipt {
-            s.last_receipt = Some(r);
+            s.last_receipt = r.transaction;
         }
     }
     // Disarm: flag already cleared above; guard drop should be a no-op.
@@ -1147,6 +1329,46 @@ mod tests {
             "disarm alone must not reset active_operation (caller owns the clear)"
         );
     }
+
+    #[test]
+    fn sync_worker_preserves_sync_error_when_refresh_also_fails_and_clears_lock() {
+        let missing_repo = tempfile::tempdir().unwrap();
+        let state = make_shared(WebSession::new(
+            missing_repo.path().to_path_buf(),
+            "tok".to_string(),
+            "csrf".to_string(),
+        ));
+        state.lock().unwrap().active_operation = true;
+
+        let error = finish_sync_worker(
+            &state,
+            missing_repo.path(),
+            Err(anyhow::anyhow!("original sync failure")),
+        )
+        .expect_err("the original sync error should be returned");
+
+        assert_eq!(error.to_string(), "original sync failure");
+        assert!(!state.lock().unwrap().active_operation);
+    }
+
+    #[test]
+    fn sync_worker_catches_panics_and_releases_its_owned_lock() {
+        let missing_repo = tempfile::tempdir().unwrap();
+        let state = make_shared(WebSession::new(
+            missing_repo.path().to_path_buf(),
+            "tok".to_string(),
+            "csrf".to_string(),
+        ));
+        state.lock().unwrap().active_operation = true;
+
+        let error = run_sync_worker(state.clone(), missing_repo.path().to_path_buf(), |_| {
+            panic!("deterministic sync panic")
+        })
+        .expect_err("worker panic should become an operation error");
+
+        assert!(error.to_string().contains("deterministic sync panic"));
+        assert!(!state.lock().unwrap().active_operation);
+    }
 }
 
 // ── Render helpers ────────────────────────────────────────────────────────────
@@ -1161,8 +1383,12 @@ async fn render_stack_pane(state: &SharedSession, token: &str) -> axum::response
             let selected = session.selected_branch.as_deref();
             let active_op = session.active_operation;
             let last_receipt = session.last_receipt.clone();
-            let interaction =
-                interaction_state(&snapshot, selected, active_op, last_receipt.as_ref());
+            let interaction = interaction_state_from_transaction(
+                &snapshot,
+                selected,
+                active_op,
+                last_receipt.as_ref(),
+            );
             let base = format!("/s/{token}");
             Html(
                 stack_pane_fragment(&session, &snapshot, &interaction, &base, &row_meta)
@@ -1190,8 +1416,12 @@ async fn render_stack_pane_with_banner(
             let selected = session.selected_branch.as_deref();
             let active_op = session.active_operation;
             let last_receipt = session.last_receipt.clone();
-            let interaction =
-                interaction_state(&snapshot, selected, active_op, last_receipt.as_ref());
+            let interaction = interaction_state_from_transaction(
+                &snapshot,
+                selected,
+                active_op,
+                last_receipt.as_ref(),
+            );
             let base = format!("/s/{token}");
             let markup = templates::op_result_with_stack(
                 banner_msg,

--- a/src/web/session.rs
+++ b/src/web/session.rs
@@ -1,6 +1,6 @@
 //! Shared session state for the `st web` workspace.
 
-use crate::application::OperationReceipt;
+use crate::application::TransactionSummary;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -85,8 +85,8 @@ pub struct WebSession {
     pub show_inspector: bool,
     /// Light / dark / system appearance.
     pub theme: ThemePreference,
-    /// Last completed operation receipt (for undo/redo state).
-    pub last_receipt: Option<OperationReceipt>,
+    /// Latest persisted local transaction summary (for undo/redo state).
+    pub last_receipt: Option<TransactionSummary>,
     /// Whether a mutation is currently in flight.
     pub active_operation: bool,
     /// Recently opened repository roots (up to 10, most recent first).

--- a/src/web/static_assets.rs
+++ b/src/web/static_assets.rs
@@ -115,6 +115,7 @@ pub const APP_CSS: &str = r#"
   --rail-bleed:     calc(var(--card-pad-y) + var(--card-border-w) + var(--card-margin-y));
   --topo-lane-w:   20px;
   --stack-rail-w:  240px;
+  --stack-pane-w:  240px;
 
   --sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
           "Segoe UI Variable Text", "Segoe UI", Inter, Roboto,
@@ -244,7 +245,7 @@ html, body {
 /* ── Three-column stage ─────────────────────────────────────────────── */
 .stage {
   display: grid;
-  grid-template-columns: max-content 1fr 280px;
+  grid-template-columns: var(--stack-pane-w) 8px minmax(0, 1fr) 280px;
   grid-template-rows: 1fr;
   flex: 1;
   overflow: hidden;
@@ -262,6 +263,15 @@ html, body {
 .pane:last-child { border-right: none; }
 
 .pane-stack  { min-width: 200px; }
+.stack-resizer {
+  cursor: col-resize;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  touch-action: none;
+}
+.stack-resizer:hover, .stack-resizer:focus-visible { background: var(--accent); outline: none; }
+.stage.stack-hidden { grid-template-columns: minmax(0, 1fr) 280px; }
 .pane-changes {
   flex-direction: column;
 }
@@ -320,7 +330,7 @@ html, body {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  width: var(--stack-rail-w, 240px);
+  width: 100%;
 }
 
 .stack-header {
@@ -1175,8 +1185,11 @@ input[type="text"]:focus { outline: none; border-color: var(--focus); }
 /* Medium: inspector moves below review */
 @media (max-width: 1100px) {
   .stage {
-    grid-template-columns: max-content 1fr;
+    grid-template-columns: var(--stack-pane-w) 8px minmax(0, 1fr);
     grid-template-rows: 1fr auto;
+  }
+  .stage.stack-hidden {
+    grid-template-columns: minmax(0, 1fr);
   }
   .pane-inspector {
     grid-column: 1 / -1;
@@ -1199,6 +1212,8 @@ input[type="text"]:focus { outline: none; border-color: var(--focus); }
   .pane-inspector { order: 1; max-height: none; }
   .pane-stack { min-width: 0; }
   .stack-rail { width: 100%; }
+  .stack-resizer { display: none; }
+  .card-name { overflow-wrap: anywhere; white-space: normal; }
 
   .changes-panel { flex-direction: column; }
   .file-nav {
@@ -1303,7 +1318,204 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   initFileList();
+  initStackPaneSizing();
 });
+
+var stackPaneSizingController = null;
+
+function clampStackPaneWidth(width, min, max) {
+  var numeric = Number(width);
+  if (!Number.isFinite(numeric)) numeric = min;
+  return Math.max(min, Math.min(max, numeric));
+}
+
+function intrinsicTextWidth(element) {
+  if (!document.createRange) return element.scrollWidth;
+  var range = document.createRange();
+  range.selectNodeContents(element);
+  var width = range.getBoundingClientRect().width;
+  if (range.detach) range.detach();
+  return Math.ceil(width);
+}
+
+function initStackPaneSizing() {
+  if (!stackPaneSizingController) {
+    var stage = document.querySelector('.stage');
+    var resizer = document.querySelector('.stack-resizer');
+    if (!stage || !resizer) return;
+    stackPaneSizingController = createStackPaneSizingController(stage, resizer);
+    window.staxStackPaneSizing = stackPaneSizingController;
+    window.staxStackSizingMath = { clampWidth: clampStackPaneWidth };
+  }
+  stackPaneSizingController.refreshSizing();
+}
+
+function refreshStackPaneSizing() {
+  if (stackPaneSizingController) stackPaneSizingController.refreshSizing();
+  else initStackPaneSizing();
+}
+
+function createStackPaneSizingController(stage, resizer) {
+  var key = 'stax.stack-pane-width:' + (stage.getAttribute('data-repository-key') || 'default');
+  var manualMin = 200;
+  var changesMin = 320;
+  var mode = readStoredWidth() === null ? 'auto' : 'manual';
+  var manualWidth = readStoredWidth();
+  var autoWidth = 240;
+
+  function readStoredWidth() {
+    var stored = localStorage.getItem(key);
+    if (stored === null || stored === '') return null;
+    var width = Number(stored);
+    return Number.isFinite(width) ? width : null;
+  }
+
+  function isVisible(element) {
+    if (!element || element.hidden || element.classList.contains('pane-hidden')) return false;
+    return getComputedStyle(element).display !== 'none';
+  }
+
+  function visibleWidth(element) {
+    return isVisible(element) ? element.getBoundingClientRect().width : 0;
+  }
+
+  function bounds() {
+    var stageWidth = stage.getBoundingClientRect().width || stage.clientWidth || window.innerWidth;
+    var stacked = window.matchMedia('(max-width: 800px)').matches;
+    if (stacked) {
+      var fullWidth = Math.max(0, Math.round(stageWidth));
+      return { min: fullWidth, max: fullWidth, stacked: true };
+    }
+    var inspector = document.querySelector('.pane-inspector');
+    var changes = document.querySelector('.pane-changes');
+    var inspectorWidth = window.matchMedia('(max-width: 1100px)').matches ? 0 : visibleWidth(inspector);
+    var dividerWidth = visibleWidth(resizer) || 8;
+    var reservedChanges = isVisible(changes) ? changesMin : 0;
+    var max = Math.max(manualMin, Math.floor(stageWidth - inspectorWidth - dividerWidth - reservedChanges));
+    return { min: manualMin, max: max, stacked: false };
+  }
+
+  function topologyMin(rail) {
+    if (!rail) return 240;
+    return Math.max(manualMin, parseInt(rail.getAttribute('data-topology-min-width') || '240', 10));
+  }
+
+  function automatic(rail, range) {
+    var width = topologyMin(rail);
+    if (rail && isVisible(rail) && rail.getBoundingClientRect().width > 0) {
+      var railWidth = rail.getBoundingClientRect().width;
+      rail.querySelectorAll('.card-name').forEach(function(name) {
+        var chromeWidth = railWidth - name.getBoundingClientRect().width;
+        width = Math.max(width, intrinsicTextWidth(name) + chromeWidth + 2);
+      });
+      autoWidth = width;
+    } else {
+      width = Math.max(width, autoWidth);
+    }
+    return clampStackPaneWidth(width, Math.min(topologyMin(rail), range.max), range.max);
+  }
+
+  function apply(width, applicationMode, rail, range) {
+    if (range.stacked) {
+      stage.style.setProperty('--stack-pane-w', '100%');
+      resizer.setAttribute('aria-valuemin', range.min);
+      resizer.setAttribute('aria-valuemax', range.max);
+      resizer.setAttribute('aria-valuenow', range.max);
+      return range.max;
+    }
+    var effectiveMin = applicationMode === 'auto'
+      ? Math.min(topologyMin(rail), range.max)
+      : range.min;
+    var applied = clampStackPaneWidth(width, effectiveMin, range.max);
+    stage.style.setProperty('--stack-pane-w', applied + 'px');
+    resizer.setAttribute('aria-valuemin', range.min);
+    resizer.setAttribute('aria-valuemax', range.max);
+    resizer.setAttribute('aria-valuenow', Math.round(applied));
+    return applied;
+  }
+
+  function refreshSizing() {
+    var rail = document.querySelector('.stack-rail');
+    var range = bounds();
+    if (range.stacked) {
+      apply(range.max, mode, rail, range);
+      return;
+    }
+    if (mode === 'manual' && manualWidth !== null) apply(manualWidth, 'manual', rail, range);
+    else apply(automatic(rail, range), 'auto', rail, range);
+  }
+
+  if (window.PointerEvent) {
+    resizer.addEventListener('pointerdown', function(e) {
+      if (bounds().stacked) return;
+      resizer.setPointerCapture(e.pointerId);
+      var start = e.clientX;
+      var initial = parseFloat(getComputedStyle(stage).getPropertyValue('--stack-pane-w')) || autoWidth;
+      var width = initial;
+      function move(event) {
+        var range = bounds();
+        width = clampStackPaneWidth(initial + event.clientX - start, range.min, range.max);
+        apply(width, 'manual', document.querySelector('.stack-rail'), range);
+      }
+      function cleanup() {
+        resizer.removeEventListener('pointermove', move);
+        resizer.removeEventListener('pointerup', end);
+        resizer.removeEventListener('pointercancel', cancel);
+        resizer.removeEventListener('lostpointercapture', cancel);
+      }
+      function release(event) {
+        if (resizer.hasPointerCapture(event.pointerId)) resizer.releasePointerCapture(event.pointerId);
+      }
+      function end(event) {
+        cleanup(); release(event);
+        mode = 'manual'; manualWidth = width;
+        localStorage.setItem(key, String(manualWidth));
+      }
+      function cancel(event) { cleanup(); release(event); refreshSizing(); }
+      resizer.addEventListener('pointermove', move);
+      resizer.addEventListener('pointerup', end);
+      resizer.addEventListener('pointercancel', cancel);
+      resizer.addEventListener('lostpointercapture', cancel);
+    });
+  }
+
+  resizer.addEventListener('keydown', function(e) {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    var range = bounds();
+    if (range.stacked) return;
+    var current = parseFloat(getComputedStyle(stage).getPropertyValue('--stack-pane-w')) || autoWidth;
+    manualWidth = clampStackPaneWidth(current + (e.key === 'ArrowLeft' ? -16 : 16), range.min, range.max);
+    mode = 'manual';
+    localStorage.setItem(key, String(manualWidth));
+    apply(manualWidth, 'manual', document.querySelector('.stack-rail'), range);
+  });
+  resizer.addEventListener('dblclick', function() {
+    localStorage.removeItem(key);
+    mode = 'auto'; manualWidth = null;
+    refreshSizing();
+  });
+  document.body.addEventListener('htmx:afterSwap', function(e) {
+    var target = e.detail && e.detail.target;
+    if (target && (target.id === 'stack-pane' || target.querySelector?.('#stack-pane'))) refreshSizing();
+  });
+  window.addEventListener('resize', refreshSizing);
+
+  return {
+    refreshSizing: refreshSizing,
+    getState: function() {
+      var range = bounds();
+      return {
+        mode: mode,
+        manualWidth: manualWidth,
+        min: range.min,
+        max: range.max,
+        now: Number(resizer.getAttribute('aria-valuenow')),
+        stacked: range.stacked,
+      };
+    },
+  };
+}
 
 function isInput(el) {
   return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.contentEditable === 'true';
@@ -1312,6 +1524,14 @@ function isInput(el) {
 function togglePane(id, pane) {
   var el = document.getElementById(id);
   if (el) el.classList.toggle('pane-hidden');
+  var stage = document.querySelector('.stage');
+  var resizer = document.querySelector('.stack-resizer');
+  if (pane === 'stack' && stage && resizer) {
+    var hidden = el.classList.contains('pane-hidden');
+    stage.classList.toggle('stack-hidden', hidden);
+    resizer.hidden = hidden;
+    if (!hidden) refreshStackPaneSizing();
+  }
   var csrf = document.querySelector('input[name="csrf"]');
   var base = location.pathname.replace(/\/?$/, '');
   if (csrf && pane) {
@@ -1432,16 +1652,36 @@ mod tests {
     #[test]
     fn stack_column_is_sized_by_rendered_topology_width() {
         assert!(
-            APP_CSS.contains("grid-template-columns: max-content 1fr 280px;"),
-            "desktop stack track should follow the rendered stack width"
+            APP_CSS
+                .contains("grid-template-columns: var(--stack-pane-w) 8px minmax(0, 1fr) 280px;"),
+            "desktop stack track should follow the adaptive stack width"
         );
         assert!(
-            APP_CSS.contains("width: var(--stack-rail-w, 240px);"),
-            "stack rail should use the lane-count-driven width until the stacked breakpoint"
+            APP_CSS.contains("width: 100%;"),
+            "stack rail should fill the adaptive pane width"
         );
         assert!(
             !APP_CSS.contains("min(var(--stack-rail-w, 240px), 40vw)"),
             "a viewport cap before the 800px breakpoint would squash dense stacks"
+        );
+    }
+
+    #[test]
+    fn hidden_stack_grid_drops_stack_tracks_at_desktop_and_medium_widths() {
+        assert!(
+            APP_CSS
+                .contains(".stage.stack-hidden { grid-template-columns: minmax(0, 1fr) 280px; }"),
+            "desktop hidden-stack layout should contain only changes and inspector tracks"
+        );
+        let medium = APP_CSS
+            .split("@media (max-width: 1100px)")
+            .nth(1)
+            .and_then(|css| css.split("@media (max-width: 800px)").next())
+            .expect("medium layout media query should exist");
+        assert!(
+            medium.contains(".stage.stack-hidden")
+                && medium.contains("grid-template-columns: minmax(0, 1fr);"),
+            "medium hidden-stack layout should not retain stack or divider tracks"
         );
     }
 

--- a/src/web/templates.rs
+++ b/src/web/templates.rs
@@ -182,7 +182,7 @@ pub fn workspace_page(
                     (topbar(session, snapshot, interaction, &base))
 
                     // Three-column stage
-                    div .stage {
+                    div class=(if session.show_stack { "stage" } else { "stage stack-hidden" }) data-repository-key=(session.repository_root.to_string_lossy()) {
                         // Stack pane (left)
                         div
                             class={
@@ -195,6 +195,8 @@ pub fn workspace_page(
                                 (stack_pane_inner(session, snapshot, interaction, &base, row_meta))
                             }
                         }
+
+                        button .stack-resizer type="button" role="separator" aria-orientation="vertical" aria-label="Resize stack pane" aria-controls="pane-stack" aria-valuemin="200" aria-valuemax="240" aria-valuenow="240" tabindex="0" hidden[!session.show_stack] {}
 
                         // Review workspace (centre)
                         div
@@ -394,6 +396,10 @@ fn topbar(
 fn topbar_actions_inner(interaction: &InteractionState, base: &str, csrf: &str) -> Markup {
     html! {
         div #topbar-actions .topbar-actions {
+            button .btn.mutating-btn
+                onclick=(format!("document.body.insertAdjacentHTML('beforeend', `{}`)", sync_confirm_overlay_escaped(base, csrf)))
+                title="Fetch updates, update trunk, and delete merged local branches"
+                { "Sync" }
             @if interaction.restack.enabled {
                 button .btn.mutating-btn
                     hx-post=(format!("{base}/op/restack"))
@@ -462,6 +468,10 @@ pub fn stack_pane_fragment(
 fn topbar_actions_oob(interaction: &InteractionState, base: &str, csrf: &str) -> Markup {
     html! {
         div #topbar-actions hx-swap-oob="true" class="topbar-actions" {
+            button .btn.mutating-btn
+                onclick=(format!("document.body.insertAdjacentHTML('beforeend', `{}`)", sync_confirm_overlay_escaped(base, csrf)))
+                title="Fetch updates, update trunk, and delete merged local branches"
+                { "Sync" }
             @if interaction.restack.enabled {
                 button .btn.mutating-btn
                     hx-post=(format!("{base}/op/restack"))
@@ -632,7 +642,7 @@ pub fn stack_pane_inner(
         .unwrap_or(snapshot.trunk.as_str());
 
     html! {
-        div .stack-rail data-lane-count=(max_lanes) style=(format!("--stack-rail-w:{rail_width}px")) {
+        div .stack-rail data-lane-count=(max_lanes) data-topology-min-width=(rail_width) style=(format!("--stack-rail-w:{rail_width}px")) {
             // Header
             div .stack-header {
                 div .stack-header-labels {
@@ -1258,6 +1268,20 @@ fn submit_confirm_overlay_escaped(base: &str, csrf: &str) -> String {
     .replace("${", "\\${")
 }
 
+fn sync_confirm_overlay_escaped(base: &str, csrf: &str) -> String {
+    confirm_overlay(
+        "Sync repository",
+        "Sync fetches updates, fast-forwards trunk, and deletes merged local branches. Your working tree must be clean; Sync never stashes and does not restack.",
+        &format!("{base}/op/sync"),
+        csrf,
+        &[],
+    )
+    .into_string()
+    .replace('\\', "\\\\")
+    .replace('`', "\\`")
+    .replace("${", "\\${")
+}
+
 pub fn operation_banner(message: &str, success: bool) -> Markup {
     let cls = if success {
         "banner banner-success"
@@ -1372,7 +1396,9 @@ pub fn error_fragment(message: &str) -> Markup {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::application::{DiffLine, DiffLineKind};
+    use crate::application::{
+        BranchSummary, DiffLine, DiffLineKind, RepositorySnapshot, interaction_state,
+    };
 
     #[test]
     fn parse_hunk_header_standard() {
@@ -1641,6 +1667,43 @@ mod tests {
     fn stack_pane_width_is_capped_to_protect_review_space() {
         assert_eq!(stack_pane_width_px(9), 400);
         assert_eq!(stack_pane_width_px(usize::MAX), 400);
+    }
+
+    #[test]
+    fn stack_pane_exposes_repository_scoped_sizing_metadata_and_separator() {
+        let mut session = WebSession::new(
+            std::path::PathBuf::from("/tmp/example-repository"),
+            "token".into(),
+            "csrf".into(),
+        );
+        session.selected_branch = Some("main".into());
+        let snapshot = RepositorySnapshot {
+            repository_root: session.repository_root.clone(),
+            current_branch: "main".into(),
+            trunk: "main".into(),
+            branches: vec![BranchSummary {
+                name: "main".into(),
+                parent: None,
+                column: 0,
+                is_current: true,
+                is_trunk: true,
+                needs_restack: false,
+                pr_number: None,
+                pr_state: None,
+                ci_state: None,
+            }],
+        };
+        let interaction = interaction_state(&snapshot, Some("main"), false, None);
+
+        let rendered =
+            workspace_page(&session, &snapshot, &interaction, &StackRowMeta::new()).into_string();
+
+        assert!(rendered.contains("data-repository-key=\"/tmp/example-repository\""));
+        assert!(rendered.contains("class=\"stack-resizer\""));
+        assert!(rendered.contains("role=\"separator\""));
+        assert!(rendered.contains("aria-valuemin=\"200\""));
+        assert!(rendered.contains("aria-valuemax=\"240\""));
+        assert!(rendered.contains("aria-valuenow=\"240\""));
     }
 }
 

--- a/tests/web_tests.rs
+++ b/tests/web_tests.rs
@@ -7,6 +7,9 @@ use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+use stax::web::server::BoundServer;
+use stax::web::session::{SharedSession, WebSession, make_shared};
+
 fn ensure_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
@@ -38,6 +41,100 @@ fn csrf_from_workspace(html: &str) -> String {
         .and_then(|s| s.split('"').next())
         .expect("csrf token in workspace HTML")
         .to_owned()
+}
+
+async fn bind_web_test_session(
+    repo: &common::TestRepo,
+    selected_branch: Option<String>,
+) -> (BoundServer, SharedSession) {
+    let mut session = WebSession::new(
+        repo.path(),
+        "web-test-token".to_string(),
+        "web-test-csrf".to_string(),
+    );
+    session.selected_branch = selected_branch;
+    let shared = make_shared(session);
+    let server = stax::web::server::bind(0, shared.clone())
+        .await
+        .expect("test web server should bind");
+    (server, shared)
+}
+
+async fn post_sync(server: &BoundServer, csrf: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}op/sync", server.url))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(format!("csrf={csrf}"))
+        .send()
+        .await
+        .expect("sync request should receive a response")
+}
+
+fn init_remote_web_repo(repo: &common::TestRepo) {
+    let output = repo.run_stax(&["init", "--trunk", "main"]);
+    assert!(
+        output.status.success(),
+        "stax init failed: {}",
+        common::TestRepo::stderr(&output)
+    );
+    repo.create_file("stax.toml", "[remote]\nname = \"origin\"\n");
+    let add = repo.git(&["add", "-f", "stax.toml"]);
+    assert!(
+        add.status.success(),
+        "test config add failed: {}",
+        common::TestRepo::stderr(&add)
+    );
+    repo.commit("Configure web sync test remote");
+    let push = repo.git(&["push", "origin", "main"]);
+    assert!(
+        push.status.success(),
+        "test config push failed: {}",
+        common::TestRepo::stderr(&push)
+    );
+    let status = repo.git(&["status", "--porcelain"]);
+    assert!(status.status.success());
+    assert!(
+        common::TestRepo::stdout(&status).trim().is_empty(),
+        "web sync fixture must start clean"
+    );
+}
+
+fn create_remote_merged_feature(repo: &common::TestRepo, name: &str) -> String {
+    let create = repo.run_stax(&["bc", name]);
+    assert!(
+        create.status.success(),
+        "feature create failed: {}",
+        common::TestRepo::stderr(&create)
+    );
+    let feature = repo.current_branch();
+    repo.create_file(&format!("{name}.txt"), "feature\n");
+    repo.commit("Feature commit");
+    let push = repo.git(&["push", "-u", "origin", &feature]);
+    assert!(
+        push.status.success(),
+        "feature push failed: {}",
+        common::TestRepo::stderr(&push)
+    );
+    let trunk = repo.run_stax(&["t"]);
+    assert!(
+        trunk.status.success(),
+        "trunk checkout failed: {}",
+        common::TestRepo::stderr(&trunk)
+    );
+    repo.merge_branch_on_remote(&feature);
+    feature
+}
+
+fn refs_snapshot(repo: &common::TestRepo) -> String {
+    let output = repo.git(&["show-ref"]);
+    assert!(output.status.success(), "git show-ref failed");
+    common::TestRepo::stdout(&output)
+}
+
+fn stash_snapshot(repo: &common::TestRepo) -> String {
+    let output = repo.git(&["stash", "list"]);
+    assert!(output.status.success(), "git stash list failed");
+    common::TestRepo::stdout(&output)
 }
 
 // ── CLI shape tests ──────────────────────────────────────────────────────────
@@ -280,6 +377,7 @@ fn web_token_routes_reject_cross_site_origin_before_every_handler() {
             ("POST", "op/rename"),
             ("POST", "op/delete"),
             ("POST", "op/restack"),
+            ("POST", "op/sync"),
             ("POST", "op/submit"),
             ("POST", "op/undo"),
             ("POST", "op/redo"),
@@ -540,9 +638,11 @@ fn web_server_workspace_shows_trunk_branch_after_stax_init() {
         );
         assert!(
             body.contains(r#"data-lane-count="1""#)
-                && body.contains(r#"style="--stack-rail-w:240px""#),
-            "a linear stack should keep the reference 240px width"
+                && body.contains(r#"data-topology-min-width="240""#),
+            "a linear stack should retain its topology sizing minimum"
         );
+        assert!(body.contains("stack-resizer") && body.contains("data-repository-key"));
+        assert!(body.contains("Sync repository") && body.contains("/op/sync"));
         assert!(
             body.contains(r#"class="review-tab active""#),
             "workspace should render Changes as the active initial tab"
@@ -1007,5 +1107,252 @@ fn web_select_branch_emits_pane_refresh_trigger() {
             Some("stax:branch-selected"),
             "/select must tell the changes + inspector panes to refresh"
         );
+    });
+}
+
+#[test]
+fn web_sync_rejects_invalid_csrf_without_starting_an_operation() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new_with_remote();
+        init_remote_web_repo(&repo);
+        let (server, shared) = bind_web_test_session(&repo, Some("main".to_string())).await;
+
+        let response = post_sync(&server, "wrong-token").await;
+
+        assert_eq!(response.status(), 403);
+        assert!(!shared.lock().unwrap().active_operation);
+        server.join_handle.abort();
+    });
+}
+
+#[test]
+fn web_sync_rejects_a_concurrent_active_operation() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new_with_remote();
+        init_remote_web_repo(&repo);
+        let (server, shared) = bind_web_test_session(&repo, Some("main".to_string())).await;
+        shared.lock().unwrap().active_operation = true;
+
+        let response = post_sync(&server, "web-test-csrf").await;
+        let body = response.text().await.unwrap();
+
+        assert!(
+            body.contains("Another operation is already in progress"),
+            "busy response should explain the active-operation lock: {body}"
+        );
+        assert!(
+            shared.lock().unwrap().active_operation,
+            "a rejected request must not clear the operation it collided with"
+        );
+        server.join_handle.abort();
+    });
+}
+
+#[test]
+fn web_sync_dirty_current_worktree_preserves_files_stash_and_refs() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new_with_remote();
+        init_remote_web_repo(&repo);
+        repo.simulate_remote_commit("remote-update.txt", "remote\n", "Remote update");
+        repo.create_file("dirty.txt", "keep this exact content\n");
+        let refs_before = refs_snapshot(&repo);
+        let stash_before = stash_snapshot(&repo);
+        let (server, shared) = bind_web_test_session(&repo, Some("main".to_string())).await;
+
+        let response = post_sync(&server, "web-test-csrf").await;
+        assert_eq!(
+            response
+                .headers()
+                .get("hx-trigger")
+                .and_then(|value| value.to_str().ok()),
+            Some("stax:branch-selected")
+        );
+        let body = response.text().await.unwrap();
+
+        assert!(
+            body.contains("Sync failed") && body.contains("uncommitted changes"),
+            "dirty sync should render an actionable failure banner: {body}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("dirty.txt")).unwrap(),
+            "keep this exact content\n"
+        );
+        assert_eq!(stash_snapshot(&repo), stash_before, "sync must not stash");
+        assert_eq!(
+            refs_snapshot(&repo),
+            refs_before,
+            "dirty preflight must run before fetch or ref mutation"
+        );
+        assert!(!shared.lock().unwrap().active_operation);
+        server.join_handle.abort();
+    });
+}
+
+#[test]
+fn web_sync_targets_session_repo_updates_trunk_deletes_merged_selection_and_enables_undo() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new_with_remote();
+        init_remote_web_repo(&repo);
+        let feature = create_remote_merged_feature(&repo, "web-sync-merged");
+        let survivor_create = repo.run_stax(&["bc", "web-sync-survivor"]);
+        assert!(survivor_create.status.success());
+        let survivor = repo.current_branch();
+        repo.create_file("web-sync-survivor.txt", "survive without restack\n");
+        repo.commit("Survivor commit");
+        let survivor_before = repo.get_commit_sha(&survivor);
+        let trunk = repo.run_stax(&["t"]);
+        assert!(trunk.status.success());
+        let main_before = repo.get_commit_sha("main");
+        let (server, shared) = bind_web_test_session(&repo, Some(feature.clone())).await;
+
+        let response = post_sync(&server, "web-test-csrf").await;
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response
+                .headers()
+                .get("hx-trigger")
+                .and_then(|value| value.to_str().ok()),
+            Some("stax:branch-selected")
+        );
+        let body = response.text().await.unwrap();
+
+        assert!(
+            body.contains("Sync complete"),
+            "success banner missing: {body}"
+        );
+        assert_ne!(repo.get_commit_sha("main"), main_before);
+        assert_eq!(
+            repo.get_commit_sha("main"),
+            repo.get_commit_sha("origin/main")
+        );
+        assert!(
+            !repo.list_branches().contains(&feature),
+            "browser confirmation must approve merged-local deletion without force mode"
+        );
+        assert_eq!(
+            repo.get_commit_sha(&survivor),
+            survivor_before,
+            "browser Sync must not restack surviving feature branches"
+        );
+        let session = shared.lock().unwrap();
+        assert_eq!(session.selected_branch.as_deref(), Some("main"));
+        let transaction = session
+            .last_receipt
+            .as_ref()
+            .expect("sync should refresh the latest persisted receipt");
+        assert_eq!(transaction.kind, "sync");
+        assert!(transaction.can_undo);
+        assert!(
+            body.contains("qa-undo mutating-btn"),
+            "successful local sync should enable Undo in refreshed markup: {body}"
+        );
+        drop(session);
+        server.join_handle.abort();
+    });
+}
+
+#[test]
+fn web_sync_does_not_force_reset_a_diverged_trunk() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new_with_remote();
+        init_remote_web_repo(&repo);
+        repo.create_file("local-only.txt", "local\n");
+        repo.commit("Local-only trunk commit");
+        let local_main = repo.get_commit_sha("main");
+        repo.simulate_remote_commit("remote-only.txt", "remote\n", "Remote-only trunk commit");
+        let (server, shared) = bind_web_test_session(&repo, Some("main".to_string())).await;
+
+        let response = post_sync(&server, "web-test-csrf").await;
+        let body = response.text().await.unwrap();
+
+        assert!(
+            body.contains("Sync complete"),
+            "the CLI treats a preserved diverged trunk as a completed sync: {body}"
+        );
+        assert_eq!(repo.get_commit_sha("main"), local_main);
+        assert_ne!(
+            repo.get_commit_sha("main"),
+            repo.get_commit_sha("origin/main")
+        );
+        assert!(!shared.lock().unwrap().active_operation);
+        server.join_handle.abort();
+    });
+}
+
+#[test]
+fn web_sync_dirty_linked_worktree_fails_before_fetch_or_stash() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let repo = common::TestRepo::new_with_remote();
+        init_remote_web_repo(&repo);
+        let branch = "linked-dirty";
+        let create_branch = repo.git(&["branch", branch, "main"]);
+        assert!(create_branch.status.success());
+        let linked_parent = tempfile::tempdir().unwrap();
+        let linked = linked_parent.path().join("worktree");
+        let add = repo.git(&["worktree", "add", linked.to_str().unwrap(), branch]);
+        assert!(
+            add.status.success(),
+            "linked worktree setup failed: {}",
+            common::TestRepo::stderr(&add)
+        );
+        std::fs::write(linked.join("linked-dirty.txt"), "preserve me\n").unwrap();
+        repo.simulate_remote_commit("remote-linked-check.txt", "remote\n", "Remote update");
+        let refs_before = refs_snapshot(&repo);
+        let stash_before = stash_snapshot(&repo);
+        let (server, shared) = bind_web_test_session(&repo, Some("main".to_string())).await;
+
+        let response = post_sync(&server, "web-test-csrf").await;
+        let body = response.text().await.unwrap();
+
+        assert!(
+            body.contains("Sync failed") && !body.contains("preserve me"),
+            "linked dirty preflight should fail without exposing file contents: {body}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(linked.join("linked-dirty.txt")).unwrap(),
+            "preserve me\n"
+        );
+        assert_eq!(stash_snapshot(&repo), stash_before);
+        assert_eq!(refs_snapshot(&repo), refs_before);
+        assert!(!shared.lock().unwrap().active_operation);
+        server.join_handle.abort();
+    });
+}
+
+#[test]
+fn web_project_switch_rejects_while_a_repository_operation_is_active() {
+    async_test!(async {
+        ensure_crypto_provider();
+        let current = common::TestRepo::new();
+        let target = common::TestRepo::new();
+        let (server, shared) = bind_web_test_session(&current, Some("main".to_string())).await;
+        shared.lock().unwrap().active_operation = true;
+
+        let response = reqwest::Client::new()
+            .post(format!("{}project", server.url))
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(format!(
+                "path={}&csrf=web-test-csrf",
+                target.path().to_string_lossy()
+            ))
+            .send()
+            .await
+            .expect("project switch should receive a response");
+        let status = response.status();
+        let body = response.text().await.unwrap();
+
+        assert_eq!(status, reqwest::StatusCode::CONFLICT);
+        assert!(
+            body.contains("Another operation is already in progress"),
+            "busy project switch should explain how to retry: {body}"
+        );
+        assert_eq!(shared.lock().unwrap().repository_root, current.path());
+        server.join_handle.abort();
     });
 }


### PR DESCRIPTION
## Motivation

Improve the web workspace by making the stack pane fit branch names and remain user-resizable, and add a browser-confirmed Sync action equivalent to the default `st rs` flow.

## Description of changes

- Auto-size the stack pane from intrinsic branch-name width while preserving topology space.
- Add accessible drag and keyboard resizing, per-repository persistence, responsive collapse/restore, and double-click reset to automatic sizing.
- Add a top-level Sync action and `/op/sync` route using the default safe sync preset: explicit session repository, no stash, no restack, clean-worktree preflight, merged-branch confirmation, refreshed selection, and Undo support.
- Update README, web documentation, agent skills guidance, and integration/unit coverage.

## Verification

- Full local lint gate: `make lint` passed.
- Focused draft gate passed: 27 web integration tests, 4 web route tests, 9 static-asset tests, 17 template tests, 5 sync-confirm tests, and 7 sync-JSON tests.
- `git diff --check` passed.
- Full local `make test` was stopped at the requester direction after 1,485 tests passed; the full gate is delegated to this draft PR CI.