### PR TITLE
feat(board): add stax board dashboard for PRs and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st next` | Move to the next unmerged branch upstack; fork choices are deterministic |
 | `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--stack`, `--stack --full`, `--remote`, `--all`) |
 | `st ready` | Interactive PR readiness TUI — CI, review approval, and merge state for unmerged tracked PRs; auto-refreshes every 15s and drops remotely merged PRs without cleaning up their local branches (`--current`/`--stack` for current stack, `--plain` for a static table, `--json` for machine-readable readiness schema) |
+| `st board` / `st home` | Interactive repository dashboard (GitHub only) — PULL REQUESTS / ISSUES tabs with a detail pane, inline diff/comments, label editing, draft toggle, and API-only merge (`--limit`, `--tab`, `--interval`, `--plain` for static tables) |
 | `st ci` / `st ci --oneline` | Live CI status for each PR head — full per-check table, or one compact line per branch across the stack; GitHub statuses and check runs are fetched across all pages before roll-up |
 | `st ci -w --alert` | Watch CI until all checks finish, then play success/error sounds |
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -164,6 +164,7 @@ when it points at the same commit. `--all` conflicts with `--parent` and
 | `st pr list` | List open PRs (GitHub, GitLab, Gitea) |
 | `st pr list --ready` | Interactive PR readiness TUI for unmerged tracked PRs; remotely merged PRs disappear on live refresh (`--current`/`--stack` limits to the current stack, `--plain` for a static table) |
 | `st ready` | Same as `st pr list --ready` — interactive TUI with CI, review approval, and merge state; filtering merged PRs does not clean up local branches (`--current`, `--stack`, `--all`, `--plain`, `--json`, `--interval`) |
+| `st board` / `st home` | Interactive repository dashboard — PULL REQUESTS / ISSUES tabs, a detail pane (branch, files/+/−, CI checks, labels, body, comment count), inline diff and comment viewers, label add/remove, draft toggle, and confirm-then-merge (squash, API-only). GitHub only — errors on other forges. `--limit`, `--tab prs\|issues`, `--interval` (default 60s), `--plain` for static PR/issue tables |
 | `st draft [branch]` | Mark the current or named branch's PR as a draft |
 | `st draft --stack` | Mark every PR in the current stack as a draft |
 | `st undraft [branch]` | Mark the current or named branch's PR as ready for review |

--- a/docs/interface/board.md
+++ b/docs/interface/board.md
@@ -1,0 +1,104 @@
+# Repository Board Dashboard
+
+Run `st board` (or the alias `st home`) to open a full-screen dashboard of open
+pull requests and issues for the current repository.
+
+```bash
+stax board
+```
+
+GitHub only: on GitLab or Gitea remotes, `st board` errors and points you at
+`st pr list` / `st issue list` instead.
+
+## Tabs
+
+- **PULL REQUESTS** — open PRs sorted by most recently updated.
+- **ISSUES** — open issues (pull requests excluded), sorted by most recently
+  updated.
+
+`Tab`, `1`, and `2` switch between them; each tab remembers its own selection.
+
+By default both tabs are filtered to items authored by the current GitHub
+user ("mine only"). Press `a` to toggle between "mine" and "all"; the choice
+is saved to `~/.config/stax/config.toml` (`[board] mine_only`) and reused
+next time. The header shows `(3/12)` when the filter is hiding items, and a
+`· mine` marker while it's active. Until your GitHub login is resolved (a
+one-time lookup at startup), the filter fails open and shows everything
+rather than an empty list.
+
+## Detail pane
+
+The detail pane is a live preview of whatever row is currently selected — it
+loads automatically as you move through the list, no need to press `Enter`
+first (on terminals narrower than 100 columns it's hidden and the list takes
+the full width instead). Once fetched, a PR or issue's detail, files, CI
+checks, diff, and comments stay cached for the rest of the session, so
+revisiting something you already viewed doesn't re-fetch it — press `r` to
+force a refresh. Press `v` to hide the pane entirely (falls back to a
+list-only layout regardless of terminal width, and also stops the automatic
+prefetching); `Enter` or `v` again brings it back.
+
+- **PR detail**: branch (`head → base`), files changed with `+`/`-` counts,
+  per-check CI status (`✓` success/neutral/skipped, `✗` failure/timed
+  out/cancelled/action-required, `•` still running), labels, comment count,
+  and the PR body.
+- **Issue detail**: labels, comment count, and the issue body.
+
+## Overlays
+
+| Key | Opens |
+|---|---|
+| `d` | Inline diff viewer (pull requests only) |
+| `c` | Full comment thread (issue comments + review comments for PRs) |
+| `l` | Label picker — `Space` toggles a label on/off, `Esc` closes |
+| `m` | Merge confirmation (pull requests only, see below) |
+| `?` | Help |
+
+## Actions
+
+- `t` toggles a PR between draft and ready for review.
+- `m` opens a confirmation, then performs a **squash merge via the GitHub API
+  only**. Unlike `st merge`, this does not rebase descendants, retarget PR
+  bases, or delete branches — run `st sync` afterwards to bring your local
+  stack up to date.
+- `o` opens the selected PR or issue in your browser.
+- `r` refreshes the current view.
+- `/` filters the current tab's list by number, title, author, branch (PRs),
+  or labels.
+
+## Keybindings
+
+| Key | Action |
+|---|---|
+| `Tab` / `1` / `2` | Switch between PULL REQUESTS and ISSUES |
+| `j/k` or `↑/↓` | Move selection |
+| `g` / `G` | Jump to top / bottom |
+| `Ctrl-d` / `Ctrl-u` | Page down / up |
+| `Enter` | Open detail |
+| `d` | Diff (PRs) |
+| `c` | Comments |
+| `l` | Label picker |
+| `t` | Toggle draft (PRs) |
+| `m` | Merge (PRs, opens confirmation) |
+| `o` | Open in browser |
+| `r` | Refresh |
+| `/` | Filter |
+| `v` | Toggle the detail pane on/off |
+| `a` | Toggle "mine only" / "all" (persisted) |
+| `?` | Help |
+| `q` / `Esc` | Back one mode, or quit from the list |
+
+Note the divergence from the main `st` TUI and `st ready`: there, `d` toggles
+draft status. In the board dashboard `d` opens the diff viewer instead — `t`
+handles the draft toggle here, chosen so no binding depends on Shift state
+(terminals disagree on whether Shift+key arrives as the plain or the
+uppercase character).
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `--limit <N>` | Maximum PRs/issues to list per tab (default 30, max 100) |
+| `--tab prs\|issues` | Tab to open on launch (default: `prs`) |
+| `--interval <seconds>` | Auto-refresh interval for the interactive dashboard (default: 60) |
+| `--plain` | Render static PR and issue tables instead of the interactive dashboard (also used automatically when stdin/stdout aren't a TTY) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Multiple Stacks: concepts/multiple-stacks.md
   - Interface:
       - Interactive TUI: interface/tui.md
+      - Repository board dashboard: interface/board.md
       - Localhost web workspace: interface/web.md
   - Commands:
       - Core Commands: commands/core.md

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -200,6 +200,21 @@ impl From<RestackSubmitAfter> for commands::restack::SubmitAfterRestack {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum BoardTabArg {
+    Prs,
+    Issues,
+}
+
+impl From<BoardTabArg> for commands::board::BoardTabSelection {
+    fn from(value: BoardTabArg) -> Self {
+        match value {
+            BoardTabArg::Prs => commands::board::BoardTabSelection::PullRequests,
+            BoardTabArg::Issues => commands::board::BoardTabSelection::Issues,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub(crate) enum StandupSummaryStyle {
     Spoken,
@@ -454,7 +469,7 @@ pub(crate) enum Commands {
         /// Deprecated no-op, accepted for compatibility (use `--full` for fetch --prune of all remote-tracking refs)
         #[arg(long)]
         prune: bool,
-        /// Fetch all remote branches with `--prune` (slower; default is trunk-only fetch + ls-remote)
+        /// Fetch all remote branches and tags with `--prune` (slower; default is trunk-only fetch + ls-remote)
         #[arg(long)]
         full: bool,
         /// Don't delete merged branches
@@ -861,6 +876,23 @@ pub(crate) enum Commands {
         /// Auto-refresh interval in seconds for the interactive TUI (default: 15)
         #[arg(long, default_value = "15")]
         interval: u64,
+    },
+
+    /// Interactive dashboard of open pull requests and issues for this repository
+    #[command(visible_alias = "home")]
+    Board {
+        /// Maximum number of pull requests / issues to list (max: 100)
+        #[arg(long, default_value_t = DEFAULT_GITHUB_LIST_LIMIT, value_parser = clap::value_parser!(u8).range(1..=100))]
+        limit: u8,
+        /// Tab to open on launch
+        #[arg(long, value_enum, default_value_t = BoardTabArg::Prs)]
+        tab: BoardTabArg,
+        /// Auto-refresh interval in seconds for the interactive TUI (default: 60)
+        #[arg(long, default_value = "60")]
+        interval: u64,
+        /// Render static tables instead of the interactive dashboard
+        #[arg(long)]
+        plain: bool,
     },
 
     /// Browse open issues in the current repository
@@ -1902,6 +1934,7 @@ impl Commands {
             | Commands::Ll { .. }
             | Commands::Log { .. }
             | Commands::Ready { .. }
+            | Commands::Board { .. }
             | Commands::Ci { .. }
             | Commands::Watch { .. }
             | Commands::Diff { .. }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -564,6 +564,24 @@ pub fn run() -> Result<()> {
             plain,
             interval,
         ),
+        Commands::Board {
+            limit,
+            tab,
+            interval,
+            plain,
+        } => {
+            let interactive = check_interactive_terminal(stdin_is_terminal, stdout_is_terminal);
+            if plain || !interactive.available {
+                print_interactive_fallback(
+                    interactive.reason.as_deref(),
+                    "board dashboard",
+                    "printing static PR and issue tables",
+                );
+                commands::board::run_plain(limit)
+            } else {
+                commands::board::run_tui(limit, tab.into(), interval)
+            }
+        }
         Commands::Issue { command } => match command {
             Some(IssueCommands::List { limit, json }) => commands::issue::run_list(limit, json),
             None => print_subcommand_help("issue"),

--- a/src/commands/board.rs
+++ b/src/commands/board.rs
@@ -1,0 +1,81 @@
+use crate::config::Config;
+use crate::forge::{ForgeClient, forge_token};
+use crate::git::GitRepo;
+use crate::remote::{ForgeType, RemoteInfo};
+use anyhow::Result;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoardTabSelection {
+    PullRequests,
+    Issues,
+}
+
+#[derive(Clone)]
+pub struct BoardScope {
+    pub git_dir: PathBuf,
+    pub remote: RemoteInfo,
+    pub config: Config,
+    pub repo_label: String,
+    pub limit: u8,
+}
+
+pub fn load_board_scope(limit: u8) -> Result<BoardScope> {
+    let repo = GitRepo::open()?;
+    let config = Config::load()?;
+    let remote = RemoteInfo::from_repo(&repo, &config)?;
+
+    if remote.forge != ForgeType::GitHub {
+        anyhow::bail!(
+            "`stax board` supports GitHub only; use `stax pr list` / `stax issue list` on {}.",
+            remote.forge
+        );
+    }
+
+    if forge_token(remote.forge).is_none() {
+        anyhow::bail!(
+            "{} auth not configured; the board dashboard cannot be fetched.",
+            remote.forge
+        );
+    }
+
+    let repo_label = format!("{}/{}", remote.namespace, remote.repo);
+    let git_dir = repo.git_dir()?.to_path_buf();
+
+    Ok(BoardScope {
+        git_dir,
+        remote,
+        config,
+        repo_label,
+        limit,
+    })
+}
+
+pub fn run_tui(limit: u8, tab: BoardTabSelection, interval: u64) -> Result<()> {
+    let scope = load_board_scope(limit)?;
+    let mine_only = scope.config.board.mine_only;
+    crate::tui::board::run(scope, tab, interval, mine_only)
+}
+
+pub fn run_plain(limit: u8) -> Result<()> {
+    // Reuses `load_board_scope`'s GitHub-only + auth gate rather than
+    // re-deriving `RemoteInfo` here, so plain and interactive mode enforce
+    // the same preconditions. `ForgeClient` (not `GitHubClient`) is used for
+    // the actual listing since `print_pr_table`/`print_issue_table` already
+    // work off the forge-neutral `RepoPrListItem`/`RepoIssueListItem` types.
+    let scope = load_board_scope(limit)?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let _enter = rt.enter();
+    let client = ForgeClient::new(&scope.remote)?;
+    let (prs, issues) = rt.block_on(async {
+        tokio::try_join!(
+            client.list_open_pull_requests(scope.limit),
+            client.list_open_issues(scope.limit)
+        )
+    })?;
+
+    crate::commands::pr::print_pr_table(&scope.repo_label, &prs);
+    crate::commands::issue::print_issue_table(&scope.repo_label, &issues);
+    Ok(())
+}

--- a/src/commands/issue.rs
+++ b/src/commands/issue.rs
@@ -33,7 +33,7 @@ pub fn run_list(limit: u8, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn print_issue_table(repo_label: &str, issues: &[RepoIssueListItem]) {
+pub(crate) fn print_issue_table(repo_label: &str, issues: &[RepoIssueListItem]) {
     let updated_strings: Vec<String> = issues
         .iter()
         .map(|issue| format_relative_time(issue.updated_at))

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod abort;
 pub mod absorb;
 pub mod auth;
+pub mod board;
 pub mod branch;
 pub mod cascade;
 pub mod changelog;

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -209,7 +209,7 @@ fn edit_body(body: &str) -> Result<String> {
     std::fs::read_to_string(&path).context("Failed to read edited PR body")
 }
 
-fn print_pr_table(repo_label: &str, prs: &[RepoPrListItem]) {
+pub(crate) fn print_pr_table(repo_label: &str, prs: &[RepoPrListItem]) {
     let branch_strings: Vec<String> = prs.iter().map(|pr| pr.head_branch.clone()).collect();
     let created_strings: Vec<String> = prs
         .iter()

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -49,6 +49,9 @@
 # harnesses = ["claude", "codex"] # which agent harnesses get skill files
 #   valid ids: claude, codex, cursor, opencode, pi. Unset = auto (detected + already installed).
 
+[board]
+# mine_only = true # `st board` starts filtered to PRs/issues you authored; toggle with `a` (persisted here)
+
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" | "pi" — global default
 # model = "claude-opus-4-8"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use crate::remote::ForgeType;
 
 /// Main config (safe to commit to dotfiles)
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
     pub branch: BranchConfig,
@@ -33,10 +33,33 @@ pub struct Config {
     pub restack: RestackConfig,
     #[serde(default)]
     pub skills: SkillsConfig,
+    #[serde(default)]
+    pub board: BoardConfig,
+}
+
+/// Preferences for the `stax board` dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardConfig {
+    /// Show only PRs/issues authored by the current user by default.
+    /// Toggled at runtime with `a`; the choice is persisted here.
+    #[serde(default = "default_board_mine_only")]
+    pub mine_only: bool,
+}
+
+impl Default for BoardConfig {
+    fn default() -> Self {
+        Self {
+            mine_only: default_board_mine_only(),
+        }
+    }
+}
+
+fn default_board_mine_only() -> bool {
+    true
 }
 
 /// Which agent harnesses receive stax skill files.
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SkillsConfig {
     /// Harness ids to manage (`claude`, `codex`, `cursor`, `opencode`, `pi`).
     /// Unset = auto (detected harnesses plus any that already have a skill file).
@@ -57,7 +80,7 @@ struct TrustedNetworkRepoRemoteConfig {
 }
 
 /// User-configurable restack behaviour.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RestackConfig {
     /// Automatically use `merge-base(parent, branch)` as the rebase boundary
     /// when the stored `parentBranchRevision` would replay a much larger range
@@ -80,7 +103,7 @@ impl Default for RestackConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchConfig {
     /// Prefix for new branches (e.g., "cesar/")
     /// DEPRECATED: Use `format` instead. Kept for backward compatibility.
@@ -113,7 +136,7 @@ pub struct BranchConfig {
     pub stale_days: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteConfig {
     /// Git remote name (default: "origin")
     #[serde(default = "default_remote_name")]
@@ -159,7 +182,7 @@ pub struct SubmitConfig {
     pub single_stack: SingleStackMode,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CiConfig {
     /// Play a sound when `stax ci --watch` exits after CI completion.
     #[serde(default)]
@@ -207,14 +230,14 @@ pub enum SingleStackMode {
     Off,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiConfig {
     /// Whether to show contextual tips/suggestions (default: true)
     #[serde(default = "default_tips")]
     pub tips: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DisplayConfig {
     /// Linked-worktree marker in stack views: "auto", "tree" (Nerd Font), or "wt" (ASCII).
     #[serde(default = "default_worktree_glyph")]
@@ -245,7 +268,7 @@ pub struct AiFeatureConfig {
     pub body: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AiConfig {
     /// AI agent to use: "claude", "codex", "gemini", "opencode", or "pi" (default: auto-detect)
     #[serde(default)]
@@ -319,7 +342,7 @@ impl AiConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthConfig {
     /// Whether to use `gh auth token` as a fallback auth source (default: true)
     #[serde(default = "default_use_gh_cli")]
@@ -332,7 +355,7 @@ pub struct AuthConfig {
     pub gh_hostname: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorktreeConfig {
     /// Directory for stax-managed worktrees. Relative paths resolve from the main
     /// checkout. Empty means the default external root: ~/.stax/worktrees/<repo>.
@@ -354,7 +377,7 @@ pub struct WorktreeConfig {
     pub hooks: WorktreeHooksConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct WorktreeHooksConfig {
     /// Blocking hook run after creating a worktree and before launch
     #[serde(default)]
@@ -385,7 +408,7 @@ impl Default for WorktreeConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitConfig {
     /// Auto-enable git rerere on init (default: true)
     #[serde(default = "default_true")]
@@ -709,6 +732,14 @@ impl Config {
         let path = Self::path()?;
         let mut config = Self::load_path_or_default(&path)?;
         config.skills.harnesses = Some(harnesses.to_vec());
+        config.save()
+    }
+
+    /// Persist the `stax board` "mine only" preference (global config only).
+    pub fn set_board_mine_only(mine_only: bool) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.board.mine_only = mine_only;
         config.save()
     }
 

--- a/src/github/board.rs
+++ b/src/github/board.rs
@@ -1,0 +1,630 @@
+use super::client::GitHubClient;
+use crate::forge::IssueComment;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+const PER_PAGE: usize = 100;
+const MAX_FILE_PAGES: u32 = 5;
+const MAX_PAGES: u32 = 5;
+
+#[derive(Debug, Clone)]
+pub struct BoardPrSummary {
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub is_draft: bool,
+    pub labels: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardIssueSummary {
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub labels: Vec<String>,
+    pub comment_count: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardPrFile {
+    pub filename: String,
+    pub status: String,
+    pub additions: u64,
+    pub deletions: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardPrDetail {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub head_sha: String,
+    pub is_draft: bool,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: Option<String>,
+    pub additions: u64,
+    pub deletions: u64,
+    pub changed_files: u64,
+    pub comment_count: u32,
+    pub review_comment_count: u32,
+    pub labels: Vec<String>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardIssueDetail {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub author: String,
+    pub labels: Vec<String>,
+    pub comment_count: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardUser {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardRef {
+    #[serde(rename = "ref")]
+    ref_field: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardLabel {
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardPrListItem {
+    number: u64,
+    title: String,
+    html_url: String,
+    user: BoardUser,
+    head: BoardRef,
+    base: BoardRef,
+    draft: Option<bool>,
+    #[serde(default)]
+    labels: Vec<BoardLabel>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardIssueListItem {
+    number: u64,
+    title: String,
+    html_url: String,
+    user: BoardUser,
+    #[serde(default)]
+    labels: Vec<BoardLabel>,
+    #[serde(default)]
+    comments: u32,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardPrDetailHead {
+    #[serde(rename = "ref")]
+    ref_field: String,
+    sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardPrDetailResponse {
+    number: u64,
+    title: String,
+    body: Option<String>,
+    head: BoardPrDetailHead,
+    base: BoardRef,
+    draft: Option<bool>,
+    mergeable: Option<bool>,
+    mergeable_state: Option<String>,
+    additions: Option<u64>,
+    deletions: Option<u64>,
+    changed_files: Option<u64>,
+    comments: Option<u32>,
+    review_comments: Option<u32>,
+    #[serde(default)]
+    labels: Vec<BoardLabel>,
+    html_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardPrFileResponse {
+    filename: String,
+    status: String,
+    additions: u64,
+    deletions: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardIssueDetailResponse {
+    number: u64,
+    title: String,
+    body: Option<String>,
+    user: BoardUser,
+    #[serde(default)]
+    labels: Vec<BoardLabel>,
+    comments: Option<u32>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    html_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardIssueCommentResponse {
+    id: u64,
+    body: Option<String>,
+    user: BoardUser,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BoardRepoLabel {
+    name: String,
+}
+
+fn label_names(labels: Vec<BoardLabel>) -> Vec<String> {
+    labels.into_iter().filter_map(|label| label.name).collect()
+}
+
+impl GitHubClient {
+    /// List the most recently updated open pull requests.
+    pub(crate) async fn board_list_open_prs(&self, limit: u8) -> Result<Vec<BoardPrSummary>> {
+        self.record_api_call("board.pulls.list");
+        let per_page = limit.clamp(1, 100);
+        let url = format!(
+            "/repos/{}/{}/pulls?state=open&sort=updated&direction=desc&per_page={}",
+            self.owner, self.repo, per_page
+        );
+
+        let response: Vec<BoardPrListItem> = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to list pull requests")
+            .map_err(|e| self.enrich_api_error(e))?;
+
+        Ok(response
+            .into_iter()
+            .take(per_page as usize)
+            .map(|pr| BoardPrSummary {
+                number: pr.number,
+                title: pr.title,
+                author: pr.user.login,
+                head_branch: pr.head.ref_field,
+                base_branch: pr.base.ref_field,
+                is_draft: pr.draft.unwrap_or(false),
+                labels: label_names(pr.labels),
+                created_at: pr.created_at,
+                updated_at: pr.updated_at,
+                url: pr.html_url,
+            })
+            .collect())
+    }
+
+    /// List open issues (pull requests excluded), paginating until `limit`
+    /// real issues are collected, the API runs out of pages, or `MAX_PAGES`
+    /// is hit (the `/issues` endpoint mixes in PRs, which don't count
+    /// toward `limit`, so a repo with many open PRs could otherwise walk
+    /// hundreds of pages).
+    pub(crate) async fn board_list_open_issues(&self, limit: u8) -> Result<Vec<BoardIssueSummary>> {
+        let want = limit.clamp(1, 100) as usize;
+        let mut collected: Vec<BoardIssueSummary> = Vec::with_capacity(want);
+        let mut page = 1u32;
+
+        loop {
+            let url = format!(
+                "/repos/{}/{}/issues?state=open&sort=updated&direction=desc&per_page={PER_PAGE}&page={page}",
+                self.owner, self.repo
+            );
+
+            self.record_api_call("board.issues.list");
+            let response: Vec<BoardIssueListItem> = self
+                .octocrab
+                .get(&url, None::<&()>)
+                .await
+                .context("Failed to list issues")
+                .map_err(|e| self.enrich_api_error(e))?;
+
+            let fetched = response.len();
+
+            for issue in response {
+                if issue.pull_request.is_some() {
+                    continue;
+                }
+                collected.push(BoardIssueSummary {
+                    number: issue.number,
+                    title: issue.title,
+                    author: issue.user.login,
+                    labels: label_names(issue.labels),
+                    comment_count: issue.comments,
+                    created_at: issue.created_at,
+                    updated_at: issue.updated_at,
+                    url: issue.html_url,
+                });
+                if collected.len() >= want {
+                    return Ok(collected);
+                }
+            }
+
+            if fetched < PER_PAGE || page >= MAX_PAGES {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(collected)
+    }
+
+    pub(crate) async fn board_get_pr_detail(&self, number: u64) -> Result<BoardPrDetail> {
+        self.record_api_call("board.pulls.get");
+        let url = format!("/repos/{}/{}/pulls/{}", self.owner, self.repo, number);
+        let pr: BoardPrDetailResponse = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to get pull request")
+            .map_err(|e| self.enrich_api_error(e))?;
+
+        Ok(BoardPrDetail {
+            number: pr.number,
+            title: pr.title,
+            body: pr.body.unwrap_or_default(),
+            head_branch: pr.head.ref_field,
+            base_branch: pr.base.ref_field,
+            head_sha: pr.head.sha,
+            is_draft: pr.draft.unwrap_or(false),
+            mergeable: pr.mergeable,
+            mergeable_state: pr.mergeable_state,
+            additions: pr.additions.unwrap_or_default(),
+            deletions: pr.deletions.unwrap_or_default(),
+            changed_files: pr.changed_files.unwrap_or_default(),
+            comment_count: pr.comments.unwrap_or_default(),
+            review_comment_count: pr.review_comments.unwrap_or_default(),
+            labels: label_names(pr.labels),
+            url: pr.html_url,
+        })
+    }
+
+    pub(crate) async fn board_list_pr_files(&self, number: u64) -> Result<Vec<BoardPrFile>> {
+        let base_url = format!("/repos/{}/{}/pulls/{}/files", self.owner, self.repo, number);
+        let mut files = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            self.record_api_call("board.pulls.files");
+            let url = format!("{base_url}?per_page={PER_PAGE}&page={page}");
+            let response: Vec<BoardPrFileResponse> = self
+                .octocrab
+                .get(&url, None::<&()>)
+                .await
+                .context("Failed to list pull request files")
+                .map_err(|e| self.enrich_api_error(e))?;
+            let fetched = response.len();
+            files.extend(response.into_iter().map(|file| BoardPrFile {
+                filename: file.filename,
+                status: file.status,
+                additions: file.additions,
+                deletions: file.deletions,
+            }));
+
+            if fetched < PER_PAGE || page >= MAX_FILE_PAGES {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(files)
+    }
+
+    pub(crate) async fn board_get_pr_diff(&self, number: u64) -> Result<String> {
+        self.record_api_call("board.pulls.get_diff");
+        self.octocrab
+            .pulls(&self.owner, &self.repo)
+            .get_diff(number)
+            .await
+            .context("Failed to get pull request diff")
+            .map_err(|e| self.enrich_api_error(e))
+    }
+
+    pub(crate) async fn board_get_issue_detail(&self, number: u64) -> Result<BoardIssueDetail> {
+        self.record_api_call("board.issues.get");
+        let url = format!("/repos/{}/{}/issues/{}", self.owner, self.repo, number);
+        let issue: BoardIssueDetailResponse = self
+            .octocrab
+            .get(&url, None::<&()>)
+            .await
+            .context("Failed to get issue")
+            .map_err(|e| self.enrich_api_error(e))?;
+
+        Ok(BoardIssueDetail {
+            number: issue.number,
+            title: issue.title,
+            body: issue.body.unwrap_or_default(),
+            author: issue.user.login,
+            labels: label_names(issue.labels),
+            comment_count: issue.comments.unwrap_or_default(),
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            url: issue.html_url,
+        })
+    }
+
+    /// Issue-comment thread, unlike `list_issue_comments` (src/github/pr.rs)
+    /// which is single-page and truncates past 30 comments. Paginates up to
+    /// `MAX_PAGES` rather than being fully unbounded.
+    pub(crate) async fn board_list_issue_comments(&self, number: u64) -> Result<Vec<IssueComment>> {
+        let base_url = format!(
+            "/repos/{}/{}/issues/{}/comments",
+            self.owner, self.repo, number
+        );
+        let mut comments = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            self.record_api_call("board.issues.comments");
+            let url = format!("{base_url}?per_page={PER_PAGE}&page={page}");
+            let response: Vec<BoardIssueCommentResponse> = self
+                .octocrab
+                .get(&url, None::<&()>)
+                .await
+                .context("Failed to list issue comments")
+                .map_err(|e| self.enrich_api_error(e))?;
+            let fetched = response.len();
+            comments.extend(response.into_iter().map(|comment| IssueComment {
+                id: comment.id,
+                body: comment.body.unwrap_or_default(),
+                user: comment.user.login,
+                created_at: comment.created_at,
+            }));
+
+            if fetched < PER_PAGE || page >= MAX_PAGES {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(comments)
+    }
+
+    pub(crate) async fn board_list_repo_labels(&self) -> Result<Vec<String>> {
+        let base_url = format!("/repos/{}/{}/labels", self.owner, self.repo);
+        let mut labels = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            self.record_api_call("board.labels.list");
+            let url = format!("{base_url}?per_page={PER_PAGE}&page={page}");
+            let response: Vec<BoardRepoLabel> = self
+                .octocrab
+                .get(&url, None::<&()>)
+                .await
+                .context("Failed to list repository labels")
+                .map_err(|e| self.enrich_api_error(e))?;
+            let fetched = response.len();
+            labels.extend(response.into_iter().map(|label| label.name));
+
+            if fetched < PER_PAGE || page >= MAX_PAGES {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(labels)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octocrab::Octocrab;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ensure_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    async fn create_test_client(server: &MockServer) -> GitHubClient {
+        ensure_crypto_provider();
+        let octocrab = Octocrab::builder()
+            .base_uri(server.uri())
+            .unwrap()
+            .personal_token("test-token".to_string())
+            .build()
+            .unwrap();
+
+        GitHubClient::with_octocrab(octocrab, "test-owner", "test-repo")
+    }
+
+    #[tokio::test]
+    async fn board_get_pr_detail_parses_stats_and_labels() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "number": 42,
+                "title": "Add board dashboard",
+                "body": "Some description",
+                "head": { "ref": "feature/board", "sha": "abc123" },
+                "base": { "ref": "main" },
+                "draft": false,
+                "mergeable": true,
+                "mergeable_state": "clean",
+                "additions": 120,
+                "deletions": 30,
+                "changed_files": 7,
+                "comments": 3,
+                "review_comments": 5,
+                "labels": [{ "name": "enhancement" }, { "name": "cli" }],
+                "html_url": "https://github.com/test-owner/test-repo/pull/42"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let detail = client.board_get_pr_detail(42).await.unwrap();
+
+        assert_eq!(detail.number, 42);
+        assert_eq!(detail.head_sha, "abc123");
+        assert_eq!(detail.additions, 120);
+        assert_eq!(detail.deletions, 30);
+        assert_eq!(detail.changed_files, 7);
+        assert_eq!(detail.comment_count, 3);
+        assert_eq!(detail.review_comment_count, 5);
+        assert_eq!(detail.labels, vec!["enhancement", "cli"]);
+        assert_eq!(detail.mergeable, Some(true));
+    }
+
+    #[tokio::test]
+    async fn board_get_pr_detail_defaults_missing_optional_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/pulls/7"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "number": 7,
+                "title": "Minimal PR",
+                "head": { "ref": "feature/minimal", "sha": "deadbeef" },
+                "base": { "ref": "main" },
+                "html_url": "https://github.com/test-owner/test-repo/pull/7"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let detail = client.board_get_pr_detail(7).await.unwrap();
+
+        assert_eq!(detail.body, "");
+        assert!(!detail.is_draft);
+        assert_eq!(detail.mergeable, None);
+        assert_eq!(detail.additions, 0);
+        assert_eq!(detail.deletions, 0);
+        assert_eq!(detail.changed_files, 0);
+        assert!(detail.labels.is_empty());
+    }
+
+    #[tokio::test]
+    async fn board_list_pr_files_paginates_and_stops_at_five_pages() {
+        let server = MockServer::start().await;
+        let full_page = |offset: usize| -> Vec<serde_json::Value> {
+            (0..100)
+                .map(|i| {
+                    serde_json::json!({
+                        "filename": format!("file-{}.rs", offset + i),
+                        "status": "modified",
+                        "additions": 1,
+                        "deletions": 1,
+                    })
+                })
+                .collect()
+        };
+
+        for page in 1..=6u32 {
+            Mock::given(method("GET"))
+                .and(path("/repos/test-owner/test-repo/pulls/9/files"))
+                .and(query_param("page", page.to_string()))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!(full_page((page as usize - 1) * 100))),
+                )
+                .mount(&server)
+                .await;
+        }
+
+        let client = create_test_client(&server).await;
+        let files = client.board_list_pr_files(9).await.unwrap();
+
+        // 5 pages of 100 full items each; the 6th page must never be requested.
+        assert_eq!(files.len(), 500);
+    }
+
+    #[tokio::test]
+    async fn board_list_repo_labels_paginates_until_short_page() {
+        let server = MockServer::start().await;
+        let first_page: Vec<serde_json::Value> = (0..100)
+            .map(|i| serde_json::json!({ "name": format!("label-{i}") }))
+            .collect();
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/labels"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(first_page)))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/labels"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                { "name": "last-label" }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let labels = client.board_list_repo_labels().await.unwrap();
+
+        assert_eq!(labels.len(), 101);
+        assert_eq!(labels.last().map(String::as_str), Some("last-label"));
+    }
+
+    #[tokio::test]
+    async fn board_list_open_issues_filters_out_pull_requests() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/test-owner/test-repo/issues"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "number": 1,
+                    "title": "A real issue",
+                    "html_url": "https://github.com/test-owner/test-repo/issues/1",
+                    "user": { "login": "alice" },
+                    "labels": [],
+                    "comments": 2,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-02T00:00:00Z"
+                },
+                {
+                    "number": 2,
+                    "title": "Actually a PR",
+                    "html_url": "https://github.com/test-owner/test-repo/issues/2",
+                    "user": { "login": "bob" },
+                    "labels": [],
+                    "comments": 0,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-02T00:00:00Z",
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/test-owner/test-repo/pulls/2"
+                    }
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = create_test_client(&server).await;
+        let issues = client.board_list_open_issues(30).await.unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].number, 1);
+        assert_eq!(issues[0].comment_count, 2);
+    }
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,3 +1,4 @@
+pub mod board;
 pub mod checks;
 pub mod client;
 pub mod gh_stack;

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -842,6 +842,16 @@ impl GitHubClient {
         Ok(())
     }
 
+    pub async fn remove_label(&self, number: u64, label: &str) -> Result<()> {
+        self.record_api_call("issues.remove_label");
+        self.octocrab
+            .issues(&self.owner, &self.repo)
+            .remove_label(number, label)
+            .await
+            .context("Failed to remove label")?;
+        Ok(())
+    }
+
     pub async fn add_assignees(&self, pr_number: u64, assignees: &[String]) -> Result<()> {
         if assignees.is_empty() {
             return Ok(());

--- a/src/tui/board/app.rs
+++ b/src/tui/board/app.rs
@@ -1,0 +1,741 @@
+use crate::ci::CheckRunInfo;
+use crate::commands::board::BoardTabSelection;
+use crate::forge::PrComment;
+use crate::github::board::{
+    BoardIssueDetail, BoardIssueSummary, BoardPrDetail, BoardPrFile, BoardPrSummary,
+};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoardTab {
+    PullRequests,
+    Issues,
+}
+
+impl From<BoardTabSelection> for BoardTab {
+    fn from(value: BoardTabSelection) -> Self {
+        match value {
+            BoardTabSelection::PullRequests => BoardTab::PullRequests,
+            BoardTabSelection::Issues => BoardTab::Issues,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoardMode {
+    List,
+    Detail,
+    Diff,
+    Comments,
+    LabelPicker,
+    ConfirmMerge,
+    Filter,
+    Help,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BoardTarget {
+    Pr(u64),
+    Issue(u64),
+}
+
+pub enum BoardUpdate {
+    Prs(Vec<BoardPrSummary>),
+    Issues(Vec<BoardIssueSummary>),
+    PrDetail {
+        number: u64,
+        detail: Box<BoardPrDetail>,
+        files: Vec<BoardPrFile>,
+        checks: Vec<CheckRunInfo>,
+    },
+    IssueDetail {
+        number: u64,
+        detail: Box<BoardIssueDetail>,
+    },
+    Comments {
+        target: BoardTarget,
+        comments: Vec<PrComment>,
+    },
+    Diff {
+        number: u64,
+        diff: String,
+    },
+    RepoLabels(Vec<String>),
+    ViewerLogin(String),
+    ActionDone {
+        message: String,
+        refresh: bool,
+    },
+    DetailError {
+        target: BoardTarget,
+        message: String,
+    },
+    Error(String),
+}
+
+pub struct BoardApp {
+    pub repo_label: String,
+    pub tab: BoardTab,
+    pub mode: BoardMode,
+    /// Whether the side detail preview panel renders next to the list.
+    /// Toggled with `v`; independent of the narrow-terminal auto-hide.
+    pub show_detail: bool,
+    /// Filter the list to items authored by `viewer_login`. Toggled with
+    /// `a` and persisted to config; fails open (shows everything) while
+    /// `viewer_login` hasn't resolved yet.
+    pub mine_only: bool,
+    pub viewer_login: Option<String>,
+    pub prs: Vec<BoardPrSummary>,
+    pub issues: Vec<BoardIssueSummary>,
+    pub pr_selected: usize,
+    pub issue_selected: usize,
+    pub filter: String,
+    /// Per-item caches for the lifetime of the session: once a PR/issue's
+    /// detail, files, checks, diff, or comments have been fetched they stay
+    /// available without re-fetching when navigating away and back.
+    pub pr_details: HashMap<u64, BoardPrDetail>,
+    pub pr_files: HashMap<u64, Vec<BoardPrFile>>,
+    pub pr_checks: HashMap<u64, Vec<CheckRunInfo>>,
+    pub issue_details: HashMap<u64, BoardIssueDetail>,
+    pub comments: HashMap<BoardTarget, Vec<PrComment>>,
+    pub diff_lines: HashMap<u64, Vec<Line<'static>>>,
+    pub detail_scroll: u16,
+    pub diff_scroll: u16,
+    pub comments_scroll: u16,
+    pub repo_labels: Vec<String>,
+    pub label_cursor: usize,
+    pub active_labels: Vec<String>,
+    pub loading_list: bool,
+    pub loading_detail: Option<BoardTarget>,
+    pub loading_diff: Option<u64>,
+    pub loading_comments: Option<BoardTarget>,
+    pub detail_error: HashMap<BoardTarget, String>,
+    pub status_message: Option<String>,
+    pub should_quit: bool,
+}
+
+const MAX_DIFF_LINES: usize = 20_000;
+
+impl BoardApp {
+    pub fn new(repo_label: String, tab: BoardTabSelection, mine_only: bool) -> Self {
+        Self {
+            repo_label,
+            tab: tab.into(),
+            mode: BoardMode::List,
+            show_detail: true,
+            mine_only,
+            viewer_login: None,
+            prs: Vec::new(),
+            issues: Vec::new(),
+            pr_selected: 0,
+            issue_selected: 0,
+            filter: String::new(),
+            pr_details: HashMap::new(),
+            pr_files: HashMap::new(),
+            pr_checks: HashMap::new(),
+            issue_details: HashMap::new(),
+            comments: HashMap::new(),
+            diff_lines: HashMap::new(),
+            detail_scroll: 0,
+            diff_scroll: 0,
+            comments_scroll: 0,
+            repo_labels: Vec::new(),
+            label_cursor: 0,
+            active_labels: Vec::new(),
+            loading_list: true,
+            loading_detail: None,
+            loading_diff: None,
+            loading_comments: None,
+            detail_error: HashMap::new(),
+            status_message: None,
+            should_quit: false,
+        }
+    }
+
+    pub fn visible_pr_indices(&self) -> Vec<usize> {
+        self.prs
+            .iter()
+            .enumerate()
+            .filter(|(_, pr)| {
+                matches_filter(&self.filter, &pr_haystack(pr)) && self.passes_mine_only(&pr.author)
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    pub fn visible_issue_indices(&self) -> Vec<usize> {
+        self.issues
+            .iter()
+            .enumerate()
+            .filter(|(_, issue)| {
+                matches_filter(&self.filter, &issue_haystack(issue))
+                    && self.passes_mine_only(&issue.author)
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// `mine_only` fails open (shows everything) until `viewer_login` is
+    /// known, so the list never looks empty while the viewer lookup is
+    /// still in flight.
+    fn passes_mine_only(&self, author: &str) -> bool {
+        if !self.mine_only {
+            return true;
+        }
+        match &self.viewer_login {
+            Some(login) => author.eq_ignore_ascii_case(login),
+            None => true,
+        }
+    }
+
+    fn clamp_pr_selection(&mut self) {
+        let len = self.visible_pr_indices().len();
+        if self.pr_selected >= len {
+            self.pr_selected = len.saturating_sub(1);
+        }
+    }
+
+    fn clamp_issue_selection(&mut self) {
+        let len = self.visible_issue_indices().len();
+        if self.issue_selected >= len {
+            self.issue_selected = len.saturating_sub(1);
+        }
+    }
+
+    pub fn select_next(&mut self) {
+        match self.tab {
+            BoardTab::PullRequests => {
+                let len = self.visible_pr_indices().len();
+                if len > 0 && self.pr_selected + 1 < len {
+                    self.pr_selected += 1;
+                }
+            }
+            BoardTab::Issues => {
+                let len = self.visible_issue_indices().len();
+                if len > 0 && self.issue_selected + 1 < len {
+                    self.issue_selected += 1;
+                }
+            }
+        }
+    }
+
+    pub fn select_previous(&mut self) {
+        match self.tab {
+            BoardTab::PullRequests => {
+                if self.pr_selected > 0 {
+                    self.pr_selected -= 1;
+                }
+            }
+            BoardTab::Issues => {
+                if self.issue_selected > 0 {
+                    self.issue_selected -= 1;
+                }
+            }
+        }
+    }
+
+    pub fn select_first(&mut self) {
+        match self.tab {
+            BoardTab::PullRequests => self.pr_selected = 0,
+            BoardTab::Issues => self.issue_selected = 0,
+        }
+    }
+
+    pub fn select_last(&mut self) {
+        match self.tab {
+            BoardTab::PullRequests => {
+                self.pr_selected = self.visible_pr_indices().len().saturating_sub(1)
+            }
+            BoardTab::Issues => {
+                self.issue_selected = self.visible_issue_indices().len().saturating_sub(1)
+            }
+        }
+    }
+
+    pub fn switch_tab(&mut self, tab: BoardTab) {
+        if self.tab == tab {
+            return;
+        }
+        self.tab = tab;
+        self.clear_detail();
+    }
+
+    /// Toggles the side detail preview panel. Hiding it also drops out of
+    /// `Detail` mode, since there'd be nothing visible left to scroll.
+    pub fn toggle_show_detail(&mut self) {
+        self.show_detail = !self.show_detail;
+        if !self.show_detail && self.mode == BoardMode::Detail {
+            self.mode = BoardMode::List;
+        }
+    }
+
+    /// Toggles the "mine only" filter and re-clamps selection, since
+    /// narrowing or widening the visible set can shift the currently
+    /// selected row out of range.
+    pub fn toggle_mine_only(&mut self) {
+        self.mine_only = !self.mine_only;
+        self.clamp_pr_selection();
+        self.clamp_issue_selection();
+    }
+
+    pub fn selected_pr(&self) -> Option<&BoardPrSummary> {
+        let index = *self.visible_pr_indices().get(self.pr_selected)?;
+        self.prs.get(index)
+    }
+
+    pub fn selected_issue(&self) -> Option<&BoardIssueSummary> {
+        let index = *self.visible_issue_indices().get(self.issue_selected)?;
+        self.issues.get(index)
+    }
+
+    pub fn selected_target(&self) -> Option<BoardTarget> {
+        match self.tab {
+            BoardTab::PullRequests => self.selected_pr().map(|pr| BoardTarget::Pr(pr.number)),
+            BoardTab::Issues => self
+                .selected_issue()
+                .map(|issue| BoardTarget::Issue(issue.number)),
+        }
+    }
+
+    pub fn selected_url(&self) -> Option<String> {
+        match self.tab {
+            BoardTab::PullRequests => self.selected_pr().map(|pr| pr.url.clone()),
+            BoardTab::Issues => self.selected_issue().map(|issue| issue.url.clone()),
+        }
+    }
+
+    /// `(number, head_sha)` when the currently selected PR's detail is loaded
+    /// and it is not a draft.
+    pub fn merge_target(&self) -> Option<(u64, String)> {
+        let pr = self.selected_pr()?;
+        let detail = self.pr_details.get(&pr.number)?;
+        if detail.is_draft {
+            return None;
+        }
+        Some((detail.number, detail.head_sha.clone()))
+    }
+
+    /// Resets transient view state when switching tabs. Per-item caches
+    /// (`pr_details`, `issue_details`, `comments`, `diff_lines`, ...) are
+    /// intentionally left intact — they persist for the whole session so
+    /// revisiting an item doesn't re-fetch it.
+    pub fn clear_detail(&mut self) {
+        self.detail_scroll = 0;
+        self.diff_scroll = 0;
+        self.comments_scroll = 0;
+        self.loading_detail = None;
+        self.loading_diff = None;
+        self.loading_comments = None;
+    }
+
+    pub fn footer_hints(&self) -> Vec<(&'static str, &'static str)> {
+        match self.mode {
+            BoardMode::List => vec![
+                ("Tab", "tab"),
+                ("j/k", "move"),
+                ("Enter", "detail"),
+                ("d", "diff"),
+                ("c", "comments"),
+                ("l", "labels"),
+                ("t", "draft"),
+                ("m", "merge"),
+                ("o", "open"),
+                ("r", "refresh"),
+                ("/", "filter"),
+                (
+                    "v",
+                    if self.show_detail {
+                        "hide detail"
+                    } else {
+                        "show detail"
+                    },
+                ),
+                (
+                    "a",
+                    if self.mine_only {
+                        "show all"
+                    } else {
+                        "show mine"
+                    },
+                ),
+                ("?", "help"),
+                ("q", "quit"),
+            ],
+            BoardMode::Detail => vec![
+                ("d", "diff"),
+                ("c", "comments"),
+                ("l", "labels"),
+                ("t", "draft"),
+                ("m", "merge"),
+                ("o", "open"),
+                ("v", "hide detail"),
+                ("Esc", "back"),
+            ],
+            BoardMode::Diff | BoardMode::Comments => vec![("j/k", "scroll"), ("Esc", "back")],
+            BoardMode::LabelPicker => vec![("j/k", "move"), ("Space", "toggle"), ("Esc", "close")],
+            BoardMode::ConfirmMerge => vec![("y", "confirm"), ("n/Esc", "cancel")],
+            BoardMode::Filter => vec![("Enter", "apply"), ("Esc", "cancel")],
+            BoardMode::Help => vec![("any key", "close")],
+        }
+    }
+
+    pub fn apply_update(&mut self, update: BoardUpdate) {
+        match update {
+            BoardUpdate::Prs(prs) => {
+                self.prs = prs;
+                self.loading_list = false;
+                self.clamp_pr_selection();
+            }
+            BoardUpdate::Issues(issues) => {
+                self.issues = issues;
+                self.loading_list = false;
+                self.clamp_issue_selection();
+            }
+            BoardUpdate::PrDetail {
+                number,
+                detail,
+                files,
+                checks,
+            } => {
+                if self.loading_detail == Some(BoardTarget::Pr(number)) {
+                    self.loading_detail = None;
+                }
+                self.pr_details.insert(number, *detail);
+                self.pr_files.insert(number, files);
+                self.pr_checks.insert(number, checks);
+                self.detail_error.remove(&BoardTarget::Pr(number));
+            }
+            BoardUpdate::IssueDetail { number, detail } => {
+                if self.loading_detail == Some(BoardTarget::Issue(number)) {
+                    self.loading_detail = None;
+                }
+                self.issue_details.insert(number, *detail);
+                self.detail_error.remove(&BoardTarget::Issue(number));
+            }
+            BoardUpdate::Comments { target, comments } => {
+                if self.loading_comments == Some(target) {
+                    self.loading_comments = None;
+                }
+                if self.selected_target() == Some(target) {
+                    self.comments_scroll = 0;
+                }
+                self.comments.insert(target, comments);
+            }
+            BoardUpdate::Diff { number, diff } => {
+                if self.loading_diff == Some(number) {
+                    self.loading_diff = None;
+                }
+                if self.selected_target() == Some(BoardTarget::Pr(number)) {
+                    self.diff_scroll = 0;
+                }
+                self.diff_lines.insert(number, build_diff_lines(&diff));
+            }
+            BoardUpdate::RepoLabels(labels) => {
+                self.repo_labels = labels;
+            }
+            BoardUpdate::ViewerLogin(login) => {
+                self.viewer_login = Some(login);
+                self.clamp_pr_selection();
+                self.clamp_issue_selection();
+            }
+            BoardUpdate::ActionDone { message, .. } => {
+                self.status_message = Some(message);
+            }
+            BoardUpdate::DetailError { target, message } => {
+                if self.loading_detail == Some(target) {
+                    self.loading_detail = None;
+                }
+                self.detail_error.insert(target, message.clone());
+                self.status_message = Some(message);
+            }
+            BoardUpdate::Error(message) => {
+                self.status_message = Some(message);
+                self.loading_list = false;
+                self.loading_detail = None;
+                self.loading_diff = None;
+                self.loading_comments = None;
+            }
+        }
+    }
+}
+
+fn matches_filter(filter: &str, haystack: &str) -> bool {
+    if filter.trim().is_empty() {
+        return true;
+    }
+    haystack.to_lowercase().contains(&filter.to_lowercase())
+}
+
+fn pr_haystack(pr: &BoardPrSummary) -> String {
+    format!(
+        "#{} {} {} {} {}",
+        pr.number,
+        pr.title,
+        pr.author,
+        pr.head_branch,
+        pr.labels.join(" ")
+    )
+}
+
+fn issue_haystack(issue: &BoardIssueSummary) -> String {
+    format!(
+        "#{} {} {} {}",
+        issue.number,
+        issue.title,
+        issue.author,
+        issue.labels.join(" ")
+    )
+}
+
+/// Parse a unified diff into styled lines, truncating past `MAX_DIFF_LINES`
+/// so a huge PR diff cannot blow up memory/render time. Built once here
+/// rather than per-frame in `ui.rs`.
+fn build_diff_lines(diff: &str) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = diff.lines().take(MAX_DIFF_LINES).map(diff_line).collect();
+
+    if diff.lines().count() > MAX_DIFF_LINES {
+        lines.push(Line::from(Span::styled(
+            "… diff truncated",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines
+}
+
+fn diff_line(line: &str) -> Line<'static> {
+    let style = if line.starts_with("diff --git")
+        || line.starts_with("index ")
+        || line.starts_with("+++")
+        || line.starts_with("---")
+    {
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD)
+    } else if line.starts_with("@@") {
+        Style::default().fg(Color::Cyan)
+    } else if line.starts_with('+') {
+        Style::default().fg(Color::Green)
+    } else if line.starts_with('-') {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default()
+    };
+    Line::from(Span::styled(line.to_string(), style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn pr(number: u64, title: &str, labels: &[&str]) -> BoardPrSummary {
+        BoardPrSummary {
+            number,
+            title: title.to_string(),
+            author: "octocat".to_string(),
+            head_branch: format!("feature/{number}"),
+            base_branch: "main".to_string(),
+            is_draft: false,
+            labels: labels.iter().map(|l| l.to_string()).collect(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            url: format!("https://github.com/o/r/pull/{number}"),
+        }
+    }
+
+    fn pr_detail(number: u64, is_draft: bool) -> BoardPrDetail {
+        BoardPrDetail {
+            number,
+            title: "title".to_string(),
+            body: "body".to_string(),
+            head_branch: "feature".to_string(),
+            base_branch: "main".to_string(),
+            head_sha: "sha123".to_string(),
+            is_draft,
+            mergeable: Some(true),
+            mergeable_state: Some("clean".to_string()),
+            additions: 1,
+            deletions: 1,
+            changed_files: 1,
+            comment_count: 0,
+            review_comment_count: 0,
+            labels: Vec::new(),
+            url: format!("https://github.com/o/r/pull/{number}"),
+        }
+    }
+
+    #[test]
+    fn filter_matches_title_author_branch_and_labels() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![
+            pr(1, "Add board dashboard", &["cli"]),
+            pr(2, "Fix flaky test", &["ci", "bug"]),
+        ];
+
+        app.filter = "flaky".to_string();
+        assert_eq!(app.visible_pr_indices(), vec![1]);
+
+        app.filter = "bug".to_string();
+        assert_eq!(app.visible_pr_indices(), vec![1]);
+
+        app.filter = "feature/1".to_string();
+        assert_eq!(app.visible_pr_indices(), vec![0]);
+
+        app.filter = String::new();
+        assert_eq!(app.visible_pr_indices(), vec![0, 1]);
+    }
+
+    #[test]
+    fn mine_only_fails_open_until_viewer_login_known_then_filters() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, true);
+        let mut mine = pr(1, "Mine", &[]);
+        mine.author = "cesarferreira".to_string();
+        let mut theirs = pr(2, "Theirs", &[]);
+        theirs.author = "octocat".to_string();
+        app.prs = vec![mine, theirs];
+
+        // Viewer login hasn't resolved yet: fail open, show everything.
+        assert_eq!(app.visible_pr_indices(), vec![0, 1]);
+
+        app.apply_update(BoardUpdate::ViewerLogin("cesarferreira".to_string()));
+        assert_eq!(app.visible_pr_indices(), vec![0]);
+
+        app.toggle_mine_only();
+        assert_eq!(app.visible_pr_indices(), vec![0, 1]);
+
+        app.toggle_mine_only();
+        assert_eq!(app.visible_pr_indices(), vec![0]);
+    }
+
+    #[test]
+    fn per_tab_selection_preserved_across_switch_tab() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, "a", &[]), pr(2, "b", &[])];
+        app.pr_selected = 1;
+
+        app.switch_tab(BoardTab::Issues);
+        app.issue_selected = 0;
+        app.switch_tab(BoardTab::PullRequests);
+
+        assert_eq!(app.pr_selected, 1);
+    }
+
+    #[test]
+    fn selection_clamps_on_shorter_refresh() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.apply_update(BoardUpdate::Prs(vec![pr(1, "a", &[]), pr(2, "b", &[])]));
+        app.pr_selected = 1;
+
+        app.apply_update(BoardUpdate::Prs(vec![pr(1, "a", &[])]));
+
+        assert_eq!(app.pr_selected, 0);
+    }
+
+    #[test]
+    fn detail_response_is_cached_regardless_of_current_selection() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, "a", &[]), pr(2, "b", &[])];
+        app.pr_selected = 0;
+        app.loading_detail = Some(BoardTarget::Pr(2));
+
+        app.apply_update(BoardUpdate::PrDetail {
+            number: 2,
+            detail: Box::new(pr_detail(2, false)),
+            files: Vec::new(),
+            checks: Vec::new(),
+        });
+
+        // A response for a PR that isn't currently selected still gets
+        // cached — the point of per-item caching is that background/late
+        // responses aren't wasted, they're just waiting to be viewed.
+        assert!(app.pr_details.contains_key(&2));
+        assert!(app.loading_detail.is_none());
+    }
+
+    #[test]
+    fn detail_error_surfaces_for_current_selection_and_clears_on_success() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, "a", &[])];
+        app.pr_selected = 0;
+        app.loading_detail = Some(BoardTarget::Pr(1));
+
+        app.apply_update(BoardUpdate::DetailError {
+            target: BoardTarget::Pr(1),
+            message: "Failed to load PR #1: connection reset".to_string(),
+        });
+
+        assert!(app.loading_detail.is_none());
+        assert_eq!(
+            app.detail_error.get(&BoardTarget::Pr(1)),
+            Some(&"Failed to load PR #1: connection reset".to_string())
+        );
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Failed to load PR #1: connection reset")
+        );
+
+        app.apply_update(BoardUpdate::PrDetail {
+            number: 1,
+            detail: Box::new(pr_detail(1, false)),
+            files: Vec::new(),
+            checks: Vec::new(),
+        });
+
+        assert!(!app.detail_error.contains_key(&BoardTarget::Pr(1)));
+    }
+
+    #[test]
+    fn diff_cache_persists_across_selection_change() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, "a", &[]), pr(2, "b", &[])];
+        app.pr_selected = 0;
+
+        app.apply_update(BoardUpdate::Diff {
+            number: 1,
+            diff: "diff --git a/f b/f\n".to_string(),
+        });
+        assert!(app.diff_lines.contains_key(&1));
+
+        // Select PR #2, then back to PR #1 — the cached diff for #1 must
+        // still be there, so re-selecting it doesn't require a re-fetch.
+        app.pr_selected = 1;
+        assert!(
+            app.diff_lines.contains_key(&1),
+            "diff cache must persist across selection changes for the session"
+        );
+        app.pr_selected = 0;
+        assert!(app.diff_lines.contains_key(&1));
+    }
+
+    #[test]
+    fn merge_target_is_none_for_drafts_and_unloaded_details() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, "a", &[])];
+        app.pr_selected = 0;
+
+        assert_eq!(app.merge_target(), None);
+
+        app.pr_details.insert(1, pr_detail(1, true));
+        assert_eq!(app.merge_target(), None);
+
+        app.pr_details.insert(1, pr_detail(1, false));
+        assert_eq!(app.merge_target(), Some((1, "sha123".to_string())));
+    }
+
+    #[test]
+    fn toggle_show_detail_falls_back_to_list_mode_when_hidden() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.mode = BoardMode::Detail;
+        assert!(app.show_detail);
+
+        app.toggle_show_detail();
+        assert!(!app.show_detail);
+        assert_eq!(app.mode, BoardMode::List);
+
+        app.toggle_show_detail();
+        assert!(app.show_detail);
+    }
+}

--- a/src/tui/board/mod.rs
+++ b/src/tui/board/mod.rs
@@ -1,0 +1,844 @@
+pub mod app;
+pub mod ui;
+
+use anyhow::Result;
+use app::{BoardApp, BoardMode, BoardTab, BoardTarget, BoardUpdate};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+use std::io;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::ci::CheckRunInfo;
+use crate::commands::board::{BoardScope, BoardTabSelection};
+use crate::commands::open::open_url_in_browser;
+use crate::config::Config;
+use crate::forge::{MergeMethod, PrComment};
+use crate::git::GitRepo;
+use crate::github::client::GitHubClient;
+
+const PAGE_STEP: usize = 10;
+
+pub fn run(
+    scope: BoardScope,
+    tab: BoardTabSelection,
+    interval: u64,
+    mine_only: bool,
+) -> Result<()> {
+    let poll_interval = Duration::from_secs(interval.max(1));
+    let mut app = BoardApp::new(scope.repo_label.clone(), tab, mine_only);
+    let (req_tx, rx) = spawn_worker(scope);
+    let _ = req_tx.send(BoardRequest::ListPrs);
+    let _ = req_tx.send(BoardRequest::ListIssues);
+    let _ = req_tx.send(BoardRequest::ViewerLogin);
+    let mut last_refresh = Instant::now();
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run_app(
+        &mut terminal,
+        &mut app,
+        &req_tx,
+        &rx,
+        poll_interval,
+        &mut last_refresh,
+    );
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+enum BoardRequest {
+    ListPrs,
+    ListIssues,
+    PrDetail(u64),
+    IssueDetail(u64),
+    Comments(BoardTarget),
+    Diff(u64),
+    RepoLabels,
+    ViewerLogin,
+    AddLabel { target: BoardTarget, label: String },
+    RemoveLabel { target: BoardTarget, label: String },
+    ToggleDraft { number: u64, to_draft: bool },
+    Merge { number: u64, sha: String },
+}
+
+fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut BoardApp,
+    req_tx: &Sender<BoardRequest>,
+    rx: &Receiver<BoardUpdate>,
+    poll_interval: Duration,
+    last_refresh: &mut Instant,
+) -> Result<()> {
+    loop {
+        poll_updates(app, rx, req_tx);
+        maybe_auto_refresh(app, req_tx, poll_interval, last_refresh);
+        sync_selected_detail(app, req_tx);
+        terminal.draw(|f| ui::render(f, app))?;
+
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            handle_key(app, key.code, key.modifiers, req_tx);
+        }
+
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}
+
+fn poll_updates(app: &mut BoardApp, rx: &Receiver<BoardUpdate>, req_tx: &Sender<BoardRequest>) {
+    loop {
+        match rx.try_recv() {
+            Ok(update) => {
+                let refresh_after = matches!(update, BoardUpdate::ActionDone { refresh: true, .. });
+                app.apply_update(update);
+                if refresh_after {
+                    let _ = req_tx.send(BoardRequest::ListPrs);
+                    let _ = req_tx.send(BoardRequest::ListIssues);
+                }
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => break,
+        }
+    }
+}
+
+fn maybe_auto_refresh(
+    app: &mut BoardApp,
+    req_tx: &Sender<BoardRequest>,
+    poll_interval: Duration,
+    last_refresh: &mut Instant,
+) {
+    if app.loading_list || last_refresh.elapsed() < poll_interval {
+        return;
+    }
+    app.loading_list = true;
+    let _ = req_tx.send(BoardRequest::ListPrs);
+    let _ = req_tx.send(BoardRequest::ListIssues);
+    *last_refresh = Instant::now();
+}
+
+fn handle_key(
+    app: &mut BoardApp,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    req_tx: &Sender<BoardRequest>,
+) {
+    match app.mode {
+        BoardMode::List => handle_list_key(app, code, modifiers, req_tx),
+        BoardMode::Detail => handle_detail_key(app, code, req_tx),
+        BoardMode::Diff | BoardMode::Comments => handle_scroll_key(app, code),
+        BoardMode::Filter => handle_filter_key(app, code),
+        BoardMode::LabelPicker => handle_label_key(app, code, req_tx),
+        BoardMode::ConfirmMerge => handle_confirm_merge_key(app, code, req_tx),
+        BoardMode::Help => handle_help_key(app, code),
+    }
+}
+
+fn handle_list_key(
+    app: &mut BoardApp,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    req_tx: &Sender<BoardRequest>,
+) {
+    match code {
+        KeyCode::Tab => {
+            let next = match app.tab {
+                BoardTab::PullRequests => BoardTab::Issues,
+                BoardTab::Issues => BoardTab::PullRequests,
+            };
+            app.switch_tab(next);
+        }
+        KeyCode::Char('1') => app.switch_tab(BoardTab::PullRequests),
+        KeyCode::Char('2') => app.switch_tab(BoardTab::Issues),
+        KeyCode::Char('j') | KeyCode::Down => app.select_next(),
+        KeyCode::Char('k') | KeyCode::Up => app.select_previous(),
+        KeyCode::Char('g') => app.select_first(),
+        KeyCode::Char('G') => app.select_last(),
+        KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => page(app, true),
+        KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => page(app, false),
+        KeyCode::Enter => open_detail(app, req_tx),
+        KeyCode::Char('d') => {
+            request_diff(app, req_tx);
+            if app.tab == BoardTab::PullRequests {
+                app.mode = BoardMode::Diff;
+            }
+        }
+        KeyCode::Char('c') => {
+            request_comments(app, req_tx);
+            app.mode = BoardMode::Comments;
+        }
+        KeyCode::Char('l') => open_label_picker(app, req_tx),
+        KeyCode::Char('t') => toggle_draft(app, req_tx),
+        KeyCode::Char('m') => {
+            if app.merge_target().is_some() {
+                app.mode = BoardMode::ConfirmMerge;
+            } else {
+                app.status_message = Some("Open the PR detail before merging".to_string());
+            }
+        }
+        KeyCode::Char('o') => open_selected_in_browser(app),
+        KeyCode::Char('r') => request_full_refresh(app, req_tx),
+        KeyCode::Char('/') => app.mode = BoardMode::Filter,
+        KeyCode::Char('v') => app.toggle_show_detail(),
+        KeyCode::Char('a') => toggle_mine_only(app),
+        KeyCode::Char('?') => app.mode = BoardMode::Help,
+        KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
+        _ => {}
+    }
+}
+
+fn handle_detail_key(app: &mut BoardApp, code: KeyCode, req_tx: &Sender<BoardRequest>) {
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            app.detail_scroll = app.detail_scroll.saturating_add(1)
+        }
+        KeyCode::Char('k') | KeyCode::Up => app.detail_scroll = app.detail_scroll.saturating_sub(1),
+        KeyCode::Char('d') => {
+            request_diff(app, req_tx);
+            if app.tab == BoardTab::PullRequests {
+                app.mode = BoardMode::Diff;
+            }
+        }
+        KeyCode::Char('c') => {
+            request_comments(app, req_tx);
+            app.mode = BoardMode::Comments;
+        }
+        KeyCode::Char('l') => open_label_picker(app, req_tx),
+        KeyCode::Char('t') => toggle_draft(app, req_tx),
+        KeyCode::Char('m') => {
+            if app.merge_target().is_some() {
+                app.mode = BoardMode::ConfirmMerge;
+            } else {
+                app.status_message = Some("PR detail is still loading".to_string());
+            }
+        }
+        KeyCode::Char('o') => open_selected_in_browser(app),
+        KeyCode::Char('r') => request_detail_refresh(app, req_tx),
+        KeyCode::Char('v') => app.toggle_show_detail(),
+        KeyCode::Char('?') => app.mode = BoardMode::Help,
+        KeyCode::Char('q') | KeyCode::Esc => {
+            app.mode = BoardMode::List;
+            app.detail_scroll = 0;
+        }
+        _ => {}
+    }
+}
+
+fn handle_scroll_key(app: &mut BoardApp, code: KeyCode) {
+    let max = match app.mode {
+        BoardMode::Diff => match app.selected_target() {
+            Some(BoardTarget::Pr(number)) => app.diff_lines.get(&number).map(Vec::len).unwrap_or(0),
+            _ => 0,
+        },
+        BoardMode::Comments => app
+            .selected_target()
+            .and_then(|target| app.comments.get(&target))
+            .map(Vec::len)
+            .unwrap_or(0),
+        _ => 0,
+    };
+
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            let scroll = scroll_field(app);
+            if (*scroll as usize) + 1 < max.max(1) {
+                *scroll += 1;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            let scroll = scroll_field(app);
+            *scroll = scroll.saturating_sub(1);
+        }
+        KeyCode::Char('g') => *scroll_field(app) = 0,
+        KeyCode::Char('G') => *scroll_field(app) = max.saturating_sub(1) as u16,
+        KeyCode::Esc | KeyCode::Char('q') => app.mode = return_mode_after_overlay(app),
+        _ => {}
+    }
+}
+
+fn scroll_field(app: &mut BoardApp) -> &mut u16 {
+    match app.mode {
+        BoardMode::Diff => &mut app.diff_scroll,
+        BoardMode::Comments => &mut app.comments_scroll,
+        _ => &mut app.detail_scroll,
+    }
+}
+
+fn handle_filter_key(app: &mut BoardApp, code: KeyCode) {
+    match code {
+        KeyCode::Enter => app.mode = BoardMode::List,
+        KeyCode::Esc => {
+            app.filter.clear();
+            app.mode = BoardMode::List;
+        }
+        KeyCode::Backspace => {
+            app.filter.pop();
+        }
+        KeyCode::Char(ch) => app.filter.push(ch),
+        _ => {}
+    }
+}
+
+fn handle_label_key(app: &mut BoardApp, code: KeyCode, req_tx: &Sender<BoardRequest>) {
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            if app.label_cursor + 1 < app.repo_labels.len() {
+                app.label_cursor += 1;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.label_cursor = app.label_cursor.saturating_sub(1);
+        }
+        KeyCode::Char(' ') => toggle_label(app, req_tx),
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.mode = return_mode_after_overlay(app);
+        }
+        _ => {}
+    }
+}
+
+fn toggle_label(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    let Some(target) = app.selected_target() else {
+        return;
+    };
+    let Some(label) = app.repo_labels.get(app.label_cursor).cloned() else {
+        return;
+    };
+
+    if app.active_labels.contains(&label) {
+        app.active_labels.retain(|active| active != &label);
+        let _ = req_tx.send(BoardRequest::RemoveLabel { target, label });
+    } else {
+        app.active_labels.push(label.clone());
+        let _ = req_tx.send(BoardRequest::AddLabel { target, label });
+    }
+}
+
+fn handle_confirm_merge_key(app: &mut BoardApp, code: KeyCode, req_tx: &Sender<BoardRequest>) {
+    match code {
+        KeyCode::Char('y') | KeyCode::Char('Y') => {
+            if let Some((number, sha)) = app.merge_target() {
+                app.status_message = Some(format!("Merging PR #{number} (squash)..."));
+                let _ = req_tx.send(BoardRequest::Merge { number, sha });
+            }
+            app.mode = return_mode_after_overlay(app);
+        }
+        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            app.mode = return_mode_after_overlay(app);
+        }
+        _ => {}
+    }
+}
+
+fn handle_help_key(app: &mut BoardApp, _code: KeyCode) {
+    app.mode = return_mode_after_overlay(app);
+}
+
+fn return_mode_after_overlay(app: &BoardApp) -> BoardMode {
+    let has_detail = match app.selected_target() {
+        Some(BoardTarget::Pr(number)) => app.pr_details.contains_key(&number),
+        Some(BoardTarget::Issue(number)) => app.issue_details.contains_key(&number),
+        None => false,
+    };
+    if has_detail {
+        BoardMode::Detail
+    } else {
+        BoardMode::List
+    }
+}
+
+fn page(app: &mut BoardApp, down: bool) {
+    match app.tab {
+        BoardTab::PullRequests => {
+            let len = app.visible_pr_indices().len();
+            if len == 0 {
+                return;
+            }
+            app.pr_selected = if down {
+                (app.pr_selected + PAGE_STEP).min(len - 1)
+            } else {
+                app.pr_selected.saturating_sub(PAGE_STEP)
+            };
+        }
+        BoardTab::Issues => {
+            let len = app.visible_issue_indices().len();
+            if len == 0 {
+                return;
+            }
+            app.issue_selected = if down {
+                (app.issue_selected + PAGE_STEP).min(len - 1)
+            } else {
+                app.issue_selected.saturating_sub(PAGE_STEP)
+            };
+        }
+    }
+}
+
+fn toggle_mine_only(app: &mut BoardApp) {
+    app.toggle_mine_only();
+    if let Err(error) = Config::set_board_mine_only(app.mine_only) {
+        app.status_message = Some(format!("Failed to save preference: {error}"));
+    }
+}
+
+fn open_detail(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    let Some(target) = app.selected_target() else {
+        return;
+    };
+    // Enter is an explicit request to view detail, so it always works even
+    // if the ambient preview panel was hidden via `v`.
+    app.show_detail = true;
+    app.mode = BoardMode::Detail;
+    request_detail_if_needed(app, target, req_tx);
+}
+
+/// The detail pane is always visible alongside the list (at normal terminal
+/// widths) as a live preview of the current selection, not something gated
+/// behind pressing Enter — so it must keep the fetch for the current
+/// selection in sync every tick, not just when `open_detail` runs. Without
+/// this, the pane renders "Loading #N…" for whatever is selected even though
+/// no request was ever sent, which looks identical to a genuine hang.
+/// Skipped entirely while the panel is hidden (`v`), so hiding it also stops
+/// the eager prefetching, not just the rendering.
+fn sync_selected_detail(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    if !app.show_detail {
+        return;
+    }
+    let Some(target) = app.selected_target() else {
+        return;
+    };
+    request_detail_if_needed(app, target, req_tx);
+}
+
+fn request_detail_if_needed(
+    app: &mut BoardApp,
+    target: BoardTarget,
+    req_tx: &Sender<BoardRequest>,
+) {
+    let already_loaded = match target {
+        BoardTarget::Pr(number) => app.pr_details.contains_key(&number),
+        BoardTarget::Issue(number) => app.issue_details.contains_key(&number),
+    };
+    if already_loaded || app.loading_detail == Some(target) {
+        return;
+    }
+    app.loading_detail = Some(target);
+    app.detail_error.remove(&target);
+    let _ = req_tx.send(match target {
+        BoardTarget::Pr(number) => BoardRequest::PrDetail(number),
+        BoardTarget::Issue(number) => BoardRequest::IssueDetail(number),
+    });
+}
+
+fn request_detail_refresh(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    let Some(target) = app.selected_target() else {
+        return;
+    };
+    app.loading_detail = Some(target);
+    app.detail_error.remove(&target);
+    let _ = req_tx.send(match target {
+        BoardTarget::Pr(number) => BoardRequest::PrDetail(number),
+        BoardTarget::Issue(number) => BoardRequest::IssueDetail(number),
+    });
+}
+
+fn request_diff(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    let Some(BoardTarget::Pr(number)) = app.selected_target() else {
+        return;
+    };
+    let cached_for_selection = app.diff_lines.contains_key(&number);
+    if cached_for_selection || app.loading_diff == Some(number) {
+        return;
+    }
+    app.loading_diff = Some(number);
+    let _ = req_tx.send(BoardRequest::Diff(number));
+}
+
+fn request_comments(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    let Some(target) = app.selected_target() else {
+        return;
+    };
+    let cached_for_selection = app.comments.contains_key(&target);
+    if cached_for_selection || app.loading_comments == Some(target) {
+        return;
+    }
+    app.loading_comments = Some(target);
+    let _ = req_tx.send(BoardRequest::Comments(target));
+}
+
+fn open_label_picker(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    if app.selected_target().is_none() {
+        return;
+    }
+    app.active_labels = match app.tab {
+        BoardTab::PullRequests => app
+            .selected_pr()
+            .map(|pr| pr.labels.clone())
+            .unwrap_or_default(),
+        BoardTab::Issues => app
+            .selected_issue()
+            .map(|issue| issue.labels.clone())
+            .unwrap_or_default(),
+    };
+    app.label_cursor = 0;
+    app.mode = BoardMode::LabelPicker;
+    if app.repo_labels.is_empty() {
+        let _ = req_tx.send(BoardRequest::RepoLabels);
+    }
+}
+
+fn toggle_draft(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    if app.tab != BoardTab::PullRequests {
+        return;
+    }
+    let Some(pr) = app.selected_pr() else {
+        return;
+    };
+    let number = pr.number;
+    let to_draft = !pr.is_draft;
+    app.status_message = Some(format!(
+        "{} PR #{number}...",
+        if to_draft {
+            "Converting to draft"
+        } else {
+            "Marking ready for review"
+        }
+    ));
+    let _ = req_tx.send(BoardRequest::ToggleDraft { number, to_draft });
+}
+
+fn open_selected_in_browser(app: &mut BoardApp) {
+    if let Some(url) = app.selected_url() {
+        open_url_in_browser(&url);
+        app.status_message = Some(format!("Opened {url}"));
+    } else {
+        app.status_message = Some("Nothing selected to open".to_string());
+    }
+}
+
+fn request_full_refresh(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
+    app.loading_list = true;
+    let _ = req_tx.send(BoardRequest::ListPrs);
+    let _ = req_tx.send(BoardRequest::ListIssues);
+}
+
+fn spawn_worker(scope: BoardScope) -> (Sender<BoardRequest>, Receiver<BoardUpdate>) {
+    let (req_tx, req_rx) = mpsc::channel::<BoardRequest>();
+    let (update_tx, update_rx) = mpsc::channel::<BoardUpdate>();
+
+    thread::spawn(move || {
+        let runtime = match tokio::runtime::Runtime::new() {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                let _ = update_tx.send(BoardUpdate::Error(format!(
+                    "Failed to create async runtime: {error}"
+                )));
+                return;
+            }
+        };
+        let client = match create_board_client(&runtime, &scope) {
+            Ok(client) => client,
+            Err(error) => {
+                let _ = update_tx.send(BoardUpdate::Error(format!(
+                    "Failed to create GitHub client: {error}"
+                )));
+                return;
+            }
+        };
+
+        while let Ok(request) = req_rx.recv() {
+            runtime.block_on(handle_request(&client, &scope, request, &update_tx));
+        }
+    });
+
+    (req_tx, update_rx)
+}
+
+fn create_board_client(
+    runtime: &tokio::runtime::Runtime,
+    scope: &BoardScope,
+) -> Result<GitHubClient> {
+    let _enter = runtime.enter();
+    GitHubClient::new_for_trusted_remote(
+        scope.remote.owner(),
+        &scope.remote.repo,
+        scope.remote.api_base_url.clone(),
+        &scope.config,
+        &scope.remote.host,
+    )
+}
+
+async fn handle_request(
+    client: &GitHubClient,
+    scope: &BoardScope,
+    request: BoardRequest,
+    tx: &Sender<BoardUpdate>,
+) {
+    match request {
+        BoardRequest::ListPrs => match client.board_list_open_prs(scope.limit).await {
+            Ok(prs) => {
+                let _ = tx.send(BoardUpdate::Prs(prs));
+            }
+            Err(error) => {
+                let _ = tx.send(BoardUpdate::Error(format!(
+                    "Failed to list pull requests: {error}"
+                )));
+            }
+        },
+        BoardRequest::ListIssues => match client.board_list_open_issues(scope.limit).await {
+            Ok(issues) => {
+                let _ = tx.send(BoardUpdate::Issues(issues));
+            }
+            Err(error) => {
+                let _ = tx.send(BoardUpdate::Error(format!(
+                    "Failed to list issues: {error}"
+                )));
+            }
+        },
+        BoardRequest::PrDetail(number) => {
+            let (detail_result, files_result) = tokio::join!(
+                client.board_get_pr_detail(number),
+                client.board_list_pr_files(number)
+            );
+            match (detail_result, files_result) {
+                (Ok(detail), Ok(files)) => {
+                    let checks = fetch_pr_checks(client, scope, &detail.head_sha).await;
+                    let _ = tx.send(BoardUpdate::PrDetail {
+                        number,
+                        detail: Box::new(detail),
+                        files,
+                        checks,
+                    });
+                }
+                (Err(error), _) | (_, Err(error)) => {
+                    let _ = tx.send(BoardUpdate::DetailError {
+                        target: BoardTarget::Pr(number),
+                        message: format!("Failed to load PR #{number}: {error}"),
+                    });
+                }
+            }
+        }
+        BoardRequest::IssueDetail(number) => match client.board_get_issue_detail(number).await {
+            Ok(detail) => {
+                let _ = tx.send(BoardUpdate::IssueDetail {
+                    number,
+                    detail: Box::new(detail),
+                });
+            }
+            Err(error) => {
+                let _ = tx.send(BoardUpdate::DetailError {
+                    target: BoardTarget::Issue(number),
+                    message: format!("Failed to load issue #{number}: {error}"),
+                });
+            }
+        },
+        BoardRequest::Comments(target) => {
+            let result = match target {
+                BoardTarget::Pr(number) => client.list_all_comments(number).await,
+                BoardTarget::Issue(number) => client
+                    .board_list_issue_comments(number)
+                    .await
+                    .map(|comments| comments.into_iter().map(PrComment::Issue).collect()),
+            };
+            match result {
+                Ok(comments) => {
+                    let _ = tx.send(BoardUpdate::Comments { target, comments });
+                }
+                Err(error) => {
+                    let _ = tx.send(BoardUpdate::Error(format!(
+                        "Failed to load comments: {error}"
+                    )));
+                }
+            }
+        }
+        BoardRequest::Diff(number) => match client.board_get_pr_diff(number).await {
+            Ok(diff) => {
+                let _ = tx.send(BoardUpdate::Diff { number, diff });
+            }
+            Err(error) => {
+                let _ = tx.send(BoardUpdate::Error(format!("Failed to load diff: {error}")));
+            }
+        },
+        BoardRequest::RepoLabels => match client.board_list_repo_labels().await {
+            Ok(labels) => {
+                let _ = tx.send(BoardUpdate::RepoLabels(labels));
+            }
+            Err(error) => {
+                let _ = tx.send(BoardUpdate::Error(format!(
+                    "Failed to load labels: {error}"
+                )));
+            }
+        },
+        BoardRequest::ViewerLogin => match client.get_current_user().await {
+            Ok(login) => {
+                let _ = tx.send(BoardUpdate::ViewerLogin(login));
+            }
+            Err(error) => {
+                // "Mine only" fails open (shows everything) without a
+                // viewer login, so this is worth surfacing but not fatal.
+                let _ = tx.send(BoardUpdate::Error(format!(
+                    "Couldn't determine your GitHub username, \"mine only\" won't filter: {error}"
+                )));
+            }
+        },
+        BoardRequest::AddLabel { target, label } => {
+            let number = target_number(target);
+            match client
+                .add_labels(number, std::slice::from_ref(&label))
+                .await
+            {
+                Ok(()) => {
+                    let _ = tx.send(BoardUpdate::ActionDone {
+                        message: format!("Added label \"{label}\""),
+                        refresh: false,
+                    });
+                }
+                Err(error) => {
+                    let _ = tx.send(BoardUpdate::Error(format!("Failed to add label: {error}")));
+                }
+            }
+        }
+        BoardRequest::RemoveLabel { target, label } => {
+            let number = target_number(target);
+            match client.remove_label(number, &label).await {
+                Ok(()) => {
+                    let _ = tx.send(BoardUpdate::ActionDone {
+                        message: format!("Removed label \"{label}\""),
+                        refresh: false,
+                    });
+                }
+                Err(error) => {
+                    let _ = tx.send(BoardUpdate::Error(format!(
+                        "Failed to remove label: {error}"
+                    )));
+                }
+            }
+        }
+        BoardRequest::ToggleDraft { number, to_draft } => {
+            match client.set_pr_draft(number, to_draft).await {
+                Ok(()) => {
+                    let message = format!(
+                        "PR #{number} marked as {}",
+                        if to_draft {
+                            "draft"
+                        } else {
+                            "ready for review"
+                        }
+                    );
+                    let _ = tx.send(BoardUpdate::ActionDone {
+                        message,
+                        refresh: true,
+                    });
+                }
+                Err(error) => {
+                    let _ = tx.send(BoardUpdate::Error(format!(
+                        "Failed to update PR #{number}: {error}"
+                    )));
+                }
+            }
+        }
+        BoardRequest::Merge { number, sha } => {
+            match client
+                .merge_pr(number, MergeMethod::Squash, None, None, Some(sha))
+                .await
+            {
+                Ok(()) => {
+                    let message = format!(
+                        "Merged PR #{number} (squash). Run `stax sync` to update local branches."
+                    );
+                    let _ = tx.send(BoardUpdate::ActionDone {
+                        message,
+                        refresh: true,
+                    });
+                }
+                Err(error) => {
+                    let _ = tx.send(BoardUpdate::Error(format!(
+                        "Failed to merge PR #{number}: {error}"
+                    )));
+                }
+            }
+        }
+    }
+}
+
+fn target_number(target: BoardTarget) -> u64 {
+    match target {
+        BoardTarget::Pr(number) | BoardTarget::Issue(number) => number,
+    }
+}
+
+async fn fetch_pr_checks(
+    client: &GitHubClient,
+    scope: &BoardScope,
+    sha: &str,
+) -> Vec<CheckRunInfo> {
+    let Ok(repo) = GitRepo::open_from_path(&scope.git_dir) else {
+        return Vec::new();
+    };
+    let checks = client
+        .fetch_checks(&repo, sha)
+        .await
+        .map(|(_, checks)| checks)
+        .unwrap_or_default();
+    drop(repo);
+    checks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::remote::{ForgeType, RemoteInfo};
+    use std::env;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn board_worker_constructs_github_client_with_entered_runtime() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let original_token = env::var("STAX_GITHUB_TOKEN").ok();
+        unsafe { env::set_var("STAX_GITHUB_TOKEN", "test-token") };
+
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        let scope = BoardScope {
+            git_dir: std::path::PathBuf::from("."),
+            remote: RemoteInfo {
+                name: "origin".to_string(),
+                forge: ForgeType::GitHub,
+                host: "github.com".to_string(),
+                namespace: "owner".to_string(),
+                repo: "repo".to_string(),
+                base_url: "https://github.com".to_string(),
+                api_base_url: Some("https://api.github.com".to_string()),
+            },
+            config: Config::default(),
+            repo_label: "owner/repo".to_string(),
+            limit: 30,
+        };
+
+        let result = create_board_client(&runtime, &scope);
+
+        match original_token {
+            Some(token) => unsafe { env::set_var("STAX_GITHUB_TOKEN", token) },
+            None => unsafe { env::remove_var("STAX_GITHUB_TOKEN") },
+        }
+        assert!(result.is_ok());
+    }
+}

--- a/src/tui/board/ui.rs
+++ b/src/tui/board/ui.rs
@@ -1,0 +1,738 @@
+use crate::ci::CheckRunInfo;
+use crate::commands::github_list::format_relative_time;
+use crate::forge::PrComment;
+use crate::github::board::{BoardIssueSummary, BoardPrSummary};
+use crate::tui::board::app::{BoardApp, BoardMode, BoardTab, BoardTarget};
+use console::{measure_text_width, truncate_str};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+};
+
+// Matches the branch checkout picker's selected-row background, so a
+// selected row reads as a subtle opaque highlight (src/tui/ready/ui.rs:23).
+const SELECTED_ROW_BACKGROUND: Color = Color::Indexed(236);
+const NARROW_WIDTH: u16 = 100;
+
+pub fn render(f: &mut Frame, app: &BoardApp) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    render_tab_header(f, app, chunks[0]);
+    render_body(f, app, chunks[1]);
+    render_footer(f, app, chunks[2]);
+
+    match app.mode {
+        BoardMode::Diff => render_diff_overlay(f, app),
+        BoardMode::Comments => render_comments_overlay(f, app),
+        BoardMode::Help => render_help_overlay(f),
+        BoardMode::LabelPicker => render_label_picker_overlay(f, app),
+        BoardMode::ConfirmMerge => render_confirm_merge_overlay(f, app),
+        BoardMode::List | BoardMode::Detail | BoardMode::Filter => {}
+    }
+
+    if app.mode == BoardMode::Filter {
+        render_filter_overlay(f, app, chunks[2]);
+    }
+}
+
+fn render_tab_header(f: &mut Frame, app: &BoardApp, area: Rect) {
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" {} ", app.repo_label),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            "PULL REQUESTS",
+            tab_style(app.tab == BoardTab::PullRequests),
+        ),
+        Span::raw(" │ "),
+        Span::styled("ISSUES", tab_style(app.tab == BoardTab::Issues)),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn tab_style(active: bool) -> Style {
+    if active {
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    }
+}
+
+fn render_body(f: &mut Frame, app: &BoardApp, area: Rect) {
+    if area.width < NARROW_WIDTH || !app.show_detail {
+        render_list(f, app, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(area);
+    render_list(f, app, chunks[0]);
+    render_detail(f, app, chunks[1]);
+}
+
+/// `3` when nothing is filtered out, `3/12` when a filter (search or "mine
+/// only") is hiding some of the fetched items — so the header count always
+/// matches what's actually rendered below it.
+fn count_label(visible: usize, total: usize) -> String {
+    if visible == total {
+        visible.to_string()
+    } else {
+        format!("{visible}/{total}")
+    }
+}
+
+fn render_list(f: &mut Frame, app: &BoardApp, area: Rect) {
+    let inner_width = area.width.saturating_sub(2) as usize;
+
+    let (title, items): (String, Vec<ListItem<'static>>) = match app.tab {
+        BoardTab::PullRequests => {
+            let indices = app.visible_pr_indices();
+            let title = format!(
+                " Pull Requests ({}){}{} ",
+                count_label(indices.len(), app.prs.len()),
+                if app.loading_list { " · loading" } else { "" },
+                if app.mine_only { " · mine" } else { "" }
+            );
+            let items = indices
+                .iter()
+                .enumerate()
+                .map(|(row, &index)| pr_row(&app.prs[index], row == app.pr_selected, inner_width))
+                .collect();
+            (title, items)
+        }
+        BoardTab::Issues => {
+            let indices = app.visible_issue_indices();
+            let title = format!(
+                " Issues ({}){}{} ",
+                count_label(indices.len(), app.issues.len()),
+                if app.loading_list { " · loading" } else { "" },
+                if app.mine_only { " · mine" } else { "" }
+            );
+            let items = indices
+                .iter()
+                .enumerate()
+                .map(|(row, &index)| {
+                    issue_row(&app.issues[index], row == app.issue_selected, inner_width)
+                })
+                .collect();
+            (title, items)
+        }
+    };
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue));
+
+    if items.is_empty() {
+        let message = if app.loading_list {
+            "Loading…"
+        } else {
+            "Nothing here."
+        };
+        f.render_widget(
+            Paragraph::new(Span::styled(message, Style::default().fg(Color::DarkGray)))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn pr_row(pr: &BoardPrSummary, selected: bool, width: usize) -> ListItem<'static> {
+    let number = format!("#{}", pr.number);
+    let age = format_relative_time(pr.updated_at);
+    let draft = if pr.is_draft { " [draft]" } else { "" };
+    let fixed = measure_text_width(&number)
+        + measure_text_width(&age)
+        + measure_text_width(draft)
+        + measure_text_width(&pr.author)
+        + 8;
+    let title_width = width.saturating_sub(fixed).max(8);
+    let title = truncate_str(&pr.title, title_width, "…").into_owned();
+
+    let line = Line::from(vec![
+        Span::styled(number, Style::default().fg(Color::Magenta)),
+        Span::raw("  "),
+        Span::raw(title),
+        Span::styled(draft, Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::styled(pr.author.clone(), Style::default().fg(Color::DarkGray)),
+        Span::raw("  "),
+        Span::styled(age, Style::default().fg(Color::DarkGray)),
+    ]);
+
+    row_item(line, selected)
+}
+
+fn issue_row(issue: &BoardIssueSummary, selected: bool, width: usize) -> ListItem<'static> {
+    let number = format!("#{}", issue.number);
+    let age = format_relative_time(issue.updated_at);
+    let fixed = measure_text_width(&number)
+        + measure_text_width(&age)
+        + measure_text_width(&issue.author)
+        + 6;
+    let title_width = width.saturating_sub(fixed).max(8);
+    let title = truncate_str(&issue.title, title_width, "…").into_owned();
+
+    let line = Line::from(vec![
+        Span::styled(number, Style::default().fg(Color::Magenta)),
+        Span::raw("  "),
+        Span::raw(title),
+        Span::raw("  "),
+        Span::styled(issue.author.clone(), Style::default().fg(Color::DarkGray)),
+        Span::raw("  "),
+        Span::styled(age, Style::default().fg(Color::DarkGray)),
+    ]);
+
+    row_item(line, selected)
+}
+
+fn row_item(line: Line<'static>, selected: bool) -> ListItem<'static> {
+    let item = ListItem::new(line);
+    if selected {
+        item.style(Style::default().bg(SELECTED_ROW_BACKGROUND))
+    } else {
+        item
+    }
+}
+
+fn render_detail(f: &mut Frame, app: &BoardApp, area: Rect) {
+    let block = Block::default()
+        .title(" Detail ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let lines = match app.tab {
+        BoardTab::PullRequests => pr_detail_lines(app),
+        BoardTab::Issues => issue_detail_lines(app),
+    };
+
+    f.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .scroll((app.detail_scroll, 0)),
+        inner,
+    );
+}
+
+/// While a detail request is in flight this reports the loading placeholder;
+/// once it fails, the pane shows the actual error instead of hanging on
+/// "Loading…" forever (the underlying request already gave up).
+fn detail_error_or_loading_line(
+    app: &BoardApp,
+    target: BoardTarget,
+    loading_message: String,
+) -> Line<'static> {
+    if app.loading_detail == Some(target) {
+        return Line::from(loading_message);
+    }
+    if let Some(message) = app.detail_error.get(&target) {
+        return Line::from(Span::styled(
+            format!("{message} (press Enter or r to retry)"),
+            Style::default().fg(Color::Red),
+        ));
+    }
+    Line::from(loading_message)
+}
+
+fn pr_detail_lines(app: &BoardApp) -> Vec<Line<'static>> {
+    let Some(pr) = app.selected_pr() else {
+        return vec![Line::from("No pull requests in scope.")];
+    };
+    let Some(detail) = app.pr_details.get(&pr.number) else {
+        return vec![detail_error_or_loading_line(
+            app,
+            BoardTarget::Pr(pr.number),
+            format!("Loading PR #{}…", pr.number),
+        )];
+    };
+
+    let mut lines = vec![
+        Line::from(Span::styled(
+            format!("#{} {}", detail.number, detail.title),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(detail.head_branch.clone(), Style::default().fg(Color::Cyan)),
+            Span::raw(" → "),
+            Span::styled(detail.base_branch.clone(), Style::default().fg(Color::Cyan)),
+        ]),
+        Line::from(vec![
+            Span::raw(format!(
+                "{} files  ",
+                app.pr_files
+                    .get(&pr.number)
+                    .map(Vec::len)
+                    .unwrap_or(detail.changed_files as usize)
+            )),
+            Span::styled(
+                format!("+{}", detail.additions),
+                Style::default().fg(Color::Green),
+            ),
+            Span::raw(" "),
+            Span::styled(
+                format!("-{}", detail.deletions),
+                Style::default().fg(Color::Red),
+            ),
+        ]),
+        Line::from(""),
+    ];
+
+    match app.pr_checks.get(&pr.number) {
+        Some(checks) if !checks.is_empty() => {
+            for check in checks {
+                lines.push(check_line(check));
+            }
+            lines.push(Line::from(""));
+        }
+        Some(_) => {
+            lines.push(Line::from(Span::styled(
+                "No CI checks",
+                Style::default().fg(Color::DarkGray),
+            )));
+            lines.push(Line::from(""));
+        }
+        None => {}
+    }
+
+    if !detail.labels.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Labels: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(detail.labels.join(", ")),
+        ]));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("Comments: ", Style::default().fg(Color::DarkGray)),
+        Span::raw(detail.comment_count.to_string()),
+    ]));
+    lines.push(Line::from(""));
+
+    if detail.body.trim().is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No description provided.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        lines.extend(detail.body.lines().map(|line| Line::from(line.to_string())));
+    }
+
+    lines
+}
+
+fn issue_detail_lines(app: &BoardApp) -> Vec<Line<'static>> {
+    let Some(issue) = app.selected_issue() else {
+        return vec![Line::from("No issues in scope.")];
+    };
+    let Some(detail) = app.issue_details.get(&issue.number) else {
+        return vec![detail_error_or_loading_line(
+            app,
+            BoardTarget::Issue(issue.number),
+            format!("Loading issue #{}…", issue.number),
+        )];
+    };
+
+    let mut lines = vec![
+        Line::from(Span::styled(
+            format!("#{} {}", detail.number, detail.title),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+
+    if !detail.labels.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Labels: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(detail.labels.join(", ")),
+        ]));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("Comments: ", Style::default().fg(Color::DarkGray)),
+        Span::raw(detail.comment_count.to_string()),
+    ]));
+    lines.push(Line::from(""));
+
+    if detail.body.trim().is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No description provided.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        lines.extend(detail.body.lines().map(|line| Line::from(line.to_string())));
+    }
+
+    lines
+}
+
+/// Green check for success-like conclusions, red for failure-like ones,
+/// yellow for anything still in flight.
+fn check_line(check: &CheckRunInfo) -> Line<'static> {
+    let (symbol, color) = if check.status != "completed" {
+        ("•", Color::Yellow)
+    } else {
+        match check.conclusion.as_deref() {
+            Some("success") | Some("neutral") | Some("skipped") => ("✓", Color::Green),
+            Some("failure") | Some("timed_out") | Some("cancelled") | Some("action_required") => {
+                ("✗", Color::Red)
+            }
+            _ => ("•", Color::Yellow),
+        }
+    };
+    Line::from(vec![
+        Span::styled(format!("{symbol} "), Style::default().fg(color)),
+        Span::raw(check.name.clone()),
+    ])
+}
+
+fn render_footer(f: &mut Frame, app: &BoardApp, area: Rect) {
+    if let Some(message) = &app.status_message {
+        f.render_widget(
+            Paragraph::new(Span::styled(
+                message.clone(),
+                Style::default().fg(Color::DarkGray),
+            )),
+            area,
+        );
+        return;
+    }
+
+    if app.loading_list {
+        f.render_widget(
+            Paragraph::new(Span::styled("Loading…", Style::default().fg(Color::Yellow))),
+            area,
+        );
+        return;
+    }
+
+    let mut spans = Vec::new();
+    for (index, (key, label)) in app.footer_hints().into_iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(
+            key,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(label, Style::default().fg(Color::DarkGray)));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn render_filter_overlay(f: &mut Frame, app: &BoardApp, area: Rect) {
+    let line = Line::from(vec![
+        Span::styled(
+            "/",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(app.filter.clone()),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn render_diff_overlay(f: &mut Frame, app: &BoardApp) {
+    let area = f.area();
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .title(" Diff (Esc to close) ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let selected_number = app.selected_pr().map(|pr| pr.number);
+    let lines = match selected_number.and_then(|number| app.diff_lines.get(&number)) {
+        Some(lines) => lines.clone(),
+        None => vec![Line::from(if app.loading_diff.is_some() {
+            "Loading diff…"
+        } else {
+            "No diff loaded."
+        })],
+    };
+
+    f.render_widget(Paragraph::new(lines).scroll((app.diff_scroll, 0)), inner);
+}
+
+fn render_comments_overlay(f: &mut Frame, app: &BoardApp) {
+    let area = f.area();
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .title(" Comments (Esc to close) ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let selected_target = app.selected_target();
+    let lines = match selected_target.and_then(|target| app.comments.get(&target)) {
+        Some(comments) if !comments.is_empty() => comments_lines(comments),
+        Some(_) => vec![Line::from(Span::styled(
+            "No comments yet.",
+            Style::default().fg(Color::DarkGray),
+        ))],
+        None => vec![Line::from(if app.loading_comments.is_some() {
+            "Loading comments…"
+        } else {
+            "No comments loaded."
+        })],
+    };
+
+    f.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .scroll((app.comments_scroll, 0)),
+        inner,
+    );
+}
+
+fn comments_lines(comments: &[PrComment]) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for comment in comments {
+        lines.push(Line::from(vec![
+            Span::styled(
+                comment.user().to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(
+                "  {}",
+                comment.created_at().format("%Y-%m-%d %H:%M")
+            )),
+        ]));
+        for line in comment.body().lines() {
+            lines.push(Line::from(line.to_string()));
+        }
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
+fn render_help_overlay(f: &mut Frame) {
+    let area = centered_rect(64, 60, f.area());
+    f.render_widget(Clear, area);
+    let lines = vec![
+        Line::from(Span::styled(
+            "Board Dashboard Help",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  Tab / 1 / 2   Switch PRs / Issues tab"),
+        Line::from("  j/k, ↑/↓      Move selection"),
+        Line::from("  g / G         Jump to top / bottom"),
+        Line::from("  Ctrl-d/Ctrl-u Page down / up"),
+        Line::from("  Enter         Open detail"),
+        Line::from("  d             Diff (PRs)"),
+        Line::from("  c             Comments"),
+        Line::from("  l             Label picker (Space toggles)"),
+        Line::from("  t             Toggle draft (PRs)"),
+        Line::from("  m             Merge (PRs, opens confirm)"),
+        Line::from("  o             Open in browser"),
+        Line::from("  r             Refresh"),
+        Line::from("  /             Filter"),
+        Line::from("  q / Esc       Back one mode, quit from list"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Merges here are API-only (no local rebase/cleanup) — run `stax sync` after.",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+    f.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title(" Help ").borders(Borders::ALL))
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn render_label_picker_overlay(f: &mut Frame, app: &BoardApp) {
+    let area = centered_rect(50, 60, f.area());
+    f.render_widget(Clear, area);
+
+    let items: Vec<ListItem<'static>> = if app.repo_labels.is_empty() {
+        vec![ListItem::new(Span::styled(
+            "Loading labels…",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        app.repo_labels
+            .iter()
+            .enumerate()
+            .map(|(index, label)| {
+                let active = app.active_labels.contains(label);
+                let marker = if active { "[x] " } else { "[ ] " };
+                let line = Line::from(format!("{marker}{label}"));
+                let item = ListItem::new(line);
+                if index == app.label_cursor {
+                    item.style(Style::default().bg(SELECTED_ROW_BACKGROUND))
+                } else {
+                    item
+                }
+            })
+            .collect()
+    };
+
+    f.render_widget(
+        List::new(items).block(
+            Block::default()
+                .title(" Labels (Space toggles, Esc closes) ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan)),
+        ),
+        area,
+    );
+}
+
+fn render_confirm_merge_overlay(f: &mut Frame, app: &BoardApp) {
+    let area = centered_rect(50, 20, f.area());
+    f.render_widget(Clear, area);
+
+    let number = app.selected_pr().map(|pr| pr.number).unwrap_or_default();
+    let lines = vec![
+        Line::from(format!("Merge PR #{number} (squash)? [y/N]")),
+        Line::from(""),
+        Line::from(Span::styled(
+            "This calls the GitHub API merge only — no local rebase, PR-base",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            "retargeting, or branch cleanup. Run `stax sync` afterwards.",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    f.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .title(" Confirm merge ")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Yellow)),
+            )
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::board::BoardTabSelection;
+    use chrono::Utc;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn pr(number: u64) -> BoardPrSummary {
+        BoardPrSummary {
+            number,
+            title: "Add board dashboard".to_string(),
+            author: "octocat".to_string(),
+            head_branch: "feature/board".to_string(),
+            base_branch: "main".to_string(),
+            is_draft: false,
+            labels: vec!["cli".to_string()],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            url: "https://github.com/o/r/pull/1".to_string(),
+        }
+    }
+
+    #[test]
+    fn renders_pr_list_at_normal_width() {
+        let backend = TestBackend::new(140, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut app = BoardApp::new(
+            "owner/repo".to_string(),
+            BoardTabSelection::PullRequests,
+            false,
+        );
+        app.apply_update(super::super::app::BoardUpdate::Prs(vec![pr(1)]));
+
+        terminal.draw(|f| render(f, &app)).expect("draw");
+        let rendered = format!("{:?}", terminal.backend().buffer());
+
+        assert!(rendered.contains("PULL REQUESTS"));
+        assert!(rendered.contains("Add board dashboard"));
+    }
+
+    #[test]
+    fn narrow_width_hides_detail_pane() {
+        let backend = TestBackend::new(80, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut app = BoardApp::new(
+            "owner/repo".to_string(),
+            BoardTabSelection::PullRequests,
+            false,
+        );
+        app.apply_update(super::super::app::BoardUpdate::Prs(vec![pr(1)]));
+
+        terminal.draw(|f| render(f, &app)).expect("draw");
+        let rendered = format!("{:?}", terminal.backend().buffer());
+
+        assert!(!rendered.contains("Detail"));
+    }
+
+    #[test]
+    fn toggle_hides_detail_pane_at_normal_width() {
+        let backend = TestBackend::new(140, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut app = BoardApp::new(
+            "owner/repo".to_string(),
+            BoardTabSelection::PullRequests,
+            false,
+        );
+        app.apply_update(super::super::app::BoardUpdate::Prs(vec![pr(1)]));
+        app.toggle_show_detail();
+
+        terminal.draw(|f| render(f, &app)).expect("draw");
+        let rendered = format!("{:?}", terminal.backend().buffer());
+
+        assert!(!app.show_detail);
+        assert!(!rendered.contains("Detail"));
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+pub mod board;
 mod event;
 pub mod ready;
 pub mod split;

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -24,6 +24,8 @@ mod application_operation_tests;
 mod application_session_tests;
 #[path = "auth_tests.rs"]
 mod auth_tests;
+#[path = "board_tests.rs"]
+mod board_tests;
 #[path = "changelog_tests.rs"]
 mod changelog_tests;
 #[path = "ci_tests.rs"]

--- a/tests/board_tests.rs
+++ b/tests/board_tests.rs
@@ -1,0 +1,88 @@
+//! Tests for the `stax board` command.
+
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+
+fn configure_remote(repo: &TestRepo, url: &str) {
+    let output = repo.git(&["remote", "add", "origin", url]);
+    assert!(
+        output.status.success(),
+        "Failed to add origin: {}",
+        TestRepo::stderr(&output)
+    );
+}
+
+#[test]
+fn board_help_lists_flags() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["board", "--help"]);
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+
+    assert!(stdout.contains("--limit"), "missing --limit: {stdout}");
+    assert!(stdout.contains("--tab"), "missing --tab: {stdout}");
+    assert!(
+        stdout.contains("--interval"),
+        "missing --interval: {stdout}"
+    );
+    assert!(stdout.contains("--plain"), "missing --plain: {stdout}");
+}
+
+#[test]
+fn board_home_alias_resolves() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["home", "--help"]);
+    output.assert_success();
+}
+
+#[test]
+fn board_plain_without_github_auth_fails_cleanly() {
+    let repo = TestRepo::new();
+    configure_remote(&repo, "https://github.com/test-owner/test-repo.git");
+
+    let output = repo.run_stax(&["board", "--plain"]);
+
+    output.assert_failure();
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.to_lowercase().contains("auth"),
+        "expected an auth-related error, got: {stderr}"
+    );
+}
+
+#[test]
+fn board_rejects_non_github_remote() {
+    let repo = TestRepo::new();
+    configure_remote(&repo, "https://gitlab.com/test-owner/test-repo.git");
+
+    let output = repo.run_stax(&["board", "--plain"]);
+
+    output.assert_failure();
+    let stderr = TestRepo::stderr(&output);
+    assert!(
+        stderr.contains("GitHub only"),
+        "expected a GitHub-only error, got: {stderr}"
+    );
+}
+
+#[test]
+fn board_is_allowed_during_rebase() {
+    let repo = TestRepo::new();
+    configure_remote(&repo, "https://github.com/test-owner/test-repo.git");
+    repo.create_conflict_scenario();
+    let _ = repo.run_stax(&["restack", "--yes", "--quiet"]);
+    assert!(repo.has_rebase_in_progress(), "expected rebase in progress");
+
+    let output = repo.run_stax(&["board", "--plain"]);
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+
+    assert!(
+        !combined.contains("A rebase is in progress. Resolve"),
+        "board should not be blocked by the rebase guard, got:\n{combined}"
+    );
+
+    repo.abort_rebase();
+}


### PR DESCRIPTION
## Motivation

Browsing open PRs and issues for a repo currently means bouncing to the browser. `st ready` covers CI/merge state for tracked PRs, but there's no single, keyboard-driven place to skim open PRs and issues, read details, check CI, and act on them (label, draft toggle, merge) without leaving the terminal.

## Description of changes

Adds `st board` (alias `st home`): a full-screen TUI dashboard for the current repo, GitHub only.

- **Tabs:** Pull Requests / Issues, sorted by recency
- **Detail pane:** branch, files changed, +/- lines, CI check status, labels, body, comment count
- **Overlays:** inline diff (`d`), full comment threads (`c`), label picker (`l`, add/remove), draft toggle (`t`), squash-merge with confirm (`m`)
- `o` open in browser, `r` refresh, `/` filter, `?` help
- Falls back to static `--plain` tables outside an interactive terminal, and is read-only enough to run mid-rebase
- New GitHub client methods in `src/github/board.rs` (hand-rolled wire types — existing typed models don't expose PR diff/files/labels/mergeable state), all paginated loops capped at 5 pages
- `--limit` is clap-validated to 1–100, consistent with `pr list` / `issue list`

Note: merging from the dashboard is a plain GitHub API merge, not stax's stacked-branch cascade — run `st sync` afterward to restack any dependent branches.

Also fixes a UX bug found while dogfooding this PR: if a detail fetch (PR or issue) failed, the Detail pane kept showing "Loading #N…" forever instead of surfacing the failure — the error was already visible in the footer, but the pane gave no indication anything had stopped. It now shows "Failed to load #N — press Enter or r to retry."

Also fixes the actual root cause behind that: the Detail pane is always visible next to the list (a live preview of the current selection), but the fetch for it only ever fired on `Enter` — so anything you hadn't explicitly opened just showed "Loading #N…" forever with no request ever sent behind it. The pane now eagerly fetches detail for whatever is currently selected as soon as the list loads or the selection changes, matching what the always-visible panel implies.

Two follow-ups from dogfooding after that:
- **Per-item caching.** PR/issue detail, files, checks, diffs, and comments are now cached per number/target for the session instead of a single last-loaded slot — revisiting something you already viewed no longer re-fetches it. `r` still forces a refresh.
- **`v` toggles the detail pane.** Since it's now an eager, always-on preview, `v` lets you hide it (falls back to the same list-only layout used on narrow terminals, and also pauses the prefetching); `Enter` or `v` again brings it back.
- **"Mine only" by default, persisted.** Both tabs now default to showing only PRs/issues authored by the current GitHub user (a one-time `/user` lookup at startup; fails open and shows everything until that resolves). Press `a` to toggle "mine" vs "all" — the choice is saved to `~/.config/stax/config.toml` (`[board] mine_only`) and reused on the next launch. The list header shows `(3/12)` and a `· mine` marker whenever the filter is narrowing the list.

## Verification

- `cargo fmt --check`, `cargo check`, `cargo clippy -- -D warnings` — clean
- `cargo nextest run github::board:: tui::board:: board_tests:: cli::tests::` — all passing
- `make test` — full suite green, no regressions
- Manual pass in a real GitHub-backed repo: tab switch, filter, detail, diff, comments, label add/remove, draft toggle, merge (cancel path), open-in-browser, refresh, at both 80 and 140 columns



