### PR TITLE
test: cover multi-branch undo and cross-phase metadata idempotency

### DIFF
--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -717,6 +717,70 @@ mod tests {
     }
 
     #[test]
+    fn plan_metadata_ref_across_two_phases_keeps_the_earliest_before_oid() {
+        // sync runs multiple phases against the same transaction (e.g. a
+        // deletion/reparent phase followed by a restack phase). If both
+        // phases touch the same branch's metadata ref, plan_metadata_ref's
+        // second call must be a no-op that preserves the FIRST phase's
+        // before-OID -- otherwise undo would only roll back to the
+        // intermediate state written by the first phase, not the true
+        // pre-operation state.
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git");
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(path.join("f.txt"), "a").unwrap();
+        run(&["add", "f.txt"]);
+        run(&["commit", "-m", "first"]);
+        run(&["branch", "branch-a"]);
+
+        let repo = GitRepo::open_from_path(path).unwrap();
+        refs::write_metadata(repo.inner(), "branch-a", "{\"phase\":\"original\"}").unwrap();
+        let original_oid =
+            refs::metadata_ref_oid(repo.inner(), "branch-a").expect("original metadata oid");
+
+        let mut tx = Transaction::begin(OpKind::Sync, &repo, true).unwrap();
+
+        // Phase 1 (e.g. deletion/reparent) plans and then mutates the ref.
+        tx.plan_metadata_ref(&repo, "branch-a").unwrap();
+        refs::write_metadata(repo.inner(), "branch-a", "{\"phase\":\"after_phase_one\"}").unwrap();
+
+        // Phase 2 (restack) plans the SAME branch again before its own mutation.
+        tx.plan_metadata_ref(&repo, "branch-a").unwrap();
+        refs::write_metadata(repo.inner(), "branch-a", "{\"phase\":\"after_phase_two\"}").unwrap();
+
+        let entries: Vec<_> = tx
+            .receipt
+            .local_refs
+            .iter()
+            .filter(|e| e.branch == "branch-a@meta")
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "the two plan_metadata_ref calls must fold into a single receipt entry"
+        );
+
+        // The receipt's before-OID must be the ref's state prior to EITHER
+        // phase, not the intermediate state phase 1 left behind.
+        assert_eq!(
+            entries[0].oid_before.as_deref(),
+            Some(original_oid.as_str())
+        );
+    }
+
+    #[test]
     fn record_known_after_records_deletion_as_none() {
         let temp = tempfile::tempdir().unwrap();
         let mut receipt = OpReceipt::new(

--- a/tests/sync_undo_tests.rs
+++ b/tests/sync_undo_tests.rs
@@ -659,3 +659,104 @@ fn sync_restack_success_undo_then_redo_round_trips_branch_metadata() {
         "redo should re-advance trunk to the post-sync sha"
     );
 }
+
+// ─── Test 9 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sync_restack_conflict_undo_restores_metadata_for_every_successful_branch_in_a_three_branch_stack()
+ {
+    // Extends sync_restack_conflict_undo_restores_branch_metadata to a 3-branch
+    // stack (main -> branch-a -> branch-b -> branch-c), where the two bottom
+    // branches restack successfully before the top one conflicts. Undo must
+    // restore BOTH branch-a's and branch-b's commit + metadata, not just the
+    // bottommost one.
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "branch-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a");
+    repo.commit("Branch A commit");
+
+    repo.run_stax(&["bc", "branch-b"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("b.txt", "b");
+    repo.commit("Branch B commit");
+
+    repo.run_stax(&["bc", "branch-c"]);
+    repo.create_file("shared.txt", "from branch c");
+    repo.commit("Branch C commit");
+
+    let main_sha_before = repo.get_commit_sha("main");
+    let a_sha_before = repo.get_commit_sha(&branch_a);
+    let a_parent_rev_before = read_parent_revision(&repo, &branch_a);
+    let b_sha_before = repo.get_commit_sha(&branch_b);
+    let b_parent_rev_before = read_parent_revision(&repo, &branch_b);
+    assert_eq!(
+        a_parent_rev_before, main_sha_before,
+        "branch-a's recorded parent revision should be main's sha before sync"
+    );
+    assert_eq!(
+        b_parent_rev_before, a_sha_before,
+        "branch-b's recorded parent revision should be branch-a's sha before sync"
+    );
+
+    // Advance remote main with a conflicting change to shared.txt, so
+    // branch-c's rebase conflicts while branch-a's and branch-b's do not.
+    repo.simulate_remote_commit(
+        "shared.txt",
+        "from remote main",
+        "Remote conflicting commit",
+    );
+
+    let sync_out = repo.run_stax(&["sync", "--force", "--restack"]);
+    assert!(
+        !sync_out.status.success(),
+        "sync should stop on the branch-c conflict"
+    );
+
+    assert_ne!(
+        read_parent_revision(&repo, &branch_a),
+        a_parent_rev_before,
+        "sync should have rewritten branch-a's metadata before hitting the conflict"
+    );
+    assert_ne!(
+        read_parent_revision(&repo, &branch_b),
+        b_parent_rev_before,
+        "sync should have rewritten branch-b's metadata before hitting the conflict"
+    );
+
+    repo.abort_rebase();
+
+    let undo_out = repo.run_stax(&["undo", "--yes", "--no-push"]);
+    assert!(
+        undo_out.status.success(),
+        "undo failed: {}",
+        TestRepo::stderr(&undo_out)
+    );
+
+    assert_eq!(
+        repo.get_commit_sha(&branch_a),
+        a_sha_before,
+        "undo should restore branch-a to its pre-sync commit"
+    );
+    assert_eq!(
+        read_parent_revision(&repo, &branch_a),
+        a_parent_rev_before,
+        "undo should restore branch-a's metadata to its pre-sync parent revision"
+    );
+    assert_eq!(
+        repo.get_commit_sha(&branch_b),
+        b_sha_before,
+        "undo should restore branch-b to its pre-sync commit"
+    );
+    assert_eq!(
+        read_parent_revision(&repo, &branch_b),
+        b_parent_rev_before,
+        "undo should restore branch-b's metadata to its pre-sync parent revision"
+    );
+    assert_eq!(
+        repo.get_commit_sha("main"),
+        main_sha_before,
+        "undo should restore main to its pre-sync sha"
+    );
+}


### PR DESCRIPTION
## Summary

Stacked on #826 (issue #822). Adds test coverage for two gaps flagged during review of that fix but not yet covered:

- `sync_restack_conflict_undo_restores_metadata_for_every_successful_branch_in_a_three_branch_stack` (`tests/sync_undo_tests.rs`) extends the 2-branch conflict/undo regression test to a 3-branch stack, proving `stax undo` restores commit + metadata for **every** branch that restacked successfully before the top of the stack hit a conflict, not just the bottommost one.
- `plan_metadata_ref_across_two_phases_keeps_the_earliest_before_oid` (`src/ops/tx.rs`) covers the cross-cutting concern noted in the original plan: when two sync phases (e.g. a reparent/deletion phase and the later restack phase) both plan the same branch's metadata ref within one transaction, `add_metadata_ref`'s idempotency must keep the *first* phase's before-OID, so undo rolls all the way back to the true pre-operation state rather than an intermediate one.

Both were verified to actually catch their target regression: I temporarily broke the relevant guarantee (removed the idempotency check / used a 2-branch instead of 3-branch assertion), confirmed the new test failed with the expected error, then restored the fix.

No production code changes — tests only.

## Test plan
- [x] `cargo nextest run sync_undo_tests:: ops::tx::` — all pass, including the two new tests
- [x] `cargo check && cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] Full suite (`--no-fail-fast`): 2568/2580 passed; the 12 failures are pre-existing and unrelated (only occur when running tests from inside a linked git worktree — confirmed identical on the parent branch before these test additions)