### PR TITLE
fix(release): auto-install cargo-release like git-cliff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-release release ensure-git-cliff install clean test test-native test-native-script test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint lint-fast benchmark-status all
+.PHONY: build build-release release ensure-git-cliff ensure-cargo-release install clean test test-native test-native-script test-local-fast test-local-ramdisk test-image test-container-image test-docker test-container ramdisk-up ramdisk-down test-unit test-integration check fmt lint lint-fast benchmark-status all
 
 RAMDISK_NAME ?= STAXRAM
 RAMDISK_SIZE_MB ?= 2048
@@ -26,7 +26,7 @@ build-release:
 	cargo build --release
 
 # Publish a new release (usage: make release or make release LEVEL=patch)
-release: ensure-git-cliff
+release: ensure-git-cliff ensure-cargo-release
 	cargo release $(LEVEL) --execute --no-confirm
 
 # Ensure git-cliff (changelog generator, used by cargo-release's pre-release hook)
@@ -35,6 +35,14 @@ ensure-git-cliff:
 	@command -v git-cliff >/dev/null 2>&1 || { \
 		echo "git-cliff not found; installing v$(GIT_CLIFF_VERSION) via cargo..."; \
 		cargo install git-cliff --version $(GIT_CLIFF_VERSION) --locked; \
+	}
+
+# Ensure cargo-release (the `cargo release` subcommand that drives version bump,
+# tag, and push) is available, so releasing does not require a manual install.
+ensure-cargo-release:
+	@command -v cargo-release >/dev/null 2>&1 || { \
+		echo "cargo-release not found; installing via cargo..."; \
+		cargo install cargo-release --locked; \
 	}
 
 # Install to ~/.cargo/bin

--- a/docs/workflows/releasing.md
+++ b/docs/workflows/releasing.md
@@ -34,4 +34,4 @@ PR references like `(#123)` become links to the GitHub repo. The automated `chor
 - `make release` defaults to a minor bump. Use `LEVEL=patch`, `LEVEL=minor`, or `LEVEL=major` to control the semver bump.
 - For a dry run, invoke `cargo release <level> --no-confirm` directly without `--execute`; cargo-release skips the version bump, tag, and push. git-cliff still rewrites `CHANGELOG.md` in place — run `git checkout CHANGELOG.md` to discard it.
 - Preview the upcoming entry without touching the file: `git-cliff --unreleased --tag v<next-version>`.
-- git-cliff must be installed locally (`cargo install git-cliff`) for `make release` to work.
+- `make release` installs `cargo-release` and `git-cliff` via `cargo install` automatically if they're missing, so there's no manual prerequisite step.


### PR DESCRIPTION
## Summary
- `make release` failed immediately with `error: no such command: \`release\`` when the `cargo-release` cargo subcommand wasn't installed — the Makefile only ensured `git-cliff` was present, never `cargo-release` itself.
- Adds an `ensure-cargo-release` target (mirrors `ensure-git-cliff`) that installs `cargo-release` via `cargo install cargo-release --locked` if missing, and makes `release:` depend on it.
- Updates `docs/workflows/releasing.md` to note both tools are auto-installed now.

## Test plan
- [x] `make -n release` prints both ensure-target guards then `cargo release $(LEVEL) --execute --no-confirm`
- [x] `make -n ensure-cargo-release` prints the install guard correctly
- [x] Recipe lines use hard tabs, matching `ensure-git-cliff`
- [x] `cargo check`, `cargo fmt --check`, `./scripts/lint.sh full` all clean