### PR TITLE
fix(edit): track metadata ref for undo, and fix a real cp bug in the rebase editor

### DIFF
--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -8,6 +8,7 @@ use console::Term;
 use dialoguer::Select;
 use dialoguer::theme::ColorfulTheme;
 use std::io::Write;
+use std::path::Path;
 use std::process::Command;
 
 /// Commit info parsed from `git log`.
@@ -70,7 +71,7 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
     // Find the parent branch boundary
     let meta = BranchMetadata::read(repo.inner(), &current)?
         .ok_or_else(|| anyhow::anyhow!("Branch '{}' is not tracked by stax", current))?;
-    let parent = &meta.parent_branch_name;
+    let parent = meta.parent_branch_name.clone();
     let child_branches = stack.descendants(&current);
 
     // Get commits between parent and HEAD (oldest first)
@@ -256,9 +257,45 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
         }
     }
 
-    // Create undo snapshot
-    let mut tx = Transaction::begin(OpKind::Edit, &repo, false)?;
-    tx.plan_branch(&repo, &current)?;
+    apply_edit_plan(
+        &repo,
+        &current,
+        meta,
+        &commits,
+        &actions,
+        no_verify,
+        &child_branches,
+    )
+}
+
+/// Apply an edit plan: rebase `current`'s commits per `actions`, then refresh the
+/// branch's stax metadata inside an undo transaction.
+///
+/// Split out of `run()` so the non-interactive half is directly testable
+/// without a pty -- `run()`'s per-commit `dialoguer::Select` loop requires a
+/// real terminal, which the unit tests in this module's `mod tests` bypass
+/// entirely by calling this function directly. A real end-to-end CLI test
+/// exists too (`edit_drop_via_real_interactive_session_updates_metadata_and_supports_undo`
+/// in `tests/edit_tests.rs`, driven through a pty).
+fn apply_edit_plan(
+    repo: &GitRepo,
+    current: &str,
+    meta: BranchMetadata,
+    commits: &[CommitInfo],
+    actions: &[EditAction],
+    no_verify: bool,
+    child_branches: &[String],
+) -> Result<()> {
+    let workdir = repo.workdir()?;
+    let parent = meta.parent_branch_name.clone();
+
+    // Create undo snapshot. A successful edit rewrites BOTH the branch head and
+    // the branch's `refs/branch-metadata/<branch>` blob (parentBranchRevision),
+    // so the metadata ref MUST be planned and recorded too -- otherwise `stax undo`
+    // restores the commits but leaves the post-edit boundary behind (issue #835 family).
+    let mut tx = Transaction::begin(OpKind::Edit, repo, false)?;
+    tx.plan_branch(repo, current)?;
+    tx.plan_metadata_ref(repo, current)?;
     tx.snapshot()?;
 
     // Build the rebase todo list
@@ -276,14 +313,18 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
     let todo_path = tmp.path().to_string_lossy().to_string();
 
     // Run git rebase -i with GIT_SEQUENCE_EDITOR that replaces the todo.
-    // Quote the source path to handle paths with spaces.
-    let editor_cmd = format!("cp '{}' \"$1\"", todo_path.replace('\'', "'\\''"));
+    // Quote the source path to handle paths with spaces. No explicit destination
+    // arg: git's editor launcher always appends `"$@"` (the todo-file path) to
+    // whatever command is configured, so an explicit `"$1"` here would make `cp`
+    // see the destination twice (`cp src dest dest`) and fail with
+    // "target ... Not a directory".
+    let editor_cmd = format!("cp '{}'", todo_path.replace('\'', "'\\''"));
 
     let mut rebase_args = vec!["rebase", "-i"];
     if no_verify {
         rebase_args.push("--no-verify");
     }
-    rebase_args.push(parent);
+    rebase_args.push(parent.as_str());
 
     let rebase_status = Command::new("git")
         .args(&rebase_args)
@@ -293,14 +334,21 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
 
     if rebase_status.success() {
         // Update metadata to reflect new parent boundary
-        let parent_rev = repo.branch_commit(parent)?;
+        let parent_rev = repo.branch_commit(&parent)?;
         let updated = BranchMetadata {
             parent_branch_revision: parent_rev,
             ..meta
         };
-        updated.write(repo.inner(), &current)?;
+        updated.write(repo.inner(), current)?;
 
-        tx.record_after(&repo, &current)?;
+        tx.record_after(repo, current)?;
+        // Resolved via subprocess, not `record_metadata_ref_after`: the write
+        // above goes through `git update-ref`, which libgit2's cached refdb in
+        // `repo` may not observe within this process.
+        tx.record_known_metadata_after(
+            current,
+            ref_oid(workdir, &format!("refs/branch-metadata/{}", current)).as_deref(),
+        );
         tx.finish_ok()?;
 
         println!("{}", "Edit applied successfully.".green());
@@ -328,9 +376,221 @@ pub fn run(yes: bool, no_verify: bool) -> Result<()> {
                 .yellow()
         );
     } else {
-        tx.finish_err("rebase failed", Some("edit"), Some(&current))?;
+        tx.finish_err("rebase failed", Some("edit"), Some(current))?;
         bail!("Rebase failed. Run `stax undo` to restore the previous state.");
     }
 
     Ok(())
+}
+
+/// Resolve a ref to its OID via a git subprocess; `None` when absent.
+/// Branch metadata refs are written with `git update-ref` (see
+/// `git::refs::write_metadata`), which libgit2's cached refdb may not observe
+/// within the same process -- mirrors `detach.rs`/`split.rs`'s `ref_oid`.
+fn ref_oid(workdir: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(workdir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::{NoopOperationReporter, RepositorySession};
+    use crate::ops::receipt::OpReceipt;
+
+    fn git_hermetic(cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env(
+                "GIT_CONFIG_GLOBAL",
+                if cfg!(windows) { "NUL" } else { "/dev/null" },
+            )
+            .env(
+                "GIT_CONFIG_SYSTEM",
+                if cfg!(windows) { "NUL" } else { "/dev/null" },
+            )
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// Build `main` (base -> M1) with `feature` (F1, F2) forked at `base`, and
+    /// record feature's metadata boundary as `base`. `main` is deliberately
+    /// advanced past the recorded boundary so that a successful edit rewrites
+    /// `parentBranchRevision` to a genuinely different value -- otherwise the
+    /// metadata blob would be rewritten byte-identically and its ref OID would
+    /// not move, making the assertions vacuous.
+    ///
+    /// Returns `(base_oid, main_tip_oid)`. Leaves `feature` checked out.
+    fn setup(dir: &Path) -> (String, String) {
+        git_hermetic(dir, &["init", "-b", "main"]);
+        git_hermetic(dir, &["config", "user.name", "Test"]);
+        git_hermetic(dir, &["config", "user.email", "test@example.com"]);
+        // Local config wins over the developer's global config; the `git rebase`
+        // subprocess inside apply_edit_plan does not get GIT_CONFIG_GLOBAL.
+        git_hermetic(dir, &["config", "commit.gpgsign", "false"]);
+        git_hermetic(
+            dir,
+            &["config", "core.hooksPath", "/nonexistent-stax-hooks"],
+        );
+
+        std::fs::write(dir.join("base.txt"), "base\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "base"]);
+        let base_oid = git_hermetic(dir, &["rev-parse", "HEAD"]);
+
+        GitRepo::open_from_path(dir)
+            .unwrap()
+            .set_trunk("main")
+            .unwrap();
+
+        git_hermetic(dir, &["checkout", "-b", "feature"]);
+        std::fs::write(dir.join("f1.txt"), "f1\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "F1"]);
+        std::fs::write(dir.join("f2.txt"), "f2\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "F2"]);
+
+        git_hermetic(dir, &["checkout", "main"]);
+        std::fs::write(dir.join("m1.txt"), "m1\n").unwrap();
+        git_hermetic(dir, &["add", "-A"]);
+        git_hermetic(dir, &["commit", "-m", "M1"]);
+        let main_tip = git_hermetic(dir, &["rev-parse", "HEAD"]);
+
+        git_hermetic(dir, &["checkout", "feature"]);
+        let repo = GitRepo::open_from_path(dir).unwrap();
+        BranchMetadata::new("main", &base_oid)
+            .write(repo.inner(), "feature")
+            .unwrap();
+
+        (base_oid, main_tip)
+    }
+
+    /// Same `git log` shape `run()` parses into its commit list.
+    fn collect_commits(dir: &Path) -> Vec<CommitInfo> {
+        git_hermetic(dir, &["log", "--reverse", "--format=%H %s", "main..HEAD"])
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|line| {
+                let (sha, message) = line.split_once(' ').unwrap_or((line, ""));
+                CommitInfo {
+                    sha: sha.to_string(),
+                    message: message.to_string(),
+                }
+            })
+            .collect()
+    }
+
+    /// A successful edit rewrites `parentBranchRevision`; that write must be
+    /// tracked in the op receipt or `stax undo` cannot reverse it.
+    #[test]
+    fn edit_records_the_branch_metadata_ref_in_the_op_receipt() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path();
+        let (base_oid, main_tip) = setup(dir);
+
+        let repo = GitRepo::open_from_path(dir).unwrap();
+        let meta = BranchMetadata::read(repo.inner(), "feature")
+            .unwrap()
+            .unwrap();
+        let commits = collect_commits(dir);
+        assert_eq!(commits.len(), 2);
+        let meta_oid_before = git_hermetic(dir, &["rev-parse", "refs/branch-metadata/feature"]);
+
+        // Drop the second commit -- `drop` is always legal on a non-first commit.
+        let actions = [EditAction::Pick, EditAction::Drop];
+        apply_edit_plan(&repo, "feature", meta, &commits, &actions, true, &[]).unwrap();
+
+        let meta_oid_after = git_hermetic(dir, &["rev-parse", "refs/branch-metadata/feature"]);
+        assert_ne!(
+            meta_oid_before, meta_oid_after,
+            "the edit must have rewritten the metadata blob"
+        );
+
+        // Re-open: the metadata blob was written by a `git update-ref`
+        // subprocess, which the original handle's cached refdb may not see.
+        let reopened = GitRepo::open_from_path(dir).unwrap();
+        let updated = BranchMetadata::read(reopened.inner(), "feature")
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.parent_branch_revision, main_tip);
+        assert_ne!(updated.parent_branch_revision, base_oid);
+
+        let receipt = OpReceipt::load_latest(reopened.git_dir().unwrap())
+            .unwrap()
+            .expect("edit should have written a receipt");
+        let entry = receipt
+            .local_refs
+            .iter()
+            .find(|e| e.branch == "feature@meta")
+            .expect("feature@meta must be tracked so `stax undo` can restore parentBranchRevision");
+        assert_eq!(entry.oid_before.as_deref(), Some(meta_oid_before.as_str()));
+        assert_eq!(entry.oid_after.as_deref(), Some(meta_oid_after.as_str()));
+        assert!(entry.after_recorded);
+    }
+
+    /// End-to-end: `stax undo` after `stax edit` must restore the branch head
+    /// *and* the pre-edit `parentBranchRevision`.
+    #[test]
+    fn undo_after_edit_restores_the_pre_edit_parent_branch_revision() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path();
+        let (base_oid, main_tip) = setup(dir);
+
+        let repo = GitRepo::open_from_path(dir).unwrap();
+        let meta = BranchMetadata::read(repo.inner(), "feature")
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.parent_branch_revision, base_oid);
+        let commits = collect_commits(dir);
+        let head_before = git_hermetic(dir, &["rev-parse", "feature"]);
+
+        let actions = [EditAction::Pick, EditAction::Drop];
+        apply_edit_plan(&repo, "feature", meta, &commits, &actions, true, &[]).unwrap();
+
+        let after = GitRepo::open_from_path(dir).unwrap();
+        let edited = BranchMetadata::read(after.inner(), "feature")
+            .unwrap()
+            .unwrap();
+        assert_eq!(edited.parent_branch_revision, main_tip);
+        assert_ne!(git_hermetic(dir, &["rev-parse", "feature"]), head_before);
+        assert_eq!(
+            git_hermetic(dir, &["log", "--format=%s", "main..feature"])
+                .lines()
+                .count(),
+            1,
+            "the drop should have removed one commit"
+        );
+
+        // Same code path `stax undo` uses (see commands/undo.rs).
+        RepositorySession::open(dir)
+            .unwrap()
+            .undo_transaction(None, false, &mut NoopOperationReporter)
+            .unwrap();
+
+        let restored_repo = GitRepo::open_from_path(dir).unwrap();
+        let restored = BranchMetadata::read(restored_repo.inner(), "feature")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            restored.parent_branch_revision, base_oid,
+            "undo must restore the pre-edit parentBranchRevision, not leave the post-edit one"
+        );
+        assert_eq!(git_hermetic(dir, &["rev-parse", "feature"]), head_before);
+    }
 }

--- a/tests/edit_tests.rs
+++ b/tests/edit_tests.rs
@@ -5,7 +5,7 @@
 
 use crate::common;
 
-use common::{OutputAssertions, TestRepo};
+use common::{OutputAssertions, TestRepo, run_stax_in_script_with_env};
 
 #[test]
 fn edit_on_trunk_fails() {
@@ -161,5 +161,110 @@ fn edit_yes_still_requires_terminal_for_action_selection() {
         stderr.contains("--yes") && stderr.contains("Interactive terminal"),
         "Expected explicit --yes terminal guidance, got: {}",
         stderr
+    );
+}
+
+/// Real end-to-end `stax edit`, driven through a pty like the interactive
+/// prompts it actually uses -- not the extracted `apply_edit_plan` unit tests,
+/// which bypass the terminal entirely. This is the path a previous bug in the
+/// `GIT_SEQUENCE_EDITOR` command string (fixed alongside the metadata-tracking
+/// fix below) went unexercised by: every other test in this file either stops
+/// before the rebase runs, or drives `git rebase -i` directly instead of going
+/// through `stax edit`'s own binary.
+#[test]
+fn edit_drop_via_real_interactive_session_updates_metadata_and_supports_undo() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["create", "feature"]).assert_success();
+    repo.create_file("f1.txt", "f1");
+    repo.commit("F1 first");
+    repo.create_file("f2.txt", "f2");
+    repo.commit("F2 second");
+
+    // Advance main past the recorded boundary so a successful edit genuinely
+    // moves parentBranchRevision (otherwise the metadata blob would be
+    // rewritten byte-identically and the fix's own tests would be vacuous).
+    repo.run_stax(&["checkout", "main"]).assert_success();
+    repo.create_file("m1.txt", "m1");
+    repo.commit("M1");
+    let main_tip = repo.get_commit_sha("main");
+    repo.run_stax(&["checkout", "feature"]).assert_success();
+
+    let head_before = repo.get_commit_sha("feature");
+    let meta_before_output = repo.git(&["show", "refs/branch-metadata/feature"]);
+    let meta_before: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&meta_before_output)).expect("valid JSON");
+    let parent_rev_before = meta_before["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+
+    let home = repo.clean_home();
+    let output = run_stax_in_script_with_env(
+        &repo.path(),
+        &["edit", "--yes"],
+        // Commit 1/2 menu (pick/reword/drop): Enter keeps the default "pick".
+        // Commit 2/2 menu (pick/reword/squash/fixup/drop): four Down presses
+        // reach "drop", then Enter. `--yes` skips the final confirmation.
+        "wait_for_tui_text \"[1/2]\"; printf '\\n'; \
+         wait_for_tui_text \"[2/2]\"; printf '\\033[B\\033[B\\033[B\\033[B\\n'",
+        &[("HOME", &home)],
+    );
+    assert!(
+        output.status.success(),
+        "stax edit should succeed; stdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        TestRepo::stdout(&output).contains("Edit applied successfully"),
+        "expected success message, got: {}",
+        TestRepo::stdout(&output)
+    );
+
+    assert_ne!(
+        repo.get_commit_sha("feature"),
+        head_before,
+        "the drop should have rewritten feature's head"
+    );
+    let log_after = repo.git(&["log", "--format=%s", "main..feature"]);
+    let messages = TestRepo::stdout(&log_after);
+    assert_eq!(
+        messages.lines().count(),
+        1,
+        "expected exactly one commit after dropping F2, got: {}",
+        messages
+    );
+    assert!(messages.contains("F1 first"));
+
+    let meta_output = repo.git(&["show", "refs/branch-metadata/feature"]);
+    let meta: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&meta_output)).expect("valid metadata JSON");
+    assert_eq!(
+        meta["parentBranchRevision"].as_str(),
+        Some(main_tip.as_str()),
+        "parentBranchRevision should have advanced to main's tip after a real edit"
+    );
+
+    // `stax undo` must restore both the branch head and the pre-edit metadata.
+    let undo_output = repo.run_stax(&["undo", "--yes"]);
+    assert!(
+        undo_output.status.success(),
+        "stax undo should succeed; stderr: {}",
+        TestRepo::stderr(&undo_output)
+    );
+    assert_eq!(
+        repo.get_commit_sha("feature"),
+        head_before,
+        "undo should restore feature's pre-edit head"
+    );
+    let restored_meta_output = repo.git(&["show", "refs/branch-metadata/feature"]);
+    let restored_meta: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&restored_meta_output)).expect("valid JSON");
+    assert_eq!(
+        restored_meta["parentBranchRevision"].as_str(),
+        Some(parent_rev_before.as_str()),
+        "undo must restore the pre-edit parentBranchRevision, not leave the post-edit one"
     );
 }


### PR DESCRIPTION
## Summary

Second in the stack of fixes from the broader test-coverage audit (see #842 for the first).

`stax edit`'s `Transaction` only tracked the branch's HEAD ref, never its metadata ref, even though a successful edit rewrites `parentBranchRevision`. `stax undo` after `stax edit` correctly restored the branch's commits (HEAD was tracked) but left `parentBranchRevision` at its post-edit value instead of the pre-edit one — same family of bug as `detach.rs` (#842).

## A second, unrelated bug found and fixed along the way

`stax edit`'s per-commit action selection requires a real terminal — even `--yes` doesn't help, confirmed by an existing test asserting exactly that. So fixing the metadata-tracking gap required extracting the non-interactive tail of `run()` into a separate, directly-testable `apply_edit_plan()` function first.

While doing that extraction, I found a second, completely unrelated, pre-existing bug: the `GIT_SEQUENCE_EDITOR` command string was `cp '<todo>' "$1"`. Git's editor launcher always appends the todo-file path as `"$@"` to whatever command is configured — so the explicit `"$1"` made `cp` receive the destination path twice (`cp src dest dest`), which fails with `cp: target ... Not a directory`. **This means `stax edit`'s actual rebase step never completed successfully for any real invocation.** I independently reproduced this in isolation outside the test suite to confirm it, and traced why it survived: the one existing test that performs a real rebase drives `git rebase -i` directly instead of going through `stax edit`'s own binary, and happens to use the correct form by coincidence — so this exact code path in the shipped binary was never exercised by any test.

## Fix

- `apply_edit_plan()` now plans/records `refs/branch-metadata/<branch>` via the same subprocess-resolved `ref_oid` + `record_known_metadata_after` pattern used at every other site this session (metadata refs are written via `git update-ref`, which libgit2's cached refdb can miss).
- Fixed the `cp` command string to `cp '<todo>'` (no `"$1"`).
- Added a real end-to-end test driven through a pty (not just unit tests against the extracted function, which bypass the terminal) that exercises the actual interactive `stax edit` binary — this is the test that would have caught both bugs, and does catch the `cp` regression when reverted.

## Test plan

- [x] Two new unit tests against `apply_edit_plan` directly, empirically confirmed to fail against the unfixed metadata-tracking code and pass after.
- [x] One new real end-to-end pty-driven test (`edit_drop_via_real_interactive_session_updates_metadata_and_supports_undo`), empirically confirmed to fail with the exact real-world `cp` error when the `cp` fix is reverted, and pass with both fixes applied — including a full `stax undo` round-trip verified at the CLI level.
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] All `edit_tests`/`commands::edit::tests` (9 tests) plus `detach_tests`/`sync_undo_tests` (26 tests) — pass
- [x] `make test` (full suite, 2626 tests) — pass
- [x] Independent verifier review: confirmed the `cp` bug three separate ways (raw git semantics, reverting just that line against the new tests, and a manual pty-driven CLI run), confirmed the extraction is behavior-preserving for the interactive path, and confirmed the borrow-trap fix (`meta.parent_branch_name.clone()`) doesn't change behavior elsewhere in `run()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)