### PR TITLE
fix(ops): track metadata-ref before/after OIDs at 3 more parentBranchRevision write sites

### DIFF
--- a/src/commands/split.rs
+++ b/src/commands/split.rs
@@ -1,5 +1,7 @@
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
+use crate::ops::receipt::OpKind;
+use crate::ops::tx::Transaction;
 use crate::tui;
 use anyhow::{Context, Result};
 use colored::Colorize;
@@ -154,6 +156,16 @@ fn split_by_file(
         );
     };
 
+    // Track both branches' heads and metadata refs so the op receipt records the
+    // metadata blobs this rewrites (issue #835) and `stax undo` can reverse the
+    // split. `quiet: true` keeps the command's existing output unchanged.
+    let mut tx = Transaction::begin(OpKind::Split, repo, true)?;
+    tx.plan_branch(repo, current)?;
+    tx.plan_metadata_ref(repo, current)?;
+    tx.plan_branch(repo, &new_branch)?;
+    tx.plan_metadata_ref(repo, &new_branch)?;
+    tx.snapshot()?;
+
     // Helper: run a fallible operation; rollback and return on error.
     macro_rules! try_or_rollback {
         ($expr:expr) => {
@@ -161,6 +173,7 @@ fn split_by_file(
                 Ok(val) => val,
                 Err(err) => {
                     rollback();
+                    let _ = tx.finish_err(&err.to_string(), Some("split --file"), Some(current));
                     return Err(err);
                 }
             }
@@ -219,6 +232,18 @@ fn split_by_file(
         );
         try_or_rollback!(meta.write(repo.inner(), current));
     }
+
+    for branch in [current, new_branch.as_str()] {
+        tx.record_known_after(
+            branch,
+            ref_oid(workdir, &format!("refs/heads/{}", branch)).as_deref(),
+        );
+        tx.record_known_metadata_after(
+            branch,
+            ref_oid(workdir, &format!("refs/branch-metadata/{}", branch)).as_deref(),
+        );
+    }
+    tx.finish_ok()?;
 
     println!();
     println!(
@@ -458,6 +483,21 @@ fn path_exists_in_ref(workdir: &Path, refspec: &str, path: &str) -> Result<bool>
     }
 
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+/// Resolve a ref to its OID via a git subprocess; `None` when absent.
+/// Metadata refs are written with `git update-ref`, which libgit2's cached
+/// refdb may not observe within the same process.
+fn ref_oid(workdir: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(workdir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn rollback_split_by_file(

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -918,7 +918,16 @@ impl SyncContext {
         // Refresh live PR state before merged-branch detection so squash-merged PRs
         // (missed by `git branch --merged` when the remote branch still exists) are
         // visible via Method 2 on the first sync after merge.
-        if let Some(pr_refresh_elapsed) = refresh_pr_draft_states(repo, &self.config, self.quiet) {
+        //
+        // The sync-wide transaction is threaded in so the metadata blobs this
+        // rewrites land in the op receipt (issue #835).
+        let refreshed = {
+            let Self {
+                config, quiet, tx, ..
+            } = self;
+            refresh_pr_draft_states(repo, config, *quiet, tx.as_mut())?
+        };
+        if let Some(pr_refresh_elapsed) = refreshed {
             self.step_timings
                 .push(("refresh PR metadata".to_string(), pr_refresh_elapsed));
             self.stack = Stack::load(repo)?;
@@ -2858,7 +2867,13 @@ fn run_sync_phases(ctx: &mut SyncContext, repo: GitRepo) -> Result<()> {
             println!("Aborted.");
         }
         ctx.restore_stash(&repo)?;
-        ctx.tx = None;
+        // The PR-metadata refresh above may already have snapshotted metadata refs,
+        // so close the transaction rather than dropping it -- a dropped snapshotted
+        // transaction is persisted as Failed by `Transaction::drop`. `finish_transaction`
+        // is a no-op when nothing was snapshotted, preserving "cancelling leaves no
+        // receipt" (see the doc comment on `confirm_sync_plan`).
+        let current_after = ctx.current_after_deletions.clone();
+        ctx.finish_transaction(&current_after)?;
         return Ok(());
     }
 
@@ -2898,7 +2913,12 @@ fn run_sync_phases(ctx: &mut SyncContext, repo: GitRepo) -> Result<()> {
 /// both branch metadata and CiCache. Called before merged-branch detection
 /// during sync so that operations like `gh pr ready`, `gh pr merge`, or
 /// `gh pr edit --base` are reflected in time for cleanup.
-fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Option<Duration> {
+fn refresh_pr_draft_states(
+    repo: &GitRepo,
+    config: &Config,
+    quiet: bool,
+    mut tx: Option<&mut Transaction>,
+) -> Result<Option<Duration>> {
     let started_at = Instant::now();
     let stack = match Stack::load(repo) {
         Ok(s) => s,
@@ -2906,7 +2926,7 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
             if !quiet {
                 eprintln!("{}", stale_stack_warning("skipping PR metadata refresh", e));
             }
-            return None;
+            return Ok(None);
         }
     };
     let tracked_pr_branches: Vec<(String, u64)> = stack
@@ -2922,7 +2942,7 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
         })
         .collect();
     if tracked_pr_branches.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let timer = LiveTimer::maybe_new(!quiet, "Refresh PR metadata");
@@ -2931,14 +2951,14 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
         Ok(info) => info,
         Err(_) => {
             LiveTimer::maybe_finish_skipped(timer, "skipped");
-            return Some(started_at.elapsed());
+            return Ok(Some(started_at.elapsed()));
         }
     };
     let rt = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
         Err(_) => {
             LiveTimer::maybe_finish_skipped(timer, "skipped");
-            return Some(started_at.elapsed());
+            return Ok(Some(started_at.elapsed()));
         }
     };
     let _enter = rt.enter();
@@ -2946,14 +2966,14 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
         Ok(c) => c,
         Err(_) => {
             LiveTimer::maybe_finish_skipped(timer, "skipped");
-            return Some(started_at.elapsed());
+            return Ok(Some(started_at.elapsed()));
         }
     };
     let cache_dir = match repo.common_git_dir() {
         Ok(p) => p,
         Err(_) => {
             LiveTimer::maybe_finish_skipped(timer, "skipped");
-            return Some(started_at.elapsed());
+            return Ok(Some(started_at.elapsed()));
         }
     };
 
@@ -2976,11 +2996,18 @@ fn refresh_pr_draft_states(repo: &GitRepo, config: &Config, quiet: bool) -> Opti
             continue;
         };
 
-        apply_live_pr_state(repo, &stack, &cache_dir, &branch_name, &live_pr);
+        apply_live_pr_state(
+            repo,
+            &stack,
+            &cache_dir,
+            &branch_name,
+            &live_pr,
+            tx.as_deref_mut(),
+        )?;
     }
 
     LiveTimer::maybe_finish_timed(timer);
-    Some(started_at.elapsed())
+    Ok(Some(started_at.elapsed()))
 }
 
 fn apply_live_pr_state(
@@ -2989,11 +3016,13 @@ fn apply_live_pr_state(
     cache_dir: &Path,
     branch_name: &str,
     live_pr: &ForgePrInfo,
-) {
+    mut tx: Option<&mut Transaction>,
+) -> Result<()> {
     let pr_state = live_pr.state.to_uppercase();
 
     // Update branch metadata with fresh state, is_draft, and base
     if let Ok(Some(mut meta)) = BranchMetadata::read(repo.inner(), branch_name) {
+        let before = meta.clone();
         if let Some(ref mut pr_info) = meta.pr_info {
             pr_info.is_draft = Some(live_pr.is_draft);
             pr_info.state = pr_state.clone();
@@ -3025,10 +3054,34 @@ fn apply_live_pr_state(
             }
         }
 
+        // Only snapshot when the refresh actually rewrites the blob. Metadata is
+        // content-addressed, so an unchanged rewrite leaves the ref OID untouched --
+        // snapshotting it would turn a no-op sync into an undoable receipt and break
+        // the lazy-snapshot guard in `finish_transaction` (see
+        // sync_undo_tests::sync_that_changes_nothing_leaves_the_previous_receipt_undoable).
+        let metadata_changed = meta != before;
+
+        if metadata_changed && let Some(tx) = tx.as_deref_mut() {
+            tx.plan_metadata_ref(repo, branch_name)?;
+            tx.snapshot()?;
+        }
+
         let _ = meta.write(repo.inner(), branch_name);
+
+        if metadata_changed && let Some(tx) = tx {
+            // Metadata refs are written by `git update-ref` (subprocess); libgit2's
+            // cached refdb may not see them, so resolve the after-OID the same way
+            // `cleanup_merged_branches` does (see `record_known_after`'s doc comment).
+            let meta_after = repo.workdir().ok().and_then(|workdir| {
+                resolve_ref_oid(workdir, &format!("refs/branch-metadata/{}", branch_name))
+            });
+            tx.record_known_metadata_after(branch_name, meta_after.as_deref());
+        }
     }
 
     let _ = CiCache::update_branch_pr(cache_dir, branch_name, Some(pr_state));
+
+    Ok(())
 }
 
 fn sync_fetch_refs(
@@ -5050,5 +5103,133 @@ mod tests {
         let msg = prune_deprecation_warning();
         assert!(msg.contains("--prune"), "must name --prune: {msg}");
         assert!(msg.contains("--full"), "must name --full: {msg}");
+    }
+
+    fn init_repo_with_two_branches(path: &std::path::Path) -> String {
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git");
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(path.join("f.txt"), "a").unwrap();
+        run(&["add", "f.txt"]);
+        run(&["commit", "-m", "first"]);
+        run(&["branch", "branch-a"]);
+        run(&["branch", "branch-b"]);
+
+        let output = Command::new("git")
+            .args(["rev-parse", "main"])
+            .current_dir(path)
+            .output()
+            .expect("git");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn apply_live_pr_state_records_the_metadata_ref_in_the_receipt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        let main_oid = init_repo_with_two_branches(path);
+
+        let repo = GitRepo::open_from_path(path).unwrap();
+        repo.set_trunk("main").unwrap();
+        BranchMetadata::new("branch-a", &main_oid)
+            .write(repo.inner(), "branch-b")
+            .unwrap();
+
+        let stack = Stack::load(&repo).unwrap();
+        let cache_dir = repo.common_git_dir().unwrap();
+        let ops_dir = path.join(".git/stax/ops");
+        std::fs::create_dir_all(&ops_dir).unwrap();
+
+        let meta_oid_before = Command::new("git")
+            .args(["rev-parse", "--verify", "refs/branch-metadata/branch-b"])
+            .current_dir(path)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+        let mut tx = Transaction::begin(OpKind::Sync, &repo, true).unwrap();
+
+        let live_pr = ForgePrInfo {
+            number: 1,
+            state: "OPEN".to_string(),
+            is_draft: false,
+            base: "main".to_string(),
+        };
+        apply_live_pr_state(
+            &repo,
+            &stack,
+            &cache_dir,
+            "branch-b",
+            &live_pr,
+            Some(&mut tx),
+        )
+        .unwrap();
+
+        let finalized = tx.finish_ok_preserving_receipt();
+        let entry = finalized
+            .receipt
+            .local_refs
+            .iter()
+            .find(|e| e.branch == "branch-b@meta")
+            .expect("branch-b@meta should be tracked in the receipt");
+
+        assert!(entry.after_recorded);
+        assert_eq!(entry.oid_before, meta_oid_before);
+        assert_ne!(entry.oid_after, meta_oid_before);
+        assert!(entry.oid_after.is_some());
+    }
+
+    #[test]
+    fn apply_live_pr_state_does_not_snapshot_when_metadata_is_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        let main_oid = init_repo_with_two_branches(path);
+
+        let repo = GitRepo::open_from_path(path).unwrap();
+        repo.set_trunk("main").unwrap();
+        BranchMetadata::new("branch-a", &main_oid)
+            .write(repo.inner(), "branch-b")
+            .unwrap();
+
+        let stack = Stack::load(&repo).unwrap();
+        let cache_dir = repo.common_git_dir().unwrap();
+        let ops_dir = path.join(".git/stax/ops");
+        std::fs::create_dir_all(&ops_dir).unwrap();
+
+        let mut tx = Transaction::begin(OpKind::Sync, &repo, true).unwrap();
+
+        let live_pr = ForgePrInfo {
+            number: 1,
+            state: "OPEN".to_string(),
+            is_draft: false,
+            base: "branch-a".to_string(),
+        };
+        apply_live_pr_state(
+            &repo,
+            &stack,
+            &cache_dir,
+            "branch-b",
+            &live_pr,
+            Some(&mut tx),
+        )
+        .unwrap();
+
+        assert!(!tx.is_snapshotted());
+        let finalized = tx.finish_ok_preserving_receipt();
+        assert!(
+            !finalized
+                .receipt
+                .local_refs
+                .iter()
+                .any(|e| e.branch == "branch-b@meta")
+        );
     }
 }

--- a/src/engine/metadata.rs
+++ b/src/engine/metadata.rs
@@ -4,7 +4,7 @@ use git2::Repository;
 use serde::{Deserialize, Serialize};
 
 /// Metadata stored for each tracked branch
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchMetadata {
     /// Name of the parent branch
@@ -27,7 +27,7 @@ pub struct BranchMetadata {
     pub pr_info: Option<PrInfo>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PrInfo {
     #[serde(default)]

--- a/src/tui/split_hunk/app.rs
+++ b/src/tui/split_hunk/app.rs
@@ -89,6 +89,21 @@ fn git_ok(workdir: &Path, args: &[&str]) -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve `refname` to its OID via a git subprocess; `None` when absent.
+/// `finalize` writes refs with `git branch` / `git update-ref`, which libgit2's
+/// cached refdb may not observe, so after-OIDs must not come from `GitRepo`.
+fn resolve_ref_oid(workdir: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(workdir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 impl HunkSplitApp {
     /// Initialize the hunk split: validate state, flatten branch, parse diff.
     pub fn new(no_verify: bool) -> Result<Self> {
@@ -490,6 +505,11 @@ impl HunkSplitApp {
 
         let mut tx = Transaction::begin(OpKind::Split, &repo, false)?;
         tx.plan_branches(&repo, &affected)?;
+        // Pre-existing children keep their heads but get reparented onto the split
+        // chain's tip below -- their metadata refs must be in the receipt too (#835).
+        for branch in affected.iter().chain(self.children.iter()) {
+            tx.plan_metadata_ref(&repo, branch)?;
+        }
 
         let summary = PlanSummary {
             branches_to_rebase: 0,
@@ -501,6 +521,7 @@ impl HunkSplitApp {
         };
         tx::print_plan(tx.kind(), &summary, false);
         tx.set_plan_summary(summary);
+        tx.snapshot()?;
 
         let num_branches = self.created_branches.len();
         for (i, name) in self.created_branches.iter().enumerate() {
@@ -556,7 +577,16 @@ impl HunkSplitApp {
             .clone();
         git(&self.workdir, &["checkout", &checkout_target])?;
 
-        tx.snapshot()?;
+        for branch in &affected {
+            let head_after = resolve_ref_oid(&self.workdir, &format!("refs/heads/{}", branch));
+            tx.record_known_after(branch, head_after.as_deref());
+        }
+        for branch in affected.iter().chain(self.children.iter()) {
+            let meta_after =
+                resolve_ref_oid(&self.workdir, &format!("refs/branch-metadata/{}", branch));
+            tx.record_known_metadata_after(branch, meta_after.as_deref());
+        }
+        tx.set_head_branch_after(&checkout_target);
         tx.finish_ok()?;
 
         Ok(())
@@ -607,6 +637,7 @@ fn build_flat_items(files: &[DiffFile]) -> Vec<FlatItem> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::receipt::OpReceipt;
     use crate::tui::split_hunk::diff_parser::DiffHunk;
 
     fn make_hunk(start: u32, count: u32) -> DiffHunk {
@@ -780,5 +811,96 @@ mod tests {
             "boundary {} is not an ancestor of child-branch (issue #830)",
             meta.parent_branch_revision
         );
+    }
+
+    /// Issue #835: `finalize()` reparents pre-existing children's metadata onto
+    /// the split chain's tip -- that rewrite must be tracked in the op receipt
+    /// so `stax undo` can reverse it.
+    #[test]
+    fn finalize_records_child_metadata_refs_in_the_op_receipt() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path();
+        git_hermetic(dir, &["init", "-b", "main"]);
+        git_hermetic(dir, &["config", "user.name", "Test"]);
+        git_hermetic(dir, &["config", "user.email", "test@example.com"]);
+        std::fs::write(dir.join("base.txt"), "base\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "base"]);
+        GitRepo::open_from_path(dir)
+            .unwrap()
+            .set_trunk("main")
+            .unwrap();
+
+        git_hermetic(dir, &["checkout", "-b", "parent-branch"]);
+        std::fs::write(dir.join("p.txt"), "p\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "P1"]);
+
+        git_hermetic(dir, &["checkout", "-b", "original-branch"]);
+        std::fs::write(dir.join("o.txt"), "o\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "O1"]);
+        let o1 = git_hermetic(dir, &["rev-parse", "HEAD"]);
+
+        git_hermetic(dir, &["checkout", "-b", "child-branch"]);
+        std::fs::write(dir.join("c.txt"), "c\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "C1"]);
+
+        {
+            let repo = GitRepo::open_from_path(dir).unwrap();
+            let meta = BranchMetadata::new("original-branch", &o1);
+            meta.write(repo.inner(), "child-branch").unwrap();
+        }
+
+        git_hermetic(dir, &["checkout", "original-branch"]);
+
+        let oid_before = git_hermetic(dir, &["rev-parse", "refs/branch-metadata/child-branch"]);
+
+        let mut app = HunkSplitApp {
+            workdir: dir.to_path_buf(),
+            original_branch: "original-branch".to_string(),
+            parent_branch: "parent-branch".to_string(),
+            children: vec!["child-branch".to_string()],
+            stashed: false,
+            files: vec![],
+            selected: vec![],
+            flat_items: vec![],
+            cursor: 0,
+            list_state: ListState::default(),
+            diff_scroll: 0,
+            diff_line_count: 0,
+            diff_viewport_height: 0,
+            mode: HunkSplitMode::List,
+            round: 1,
+            created_branches: vec!["original-branch".to_string()],
+            undo_stack: vec![],
+            input_buffer: String::new(),
+            input_cursor: 0,
+            status_message: None,
+            should_quit: false,
+            round_complete: false,
+            all_done: false,
+            existing_branches: vec![],
+            no_verify: true,
+        };
+
+        app.finalize().unwrap();
+
+        let oid_after = git_hermetic(dir, &["rev-parse", "refs/branch-metadata/child-branch"]);
+
+        let repo = GitRepo::open_from_path(dir).unwrap();
+        let receipt = OpReceipt::load_latest(repo.git_dir().unwrap())
+            .unwrap()
+            .expect("finalize should have written a receipt");
+        let entry = receipt
+            .local_refs
+            .iter()
+            .find(|e| e.branch == "child-branch@meta")
+            .expect("child-branch@meta should be tracked in the receipt");
+
+        assert_eq!(entry.oid_before, Some(oid_before));
+        assert_eq!(entry.oid_after, Some(oid_after));
+        assert!(entry.after_recorded);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17564,4 +17564,99 @@ exit 1
             );
         }
     }
+
+    /// Issue #835: `apply_live_pr_state`'s metadata rewrite (the PR-base
+    /// reconcile) must be tracked in the sync op receipt's `local_refs` so
+    /// `stax undo` can reverse it.
+    #[tokio::test]
+    async fn test_sync_pr_base_reconcile_records_metadata_ref_in_the_op_receipt() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config(home.path(), &mock_server.uri());
+
+        // main -> receipt-a -> receipt-b
+        let repo = setup_branch_with_remote(home.path(), "receipt-a");
+        let branch_a = repo.current_branch();
+
+        let output = run_stax_with_env(&repo, home.path(), &["bc", "receipt-b"]);
+        assert!(output.status.success());
+        let branch_b = "receipt-b".to_string();
+        repo.create_file("child.txt", "child content");
+        repo.commit("Child commit");
+        let push = git_with_env(&repo, home.path(), &["push", "-u", "origin", &branch_b]);
+        assert!(push.status.success());
+        write_branch_pr_metadata(&repo, &branch_b, &branch_a, 711, Some(false));
+
+        // Simulate GitHub having retargeted B's PR base straight to main (e.g.
+        // after an intermediate branch was deleted) with no local rebase.
+        let retargeted_pr = github_pull_fixture(711, &branch_b, "main", "aaaa");
+        Mock::given(method("GET"))
+            .and(path("/repos/test/repo/pulls/711"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(retargeted_pr))
+            .mount(&mock_server)
+            .await;
+
+        let checkout_b = git_with_env(&repo, home.path(), &["checkout", &branch_b]);
+        assert!(checkout_b.status.success());
+
+        let meta_ref = format!("refs/branch-metadata/{}", branch_b);
+        let meta_oid_before = repo.get_commit_sha(&meta_ref);
+
+        // No `--restack`, so the receipt's only metadata entry comes from the
+        // PR refresh performed by `apply_live_pr_state`.
+        let output = run_stax_with_env(&repo, home.path(), &["sync", "--no-delete", "--force"]);
+        assert!(
+            output.status.success(),
+            "Sync failed: {}\n{}",
+            TestRepo::stderr(&output),
+            TestRepo::stdout(&output)
+        );
+
+        let meta_oid_after = repo.get_commit_sha(&meta_ref);
+        assert_ne!(
+            meta_oid_before, meta_oid_after,
+            "Expected the PR-base reconcile to rewrite the metadata blob"
+        );
+
+        let stax_ops_dir = repo.path().join(".git/stax/ops");
+        assert!(
+            stax_ops_dir.exists(),
+            "Expected .git/stax/ops directory to exist after sync"
+        );
+        let mut ops: Vec<_> = std::fs::read_dir(&stax_ops_dir)
+            .expect("Failed to read stax ops dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        ops.sort_by_key(|e| {
+            e.metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        });
+        let newest = ops.last().expect("Expected at least one operation receipt");
+        let receipt_content =
+            std::fs::read_to_string(newest.path()).expect("Failed to read receipt");
+        let receipt: serde_json::Value =
+            serde_json::from_str(&receipt_content).expect("Invalid JSON receipt");
+
+        let local_refs = receipt["local_refs"]
+            .as_array()
+            .expect("local_refs should be an array");
+        let meta_entry = local_refs
+            .iter()
+            .find(|r| r["branch"].as_str() == Some(&format!("{}@meta", branch_b)))
+            .expect("Expected branch's metadata ref in local_refs");
+
+        assert_eq!(meta_entry["refname"], meta_ref);
+        assert_eq!(
+            meta_entry["oid_before"].as_str(),
+            Some(meta_oid_before.as_str())
+        );
+        assert_eq!(
+            meta_entry["oid_after"].as_str(),
+            Some(meta_oid_after.as_str())
+        );
+        assert_ne!(meta_entry["oid_before"], meta_entry["oid_after"]);
+    }
 }

--- a/tests/split_tests.rs
+++ b/tests/split_tests.rs
@@ -341,3 +341,122 @@ fn test_split_file_on_multi_commit_branch_fails() {
         branches
     );
 }
+
+/// Helper: read the newest op receipt under `.git/stax/ops` as JSON.
+fn latest_receipt(repo: &TestRepo) -> serde_json::Value {
+    let ops_dir = repo.path().join(".git/stax/ops");
+    let mut entries: Vec<_> = std::fs::read_dir(&ops_dir)
+        .expect("read ops dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    entries.sort_by_key(|e| {
+        e.metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    let newest = entries.last().expect("expected at least one op receipt");
+    let content = std::fs::read_to_string(newest.path()).expect("read receipt");
+    serde_json::from_str(&content).expect("invalid receipt JSON")
+}
+
+/// Issue #835: `split --file` must record both branches' metadata refs in the
+/// op receipt so `stax undo` can reverse the split.
+#[test]
+fn test_split_file_records_metadata_refs_in_the_op_receipt() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["status"]).assert_success();
+    repo.run_stax(&["create", "feature"]).assert_success();
+
+    repo.create_file("keep.txt", "keep");
+    repo.create_file("move.txt", "move");
+    repo.commit("add keep and move");
+
+    let feature_branch = repo.current_branch();
+
+    let output = repo.run_stax(&["split", "--file", "move.txt"]);
+    output.assert_success();
+
+    let split_branch = repo
+        .find_branch_containing("feature-split")
+        .expect("expected split branch to be created");
+
+    let receipt = latest_receipt(&repo);
+    let local_refs = receipt["local_refs"]
+        .as_array()
+        .expect("local_refs should be an array");
+
+    let feature_meta = local_refs
+        .iter()
+        .find(|e| e["branch"].as_str() == Some(&format!("{}@meta", feature_branch)))
+        .expect("expected feature branch metadata ref in receipt");
+    assert!(feature_meta["oid_before"].is_string());
+    assert!(feature_meta["oid_after"].is_string());
+    assert_ne!(feature_meta["oid_before"], feature_meta["oid_after"]);
+
+    let split_meta = local_refs
+        .iter()
+        .find(|e| e["branch"].as_str() == Some(&format!("{}@meta", split_branch)))
+        .expect("expected split branch metadata ref in receipt");
+    assert!(split_meta["oid_before"].is_null());
+    assert!(split_meta["oid_after"].is_string());
+}
+
+/// Issue #835: since `split --file` now snapshots both branches into the op
+/// receipt, `stax undo` should fully reverse it.
+#[test]
+fn test_split_file_undo_restores_the_original_branch() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["status"]).assert_success();
+    repo.run_stax(&["create", "feature"]).assert_success();
+
+    repo.create_file("keep.txt", "keep");
+    repo.create_file("move.txt", "move");
+    repo.commit("add keep and move");
+
+    let feature_branch = repo.current_branch();
+    let head_before = repo.head_sha();
+    let metadata_ref = format!("refs/branch-metadata/{}", feature_branch);
+    let meta_output_before = repo.git(&["show", &metadata_ref]);
+    let metadata_before = TestRepo::stdout(&meta_output_before);
+
+    let output = repo.run_stax(&["split", "--file", "move.txt"]);
+    output.assert_success();
+
+    let split_branch = repo
+        .find_branch_containing("feature-split")
+        .expect("expected split branch to be created");
+
+    let undo_output = repo.run_stax(&["undo", "--yes"]);
+    undo_output.assert_success();
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.iter().any(|b| b == &split_branch),
+        "split branch should be gone after undo, got branches: {:?}",
+        branches
+    );
+    let split_meta_ref = repo.git(&[
+        "rev-parse",
+        "--verify",
+        &format!("refs/branch-metadata/{}", split_branch),
+    ]);
+    assert!(
+        !split_meta_ref.status.success(),
+        "split branch metadata ref should be gone after undo"
+    );
+
+    assert_eq!(
+        repo.head_sha(),
+        head_before,
+        "original branch head should be restored after undo"
+    );
+    let meta_output_after = repo.git(&["show", &metadata_ref]);
+    let metadata_after = TestRepo::stdout(&meta_output_after);
+    assert_eq!(
+        metadata_before, metadata_after,
+        "original branch metadata should be restored after undo"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #835.

#830/#834 fixed five sites that wrote `parentBranchRevision` without verifying ancestry, but only one of the five (`cleanup_merged_branches`) recorded the metadata ref's before/after OID in the op receipt. The other four left no diagnosable trail — exactly the gap #830's own text called out: *"refs/branch-metadata/* is an unversioned blob with no reflog, so a bad write leaves no trail... Recording metadata before/after in the op JSON would make this class of bug diagnosable."*

## What changed

Wired the existing `snapshot_branch_with_metadata` / `plan_metadata_ref` / `record_known_metadata_after` machinery (added in #826) into 3 of the 4 previously-untracked sites:

- **`sync.rs` `apply_live_pr_state`** — threaded the sync-wide `Transaction` through `refresh_pr_states` → `refresh_pr_draft_states` → `apply_live_pr_state`. A `Transaction` already exists at this point in the pipeline (it begins at the top of `run_sync_phases`), so this turned out to be pure signature-threading rather than the pipeline restructuring the original issue assumed would be needed. Snapshotting is gated on `meta != before` so a no-op PR refresh still produces no receipt — preserves the existing invariant that cancelling sync leaves nothing to undo.
- **`tui/split_hunk/app.rs` `finalize()`** — extended the existing transaction to also plan and record metadata refs for `self.children` (the pre-existing stacked descendants the #830-class bug actually touches), not just the branches it creates.
- **`split.rs` `split_by_file`** — had no transaction at all; added one covering both branches' heads and metadata refs. This gives `stax split --file` `stax undo` support for the first time.

**Deliberately not touched:** `branch/create.rs` `apply_insert_reparenting`. There's no transaction anywhere in that file, and scoping one to just the reparenting step would let `stax undo` reverse the children's metadata while leaving the newly created branch behind — worse than no receipt at all. That needs its own transaction covering the whole `create` command (two independent flows, ~10 manual rollback call sites today), which is a bigger, separate piece of work — tracked as a follow-up rather than folded into this PR.

## Test plan

- [x] New unit tests: `apply_live_pr_state_records_the_metadata_ref_in_the_receipt`, `apply_live_pr_state_does_not_snapshot_when_metadata_is_unchanged`, `finalize_records_child_metadata_refs_in_the_op_receipt`.
- [x] New integration tests: `test_sync_pr_base_reconcile_records_metadata_ref_in_the_op_receipt`, `test_split_file_records_metadata_refs_in_the_op_receipt`, `test_split_file_undo_restores_the_original_branch` (verified `stax undo` after `split --file` leaves a fully clean repo state — branch deleted, metadata ref deleted, original HEAD/metadata restored, working tree clean).
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] Targeted regression suites (sync undo/json/confirm/dry-run, split, split-hunk, forge-mock PR handling, create-insert as a sanity check that the deferred file is untouched): 234 tests — pass
- [x] `make test` (full suite, 2615 tests) — pass (one unrelated pre-existing flaky TUI test on the first run, confirmed via 8/8 isolated reruns and a clean second full run; it doesn't exercise any changed code path)

Two minor, non-blocking notes from review:
- The `meta != before` gate compares post-normalization structs, so it has a narrow blind spot for legacy/corrupt metadata with empty parent fields — edge case, not a regression.
- `stax undo` after `split --file` now reports "Restored 4 branches" for a 2-branch split, since the counter includes `@meta` pseudo-entries — cosmetic, and consistent with the existing counting convention already used at the #830/#834 sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)