### PR TITLE
fix(sync): snapshot branch metadata in restack transaction, harden needs_restack

### DIFF
--- a/src/commands/range_diff.rs
+++ b/src/commands/range_diff.rs
@@ -49,7 +49,7 @@ pub fn run(stack_filter: Option<String>, all: bool) -> Result<()> {
             None => continue,
         };
 
-        let needs_restack = meta.needs_restack(repo.inner()).unwrap_or(false);
+        let needs_restack = meta.needs_restack(repo.inner(), branch).unwrap_or(false);
         if !needs_restack {
             println!(
                 "\n{} {}",

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -2216,7 +2216,12 @@ impl SyncContext {
                     .tx
                     .take()
                     .context("sync transaction was already finished")?;
-                tx.plan_branches(repo, &restack_scope_order)?;
+                for branch in &restack_scope_order {
+                    tx.plan_branch(repo, branch)?;
+                    if branch != &self.stack.trunk {
+                        tx.plan_metadata_ref(repo, branch)?;
+                    }
+                }
                 let restack_count = branches_to_restack.len();
                 let summary = PlanSummary {
                     branches_to_rebase: restack_count,
@@ -2328,6 +2333,11 @@ impl SyncContext {
 
                             // Record after-OID
                             tx.record_after(repo, branch)?;
+                            let meta_after = resolve_ref_oid(
+                                &self.workdir,
+                                &format!("refs/branch-metadata/{}", branch),
+                            );
+                            tx.record_known_metadata_after(branch, meta_after.as_deref());
                             tx.push_completed_branch(branch);
 
                             if self.verbose {

--- a/src/engine/metadata.rs
+++ b/src/engine/metadata.rs
@@ -93,15 +93,56 @@ impl BranchMetadata {
         Ok(Self::read(repo, branch)?.is_some_and(|metadata| metadata.frozen))
     }
 
-    /// Check if the branch needs restacking (parent has moved)
-    pub fn needs_restack(&self, repo: &Repository) -> Result<bool> {
+    /// Check if the branch needs restacking (parent has moved).
+    ///
+    /// The recorded `parent_branch_revision` can be a lie: an interrupted restack may have
+    /// written the new base before being rolled back, leaving a SHA that no longer sits under
+    /// the branch's tip. A bare SHA comparison would then report the branch clean forever, so
+    /// when the SHAs match we additionally verify the recorded base is still reachable from the
+    /// branch head.
+    pub fn needs_restack(&self, repo: &Repository, branch: &str) -> Result<bool> {
         if self.source_remote.is_some() {
             return Ok(false);
         }
 
         let parent_ref = repo.find_branch(&self.parent_branch_name, git2::BranchType::Local)?;
         let current_parent_rev = parent_ref.get().peel_to_commit()?.id().to_string();
-        Ok(current_parent_rev != self.parent_branch_revision)
+        if current_parent_rev != self.parent_branch_revision {
+            return Ok(true);
+        }
+
+        Ok(!Self::recorded_base_is_reachable(
+            repo,
+            branch,
+            &self.parent_branch_revision,
+        ))
+    }
+
+    /// Whether `revision` is reachable from `branch`'s tip.
+    ///
+    /// Conservative: any lookup failure (unknown branch, unparsable or missing revision)
+    /// returns `true` so unrelated repo problems never surface as a spurious "needs restack".
+    fn recorded_base_is_reachable(repo: &Repository, branch: &str, revision: &str) -> bool {
+        let Ok(base_oid) = git2::Oid::from_str(revision) else {
+            return true;
+        };
+        let Ok(branch_ref) = repo.find_branch(branch, git2::BranchType::Local) else {
+            return true;
+        };
+        let Ok(branch_oid) = branch_ref.get().peel_to_commit().map(|commit| commit.id()) else {
+            return true;
+        };
+        if branch_oid == base_oid {
+            return true;
+        }
+        if repo
+            .graph_descendant_of(base_oid, branch_oid)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        repo.graph_descendant_of(branch_oid, base_oid)
+            .unwrap_or(true)
     }
 }
 
@@ -181,5 +222,98 @@ mod tests {
         let meta: BranchMetadata = serde_json::from_str(freephite_json).unwrap();
         assert_eq!(meta.parent_branch_name, "main");
         assert_eq!(meta.parent_branch_revision, "deadbeef1234567890");
+    }
+}
+
+#[cfg(all(test, unix))]
+mod git_tests {
+    use super::*;
+    use std::process::Command;
+
+    /// Sets up a repo with `main` at c1, `feature` branched off c1 with its own
+    /// commit, then advances `main` to c2. Returns `(tempdir, repo, c2)`; the
+    /// tempdir must be kept alive for the duration of the test.
+    fn repo_with_feature_branch_and_advanced_main() -> (tempfile::TempDir, git2::Repository, String)
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+
+        let run = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(path.join("f.txt"), "c1").unwrap();
+        run(&["add", "f.txt"]);
+        run(&["commit", "-m", "c1"]);
+        run(&["branch", "feature"]);
+
+        run(&["checkout", "feature"]);
+        std::fs::write(path.join("feature.txt"), "on feature").unwrap();
+        run(&["add", "feature.txt"]);
+        run(&["commit", "-m", "feature commit"]);
+
+        run(&["checkout", "main"]);
+        std::fs::write(path.join("f.txt"), "c2").unwrap();
+        run(&["add", "f.txt"]);
+        run(&["commit", "-m", "c2"]);
+
+        let output = Command::new("git")
+            .args(["rev-parse", "main"])
+            .current_dir(path)
+            .output()
+            .expect("git");
+        let c2 = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+        let repo = git2::Repository::open(path).unwrap();
+        (dir, repo, c2)
+    }
+
+    #[test]
+    fn needs_restack_detects_a_recorded_parent_revision_that_is_not_an_ancestor() {
+        let (_dir, repo, c2) = repo_with_feature_branch_and_advanced_main();
+
+        // The lie: SHAs match the parent tip, but c2 is not reachable from feature.
+        let meta = BranchMetadata::new("main", &c2);
+
+        assert!(meta.needs_restack(&repo, "feature").unwrap());
+    }
+
+    #[test]
+    fn needs_restack_is_false_when_the_branch_sits_on_the_recorded_parent_tip() {
+        let (_dir, repo, c2) = repo_with_feature_branch_and_advanced_main();
+        let path = repo.workdir().unwrap().to_path_buf();
+
+        let run = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(&path)
+                .output()
+                .expect("git");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run(&["checkout", "feature"]);
+        run(&["rebase", "main"]);
+
+        let meta = BranchMetadata::new("main", &c2);
+
+        assert!(!meta.needs_restack(&repo, "feature").unwrap());
     }
 }

--- a/src/engine/stack.rs
+++ b/src/engine/stack.rs
@@ -46,7 +46,9 @@ impl Stack {
             }
 
             if let Some(meta) = BranchMetadata::read(repo.inner(), branch_name)? {
-                let needs_restack = meta.needs_restack(repo.inner()).unwrap_or(false);
+                let needs_restack = meta
+                    .needs_restack(repo.inner(), branch_name)
+                    .unwrap_or(false);
                 branches.insert(
                     branch_name.clone(),
                     StackBranch {

--- a/tests/sync_undo_tests.rs
+++ b/tests/sync_undo_tests.rs
@@ -17,6 +17,23 @@ fn read_parent_branch(repo: &TestRepo, branch: &str) -> String {
         .to_string()
 }
 
+/// Helper: read the parentBranchRevision from stax metadata for `branch`.
+fn read_parent_revision(repo: &TestRepo, branch: &str) -> String {
+    let metadata_ref = format!("refs/branch-metadata/{}", branch);
+    let out = repo.git(&["show", &metadata_ref]);
+    assert!(
+        out.status.success(),
+        "failed to read metadata for {branch}: {}",
+        TestRepo::stderr(&out)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&out)).expect("invalid metadata JSON");
+    json["parentBranchRevision"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// Helper: resolve a local ref to its SHA via git rev-parse (returns None if the ref doesn't
 /// exist).
 fn resolve_ref(repo: &TestRepo, refname: &str) -> Option<String> {
@@ -464,5 +481,79 @@ fn sync_restack_undo_rolls_back_trunk_fast_forward() {
     assert!(
         branch_exists(&repo, &feature),
         "feature branch should still exist after undo"
+    );
+}
+
+// ─── Test 7 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_restack_conflict_undo_restores_branch_metadata() {
+    // Regression test: sync's restack phase only snapshotted branch heads, not
+    // branch-metadata refs. When a later branch in the restack scope hit a
+    // conflict and sync stopped, undo restored earlier branches' commits but
+    // left their rewritten parentBranchRevision in place.
+    let repo = TestRepo::new_with_remote();
+
+    // Build stack: main → branch-a → branch-b.
+    repo.run_stax(&["bc", "branch-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a");
+    repo.commit("Branch A commit");
+
+    repo.run_stax(&["bc", "branch-b"]);
+    repo.create_file("shared.txt", "from branch b");
+    repo.commit("Branch B commit");
+
+    let main_sha_before = repo.get_commit_sha("main");
+    let a_sha_before = repo.get_commit_sha(&branch_a);
+    let a_parent_rev_before = read_parent_revision(&repo, &branch_a);
+    assert_eq!(
+        a_parent_rev_before, main_sha_before,
+        "branch-a's recorded parent revision should be main's sha before sync"
+    );
+
+    // Advance remote main with a conflicting change to shared.txt, so branch-b's
+    // rebase conflicts while branch-a's does not.
+    repo.simulate_remote_commit(
+        "shared.txt",
+        "from remote main",
+        "Remote conflicting commit",
+    );
+
+    let sync_out = repo.run_stax(&["sync", "--force", "--restack"]);
+    assert!(
+        !sync_out.status.success(),
+        "sync should stop on the branch-b conflict"
+    );
+
+    assert_ne!(
+        read_parent_revision(&repo, &branch_a),
+        a_parent_rev_before,
+        "sync should have rewritten branch-a's metadata before hitting the conflict"
+    );
+
+    repo.abort_rebase();
+
+    let undo_out = repo.run_stax(&["undo", "--yes", "--no-push"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    assert_eq!(
+        repo.get_commit_sha(&branch_a),
+        a_sha_before,
+        "undo should restore branch-a to its pre-sync commit"
+    );
+    assert_eq!(
+        read_parent_revision(&repo, &branch_a),
+        a_parent_rev_before,
+        "undo should restore branch-a's metadata to its pre-sync parent revision"
+    );
+    assert_eq!(
+        repo.get_commit_sha("main"),
+        main_sha_before,
+        "undo should restore main to its pre-sync sha"
     );
 }

--- a/tests/sync_undo_tests.rs
+++ b/tests/sync_undo_tests.rs
@@ -556,4 +556,106 @@ fn sync_restack_conflict_undo_restores_branch_metadata() {
         main_sha_before,
         "undo should restore main to its pre-sync sha"
     );
+
+    // A *failed* sync's receipt cannot be redone (can_redo() requires
+    // OpStatus::Success) — there is no coherent "completed" state to replay
+    // back to. Confirm that's still rejected cleanly rather than silently
+    // reapplying a half-finished restack.
+    let redo_out = repo.run_stax(&["redo", "--yes", "--no-push"]);
+    assert!(
+        !redo_out.status.success(),
+        "redo of a failed sync's receipt should be rejected, not silently reapplied"
+    );
+    assert_eq!(
+        repo.get_commit_sha(&branch_a),
+        a_sha_before,
+        "rejected redo must leave branch-a exactly where undo left it"
+    );
+}
+
+// ─── Test 8 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_restack_success_undo_then_redo_round_trips_branch_metadata() {
+    // Companion to sync_restack_conflict_undo_restores_branch_metadata: that test
+    // covers the undo direction after a *failed* restack. This test covers a
+    // *successful* restack, where the receipt's after-OIDs for the metadata ref
+    // must also be recorded so redo can replay the branch head and its rewritten
+    // parentBranchRevision back together.
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "branch-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a");
+    repo.commit("Branch A commit");
+
+    let main_sha_before = repo.get_commit_sha("main");
+    let a_sha_before = repo.get_commit_sha(&branch_a);
+    let a_parent_rev_before = read_parent_revision(&repo, &branch_a);
+    assert_eq!(
+        a_parent_rev_before, main_sha_before,
+        "branch-a's recorded parent revision should be main's sha before sync"
+    );
+
+    // Advance remote main with an unrelated file so branch-a's rebase succeeds
+    // cleanly (no conflict).
+    repo.simulate_remote_commit("remote.txt", "remote", "Remote commit for restack");
+
+    let sync_out = repo.run_stax(&["sync", "--force", "--restack"]);
+    assert!(
+        sync_out.status.success(),
+        "sync --force --restack failed: {}",
+        TestRepo::stderr(&sync_out)
+    );
+
+    let main_sha_after_sync = repo.get_commit_sha("main");
+    let a_sha_after_sync = repo.get_commit_sha(&branch_a);
+    let a_parent_rev_after_sync = read_parent_revision(&repo, &branch_a);
+    assert_ne!(
+        a_sha_after_sync, a_sha_before,
+        "sync should have rebased branch-a onto the new main"
+    );
+    assert_eq!(
+        a_parent_rev_after_sync, main_sha_after_sync,
+        "sync should have rewritten branch-a's parent revision to the new main sha"
+    );
+
+    let undo_out = repo.run_stax(&["undo", "--yes", "--no-push"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+    assert_eq!(
+        repo.get_commit_sha(&branch_a),
+        a_sha_before,
+        "undo should restore branch-a to its pre-sync commit"
+    );
+    assert_eq!(
+        read_parent_revision(&repo, &branch_a),
+        a_parent_rev_before,
+        "undo should restore branch-a's metadata to its pre-sync parent revision"
+    );
+
+    let redo_out = repo.run_stax(&["redo", "--yes", "--no-push"]);
+    assert!(
+        redo_out.status.success(),
+        "redo failed: {}",
+        TestRepo::stderr(&redo_out)
+    );
+    assert_eq!(
+        repo.get_commit_sha(&branch_a),
+        a_sha_after_sync,
+        "redo should re-apply branch-a's restacked commit"
+    );
+    assert_eq!(
+        read_parent_revision(&repo, &branch_a),
+        a_parent_rev_after_sync,
+        "redo should re-apply branch-a's rewritten parent revision alongside its commit"
+    );
+    assert_eq!(
+        repo.get_commit_sha("main"),
+        main_sha_after_sync,
+        "redo should re-advance trunk to the post-sync sha"
+    );
 }

--- a/tests/validate_tests.rs
+++ b/tests/validate_tests.rs
@@ -96,3 +96,69 @@ fn test_validate_detects_orphaned_metadata() {
         stdout
     );
 }
+
+fn metadata_ref(branch: &str) -> String {
+    format!("refs/branch-metadata/{branch}")
+}
+
+/// Overwrite `branch`'s metadata so `parentBranchRevision` is `lie_revision`
+/// (SHA string, not derived from the real parent), while leaving
+/// `parentBranchName` unchanged. Mirrors what a bad snapshot/undo could leave
+/// behind: a recorded revision that matches some real commit but is no longer
+/// actually reachable from the branch.
+fn rewrite_parent_revision_lie(repo: &TestRepo, branch: &str, lie_revision: &str) {
+    let show = repo.git(&["show", &metadata_ref(branch)]);
+    show.assert_success();
+    let mut metadata: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&show)).expect("valid metadata JSON");
+    metadata["parentBranchRevision"] = serde_json::Value::String(lie_revision.to_string());
+
+    let file = tempfile::NamedTempFile::new().expect("metadata file");
+    std::fs::write(file.path(), metadata.to_string()).expect("metadata contents");
+    let hash = repo.git(&[
+        "hash-object",
+        "-w",
+        file.path().to_str().expect("metadata path"),
+    ]);
+    hash.assert_success();
+    repo.git(&[
+        "update-ref",
+        &metadata_ref(branch),
+        TestRepo::stdout(&hash).trim(),
+    ])
+    .assert_success();
+}
+
+#[test]
+fn test_validate_detects_stale_parent_revision_that_is_not_an_ancestor() {
+    // Regression test for issue #822: an interrupted sync-restack (undone)
+    // could leave a branch's parentBranchRevision pointing at a SHA that
+    // matches trunk's current tip by string comparison, but is no longer an
+    // ancestor of the branch (the rebase that would have made it one was
+    // rolled back). A bare SHA comparison in needs_restack() reported this as
+    // clean forever. validate must catch it via the ancestry check instead.
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    repo.create_stack(&["feature-a"]);
+    let branch = repo.current_branch();
+    repo.create_file("feature-change.txt", "feature work");
+    repo.commit("Feature commit");
+
+    repo.run_stax(&["t"]); // back to trunk
+    repo.create_file("trunk-change.txt", "new trunk content");
+    repo.commit("Trunk change");
+    let trunk_tip = repo.get_commit_sha("main");
+
+    // The lie: claim feature-a is already based on trunk's new tip, without
+    // actually rebasing it there.
+    rewrite_parent_revision_lie(&repo, &branch, &trunk_tip);
+
+    let output = repo.run_stax(&["validate"]);
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.contains("need restack") || stdout.contains("WARN"),
+        "Expected validate to catch the ancestry lie instead of reporting clean, got: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
## Summary
- `stax sync`'s restack phase now plans the `refs/branch-metadata/<branch>` ref alongside each branch head *before* the transaction snapshot, and records the metadata after-OID once a branch's rebase succeeds — so `stax undo` correctly restores `parentBranchRevision` after an interrupted sync restack, instead of leaving it stuck at the post-rebase value.
- `BranchMetadata::needs_restack()` now also checks that the recorded parent revision is an ancestor of the branch (not just a bare SHA match), so a stale/incorrect `parentBranchRevision` self-heals instead of permanently masking drift from `stax restack` / `stax validate` / `stax fix`.

Fixes #822

## Test plan
- [x] `cargo nextest run engine::metadata::` — new ancestry-check unit tests pass
- [x] `cargo nextest run sync_undo_tests::` — new regression test `sync_restack_conflict_undo_restores_branch_metadata` (interrupted sync restack + undo restores both head and metadata)
- [x] `cargo nextest run track_all_local_tests::` — confirms no false positives on the inverted-parent case
- [x] `cargo check && cargo clippy -- -D warnings`
- [x] `make test` (full suite)