### PR TITLE
fix(sync): persist ancestry-verified parentBranchRevision after squash-merge cleanup

### DIFF
--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -1541,9 +1541,19 @@ fn apply_insert_reparenting(repo: &GitRepo, parent_branch: &str, new_branch: &st
     let new_parent_rev = repo.branch_commit(new_branch)?;
     for child in &children {
         if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
+            // `new_branch` is created at `parent_branch`'s tip at the time of insert,
+            // not `child`'s -- if `child` was already stale relative to `parent_branch`,
+            // `new_parent_rev` isn't actually in `child`'s ancestry. Verify before
+            // trusting it, else keep the previously recorded (still-valid) boundary
+            // (see #830); `stax restack --all` (prompted below) then rebases for real.
+            let parent_branch_revision = repo.resolve_child_parent_boundary(
+                child,
+                &[Some(new_parent_rev.as_str())],
+                &child_meta.parent_branch_revision,
+            );
             let updated = BranchMetadata {
                 parent_branch_name: new_branch.to_string(),
-                parent_branch_revision: new_parent_rev.clone(),
+                parent_branch_revision,
                 ..child_meta
             };
             updated.write(repo.inner(), child)?;

--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -205,8 +205,18 @@ fn split_by_file(
     // 10. Update current branch metadata: parent is now the new branch
     let new_branch_rev = repo.branch_commit(&new_branch)?;
     if let Some(mut meta) = BranchMetadata::read(repo.inner(), current)? {
+        // `current`'s tip was amended in place, not rebased onto `new_branch` --
+        // its underlying commit chain below the tip is unchanged, so
+        // `new_branch`'s commit generally isn't in `current`'s real ancestry.
+        // Verify before trusting it, else keep the previously recorded (still-
+        // valid) boundary (see #830); `stax restack` (prompted below) then
+        // rebases for real.
         meta.parent_branch_name = new_branch.clone();
-        meta.parent_branch_revision = new_branch_rev;
+        meta.parent_branch_revision = repo.resolve_child_parent_boundary(
+            current,
+            &[Some(new_branch_rev.as_str())],
+            &meta.parent_branch_revision,
+        );
         try_or_rollback!(meta.write(repo.inner(), current));
     }
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1490,6 +1490,7 @@ impl SyncContext {
                                 );
                             }
 
+                            let mut rebased_children: Vec<String> = Vec::new();
                             for child in &children {
                                 if BranchMetadata::is_frozen(repo.inner(), child)? {
                                     if !self.quiet {
@@ -1508,6 +1509,10 @@ impl SyncContext {
                                     tx.snapshot_branch_with_metadata(&repo, child)?;
                                 }
 
+                                // Tip of the merged parent BEFORE deletion — the boundary
+                                // fallback when the child did not actually move onto trunk.
+                                let merged_parent_tip = repo.branch_commit(branch).ok();
+
                                 // Use existing provenance-aware rebase
                                 match repo.rebase_branch_onto_with_provenance(
                                     child,
@@ -1515,14 +1520,21 @@ impl SyncContext {
                                     branch, // fallback upstream
                                     false,  // auto_stash_pop
                                 ) {
-                                    Ok(_) => {
+                                    Ok(RebaseResult::Success) => {
                                         // Update child's parent metadata to trunk
+                                        let trunk_tip = repo.rev_parse(&self.stack.trunk)?;
                                         if let Some(mut metadata) =
                                             BranchMetadata::read(repo.inner(), child)?
                                         {
                                             metadata.parent_branch_name = self.stack.trunk.clone();
                                             metadata.parent_branch_revision =
-                                                repo.rev_parse(&self.stack.trunk)?;
+                                                resolve_child_parent_boundary(
+                                                    &repo,
+                                                    child,
+                                                    Some(trunk_tip.as_str()),
+                                                    merged_parent_tip.as_deref(),
+                                                    &metadata.parent_branch_revision,
+                                                );
                                             metadata.write(repo.inner(), child)?;
                                         }
 
@@ -1554,6 +1566,45 @@ impl SyncContext {
                                                 self.stack.trunk.cyan()
                                             );
                                         }
+
+                                        rebased_children.push(child.clone());
+                                    }
+                                    Ok(RebaseResult::Conflict) => {
+                                        let trunk_name = self.stack.trunk.clone();
+                                        let conflict_stack = self.stack.current_stack(child);
+                                        if !self.json {
+                                            print_restack_conflict(
+                                                &repo,
+                                                &RestackConflictContext {
+                                                    branch: child,
+                                                    parent_branch: &trunk_name,
+                                                    completed_branches: &rebased_children,
+                                                    remaining_branches: 0,
+                                                    continue_commands: &[
+                                                        "stax resolve",
+                                                        "stax continue",
+                                                        "stax sync --continue",
+                                                    ],
+                                                    stack_branches: &conflict_stack,
+                                                },
+                                            );
+                                        }
+                                        if self.stashed && !self.json {
+                                            println!(
+                                                "{}",
+                                                "Stash kept to avoid conflicts. Run `git stash pop` after resolving."
+                                                    .yellow()
+                                            );
+                                            self.stash_guard.disarm();
+                                        }
+                                        if let Some(tx) = self.tx.take() {
+                                            tx.finish_err(
+                                                "Rebase conflict",
+                                                Some("cleanup-merged"),
+                                                Some(child),
+                                            )?;
+                                        }
+                                        return Err(ConflictStopped.into());
                                     }
                                     Err(e) => {
                                         eprintln!(
@@ -4149,6 +4200,32 @@ fn children_to_reparent(
         .collect()
 }
 
+/// Resolve the `parentBranchRevision` boundary to persist for `child` when it is
+/// moved off its old parent.
+///
+/// The stored boundary is what the next restack feeds to
+/// `git rebase --onto <parent> <boundary>`, so it MUST be a commit that is really
+/// in `child`'s ancestry. Stamping a commit the child is not based on (e.g. the
+/// trunk tip after a rebase that conflicted and never landed) makes the next
+/// restack replay the already-merged parent commits and conflict (see #830).
+///
+/// Candidates are tried in order; the first one genuinely in `child`'s ancestry
+/// wins, otherwise the recorded revision is preserved (see #120).
+fn resolve_child_parent_boundary(
+    repo: &GitRepo,
+    child: &str,
+    new_base: Option<&str>,
+    old_parent_tip: Option<&str>,
+    recorded_revision: &str,
+) -> String {
+    for candidate in [new_base, old_parent_tip].into_iter().flatten() {
+        if repo.is_ancestor(candidate, child).unwrap_or(false) {
+            return candidate.to_string();
+        }
+    }
+    recorded_revision.to_string()
+}
+
 fn reparent_children_for_deletion(
     repo: &GitRepo,
     stack_snapshot: &Stack,
@@ -4170,10 +4247,13 @@ fn reparent_children_for_deletion(
         // --onto <new> <old>` precisely. Only use the deleted branch's tip
         // when it is still in the child's ancestry; otherwise keep the
         // recorded revision (see #120).
-        let old_parent_boundary = doomed_tip
-            .clone()
-            .filter(|tip| repo.is_ancestor(tip, child).unwrap_or(false))
-            .unwrap_or_else(|| child_meta.parent_branch_revision.clone());
+        let old_parent_boundary = resolve_child_parent_boundary(
+            repo,
+            child,
+            None,
+            doomed_tip.as_deref(),
+            &child_meta.parent_branch_revision,
+        );
 
         let updated_meta = BranchMetadata {
             parent_branch_name: new_parent.to_string(),

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1527,12 +1527,13 @@ impl SyncContext {
                                             BranchMetadata::read(repo.inner(), child)?
                                         {
                                             metadata.parent_branch_name = self.stack.trunk.clone();
-                                            metadata.parent_branch_revision =
-                                                resolve_child_parent_boundary(
-                                                    &repo,
+                                            metadata.parent_branch_revision = repo
+                                                .resolve_child_parent_boundary(
                                                     child,
-                                                    Some(trunk_tip.as_str()),
-                                                    merged_parent_tip.as_deref(),
+                                                    &[
+                                                        Some(trunk_tip.as_str()),
+                                                        merged_parent_tip.as_deref(),
+                                                    ],
                                                     &metadata.parent_branch_revision,
                                                 );
                                             metadata.write(repo.inner(), child)?;
@@ -3016,11 +3017,9 @@ fn apply_live_pr_state(
                     .ok()
                     .and_then(|r| r.get().peel_to_commit().ok())
                     .map(|c| c.id().to_string());
-                meta.parent_branch_revision = resolve_child_parent_boundary(
-                    repo,
+                meta.parent_branch_revision = repo.resolve_child_parent_boundary(
                     branch_name,
-                    new_parent_tip.as_deref(),
-                    None,
+                    &[new_parent_tip.as_deref()],
                     &meta.parent_branch_revision,
                 );
                 meta.parent_branch_name = live_pr.base.clone();
@@ -4210,32 +4209,6 @@ fn children_to_reparent(
         .collect()
 }
 
-/// Resolve the `parentBranchRevision` boundary to persist for `child` when it is
-/// moved off its old parent.
-///
-/// The stored boundary is what the next restack feeds to
-/// `git rebase --onto <parent> <boundary>`, so it MUST be a commit that is really
-/// in `child`'s ancestry. Stamping a commit the child is not based on (e.g. the
-/// trunk tip after a rebase that conflicted and never landed) makes the next
-/// restack replay the already-merged parent commits and conflict (see #830).
-///
-/// Candidates are tried in order; the first one genuinely in `child`'s ancestry
-/// wins, otherwise the recorded revision is preserved (see #120).
-fn resolve_child_parent_boundary(
-    repo: &GitRepo,
-    child: &str,
-    new_base: Option<&str>,
-    old_parent_tip: Option<&str>,
-    recorded_revision: &str,
-) -> String {
-    for candidate in [new_base, old_parent_tip].into_iter().flatten() {
-        if repo.is_ancestor(candidate, child).unwrap_or(false) {
-            return candidate.to_string();
-        }
-    }
-    recorded_revision.to_string()
-}
-
 fn reparent_children_for_deletion(
     repo: &GitRepo,
     stack_snapshot: &Stack,
@@ -4257,11 +4230,9 @@ fn reparent_children_for_deletion(
         // --onto <new> <old>` precisely. Only use the deleted branch's tip
         // when it is still in the child's ancestry; otherwise keep the
         // recorded revision (see #120).
-        let old_parent_boundary = resolve_child_parent_boundary(
-            repo,
+        let old_parent_boundary = repo.resolve_child_parent_boundary(
             child,
-            None,
-            doomed_tip.as_deref(),
+            &[doomed_tip.as_deref()],
             &child_meta.parent_branch_revision,
         );
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -3005,14 +3005,24 @@ fn apply_live_pr_state(
             let base_is_known =
                 live_pr.base == stack.trunk || stack.branches.contains_key(&live_pr.base);
             if base_is_known {
-                // Update parent revision to the current tip of the new parent
-                if let Ok(parent_ref) = repo
+                // The new parent's tip is only a valid boundary if `branch_name` has
+                // actually moved onto it; a GitHub-side base retarget (e.g. after an
+                // intermediate branch is deleted) can flip `live_pr.base` with no local
+                // rebase having happened. Verify ancestry before trusting it, else keep
+                // the previously recorded (still-valid) boundary (see #830).
+                let new_parent_tip = repo
                     .inner()
                     .find_branch(&live_pr.base, git2::BranchType::Local)
-                    && let Ok(commit) = parent_ref.get().peel_to_commit()
-                {
-                    meta.parent_branch_revision = commit.id().to_string();
-                }
+                    .ok()
+                    .and_then(|r| r.get().peel_to_commit().ok())
+                    .map(|c| c.id().to_string());
+                meta.parent_branch_revision = resolve_child_parent_boundary(
+                    repo,
+                    branch_name,
+                    new_parent_tip.as_deref(),
+                    None,
+                    &meta.parent_branch_revision,
+                );
                 meta.parent_branch_name = live_pr.base.clone();
             }
         }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1736,6 +1736,31 @@ Use --auto-stash-pop or stash/commit changes first.",
             .graph_descendant_of(descendant_oid, ancestor_oid)?)
     }
 
+    /// Resolve the `parentBranchRevision` boundary to persist for `child` when it is
+    /// reparented onto a new parent.
+    ///
+    /// The stored boundary is what the next restack feeds to
+    /// `git rebase --onto <parent> <boundary>`, so it MUST be a commit that is really
+    /// in `child`'s ancestry. Stamping a commit `child` was never actually rebased
+    /// onto (e.g. a sibling branch's tip after a metadata-only reparent) makes the
+    /// next restack replay stale or already-upstream commits back in (see #830).
+    ///
+    /// Candidates are tried in order; the first one genuinely in `child`'s ancestry
+    /// wins, otherwise the previously recorded revision is preserved (see #120).
+    pub fn resolve_child_parent_boundary(
+        &self,
+        child: &str,
+        candidates: &[Option<&str>],
+        recorded_revision: &str,
+    ) -> String {
+        for candidate in candidates.iter().flatten() {
+            if self.is_ancestor(candidate, child).unwrap_or(false) {
+                return candidate.to_string();
+            }
+        }
+        recorded_revision.to_string()
+    }
+
     /// Delete a branch
     pub fn delete_branch(&self, name: &str, force: bool) -> Result<()> {
         let name = normalize_local_branch_name(name);

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -529,9 +529,18 @@ impl HunkSplitApp {
                 .last()
                 .expect("at least one branch created");
             if let Some(mut meta) = BranchMetadata::read(repo.inner(), child)? {
+                // `last_branch`'s tip is only a valid boundary if `child` was
+                // never stale relative to `original_branch` before the split
+                // ran; the split itself never rebases pre-existing children.
+                // Verify ancestry before trusting it, else keep the previously
+                // recorded (still-valid) boundary (see #830).
                 let parent_rev = repo.branch_commit(last_branch)?;
                 meta.parent_branch_name = last_branch.clone();
-                meta.parent_branch_revision = parent_rev;
+                meta.parent_branch_revision = repo.resolve_child_parent_boundary(
+                    child,
+                    &[Some(parent_rev.as_str())],
+                    &meta.parent_branch_revision,
+                );
                 meta.write(repo.inner(), child)?;
             }
         }
@@ -656,5 +665,120 @@ mod tests {
     fn test_build_flat_items_empty() {
         let items = build_flat_items(&[]);
         assert!(items.is_empty());
+    }
+
+    fn git_hermetic(cwd: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env(
+                "GIT_CONFIG_GLOBAL",
+                if cfg!(windows) { "NUL" } else { "/dev/null" },
+            )
+            .env(
+                "GIT_CONFIG_SYSTEM",
+                if cfg!(windows) { "NUL" } else { "/dev/null" },
+            )
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// Issue #830: `finalize()` reparents pre-existing children of the branch
+    /// being split onto the split chain's tip with no rebase and no ancestry
+    /// check. If a child was already stale relative to `original_branch`
+    /// *before* the split ran, the written boundary isn't actually in the
+    /// child's ancestry.
+    #[test]
+    fn finalize_does_not_poison_stale_childs_boundary() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path();
+        git_hermetic(dir, &["init", "-b", "main"]);
+        git_hermetic(dir, &["config", "user.name", "Test"]);
+        git_hermetic(dir, &["config", "user.email", "test@example.com"]);
+        std::fs::write(dir.join("base.txt"), "base\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "base"]);
+        GitRepo::open_from_path(dir)
+            .unwrap()
+            .set_trunk("main")
+            .unwrap();
+
+        git_hermetic(dir, &["checkout", "-b", "parent-branch"]);
+        std::fs::write(dir.join("p.txt"), "p\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "P1"]);
+
+        git_hermetic(dir, &["checkout", "-b", "original-branch"]);
+        std::fs::write(dir.join("o.txt"), "o\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "O1"]);
+        let o1 = git_hermetic(dir, &["rev-parse", "HEAD"]);
+
+        git_hermetic(dir, &["checkout", "-b", "child-branch"]);
+        std::fs::write(dir.join("c.txt"), "c\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "C1"]);
+
+        {
+            let repo = GitRepo::open_from_path(dir).unwrap();
+            let meta = BranchMetadata::new("original-branch", &o1);
+            meta.write(repo.inner(), "child-branch").unwrap();
+        }
+
+        // Advance original-branch WITHOUT rebasing child-branch onto it --
+        // child is now stale relative to original-branch, matching the
+        // precondition where the #830 bug class actually bites.
+        git_hermetic(dir, &["checkout", "original-branch"]);
+        std::fs::write(dir.join("o2.txt"), "o2\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "O2"]);
+
+        let mut app = HunkSplitApp {
+            workdir: dir.to_path_buf(),
+            original_branch: "original-branch".to_string(),
+            parent_branch: "parent-branch".to_string(),
+            children: vec!["child-branch".to_string()],
+            stashed: false,
+            files: vec![],
+            selected: vec![],
+            flat_items: vec![],
+            cursor: 0,
+            list_state: ListState::default(),
+            diff_scroll: 0,
+            diff_line_count: 0,
+            diff_viewport_height: 0,
+            mode: HunkSplitMode::List,
+            round: 1,
+            created_branches: vec!["original-branch".to_string()],
+            undo_stack: vec![],
+            input_buffer: String::new(),
+            input_cursor: 0,
+            status_message: None,
+            should_quit: false,
+            round_complete: false,
+            all_done: false,
+            existing_branches: vec![],
+            no_verify: true,
+        };
+
+        app.finalize().unwrap();
+
+        let repo = GitRepo::open_from_path(dir).unwrap();
+        let meta = BranchMetadata::read(repo.inner(), "child-branch")
+            .unwrap()
+            .unwrap();
+        assert!(
+            repo.is_ancestor(&meta.parent_branch_revision, "child-branch")
+                .unwrap(),
+            "boundary {} is not an ancestor of child-branch (issue #830)",
+            meta.parent_branch_revision
+        );
     }
 }

--- a/tests/create_insert_tests.rs
+++ b/tests/create_insert_tests.rs
@@ -1,5 +1,6 @@
 use crate::common;
 use common::{OutputAssertions, TestRepo};
+use serde_json::Value;
 
 #[test]
 fn test_create_insert_reparents_children() {
@@ -183,5 +184,54 @@ fn test_create_insert_from_trunk_reparents_direct_children() {
             .is_some_and(|parent| parent.contains("trunk-mid")),
         "trunk-b should be reparented to trunk-mid, got parent: {:?}",
         b_parent
+    );
+}
+
+/// Issue #830: `--insert` reparents pre-existing children onto the newly
+/// created branch's tip with no rebase. If a child was already stale
+/// relative to the parent branch *before* the insert ran, that tip isn't
+/// actually in the child's ancestry -- the write must fall back to the
+/// child's previously recorded (still-valid) boundary instead.
+#[test]
+fn test_create_insert_does_not_poison_stale_childs_boundary() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["stale-insert-a", "stale-insert-b"]);
+    let branch_a = &branches[0];
+    let branch_b = &branches[1];
+
+    let metadata_ref = format!("refs/branch-metadata/{}", branch_b);
+    let read_boundary = |repo: &TestRepo| -> String {
+        let output = repo.git(&["show", &metadata_ref]);
+        assert!(output.status.success());
+        let metadata: Value = serde_json::from_str(&TestRepo::stdout(&output)).unwrap();
+        metadata["parentBranchRevision"]
+            .as_str()
+            .expect("parentBranchRevision missing")
+            .to_string()
+    };
+    let recorded_boundary = read_boundary(&repo);
+
+    // Advance A without rebasing B onto it: B is now stale relative to A.
+    repo.run_stax(&["checkout", branch_a]).assert_success();
+    repo.create_file("a-extra.txt", "more work on A");
+    repo.commit("More work on A");
+
+    let output = repo.run_stax(&["create", "stale-insert-mid", "--insert"]);
+    output.assert_success();
+    assert!(TestRepo::stdout(&output).contains("Reparented"));
+
+    let boundary = read_boundary(&repo);
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, branch_b]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {} (issue #830)",
+        boundary,
+        branch_b
+    );
+    assert_eq!(
+        boundary, recorded_boundary,
+        "Expected the pre-existing boundary to be preserved when the new branch's tip isn't in B's ancestry"
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17414,6 +17414,111 @@ exit 1
         );
     }
 
+    /// Issue #830 (second write site): when a live PR base is reconciled to a
+    /// new parent whose *current* tip is not actually an ancestor of the
+    /// child (trunk has advanced independently, e.g. after a GitHub-side base
+    /// auto-retarget with no local rebase), `apply_live_pr_state` must not
+    /// stamp that tip as `parentBranchRevision` — it must keep the previously
+    /// recorded (still-valid) boundary and let restack compute the real one.
+    #[tokio::test]
+    async fn test_sync_pr_base_reconcile_does_not_poison_boundary_when_trunk_has_advanced() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+
+        // main -> retarget-a -> retarget-b
+        let repo = setup_branch_with_remote(home.path(), "retarget-a");
+        let branch_a = repo.current_branch();
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "retarget-b"]);
+        assert!(output.status.success());
+        let branch_b = "retarget-b".to_string();
+        repo.create_file("child.txt", "child content");
+        repo.commit("Child commit");
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push.status.success());
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 611, Some(false));
+
+        let recorded_boundary = repo.get_commit_sha(&branch_a);
+
+        // Advance trunk independently of the stack (B has not been rebased onto this).
+        let checkout_main = git_with_env(&repo, home.path(), &["checkout", "main"]);
+        assert!(checkout_main.status.success());
+        repo.create_file("trunk-advance.txt", "trunk moved on\n");
+        repo.commit("Advance trunk");
+        let push_main = git_with_env(&repo, home.path(), &["push", "origin", "main"]);
+        assert!(push_main.status.success());
+
+        // Simulate GitHub having retargeted B's PR base straight to main (e.g. after
+        // an intermediate branch was deleted) with no local rebase having happened.
+        let retargeted_pr = github_pull_fixture(611, &branch_b, "main", "aaaa");
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/611"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(retargeted_pr))
+            .mount(&mock_server)
+            .await;
+
+        // Restack scope follows the checked-out branch's own stack.
+        let checkout_b = git_with_env(&repo, home.path(), &["checkout", &branch_b]);
+        assert!(checkout_b.status.success());
+
+        let output = run_stax_with_env(&repo, home.path(), &["sync", "--restack", "--force"]);
+        assert!(
+            output.status.success(),
+            "Sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        let metadata_ref = format!("refs/branch-metadata/{}", branch_b);
+        let metadata_output = repo.git(&["show", &metadata_ref]);
+        assert!(metadata_output.status.success());
+        let metadata: serde_json::Value =
+            serde_json::from_str(&TestRepo::stdout(&metadata_output)).unwrap();
+        assert_eq!(
+            metadata["parentBranchName"], "main",
+            "Expected parentBranchName reconciled to 'main', got: {}",
+            metadata["parentBranchName"]
+        );
+
+        let boundary = metadata["parentBranchRevision"]
+            .as_str()
+            .expect("parentBranchRevision missing")
+            .to_string();
+
+        // Core invariant (issue #830): whatever boundary is recorded must
+        // actually be in B's ancestry -- never the trunk tip B was never
+        // rebased onto.
+        let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &branch_b]);
+        assert!(
+            ancestry_check.status.success(),
+            "Recorded boundary {} is not an ancestor of {} (issue #830)",
+            boundary,
+            branch_b
+        );
+
+        // Restack (which runs later in the same sync) should have picked up
+        // the mismatch between the recorded boundary and main's real tip and
+        // replayed only B's own commit onto the new trunk tip.
+        let trunk_sha = repo.get_commit_sha("main");
+        assert_eq!(
+            boundary, trunk_sha,
+            "Expected restack to advance the boundary to the real trunk tip"
+        );
+        let count_output = repo.git(&["rev-list", "--count", &format!("main..{}", branch_b)]);
+        assert!(count_output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&count_output.stdout).trim(),
+            "1",
+            "Expected B to carry only its own commit after restack"
+        );
+
+        // Sanity: the pre-reconciliation recorded boundary really was stale
+        // (main advanced past it), proving this scenario exercises the guard.
+        assert_ne!(recorded_boundary, trunk_sha);
+    }
+
     /// Verify that get_pr returns "MERGED" state (not "Closed") when GitHub
     /// reports a PR with merged_at set.
     #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6935,6 +6935,282 @@ fn test_sync_restack_no_ghost_commits_after_two_step_squash_merge() {
     );
 }
 
+/// Regression test for issue #830: when a squash-merged parent's child rebase
+/// *conflicts* (child stale w.r.t. the merged parent), sync must stop with an
+/// error instead of silently claiming success and stamping the trunk tip as
+/// the child's `parentBranchRevision` — a boundary the child was never
+/// actually rebased onto.
+#[test]
+fn test_sync_child_boundary_stays_in_ancestry_when_squash_parent_rebase_conflicts() {
+    let repo = TestRepo::new_with_remote();
+
+    // Build stack: main -> A -> B
+    repo.run_stax(&["bc", "conflict-parent"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("shared.txt", "a-original\n");
+    repo.commit("A commit");
+    repo.git(&["push", "-u", "origin", &branch_a]);
+
+    repo.run_stax(&["bc", "conflict-child"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("shared.txt", "a-original + b\n");
+    repo.commit("B commit 1");
+    repo.create_file("b.txt", "b\n");
+    repo.commit("B commit 2");
+    repo.git(&["push", "-u", "origin", &branch_b]);
+
+    // Capture B's recorded parentBranchRevision before anything moves.
+    let metadata_ref = format!("refs/branch-metadata/{}", branch_b);
+    let metadata_output = repo.git(&["show", &metadata_ref]);
+    assert!(metadata_output.status.success());
+    let metadata: Value =
+        serde_json::from_str(&TestRepo::stdout(&metadata_output)).expect("Invalid JSON metadata");
+    let recorded_boundary = metadata["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+
+    // Amend A so B becomes stale w.r.t. A's new tip; this makes the eventual
+    // child rebase replay a change that conflicts with shared.txt.
+    repo.git(&["checkout", &branch_a]);
+    repo.create_file("shared.txt", "a-amended\n");
+    repo.git(&["add", "shared.txt"]);
+    repo.git(&["commit", "--amend", "-m", "A commit (amended)"]);
+    repo.git(&["push", "-f", "origin", &branch_a]);
+
+    // Squash-merge A on remote plus one unrelated trunk commit, so merge
+    // detection classifies A as `MergeType::SquashMerge` (not `Ancestor`).
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let clone_dir = test_tempdir();
+    let run_remote_git = |args: &[&str]| {
+        let output = hermetic_git_command()
+            .args(args)
+            .current_dir(clone_dir.path())
+            .output()
+            .expect("Failed to run git in remote clone");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run_remote_git(&["clone", remote_path.to_str().unwrap(), "."]);
+    run_remote_git(&["checkout", "-B", "main", "origin/main"]);
+    run_remote_git(&["config", "user.email", "merger@test.com"]);
+    run_remote_git(&["config", "user.name", "Merger"]);
+    run_remote_git(&["fetch", "origin", &branch_a]);
+    run_remote_git(&["merge", "--squash", &format!("origin/{}", branch_a)]);
+    run_remote_git(&["commit", "-m", "Squash merge A"]);
+    // Advance trunk with unrelated work so merge detection sees SquashMerge,
+    // not a trivial Ancestor relationship.
+    std::fs::write(clone_dir.path().join("later.txt"), "later trunk work\n").unwrap();
+    run_remote_git(&["add", "later.txt"]);
+    run_remote_git(&["commit", "-m", "Later trunk commit"]);
+    run_remote_git(&["push", "origin", "main"]);
+    run_remote_git(&["push", "origin", "--delete", &branch_a]);
+
+    repo.run_stax(&["checkout", &branch_b]);
+    let output = repo.run_stax(&["sync", "--force"]);
+
+    assert!(
+        !output.status.success(),
+        "Expected sync to stop on conflict, but it succeeded\nstdout: {}",
+        TestRepo::stdout(&output)
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "Expected ConflictStopped exit code 2\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        !TestRepo::stdout(&output).contains("✓ Rebased"),
+        "Expected no success marker for the conflicting rebase\nstdout: {}",
+        TestRepo::stdout(&output)
+    );
+
+    // A must still exist locally — sync must not have deleted it mid-conflict.
+    let branches = repo.list_branches();
+    assert!(
+        branches.iter().any(|b| b == &branch_a),
+        "Expected merged parent A to remain (rebase conflicted), branches: {:?}",
+        branches
+    );
+
+    // Core invariant: whatever boundary is now recorded for B must actually be
+    // in B's ancestry, and must not have been stamped to the trunk tip.
+    let metadata_output = repo.git(&["show", &metadata_ref]);
+    assert!(metadata_output.status.success());
+    let metadata: Value =
+        serde_json::from_str(&TestRepo::stdout(&metadata_output)).expect("Invalid JSON metadata");
+    let boundary = metadata["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &branch_b]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {} (issue #830)",
+        boundary,
+        branch_b
+    );
+    let trunk_sha = repo.get_commit_sha("main");
+    assert_ne!(
+        boundary, trunk_sha,
+        "Boundary must not have been stamped to trunk tip after a conflicting rebase"
+    );
+    assert_eq!(
+        boundary, recorded_boundary,
+        "Expected the pre-existing boundary to be preserved when the rebase conflicts"
+    );
+}
+
+/// Companion test to the #830 regression above: on the clean (non-conflicting)
+/// path, the child's new boundary must match the new base it actually landed
+/// on (the trunk tip), and subsequent restacks must not re-replay commits.
+#[test]
+fn test_sync_squash_merged_child_boundary_matches_new_base() {
+    let repo = TestRepo::new_with_remote();
+
+    // Build stack: main -> A -> B
+    repo.run_stax(&["bc", "clean-squash-parent"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a content\n");
+    repo.commit("A commit");
+    repo.git(&["push", "-u", "origin", &branch_a]);
+
+    repo.run_stax(&["bc", "clean-squash-child"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("b.txt", "b content\n");
+    repo.commit("B commit");
+    repo.git(&["push", "-u", "origin", &branch_b]);
+
+    // Squash-merge A on remote plus one unrelated trunk commit.
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let clone_dir = test_tempdir();
+    let run_remote_git = |args: &[&str]| {
+        let output = hermetic_git_command()
+            .args(args)
+            .current_dir(clone_dir.path())
+            .output()
+            .expect("Failed to run git in remote clone");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run_remote_git(&["clone", remote_path.to_str().unwrap(), "."]);
+    run_remote_git(&["checkout", "-B", "main", "origin/main"]);
+    run_remote_git(&["config", "user.email", "merger@test.com"]);
+    run_remote_git(&["config", "user.name", "Merger"]);
+    run_remote_git(&["fetch", "origin", &branch_a]);
+    run_remote_git(&["merge", "--squash", &format!("origin/{}", branch_a)]);
+    run_remote_git(&["commit", "-m", "Squash merge A"]);
+    std::fs::write(clone_dir.path().join("later.txt"), "later trunk work\n").unwrap();
+    run_remote_git(&["add", "later.txt"]);
+    run_remote_git(&["commit", "-m", "Later trunk commit"]);
+    run_remote_git(&["push", "origin", "main"]);
+    run_remote_git(&["push", "origin", "--delete", &branch_a]);
+
+    repo.run_stax(&["checkout", &branch_b]);
+    let output = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        output.status.success(),
+        "sync --force failed on clean squash-merge path\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+
+    let metadata_ref = format!("refs/branch-metadata/{}", branch_b);
+    let metadata_output = repo.git(&["show", &metadata_ref]);
+    assert!(metadata_output.status.success());
+    let metadata: Value =
+        serde_json::from_str(&TestRepo::stdout(&metadata_output)).expect("Invalid JSON metadata");
+    assert_eq!(
+        metadata["parentBranchName"], "main",
+        "Expected child reparented to trunk, metadata was: {}",
+        metadata
+    );
+    let boundary = metadata["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+    let trunk_sha = repo.get_commit_sha("main");
+    assert_eq!(
+        boundary, trunk_sha,
+        "Expected boundary to match the new base the child actually landed on"
+    );
+
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &branch_b]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {}",
+        boundary,
+        branch_b
+    );
+
+    let count_output = repo.git(&["rev-list", "--count", &format!("main..{}", branch_b)]);
+    assert!(count_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&count_output.stdout).trim(),
+        "1",
+        "Expected child to keep only its own commit after clean squash-merge sync"
+    );
+
+    // Push another unrelated trunk commit remotely and restack again; the
+    // boundary should hold steady and no conflict should occur.
+    run_remote_git(&["fetch", "origin", "main"]);
+    run_remote_git(&["checkout", "main"]);
+    std::fs::write(clone_dir.path().join("later2.txt"), "even later\n").unwrap();
+    run_remote_git(&["add", "later2.txt"]);
+    run_remote_git(&["commit", "-m", "Yet another trunk commit"]);
+    run_remote_git(&["push", "origin", "main"]);
+
+    let output2 = repo.run_stax(&["sync", "--restack", "--force"]);
+    assert!(
+        output2.status.success(),
+        "sync --restack failed on follow-up trunk advance\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output2),
+        TestRepo::stderr(&output2)
+    );
+    assert!(
+        !TestRepo::stdout(&output2).contains("conflict"),
+        "Expected no conflict on follow-up restack\nstdout: {}",
+        TestRepo::stdout(&output2)
+    );
+
+    let count_output2 = repo.git(&["rev-list", "--count", &format!("main..{}", branch_b)]);
+    assert!(count_output2.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&count_output2.stdout).trim(),
+        "1",
+        "Expected child to still have only its own commit after follow-up restack"
+    );
+
+    let metadata_output2 = repo.git(&["show", &metadata_ref]);
+    assert!(metadata_output2.status.success());
+    let metadata2: Value =
+        serde_json::from_str(&TestRepo::stdout(&metadata_output2)).expect("Invalid JSON metadata");
+    let boundary2 = metadata2["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+    let ancestry_check2 = repo.git(&["merge-base", "--is-ancestor", &boundary2, &branch_b]);
+    assert!(
+        ancestry_check2.status.success(),
+        "Recorded boundary {} is not an ancestor of {} after follow-up restack",
+        boundary2,
+        branch_b
+    );
+}
+
 // =============================================================================
 // Merge Command Tests
 // =============================================================================

--- a/tests/split_tests.rs
+++ b/tests/split_tests.rs
@@ -255,6 +255,54 @@ fn test_split_file_extracts_matching_paths_into_new_parent_branch() {
     );
 }
 
+/// Issue #830: after `split --file`, the original branch's tip is amended
+/// in place (files removed) rather than rebased onto the newly created split
+/// branch -- its underlying commit chain never actually moves onto the new
+/// branch. The recorded `parentBranchRevision` must reflect that: either a
+/// real ancestor of the (amended) branch, or the previously recorded value.
+#[test]
+fn test_split_file_records_ancestry_valid_boundary_for_original_branch() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["status"]).assert_success();
+    repo.run_stax(&["create", "boundary-feature"])
+        .assert_success();
+
+    repo.create_file("keep.txt", "keep");
+    repo.create_file("move.txt", "move");
+    repo.commit("add keep and move");
+
+    let feature_branch = repo.current_branch();
+    let metadata_ref = format!("refs/branch-metadata/{}", feature_branch);
+    let read_boundary = |repo: &TestRepo| -> String {
+        let output = repo.git(&["show", &metadata_ref]);
+        assert!(output.status.success());
+        let metadata: serde_json::Value = serde_json::from_str(&TestRepo::stdout(&output)).unwrap();
+        metadata["parentBranchRevision"]
+            .as_str()
+            .expect("parentBranchRevision missing")
+            .to_string()
+    };
+    let recorded_boundary = read_boundary(&repo);
+
+    let output = repo.run_stax(&["split", "--file", "move.txt"]);
+    output.assert_success();
+
+    let boundary = read_boundary(&repo);
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &feature_branch]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {} (issue #830)",
+        boundary,
+        feature_branch
+    );
+    assert_eq!(
+        boundary, recorded_boundary,
+        "Expected the pre-existing boundary to be preserved -- the split branch's tip \
+         is never actually in the amended original branch's ancestry"
+    );
+}
+
 #[test]
 fn test_split_file_on_multi_commit_branch_fails() {
     let repo = TestRepo::new();


### PR DESCRIPTION
## Summary

Fixes #830, plus the same bug class found and fixed at three more sites during review.

`parentBranchRevision` is the boundary the *next* restack feeds straight into `git rebase --onto <parent> <boundary>`, so it must always be a real ancestor of the branch it's recorded for. Five write sites across the codebase violated that invariant by stamping "the current tip of some branch" without checking whether the branch had actually moved onto it.

### The two named/related to the original issue (`src/commands/sync.rs`)

1. **`cleanup_merged_branches`** — the rebase result match arm was `Ok(_)`, so a genuinely **conflicting** rebase (`RebaseResult::Conflict`) was treated identically to success: sync would report `✓ Rebased <child> onto main`, stamp the trunk tip as the boundary, and delete the merged parent branch, even though the rebase never completed. Wrong but nothing fails immediately — it only surfaces on the *next* sync, which replays the merged parent's already-upstream commits and conflicts (worse with squash-merges, where patch-id detection can't recognize the duplicate).
2. **`apply_live_pr_state`** (found during review) — reconciles a branch's recorded parent with GitHub's live PR base (e.g. `gh pr edit --base`, or GitHub auto-retargeting a child PR when an intermediate branch is deleted). Same defect, but with **no rebase attempt at all** — a stronger match for the issue's own real-world "Observed" trace, where a grandchild's metadata parent flipped straight to `main` with no corresponding rebase.

### Three more found during a full-codebase audit of every `parentBranchRevision` write site

3. **`branch/create.rs` `apply_insert_reparenting`** (`stax branch create --insert`) — reparents pre-existing children onto the newly inserted branch's tip with zero rebase. If a child was already stale relative to the parent before the insert ran, that tip was never in the child's real ancestry.
4. **`split.rs`** (`stax split --file`) — the original branch's tip is amended in place (extracted files removed), never rebased onto the new split branch. This one is **unconditional**: it reproduces on every `stax split` invocation, not just a stale-precondition edge case.
5. **`tui/split_hunk/app.rs` `finalize()`** — the hunk-split TUI's equivalent reparent of pre-existing stacked children, same no-rebase shape as plain split.

Sites 3–5 are lower severity than 1–2: `needs_restack()` (`engine/metadata.rs`) has its own independent ancestry-reachability check (not just SHA equality), so `stax log`/`status` still correctly report "needs restack" and the next restack self-heals — this works only because none of these three commands rewrite/squash shared history, so plain git range math still isolates the right commits. `stax submit` bypasses that safety net entirely (it reads `parentBranchRevision` directly as its own rebase-range upstream), so the corrupted window isn't fully inert.

Two narrower cases were found and *not* fixed (only trigger if the `git merge-base` call itself errors, essentially unreachable in practice): `tui/mod.rs:876`, `detach.rs:70/87`. `sweep.rs` independently re-implements the same correct guard already used by `reparent_children_for_deletion` — not a bug, just duplication, worth centralizing separately.

## Fix

- Centralized the ancestry-guard logic (try each candidate boundary in order, keep it only if `is_ancestor(candidate, branch)`, else preserve the previously recorded revision) into `GitRepo::resolve_child_parent_boundary`, used by all five write sites.
- Split `cleanup_merged_branches`'s `Ok(_)` match arm into `Ok(RebaseResult::Success)` and a new `Ok(RebaseResult::Conflict)` arm that stops sync with a proper conflict error (mirroring `restack_phase`) instead of silently continuing and deleting the merged branch out from under an incomplete rebase.

## Test plan

- [x] `test_sync_child_boundary_stays_in_ancestry_when_squash_parent_rebase_conflicts` (site 1) — confirmed failing pre-fix, passing post-fix.
- [x] `test_sync_squash_merged_child_boundary_matches_new_base` — clean-path companion.
- [x] `test_sync_pr_base_reconcile_does_not_poison_boundary_when_trunk_has_advanced` (site 2) — confirmed failing pre-fix (ghost-commit count goes from 1 to 2), passing post-fix.
- [x] `test_create_insert_does_not_poison_stale_childs_boundary` (site 3) — confirmed failing pre-fix, passing post-fix.
- [x] `test_split_file_records_ancestry_valid_boundary_for_original_branch` (site 4) — confirmed failing pre-fix, passing post-fix.
- [x] `finalize_does_not_poison_stale_childs_boundary` (site 5, direct unit test since it isn't reachable through the CLI) — confirmed failing pre-fix, passing post-fix.
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] Targeted regression suites (squash-merge, undo, json, conflict handling, continue, restack provenance, PR tracking/base reconciliation, insert, split, hunk-split): 149 tests — pass
- [x] `make test` (full suite, 2586 tests) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)