### PR TITLE
test(sync): cover full fetch of remote-only tags

### DIFF
--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -146,6 +146,8 @@ mod sweep_tests;
 mod sync_confirm_tests;
 #[path = "sync_dry_run_tests.rs"]
 mod sync_dry_run_tests;
+#[path = "sync_fetch_tests.rs"]
+mod sync_fetch_tests;
 #[path = "sync_json_tests.rs"]
 mod sync_json_tests;
 #[path = "sync_stash_tests.rs"]

--- a/tests/sync_fetch_tests.rs
+++ b/tests/sync_fetch_tests.rs
@@ -1,0 +1,45 @@
+use crate::common::TestRepo;
+
+fn tag_exists_locally(repo: &TestRepo, tag: &str) -> bool {
+    repo.git(&["rev-parse", "--verify", &format!("refs/tags/{tag}")])
+        .status
+        .success()
+}
+
+#[test]
+fn sync_full_fetches_remote_only_tags_while_default_sync_does_not() {
+    let repo = TestRepo::new_with_remote();
+    let tag = "remote-only-sync-tag";
+
+    // Publish a tag without leaving its local ref behind. This makes the tag
+    // observable only through origin, just like a release published elsewhere.
+    repo.git(&["tag", tag, "main"]);
+    repo.git(&["push", "origin", &format!("refs/tags/{tag}")]);
+    repo.git(&["tag", "--delete", tag]);
+    assert!(
+        !tag_exists_locally(&repo, tag),
+        "test setup must leave the tag on origin only"
+    );
+
+    let default_sync = repo.run_stax(&["sync", "--force"]);
+    assert!(
+        default_sync.status.success(),
+        "default sync failed: {}",
+        TestRepo::stderr(&default_sync)
+    );
+    assert!(
+        !tag_exists_locally(&repo, tag),
+        "default sync must retain its --no-tags fast path"
+    );
+
+    let full_sync = repo.run_stax(&["sync", "--full", "--force"]);
+    assert!(
+        full_sync.status.success(),
+        "sync --full failed: {}",
+        TestRepo::stderr(&full_sync)
+    );
+    assert!(
+        tag_exists_locally(&repo, tag),
+        "sync --full must fetch a tag that exists only on origin"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #833.

Adds end-to-end coverage for sync fetching a tag that exists only on `origin`:

- ordinary `stax sync --force` keeps the documented `--no-tags` fast path;
- `stax sync --full --force` fetches that remote-only tag locally.

## Verification

- `cargo nextest run sync_fetch_tests:: --no-fail-fast` — 1 passed
- `make lint-fast` — passed
- `git diff --check` — passed
- Full local gate: `make test` — 2,581 passed

Documentation note: no user-facing behavior changes; this only locks existing `--full` behavior in an integration test.