### PR TITLE
fix(restack): verify ancestry when recovering metadata after a manual rebase --continue

### DIFF
--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -56,13 +56,24 @@ pub fn run(
             {
                 if let Some(meta) = BranchMetadata::read(repo.inner(), failed_branch)?
                     && let Ok(actual_parent_rev) = repo.branch_commit(&meta.parent_branch_name)
-                    && meta.parent_branch_revision != actual_parent_rev
                 {
-                    let updated = BranchMetadata {
-                        parent_branch_revision: actual_parent_rev,
-                        ..meta
-                    };
-                    updated.write(repo.inner(), failed_branch)?;
+                    // `actual_parent_rev` is only a valid boundary if `failed_branch` was
+                    // actually rebased onto it. If the parent advanced again during the
+                    // pause window (between the conflict and a manual `git rebase
+                    // --continue`), it wasn't -- verify ancestry before trusting it, else
+                    // keep the previously recorded (still-valid) boundary (see #830).
+                    let resolved = repo.resolve_child_parent_boundary(
+                        failed_branch,
+                        &[Some(actual_parent_rev.as_str())],
+                        &meta.parent_branch_revision,
+                    );
+                    if resolved != meta.parent_branch_revision {
+                        let updated = BranchMetadata {
+                            parent_branch_revision: resolved,
+                            ..meta
+                        };
+                        updated.write(repo.inner(), failed_branch)?;
+                    }
                 }
                 completed_from_receipt.insert(failed_branch.to_string());
             }

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -287,7 +287,11 @@ fn restack_continue_after_manual_rebase_continue_and_parent_advance_keeps_ancest
     // `stax continue` -- this is the exact scenario the bug requires: stax's own
     // metadata write for `race-b` never runs.
     repo.resolve_conflicts_ours();
-    let manual_continue = repo.git(&["rebase", "--continue"]);
+    // `rebase --continue` after a conflict opens an editor to confirm the
+    // commit message; force a no-op editor so this doesn't depend on the
+    // ambient environment having one configured (it isn't in CI's dumb
+    // terminal, which otherwise fails with "Terminal is dumb, but EDITOR unset").
+    let manual_continue = repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")]);
     assert!(
         manual_continue.status.success(),
         "manual git rebase --continue should complete: {}",

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -252,6 +252,86 @@ fn test_continue_resumes_remaining_restack_after_conflict() {
     );
 }
 
+#[test]
+fn restack_continue_after_manual_rebase_continue_and_parent_advance_keeps_ancestry_valid_boundary()
+{
+    let repo = TestRepo::new();
+
+    // main -> A -> B, with a change on B that will conflict with a later A commit.
+    repo.run_stax(&["bc", "race-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("shared.txt", "a1\n");
+    repo.commit("A1");
+
+    repo.run_stax(&["bc", "race-b"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("shared.txt", "a1\nb\n");
+    repo.commit("B commit");
+
+    // Advance A with a conflicting change so restacking B triggers a real conflict.
+    repo.run_stax(&["checkout", &branch_a]);
+    repo.create_file("shared.txt", "a2\n");
+    repo.commit("A2");
+
+    repo.run_stax(&["checkout", &branch_b]);
+    let output = repo.run_stax(&["restack"]);
+    assert!(
+        !output.status.success(),
+        "expected restack to conflict\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(repo.has_rebase_in_progress());
+
+    // Resolve and complete the rebase MANUALLY (git rebase --continue), not via
+    // `stax continue` -- this is the exact scenario the bug requires: stax's own
+    // metadata write for `race-b` never runs.
+    repo.resolve_conflicts_ours();
+    let manual_continue = repo.git(&["rebase", "--continue"]);
+    assert!(
+        manual_continue.status.success(),
+        "manual git rebase --continue should complete: {}",
+        TestRepo::stderr(&manual_continue)
+    );
+    assert!(!repo.has_rebase_in_progress());
+
+    // Advance A AGAIN during the "pause" window -- B's real tip only contains
+    // A2, not this next commit.
+    repo.run_stax(&["checkout", &branch_a]);
+    repo.create_file("shared.txt", "a2\na3\n");
+    repo.commit("A3");
+    repo.run_stax(&["checkout", &branch_b]);
+
+    let recovery = repo.run_stax(&["restack", "--continue"]);
+    assert!(
+        recovery.status.success(),
+        "restack --continue recovery should succeed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&recovery),
+        TestRepo::stderr(&recovery)
+    );
+
+    let meta_output = repo.git(&["show", &format!("refs/branch-metadata/{}", branch_b)]);
+    let meta: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&meta_output)).expect("valid JSON");
+    let boundary = meta["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &branch_b]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {} (issue #830)",
+        boundary,
+        branch_b
+    );
+    let a_tip_after_third_commit = repo.get_commit_sha(&branch_a);
+    assert_ne!(
+        boundary, a_tip_after_third_commit,
+        "boundary must not have been stamped to the parent's latest tip, which B was never rebased onto"
+    );
+}
+
 // =============================================================================
 // Sync Continue Tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Third in the stack of fixes from the broader test-coverage audit (see #842, #844 for the first two).

When `stax restack --continue` recovers from a rebase that was completed *manually* (`git rebase --continue` instead of `stax continue`), it blindly stamped the parent branch's current tip as `parentBranchRevision` — same #830 pattern fixed at five other sites earlier this session. If the parent advanced again during the pause window between the conflict and the manual completion, the child was never actually rebased onto that newer tip — poisoning the boundary for the next restack.

## Fix

Route the value through the existing `GitRepo::resolve_child_parent_boundary` helper (added in the original #830 fix): only trust the parent's current tip if it's verified to be an ancestor of the child, else keep the previously recorded (still-valid) boundary. Behavior is unchanged in the normal (non-race) case, since the resolved value equals the parent's tip whenever it really is an ancestor — confirmed via case analysis and by an independent verifier.

## Test plan

- [x] New test reproduces the exact race (conflict → resolve → manual `git rebase --continue`, bypassing stax's own metadata write entirely → parent advances *again* → `stax restack --continue`), empirically confirmed to fail against the unfixed code (`Recorded boundary ... is not an ancestor` panic) and pass after.
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] `continue_tests::` (13 tests) — pass
- [x] `make test` (full suite, 2627 tests) — pass, confirmed independently twice
- [x] Independent verifier confirmed structurally: the candidate/fallback ordering is correct for this recovery context (no second "old parent" candidate exists here, unlike the reparent-on-deletion site), and the removed guard is provably redundant with the new one via full case analysis over ancestry × equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)