### PR TITLE
fix(create): wrap stax create in a Transaction, closing the last of #830's write sites

### DIFF
--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -28,6 +28,8 @@ use crate::commands::staging::{self, ContinueLabel, StagingAction};
 use crate::config::Config;
 use crate::engine::{BranchMetadata, Stack};
 use crate::git::GitRepo;
+use crate::ops::receipt::OpKind;
+use crate::ops::tx::Transaction;
 use crate::progress::LiveTimer;
 use crate::remote;
 use anyhow::{Context, Result, anyhow, bail};
@@ -666,7 +668,9 @@ pub fn run(
         return Ok(());
     }
 
-    create_branch_with_banner(
+    let mut tx = Transaction::begin(OpKind::Create, &repo, true)?;
+    let below_current = below_current_meta.as_ref().map(|_| current.as_str());
+    if let Err(e) = create_branch_with_banner(
         &repo,
         &config,
         &current,
@@ -675,7 +679,12 @@ pub fn run(
         insert,
         below_current_meta.as_ref(),
         !staging::is_staging_area_empty(workdir)?,
-    )?;
+        &mut tx,
+    ) {
+        record_create_after(&mut tx, workdir, &branch_name, below_current);
+        let _ = tx.finish_err(&e.to_string(), Some("create"), Some(&branch_name));
+        return Err(e);
+    }
     print_branch_name_warnings(&branch_name_result.warnings);
 
     // Stage/commit behavior:
@@ -683,12 +692,12 @@ pub fn run(
     // - StageMode::ExistingOnly (files already staged) => keep current index
     // - StageMode::None => no staging/committing
     if stage_mode != StageMode::None {
-        let workdir = repo.workdir()?;
-
         if (stage_mode == StageMode::All || needs_stage_all)
             && let Err(e) = staging::stage_all(workdir)
         {
             rollback_create_and_restore(&repo, &current, &branch_name, below_current_meta.as_ref());
+            record_create_after(&mut tx, workdir, &branch_name, below_current);
+            let _ = tx.finish_err(&e.to_string(), Some("stage"), Some(&branch_name));
             return Err(e);
         }
 
@@ -696,6 +705,10 @@ pub fn run(
             println!("{}", "Changes staged".dimmed());
         }
     }
+
+    record_create_after(&mut tx, workdir, &branch_name, below_current);
+    tx.set_head_branch_after(&branch_name);
+    tx.finish_ok()?;
 
     if config.ui.tips {
         println!(
@@ -738,6 +751,49 @@ fn rollback_create_and_restore(
         let _ = meta.write(repo.inner(), original_branch);
     }
     rollback_create(repo, original_branch, new_branch);
+}
+
+/// Resolve a ref to its OID via a git subprocess; `None` when absent.
+/// Branch metadata refs are written with `git update-ref` (see
+/// `git::refs::write_metadata`), which libgit2's cached refdb may not observe
+/// within the same process — mirrors `split.rs`'s `ref_oid`.
+fn ref_oid(workdir: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(workdir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Record the create's after-state for the new branch's head + metadata ref,
+/// and (for `--below`) the reparented original branch's metadata ref.
+///
+/// Safe to call on failure paths too: after a rollback the refs read back as
+/// absent/unchanged, which is exactly what the receipt should record.
+fn record_create_after(
+    tx: &mut Transaction,
+    workdir: &Path,
+    branch_name: &str,
+    below_current: Option<&str>,
+) {
+    tx.record_known_after(
+        branch_name,
+        ref_oid(workdir, &format!("refs/heads/{}", branch_name)).as_deref(),
+    );
+    tx.record_known_metadata_after(
+        branch_name,
+        ref_oid(workdir, &format!("refs/branch-metadata/{}", branch_name)).as_deref(),
+    );
+    if let Some(current) = below_current {
+        tx.record_known_metadata_after(
+            current,
+            ref_oid(workdir, &format!("refs/branch-metadata/{}", current)).as_deref(),
+        );
+    }
 }
 
 const CREATE_BELOW_AUTO_STASH_MESSAGE: &str = "stax create --below auto-stash";
@@ -937,6 +993,8 @@ fn run_commit_first(
     no_verify: bool,
 ) -> Result<()> {
     let workdir = repo.workdir()?;
+    let mut tx = Transaction::begin(OpKind::Create, repo, true)?;
+    let below_current = below_current_meta.map(|_| current);
     let committing_on_current = parent_branch == current;
     let parent_sha = repo.branch_commit(parent_branch)?;
     let mut auto_stash = if !committing_on_current && below_current_meta.is_some() {
@@ -1012,7 +1070,7 @@ fn run_commit_first(
     };
 
     if staging_area_empty {
-        create_branch_with_banner(
+        if let Err(e) = create_branch_with_banner(
             repo,
             config,
             current,
@@ -1021,11 +1079,24 @@ fn run_commit_first(
             insert,
             below_current_meta,
             false,
-        )?;
+            &mut tx,
+        ) {
+            record_create_after(&mut tx, workdir, branch_name, below_current);
+            let _ = tx.finish_err(&e.to_string(), Some("create"), Some(branch_name));
+            return Err(e);
+        }
         println!("{}", "No changes to commit".dimmed());
         print_tips(config);
-        auto_stash.drop_stash(workdir)?;
-        return Ok(());
+        let stash_result = auto_stash.drop_stash(workdir);
+        record_create_after(&mut tx, workdir, branch_name, below_current);
+        tx.set_head_branch_after(branch_name);
+        return match stash_result {
+            Ok(()) => tx.finish_ok().map(|_| ()),
+            Err(e) => {
+                let _ = tx.finish_err(&e.to_string(), Some("drop auto-stash"), Some(branch_name));
+                Err(e)
+            }
+        };
     }
 
     // Run the commit before the destination branch exists. `--quiet`
@@ -1104,7 +1175,15 @@ fn run_commit_first(
         }
     };
 
-    if let Err(e) = repo.create_branch_at_commit(branch_name, &new_sha) {
+    let snapshot_result = (|| -> Result<()> {
+        tx.plan_branch(repo, branch_name)?;
+        tx.plan_metadata_ref(repo, branch_name)?;
+        if below_current_meta.is_some() {
+            tx.plan_metadata_ref(repo, current)?;
+        }
+        tx.snapshot()
+    })();
+    if let Err(e) = snapshot_result {
         rollback_after_commit(
             workdir,
             current,
@@ -1118,49 +1197,47 @@ fn run_commit_first(
         return Err(e);
     }
 
-    let meta = BranchMetadata::new(parent_branch, &parent_sha);
-    if let Err(e) = meta.write(repo.inner(), branch_name) {
-        rollback_after_commit(
-            workdir,
-            current,
-            &parent_sha,
-            Some(branch_name),
-            repo,
-            committing_on_current,
-            below_current_meta,
-            &mut auto_stash,
-        );
-        return Err(e);
+    macro_rules! rollback_and_finish {
+        ($err:expr, $step:expr, $new_branch:expr) => {{
+            let err = $err;
+            rollback_after_commit(
+                workdir,
+                current,
+                &parent_sha,
+                $new_branch,
+                repo,
+                committing_on_current,
+                below_current_meta,
+                &mut auto_stash,
+            );
+            record_create_after(&mut tx, workdir, branch_name, below_current);
+            let _ = tx.finish_err(&err.to_string(), Some($step), Some(branch_name));
+            return Err(err);
+        }};
     }
 
-    if insert && let Err(e) = apply_insert_reparenting(repo, parent_branch, branch_name) {
-        rollback_after_commit(
-            workdir,
-            current,
-            &parent_sha,
-            Some(branch_name),
-            repo,
-            committing_on_current,
-            below_current_meta,
-            &mut auto_stash,
-        );
-        return Err(e);
+    if let Err(e) = repo.create_branch_at_commit(branch_name, &new_sha) {
+        rollback_and_finish!(e, "create branch", None);
+    }
+
+    let meta = BranchMetadata::new(parent_branch, &parent_sha);
+    if let Err(e) = meta.write(repo.inner(), branch_name) {
+        rollback_and_finish!(e, "write metadata", Some(branch_name));
+    }
+
+    if insert {
+        match apply_insert_reparenting(repo, parent_branch, branch_name, &mut tx) {
+            Ok(()) => {}
+            Err(e) => {
+                rollback_and_finish!(e, "insert reparent", Some(branch_name));
+            }
+        }
     }
 
     if let Some(current_meta) = below_current_meta
         && let Err(e) = apply_below_reparenting(repo, current, branch_name, current_meta)
     {
-        rollback_after_commit(
-            workdir,
-            current,
-            &parent_sha,
-            Some(branch_name),
-            repo,
-            committing_on_current,
-            below_current_meta,
-            &mut auto_stash,
-        );
-        return Err(e);
+        rollback_and_finish!(e, "below reparent", Some(branch_name));
     }
 
     if committing_on_current {
@@ -1168,17 +1245,7 @@ fn run_commit_first(
         // now lives only on `branch_name`.
         let current_ref = format!("refs/heads/{}", current);
         if let Err(e) = repo.update_ref(&current_ref, &parent_sha) {
-            rollback_after_commit(
-                workdir,
-                current,
-                &parent_sha,
-                Some(branch_name),
-                repo,
-                committing_on_current,
-                below_current_meta,
-                &mut auto_stash,
-            );
-            return Err(e);
+            rollback_and_finish!(e, "rewind current branch", Some(branch_name));
         }
     }
 
@@ -1187,19 +1254,19 @@ fn run_commit_first(
     // commit; in the detached-parent case HEAD already points at the new commit.
     // `git checkout` only moves HEAD in both cases.
     if let Err(e) = repo.checkout(branch_name) {
-        rollback_after_commit(
-            workdir,
-            current,
-            &parent_sha,
-            Some(branch_name),
-            repo,
-            committing_on_current,
-            below_current_meta,
-            &mut auto_stash,
-        );
-        return Err(e);
+        rollback_and_finish!(e, "checkout", Some(branch_name));
     }
-    auto_stash.drop_stash(workdir)?;
+
+    let stash_result = auto_stash.drop_stash(workdir);
+    record_create_after(&mut tx, workdir, branch_name, below_current);
+    tx.set_head_branch_after(branch_name);
+    match stash_result {
+        Ok(()) => tx.finish_ok()?,
+        Err(e) => {
+            let _ = tx.finish_err(&e.to_string(), Some("drop auto-stash"), Some(branch_name));
+            return Err(e);
+        }
+    }
 
     print_remote_parent_warning(repo, config, parent_branch);
     println!(
@@ -1396,8 +1463,15 @@ fn create_branch_with_banner(
     insert: bool,
     below_current_meta: Option<&BranchMetadata>,
     restore_stash_index: bool,
+    tx: &mut Transaction,
 ) -> Result<()> {
     let workdir = repo.workdir()?;
+    tx.plan_branch(repo, branch_name)?;
+    tx.plan_metadata_ref(repo, branch_name)?;
+    if below_current_meta.is_some() {
+        tx.plan_metadata_ref(repo, original)?;
+    }
+    tx.snapshot()?;
     let mut auto_stash = if below_current_meta.is_some() {
         CreateBelowAutoStash::push_if_dirty(workdir, restore_stash_index)?
     } else {
@@ -1421,7 +1495,7 @@ fn create_branch_with_banner(
         return Err(e);
     }
 
-    if insert && let Err(e) = apply_insert_reparenting(repo, parent_branch, branch_name) {
+    if insert && let Err(e) = apply_insert_reparenting(repo, parent_branch, branch_name, tx) {
         rollback_create(repo, original, branch_name);
         auto_stash.restore_on_original_branch(repo, workdir, original)?;
         return Err(e);
@@ -1522,7 +1596,12 @@ fn resolve_below_current_metadata(repo: &GitRepo, current: &str) -> Result<Branc
 /// Reparent children of `parent_branch` onto `new_branch` and print the usual
 /// `--insert` summary. Extracted from the branch-first path so both flows
 /// share the same behaviour.
-fn apply_insert_reparenting(repo: &GitRepo, parent_branch: &str, new_branch: &str) -> Result<()> {
+fn apply_insert_reparenting(
+    repo: &GitRepo,
+    parent_branch: &str,
+    new_branch: &str,
+    tx: &mut Transaction,
+) -> Result<()> {
     let stack = Stack::load(repo)?;
     let Some(parent_info) = stack.branches.get(parent_branch) else {
         return Ok(());
@@ -1539,8 +1618,11 @@ fn apply_insert_reparenting(repo: &GitRepo, parent_branch: &str, new_branch: &st
     }
 
     let new_parent_rev = repo.branch_commit(new_branch)?;
+    let workdir = repo.workdir()?;
     for child in &children {
         if let Some(child_meta) = BranchMetadata::read(repo.inner(), child)? {
+            tx.plan_metadata_ref(repo, child)?;
+            tx.snapshot()?;
             // `new_branch` is created at `parent_branch`'s tip at the time of insert,
             // not `child`'s -- if `child` was already stale relative to `parent_branch`,
             // `new_parent_rev` isn't actually in `child`'s ancestry. Verify before
@@ -1557,6 +1639,10 @@ fn apply_insert_reparenting(repo: &GitRepo, parent_branch: &str, new_branch: &st
                 ..child_meta
             };
             updated.write(repo.inner(), child)?;
+            tx.record_known_metadata_after(
+                child,
+                ref_oid(workdir, &format!("refs/branch-metadata/{}", child)).as_deref(),
+            );
         }
     }
 

--- a/src/ops/receipt.rs
+++ b/src/ops/receipt.rs
@@ -34,6 +34,7 @@ pub enum OpKind {
     Fix,
     Edit,
     Fold,
+    Create,
 }
 
 impl OpKind {
@@ -54,6 +55,7 @@ impl OpKind {
             OpKind::Fix => "stack fix",
             OpKind::Edit => "edit",
             OpKind::Fold => "fold",
+            OpKind::Create => "create",
         }
     }
 }

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -54,6 +54,8 @@ mod create_insert_tests;
 mod create_message_tests;
 #[path = "create_rollback_tests.rs"]
 mod create_rollback_tests;
+#[path = "create_undo_tests.rs"]
+mod create_undo_tests;
 #[path = "demo_tests.rs"]
 mod demo_tests;
 #[path = "detach_tests.rs"]

--- a/tests/create_undo_tests.rs
+++ b/tests/create_undo_tests.rs
@@ -1,0 +1,209 @@
+//! Issue #839: `stax create` must wrap both its branch-first and commit-first
+//! flows in a single `Transaction` so the whole create — branch ref, its
+//! metadata ref, `--insert` child reparenting, and `--below` reparenting — is
+//! one undoable unit.
+
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+
+/// Helper: read the newest op receipt under `.git/stax/ops` as JSON.
+fn latest_receipt(repo: &TestRepo) -> serde_json::Value {
+    let ops_dir = repo.path().join(".git/stax/ops");
+    let mut entries: Vec<_> = std::fs::read_dir(&ops_dir)
+        .expect("read ops dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    entries.sort_by_key(|e| {
+        e.metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    let newest = entries.last().expect("expected at least one op receipt");
+    let content = std::fs::read_to_string(newest.path()).expect("read receipt");
+    serde_json::from_str(&content).expect("invalid receipt JSON")
+}
+
+#[cfg(unix)]
+fn install_failing_pre_commit_hook(repo: &TestRepo) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let hooks_dir = repo.path().join(".git").join("hooks");
+    std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+    let hook = hooks_dir.join("pre-commit");
+    std::fs::write(&hook, "#!/bin/sh\necho hook failed >&2\nexit 1\n").expect("write failing hook");
+    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod failing hook");
+}
+
+#[test]
+fn create_insert_records_child_metadata_in_the_op_receipt() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["ins-a", "ins-b"]);
+    let ins_a = &branches[0];
+    let ins_b = &branches[1];
+
+    repo.run_stax(&["checkout", ins_a]).assert_success();
+    repo.run_stax(&["create", "ins-mid", "--insert"])
+        .assert_success();
+
+    let receipt = latest_receipt(&repo);
+    assert_eq!(receipt["kind"], "create");
+    assert_eq!(receipt["status"], "success");
+
+    let local_refs = receipt["local_refs"]
+        .as_array()
+        .expect("local_refs should be an array");
+
+    let branch_entry = local_refs
+        .iter()
+        .find(|e| e["branch"].as_str() == Some("ins-mid"))
+        .expect("expected ins-mid branch entry in receipt");
+    assert!(branch_entry["oid_before"].is_null());
+    assert!(branch_entry["oid_after"].is_string());
+
+    let meta_entry = local_refs
+        .iter()
+        .find(|e| e["branch"].as_str() == Some("ins-mid@meta"))
+        .expect("expected ins-mid@meta entry in receipt");
+    assert!(meta_entry["oid_before"].is_null());
+    assert!(meta_entry["oid_after"].is_string());
+
+    let child_meta_entry = local_refs
+        .iter()
+        .find(|e| e["branch"].as_str() == Some(&format!("{}@meta", ins_b)))
+        .unwrap_or_else(|| panic!("expected {}@meta entry in receipt", ins_b));
+    assert!(child_meta_entry["oid_before"].is_string());
+    assert!(child_meta_entry["oid_after"].is_string());
+    assert_ne!(
+        child_meta_entry["oid_before"], child_meta_entry["oid_after"],
+        "child's metadata ref should have changed"
+    );
+}
+
+#[test]
+fn create_insert_undo_restores_the_childs_original_parent() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["ins-a", "ins-b"]);
+    let ins_a = &branches[0];
+    let ins_b = &branches[1];
+
+    repo.run_stax(&["checkout", ins_a]).assert_success();
+    repo.run_stax(&["create", "ins-mid", "--insert"])
+        .assert_success();
+
+    let undo_output = repo.run_stax(&["undo", "--yes"]);
+    undo_output.assert_success();
+
+    let branches_after = repo.list_branches();
+    assert!(
+        !branches_after.iter().any(|b| b == "ins-mid"),
+        "ins-mid should be gone after undo, got branches: {:?}",
+        branches_after
+    );
+    assert_eq!(repo.current_branch(), *ins_a);
+
+    repo.run_stax(&["checkout", ins_b]).assert_success();
+    let parent = repo.get_current_parent();
+    assert!(
+        parent.as_ref().is_some_and(|p| p.contains(ins_a)),
+        "expected {}'s parent to be restored to {}, got: {:?}",
+        ins_b,
+        ins_a,
+        parent
+    );
+}
+
+#[test]
+fn create_below_undo_restores_the_original_parent() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    let branches = repo.create_stack(&["bel-p", "bel-c"]);
+    let bel_p = &branches[0];
+    let bel_c = &branches[1];
+
+    repo.run_stax(&["checkout", bel_c]).assert_success();
+    repo.run_stax(&["create", "bel-low", "--below"])
+        .assert_success();
+
+    let undo_output = repo.run_stax(&["undo", "--yes"]);
+    undo_output.assert_success();
+
+    let branches_after = repo.list_branches();
+    assert!(
+        !branches_after.iter().any(|b| b == "bel-low"),
+        "bel-low should be gone after undo, got branches: {:?}",
+        branches_after
+    );
+    assert_eq!(repo.current_branch(), *bel_c);
+
+    let parent = repo.get_current_parent();
+    assert!(
+        parent.as_ref().is_some_and(|p| p.contains(bel_p)),
+        "expected {}'s parent to be restored to {}, got: {:?}",
+        bel_c,
+        bel_p,
+        parent
+    );
+}
+
+#[test]
+fn create_commit_first_undo_removes_the_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.create_file("u.txt", "undo me content\n");
+    let main_sha_before = repo.get_commit_sha("main");
+
+    repo.run_stax(&["create", "-a", "-m", "undo me"])
+        .assert_success();
+
+    let undo_output = repo.run_stax(&["undo", "--yes"]);
+    undo_output.assert_success();
+
+    let branches_after = repo.list_branches();
+    assert!(
+        !branches_after.iter().any(|b| b.contains("undo-me")),
+        "undo-me branch should be gone after undo, got branches: {:?}",
+        branches_after
+    );
+    assert_eq!(repo.current_branch(), "main");
+    assert_eq!(repo.get_commit_sha("main"), main_sha_before);
+    assert!(
+        repo.path().join("u.txt").exists(),
+        "undo must not destroy the user's file"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn create_hook_failure_writes_no_receipt() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    install_failing_pre_commit_hook(&repo);
+
+    repo.create_file("hook.txt", "hook fail content\n");
+
+    let output = repo.run_stax(&["create", "-a", "-m", "hook fail"]);
+    output.assert_failure();
+
+    let ops_dir = repo.path().join(".git/stax/ops");
+    let receipt_count = std::fs::read_dir(&ops_dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+                .count()
+        })
+        .unwrap_or(0);
+    assert_eq!(
+        receipt_count, 0,
+        "a hook failure before the snapshot must not write a receipt"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #839.

#835/#838 tracked before/after metadata-ref OIDs at 4 of the 5 `parentBranchRevision` write sites fixed in #830/#834. The 5th, `apply_insert_reparenting` (`stax branch create --insert`), was deliberately deferred: `create.rs` had no `Transaction` anywhere, and scoping one to just the reparenting step would let `stax undo` reverse a child's metadata while leaving the newly created branch behind — worse than no receipt at all.

## What changed

Added a new `OpKind::Create` and threaded a `Transaction` through both of `create`'s independent flows:

- **`create_branch_with_banner`** (branch-first: plain name-only, or `--insert`/`--below` without `-m`) — plans + snapshots the new branch's head/metadata ref (and the reparented branch's metadata ref for `--below`) up front. Every existing manual rollback site already returns `Err`, so the two owning callers convert that into exactly one `finish_err`.
- **`run_commit_first`** (`-m` commit-first flow) — snapshots **lazily**, right before the first real mutation (branch ref creation). Earlier failures (pre-commit hook failure, non-zero commit exit, Ctrl+C, `rev-parse` failure) leave the transaction unsnapshotted and silently dropped — so pre-commit failures still produce no receipt, exactly matching current behavior. The ~6 existing rollback call sites are converted to a `rollback_and_finish!` macro that also calls `tx.finish_err(...)`.
- **`apply_insert_reparenting`** now plans/snapshots/records each reparented child's metadata ref per-child (`Transaction::snapshot` is incremental, so earlier children's before-OIDs are never clobbered) — closing the loop: its `parentBranchRevision` writes finally get before/after tracking in the op receipt.

**Deliberately untouched:** the plain `stax create <name>` fast path (`simple_explicit_empty_create`). Giving every branch creation a receipt would make `stax undo` nondeterministic in unrelated tests due to the op-ID timestamp's 1-second resolution, and that path has none of #830's write sites anyway.

## Test plan

- [x] 5 new tests in `tests/create_undo_tests.rs`: receipt completeness for `--insert`, `stax undo` after `--insert`, after `--below`, after commit-first `-m`, and a pre-commit-hook failure producing zero receipt.
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] Targeted regression suites (`create_*`, `split_tests`, `fold_tests`, `guard_rail_tests`, `sync_undo_tests`, `edge_cases_tests`, `ops::`/`receipt::`): 223 tests — pass
- [x] `make test` (full suite, 2620 tests) — pass
- [x] Independent verifier review confirmed all 6 risk areas hold structurally (correct lazy-snapshot boundary, fast path fully untouched, checked-out branch's head ref never planned so `undo` can't destroy user work, after-OIDs correctly resolved via subprocess not libgit2, `quiet: true` preserving existing stdout/stderr assertions, all 6 macro rollback-argument conversions verified byte-exact against the original code) — plus a manual scratch-repo exercise of a failing pre-commit hook, confirming zero receipt and a fully clean repo state on failure.

## Advisory finding (not introduced by this PR, flagging for follow-up)

Manual testing during verification found that **`stax undo` can target the wrong receipt when two creates land in the same second** — op IDs have only 1-second timestamp resolution (`src/ops/mod.rs:30`) with a lexicographic-string tiebreak on the random suffix (`src/ops/mod.rs:144`), so "latest by sort order" can disagree with "latest chronologically". Measured 4/6 disagreement in manual back-to-back trials. This is pre-existing infrastructure (the same hazard that's why the plain `bc <name>` fast path was deliberately excluded from receipt tracking above) — but this PR does make the commit-first `-m` path write a receipt on every invocation, without a matching exclusion, so it's newly exposed there. Will track as a separate follow-up rather than block this PR on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)