### PR TITLE
fix(detach): track metadata refs so undo actually reverses detach

### DIFF
--- a/src/commands/detach.rs
+++ b/src/commands/detach.rs
@@ -4,6 +4,8 @@ use crate::ops::receipt::OpKind;
 use crate::ops::tx::Transaction;
 use anyhow::Result;
 use colored::Colorize;
+use std::path::Path;
+use std::process::Command;
 
 pub fn run(branch: Option<String>, yes: bool) -> Result<()> {
     let repo = GitRepo::open()?;
@@ -49,49 +51,75 @@ pub fn run(branch: Option<String>, yes: bool) -> Result<()> {
         }
     }
 
-    // Begin transaction
+    // Begin transaction. detach never moves any branch HEAD -- the only mutation
+    // is each branch's `refs/branch-metadata/<branch>` blob -- so the metadata
+    // refs MUST be planned/recorded or `stax undo` restores nothing (issue #835).
     let mut tx = Transaction::begin(OpKind::Detach, &repo, false)?;
     tx.plan_branch(&repo, &target)?;
+    tx.plan_metadata_ref(&repo, &target)?;
     for child in &children {
         tx.plan_branch(&repo, child)?;
+        tx.plan_metadata_ref(&repo, child)?;
     }
     tx.snapshot()?;
 
+    let workdir = repo.workdir()?;
+
     // Reparent children to detached branch's parent
+    let parent_rev = repo.branch_commit(&parent)?;
     for child in &children {
         let child_meta = BranchMetadata::read(repo.inner(), child)?;
         if let Some(meta) = child_meta {
-            let parent_rev = repo.branch_commit(&parent)?;
-            let merge_base = repo
-                .merge_base(&parent, child)
-                .unwrap_or_else(|_| parent_rev.clone());
+            // The merge-base with the new parent is the real boundary; fall back
+            // to the parent tip only when it is genuinely in `child`'s ancestry,
+            // else keep the previously recorded boundary (see #830).
+            let merge_base = repo.merge_base(&parent, child).ok();
+            let parent_branch_revision = repo.resolve_child_parent_boundary(
+                child,
+                &[merge_base.as_deref(), Some(parent_rev.as_str())],
+                &meta.parent_branch_revision,
+            );
             let updated = BranchMetadata {
                 parent_branch_name: parent.clone(),
-                parent_branch_revision: merge_base,
+                parent_branch_revision,
                 ..meta
             };
             updated.write(repo.inner(), child)?;
         }
         tx.record_after(&repo, child)?;
+        tx.record_known_metadata_after(
+            child,
+            ref_oid(workdir, &format!("refs/branch-metadata/{}", child)).as_deref(),
+        );
     }
 
     // Set detached branch's parent to trunk
     let trunk_rev = repo.branch_commit(&trunk)?;
-    let merge_base = repo
-        .merge_base(&trunk, &target)
-        .unwrap_or_else(|_| trunk_rev.clone());
+    let trunk_merge_base = repo.merge_base(&trunk, &target).ok();
     let existing = BranchMetadata::read(repo.inner(), &target)?;
     let updated = if let Some(meta) = existing {
+        let parent_branch_revision = repo.resolve_child_parent_boundary(
+            &target,
+            &[trunk_merge_base.as_deref(), Some(trunk_rev.as_str())],
+            &meta.parent_branch_revision,
+        );
         BranchMetadata {
             parent_branch_name: trunk.clone(),
-            parent_branch_revision: merge_base,
+            parent_branch_revision,
             ..meta
         }
     } else {
-        BranchMetadata::new(&trunk, &merge_base)
+        BranchMetadata::new(
+            &trunk,
+            trunk_merge_base.as_deref().unwrap_or(trunk_rev.as_str()),
+        )
     };
     updated.write(repo.inner(), &target)?;
     tx.record_after(&repo, &target)?;
+    tx.record_known_metadata_after(
+        &target,
+        ref_oid(workdir, &format!("refs/branch-metadata/{}", target)).as_deref(),
+    );
 
     tx.finish_ok()?;
 
@@ -114,4 +142,20 @@ pub fn run(branch: Option<String>, yes: bool) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Resolve a ref to its OID via a git subprocess; `None` when absent.
+/// Branch metadata refs are written with `git update-ref` (see
+/// `git::refs::write_metadata`), which libgit2's cached refdb may not observe
+/// within the same process — mirrors `split.rs`/`branch/create.rs`'s `ref_oid`.
+fn ref_oid(workdir: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(workdir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }

--- a/tests/detach_tests.rs
+++ b/tests/detach_tests.rs
@@ -1,6 +1,138 @@
 use crate::common;
 use common::{OutputAssertions, TestRepo};
 
+/// Read the newest op receipt under `.git/stax/ops` as JSON.
+fn latest_receipt(repo: &TestRepo) -> serde_json::Value {
+    let ops_dir = repo.path().join(".git/stax/ops");
+    let mut entries: Vec<_> = std::fs::read_dir(&ops_dir)
+        .expect("read ops dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    entries.sort_by_key(|e| {
+        e.metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    let newest = entries.last().expect("expected at least one op receipt");
+    let content = std::fs::read_to_string(newest.path()).expect("read receipt");
+    serde_json::from_str(&content).expect("invalid receipt JSON")
+}
+
+/// Read a branch's stax metadata blob (`refs/branch-metadata/<branch>`) as JSON.
+fn metadata_json(repo: &TestRepo, branch: &str) -> serde_json::Value {
+    let output = repo.git(&["show", &format!("refs/branch-metadata/{}", branch)]);
+    serde_json::from_str(&TestRepo::stdout(&output))
+        .unwrap_or_else(|_| panic!("metadata for {} should be JSON", branch))
+}
+
+#[test]
+fn detach_records_metadata_refs_in_the_op_receipt() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+    let branches = repo.create_stack(&["meta-a", "meta-b", "meta-c"]);
+    let (b, c) = (&branches[1], &branches[2]);
+
+    repo.run_stax(&["checkout", b]).assert_success();
+    repo.run_stax(&["detach", "--yes"]).assert_success();
+
+    let receipt = latest_receipt(&repo);
+    assert_eq!(receipt["kind"], "detach");
+    assert_eq!(receipt["status"], "success");
+    let local_refs = receipt["local_refs"].as_array().expect("local_refs array");
+
+    for branch in [b, c] {
+        let label = format!("{}@meta", branch);
+        let entry = local_refs
+            .iter()
+            .find(|e| e["branch"].as_str() == Some(label.as_str()))
+            .unwrap_or_else(|| panic!("expected {} entry in receipt: {:#}", label, receipt));
+        assert_eq!(
+            entry["refname"].as_str(),
+            Some(format!("refs/branch-metadata/{}", branch).as_str())
+        );
+        assert!(
+            entry["oid_before"].is_string(),
+            "{} needs a before-OID",
+            label
+        );
+        assert!(
+            entry["oid_after"].is_string(),
+            "{} needs an after-OID",
+            label
+        );
+        assert_ne!(
+            entry["oid_before"], entry["oid_after"],
+            "{}'s metadata blob changed, the receipt must show it",
+            label
+        );
+    }
+}
+
+#[test]
+fn detach_undo_restores_reparented_children_metadata() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+    let branches = repo.create_stack(&["undo-a", "undo-b", "undo-c"]);
+    let (a, b, c) = (&branches[0], &branches[1], &branches[2]);
+
+    let c_meta_before = metadata_json(&repo, c);
+    assert_eq!(c_meta_before["parentBranchName"].as_str(), Some(b.as_str()));
+
+    repo.run_stax(&["checkout", b]).assert_success();
+    repo.run_stax(&["detach", "--yes"]).assert_success();
+
+    // Precondition: detach really did reparent c onto a.
+    let c_meta_after = metadata_json(&repo, c);
+    assert_eq!(c_meta_after["parentBranchName"].as_str(), Some(a.as_str()));
+
+    repo.run_stax(&["undo", "--yes"]).assert_success();
+
+    let c_meta_undone = metadata_json(&repo, c);
+    assert_eq!(
+        c_meta_undone["parentBranchName"].as_str(),
+        Some(b.as_str()),
+        "undo must restore c's parent to b, got: {:#}",
+        c_meta_undone
+    );
+    assert_eq!(
+        c_meta_undone["parentBranchRevision"], c_meta_before["parentBranchRevision"],
+        "undo must restore c's recorded parent revision exactly"
+    );
+}
+
+#[test]
+fn detach_undo_restores_the_detached_branchs_own_metadata() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+    let branches = repo.create_stack(&["self-a", "self-b"]);
+    let (a, b) = (&branches[0], &branches[1]);
+
+    let b_meta_before = metadata_json(&repo, b);
+    assert_eq!(b_meta_before["parentBranchName"].as_str(), Some(a.as_str()));
+
+    repo.run_stax(&["checkout", b]).assert_success();
+    repo.run_stax(&["detach", "--yes"]).assert_success();
+    assert_eq!(
+        metadata_json(&repo, b)["parentBranchName"].as_str(),
+        Some("main")
+    );
+
+    repo.run_stax(&["undo", "--yes"]).assert_success();
+
+    let b_meta_undone = metadata_json(&repo, b);
+    assert_eq!(
+        b_meta_undone["parentBranchName"].as_str(),
+        Some(a.as_str()),
+        "undo must restore b's parent to a, got: {:#}",
+        b_meta_undone
+    );
+    assert_eq!(
+        b_meta_undone["parentBranchRevision"],
+        b_meta_before["parentBranchRevision"]
+    );
+}
+
 #[test]
 fn test_detach_middle_of_stack() {
     let repo = TestRepo::new();


### PR DESCRIPTION
## Summary

First of a stack of fixes from a broader test-coverage audit prompted by the #830 series — after fixing 5 confirmed instances of unguarded `parentBranchRevision` writes and the diagnosability gaps around them, I ran `cargo llvm-cov` over the full suite and dug into the highest-risk, lowest-coverage areas of the codebase (git-mutating code, not just UI). This is the worst finding.

`stax detach`'s `Transaction` only planned/recorded each branch's HEAD ref via `plan_branch`/`record_after`. But `detach` never moves any branch's HEAD at all — its only mutation is rewriting `parentBranchName`/`parentBranchRevision` in each branch's *metadata* ref (`refs/branch-metadata/<branch>`). Since the tracked ref never changes, `oid_before == oid_after` for every entry the receipt records, so **`stax undo` after `stax detach` appeared to succeed but silently reversed nothing** — no error, a plausible-looking receipt, but the reparenting stayed in place.

## Fix

- Plan and record `refs/branch-metadata/<branch>` too, for the detached branch and every reparented child, via `plan_metadata_ref` + a subprocess-resolved `ref_oid` helper + `record_known_metadata_after` — metadata refs are written by a `git update-ref` subprocess, which libgit2's cached refdb can miss, so after-OIDs can't come from the same `record_metadata_ref_after`/libgit2 path used for before-OIDs. Same pattern used at every other site fixed this session (`sync.rs`, `split.rs`, `split_hunk/app.rs`, `branch/create.rs`).
- Routed the new `parentBranchRevision` through `GitRepo::resolve_child_parent_boundary` (merge-base tried first, then the tip, then the previously recorded value) instead of a raw `unwrap_or_else` fallback to an unverified branch tip — consistent with the #830 fixes. Behavior is unchanged in the normal case, since a merge-base is by definition an ancestor.

## Test plan

- [x] Three new tests, empirically confirmed to **fail against the unfixed code** (receipt missing the `@meta` entries; both undo tests showing `parentBranchName` still at its post-detach value even though `stax undo` exited 0) and pass after the fix: `detach_records_metadata_refs_in_the_op_receipt`, `detach_undo_restores_reparented_children_metadata`, `detach_undo_restores_the_detached_branchs_own_metadata`.
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] All 8 `detach_tests` (5 pre-existing + 3 new), plus `create_undo_tests`/`sync_undo_tests`/`split_tests`/`fold_tests` (41 tests) — pass
- [x] `make test` (full suite, 2620 tests) — pass
- [x] Independent verifier confirmed the `resolve_child_parent_boundary` candidate ordering/fallback is correct and behavior-preserving in the happy path, and that subprocess-resolved recording (not libgit2) is used throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)