### PR TITLE
test(reorder): pin the metadata-ref after-OID invariant, confirmed safe not buggy

### DIFF
--- a/src/ops/tx.rs
+++ b/src/ops/tx.rs
@@ -231,6 +231,17 @@ impl Transaction {
     /// may be absent (e.g., metadata was deleted) — that's recorded as
     /// `oid_after = None`, which `stax undo` handles by re-creating the ref
     /// from `oid_before`.
+    ///
+    /// Safe for callers that only ever *write* a branch's metadata ref (via
+    /// `BranchMetadata::write` -> `git::refs::write_metadata`, a `git update-ref`
+    /// subprocess): `update-ref` always leaves a loose ref file, and libgit2 reads
+    /// loose refs straight off disk, ahead of the stat-cached packed-refs backend,
+    /// so there's no staleness window to worry about here (verified empirically,
+    /// including with the ref pre-packed via `git pack-refs`). Callers that instead
+    /// *delete* a metadata ref (`git update-ref -d`, which does rewrite packed-refs)
+    /// must resolve the after-OID via a subprocess `git rev-parse --verify <ref>`
+    /// helper and `record_known_metadata_after` instead — see `sync.rs`, `split.rs`,
+    /// `branch/create.rs`, `detach.rs`, `edit.rs`, `tui/split/app.rs` for the pattern.
     pub fn record_metadata_ref_after(&mut self, repo: &GitRepo, branch: &str) -> Result<()> {
         let oid = refs::metadata_ref_oid(repo.inner(), branch);
         self.receipt

--- a/tests/application_operation_tests.rs
+++ b/tests/application_operation_tests.rs
@@ -1052,3 +1052,120 @@ fn restack_success_receipt_persistence_failure_returns_in_memory_receipt() {
         OperationOutcome::Restacked { ref branches, .. } if branches == &vec![branch]
     ));
 }
+
+/// The op receipt's recorded after-OIDs must match what git itself reports.
+/// reorder/move_subtree record metadata-ref after-OIDs through libgit2
+/// (`Transaction::record_metadata_ref_after`) even though the refs are written
+/// by a `git update-ref` subprocess. That is safe only because `update-ref`
+/// always leaves a loose ref, which libgit2 reads from disk and which shadows
+/// packed-refs. The packed pass below removes the loose files first, pinning
+/// the case where libgit2's stat-cached packed backend is the only source --
+/// investigated during a broader test-coverage audit (issue #830 follow-up)
+/// and confirmed safe; this test exists so that finding doesn't need
+/// re-litigating if the write path here ever changes.
+#[test]
+fn reorder_and_move_record_metadata_after_oids_that_match_git() {
+    fn rev_parse(repo: &TestRepo, refname: &str) -> Option<String> {
+        let out = repo.git(&["rev-parse", "--verify", refname]);
+        out.status
+            .success()
+            .then(|| TestRepo::stdout(&out).trim().to_string())
+    }
+
+    fn latest_receipt(repo: &TestRepo) -> serde_json::Value {
+        let ops_dir = repository_git_dir(repo).join("stax").join("ops");
+        let mut entries: Vec<_> = std::fs::read_dir(&ops_dir)
+            .expect("read ops dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        entries.sort_by_key(|e| {
+            e.metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        });
+        let newest = entries.last().expect("expected at least one op receipt");
+        serde_json::from_str(&std::fs::read_to_string(newest.path()).unwrap()).unwrap()
+    }
+
+    fn assert_receipt_matches_git(repo: &TestRepo, branches: &[String], label: &str) {
+        let receipt = latest_receipt(repo);
+        let refs = receipt["local_refs"].as_array().unwrap();
+        for branch in branches {
+            for (entry_label, refname) in [
+                (branch.clone(), format!("refs/heads/{branch}")),
+                (
+                    format!("{branch}@meta"),
+                    format!("refs/branch-metadata/{branch}"),
+                ),
+            ] {
+                let entry = refs
+                    .iter()
+                    .find(|e| e["branch"] == serde_json::Value::String(entry_label.clone()))
+                    .unwrap_or_else(|| panic!("{label}: no receipt entry for {entry_label}"));
+                assert_eq!(entry["after_recorded"], serde_json::Value::Bool(true));
+                assert_eq!(
+                    entry["oid_after"].as_str().map(str::to_string),
+                    rev_parse(repo, &refname),
+                    "{label}: receipt oid_after for {entry_label} disagrees with git"
+                );
+            }
+            // The stamped boundary must really be in the branch's ancestry.
+            let meta: serde_json::Value = serde_json::from_str(&TestRepo::stdout(
+                &repo.git(&["show", &format!("refs/branch-metadata/{branch}")]),
+            ))
+            .unwrap();
+            let revision = meta["parentBranchRevision"].as_str().unwrap_or_default();
+            assert!(
+                repo.git(&["merge-base", "--is-ancestor", revision, branch])
+                    .status
+                    .success(),
+                "{label}: {branch} parentBranchRevision {revision} is not an ancestor"
+            );
+        }
+    }
+
+    for packed in [false, true] {
+        let label = if packed { "packed" } else { "loose" };
+
+        let repo = TestRepo::new();
+        repo.set_trunk("main");
+        let original = repo.create_stack(&["a", "b", "c"]);
+        let proposed = vec![
+            original[2].clone(),
+            original[0].clone(),
+            original[1].clone(),
+        ];
+        if packed {
+            repo.git(&["pack-refs", "--all"]).assert_success();
+            for branch in &original {
+                assert!(
+                    !repo
+                        .path()
+                        .join(".git/refs/branch-metadata")
+                        .join(branch)
+                        .exists(),
+                    "pack-refs should have removed the loose metadata ref for {branch}"
+                );
+            }
+        }
+        RepositorySession::open(repo.path())
+            .unwrap()
+            .reorder_stack(&original, &proposed, false, &mut NoopOperationReporter)
+            .unwrap();
+        assert_receipt_matches_git(&repo, &original, &format!("reorder/{label}"));
+
+        let repo = TestRepo::new();
+        repo.set_trunk("main");
+        let branches = repo.create_stack(&["a", "b", "c"]);
+        repo.git(&["checkout", "main"]).assert_success();
+        if packed {
+            repo.git(&["pack-refs", "--all"]).assert_success();
+        }
+        RepositorySession::open(repo.path())
+            .unwrap()
+            .move_subtree(&branches[1], "main", false, &mut NoopOperationReporter)
+            .unwrap();
+        assert_receipt_matches_git(&repo, &branches[1..], &format!("move_subtree/{label}"));
+    }
+}


### PR DESCRIPTION
## Summary

Fifth and final in the stack of fixes from the broader test-coverage audit (see #842, #844, #845, #846 for the first four).

## What was investigated

`application/reorder.rs` and `application/move_subtree.rs` both call `Transaction::record_metadata_ref_after`, which resolves a metadata ref's after-OID via libgit2 (`repo.find_reference`) even though metadata refs are written by a `git update-ref` **subprocess** — the exact pattern that turned out to be a real bug at 6 other sites fixed this session. Flagged during the audit as a "strong candidate, not confirmed via repro."

## What I found

**Not a bug.** Empirically confirmed via a real reorder and move-subtree operation, in both normal (loose refs) and adversarially-forced (`git pack-refs --all` beforehand) modes, that the recorded after-OIDs always match a fresh subprocess `git rev-parse`.

Root cause of why this differs from the 6 confirmed-buggy sites: `git update-ref` always leaves a loose ref file on disk, and libgit2 reads loose refs straight off disk, ahead of the stat-cached packed-refs backend — so there's no staleness window for a pure write. The staleness risk that bit the other 6 sites is specific to **deletion** (`git update-ref -d`, which does rewrite packed-refs and can leave libgit2 serving a stale cached value) — something neither `reorder.rs` nor `move_subtree.rs` ever does to a metadata ref.

I also checked the unguarded-ancestry-write pattern (bug class 1 from #830) at both files' `parent_branch_revision` writes — also not applicable here, since both writes happen immediately after a real, successful rebase onto that exact parent, with no metadata-only-reparent gap.

## What this PR does

No code fix — because none is needed. Instead:
- A regression test (`reorder_and_move_record_metadata_after_oids_that_match_git`, run in both loose and packed-refs modes) pins this invariant, so a future change to the write path here (e.g. switching to a delete-then-recreate strategy) would fail loudly instead of silently reintroducing the bug.
- A doc comment on `Transaction::record_metadata_ref_after` explaining precisely when it's safe (write-only callers) versus when it's not (callers that delete the ref, which must use the subprocess-resolved `record_known_metadata_after` pattern instead) — so this doesn't need re-investigating a third time.

## Test plan

- [x] New test passes in both loose-refs and packed-refs modes, confirming the invariant holds.
- [x] `cargo check && cargo clippy -- -D warnings && cargo fmt --check` — clean
- [x] `application_operation_tests::` + `ops::` (94 tests) — pass
- [x] `make test` (full suite, 2630 tests) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)