### PR TITLE
chore(deps): bump chacha20 to unyank Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Summary
- `cargo install --locked` was printing `warning: package \`chacha20 v0.10.1\` in Cargo.lock is yanked in registry \`crates-io\``
- Bumps `chacha20` 0.10.1 -> 0.10.2 (a non-yanked patch release) via `cargo update -p chacha20@0.10.1`
- No other packages touched — minimal, targeted lockfile diff

## Test plan
- [x] `cargo build --locked` succeeds, no yanked-package warning
- [x] `cargo check --locked` clean
- [x] `cargo clippy --locked -- -D warnings` clean