### PR TITLE
feat(user): add `stax user` command for personal preferences

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -186,6 +186,7 @@ when it points at the same commit. `--all` conflicts with `--parent` and
 |---|---|
 | `st auth` | Configure GitHub token (`--from-gh`, `--token <token>`, `status`) |
 | `st config` | Show current configuration |
+| `st user` | View or set personal preferences (`branch-prefix`, `branch-date`, `branch-replacement`, `editor`, `tips`, `submit-body`) |
 | `st config --set-ai` | Interactively set AI agent/model (global or per-feature) |
 | `st config --reset-ai` | Clear saved AI defaults and re-prompt (`--no-prompt` to clear only) |
 | `st --default-config` | Print annotated config template (all options and allowed values) |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -14,6 +14,29 @@ Config is loaded as follows:
 2. Otherwise, `~/.config/stax/config.toml` is loaded.
 3. If present, `stax.toml` at the current git repository root overlays only the values it sets.
 
+## User preferences
+
+`stax user` is a shortcut for setting common personal preferences in the global config, without hand-editing `config.toml`:
+
+```bash
+st user                                      # print current values
+st user branch-prefix --set "cesar/"         # config.branch.prefix
+st user branch-prefix --unset
+st user branch-date --enable                 # config.branch.date
+st user branch-date --disable
+st user branch-replacement --set "_"         # config.branch.replacement
+st user branch-replacement --set-dash        # shorthand for --set "-"
+st user branch-replacement --set-underscore  # shorthand for --set "_"
+st user editor --set vim                     # config.editor (falls back to $EDITOR when unset)
+st user editor --unset
+st user tips --enable                        # config.ui.tips
+st user tips --disable
+st user submit-body --enable                 # config.submit.commit_messages_in_body
+st user submit-body --disable
+```
+
+If `branch.format` is already set, `branch-date --enable`/`--disable` prints a warning: `format` takes precedence and the date toggle has no effect until `format` is unset.
+
 ## Example config
 
 Run `st --default-config` for the full annotated template (every section, with allowed values in comments). Copy the output to `~/.config/stax/config.toml` and uncomment only the keys you want to override.
@@ -30,6 +53,8 @@ single_stack = "on"    # "on" | "off"
 <summary>Full template (same as <code>st --default-config</code>)</summary>
 
 ```toml
+# editor = "vim" # preferred editor for interactive edits (e.g. `stax pr --edit`); falls back to $EDITOR
+
 [branch]
 # format = "{user}/{date}/{message}"
 # user = "cesar"
@@ -53,6 +78,7 @@ single_stack = "on"    # "on" | "off"
 # single_stack = "on"     # "on" | "off" — when "off", skip stack-link sync while the stack has only one PR
 # native_stack = "auto"   # "auto" | "off" | "link" — GitHub gh-stack registration; use "off" to disable entirely
 # stack_links_when_native = "keep" # "keep" | "off" — stax PR links when native registration succeeds
+# commit_messages_in_body = true # include a `## Summary` commit-message list in the default PR body
 
 [ci]
 # alert = false

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -765,6 +765,12 @@ pub(crate) enum Commands {
         command: Option<SkillsCommands>,
     },
 
+    /// View or set personal preferences (branch naming, editor, tips, submit body)
+    User {
+        #[command(subcommand)]
+        command: Option<UserSubcommand>,
+    },
+
     /// Switch to the trunk branch, or set it with `stax trunk <branch>`
     #[command(visible_alias = "t")]
     Trunk {
@@ -1492,6 +1498,67 @@ pub(crate) enum Commands {
 pub(crate) enum AuthSubcommand {
     /// Show which auth source is currently active
     Status,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum UserSubcommand {
+    /// Prefix applied to new branch names (e.g. "cesar/")
+    BranchPrefix {
+        /// Set the branch prefix
+        #[arg(long)]
+        set: Option<String>,
+        /// Clear the branch prefix
+        #[arg(long, conflicts_with = "set")]
+        unset: bool,
+    },
+    /// Whether new branch names include a date
+    BranchDate {
+        /// Include a date in new branch names
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+        /// Do not include a date in new branch names
+        #[arg(long)]
+        disable: bool,
+    },
+    /// Character used to replace spaces and special chars in branch names
+    BranchReplacement {
+        /// Set the replacement character
+        #[arg(long, conflicts_with_all = ["set_dash", "set_underscore"])]
+        set: Option<String>,
+        /// Shorthand for --set "-"
+        #[arg(long, conflicts_with = "set_underscore")]
+        set_dash: bool,
+        /// Shorthand for --set "_"
+        #[arg(long)]
+        set_underscore: bool,
+    },
+    /// Preferred editor for interactive text edits (e.g. `stax pr --edit`)
+    Editor {
+        /// Set the preferred editor
+        #[arg(long)]
+        set: Option<String>,
+        /// Clear the preferred editor (fall back to $EDITOR)
+        #[arg(long, conflicts_with = "set")]
+        unset: bool,
+    },
+    /// Contextual tips/suggestions shown by stax commands
+    Tips {
+        /// Show contextual tips/suggestions
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+        /// Hide contextual tips/suggestions
+        #[arg(long)]
+        disable: bool,
+    },
+    /// Whether the default PR body includes a commit-message summary
+    SubmitBody {
+        /// Include a commit-message summary in the default PR body
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+        /// Omit the commit-message summary from the default PR body
+        #[arg(long)]
+        disable: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -216,6 +216,33 @@ pub fn run() -> Result<()> {
             update::show_update_notification();
             return result;
         }
+        Commands::User { command } => {
+            let result = match command {
+                None => commands::user::run_default(),
+                Some(UserSubcommand::BranchPrefix { set, unset }) => {
+                    commands::user::branch_prefix(set.clone(), *unset)
+                }
+                Some(UserSubcommand::BranchDate { enable, disable }) => {
+                    commands::user::branch_date(*enable, *disable)
+                }
+                Some(UserSubcommand::BranchReplacement {
+                    set,
+                    set_dash,
+                    set_underscore,
+                }) => commands::user::branch_replacement(set.clone(), *set_dash, *set_underscore),
+                Some(UserSubcommand::Editor { set, unset }) => {
+                    commands::user::editor(set.clone(), *unset)
+                }
+                Some(UserSubcommand::Tips { enable, disable }) => {
+                    commands::user::tips(*enable, *disable)
+                }
+                Some(UserSubcommand::SubmitBody { enable, disable }) => {
+                    commands::user::submit_body(*enable, *disable)
+                }
+            };
+            update::show_update_notification();
+            return result;
+        }
         _ => {}
     }
 
@@ -511,6 +538,7 @@ pub fn run() -> Result<()> {
         Commands::RangeDiff { stack, all } => commands::range_diff::run(stack, all),
         Commands::Doctor { .. } => unreachable!(), // Handled above
         Commands::Skills { .. } => unreachable!(), // Handled above
+        Commands::User { .. } => unreachable!(),   // Handled above
         Commands::Trunk { branch } => {
             if let Some(name) = branch {
                 commands::set_trunk::run(&name)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -63,6 +63,7 @@ pub mod sync_plan;
 pub mod tmux;
 pub mod undo;
 pub mod upstack;
+pub mod user;
 pub mod watch;
 pub mod web;
 pub mod worktree;

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -144,7 +144,7 @@ pub fn run_body(edit: bool) -> Result<()> {
     let body = rt.block_on(async { client.get_pr_body(pr_number).await })?;
 
     if edit {
-        let updated = edit_body(&body)?;
+        let updated = edit_body(&body, config.editor.as_deref())?;
         if updated == body {
             println!("PR #{} body unchanged", pr_number.to_string().cyan());
             return Ok(());
@@ -170,11 +170,13 @@ fn print_rendered_body(body: &str) {
     println!("{}", rendered);
 }
 
-fn edit_body(body: &str) -> Result<String> {
-    let editor =
-        std::env::var("EDITOR").context("$EDITOR is not set; set EDITOR to edit PR body")?;
+fn edit_body(body: &str, configured_editor: Option<&str>) -> Result<String> {
+    let editor = configured_editor
+        .map(str::to_string)
+        .or_else(|| std::env::var("EDITOR").ok())
+        .context("No editor configured; set `stax user editor --set <editor>` or $EDITOR")?;
     if editor.trim().is_empty() {
-        bail!("$EDITOR is empty; set EDITOR to edit PR body");
+        bail!("Configured editor is empty; set `stax user editor --set <editor>` or $EDITOR");
     }
 
     let mut file = tempfile::Builder::new()

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1243,8 +1243,12 @@ pub fn run(scope: SubmitScope, options: SubmitOptions) -> Result<()> {
 
             // Use selected template content if available
             let template_content = selected_template.as_ref().map(|t| t.content.as_str());
-            let default_body =
-                build_default_pr_body(template_content, &plan.branch, &commit_messages);
+            let default_body = build_default_pr_body(
+                template_content,
+                &plan.branch,
+                &commit_messages,
+                config.submit.commit_messages_in_body,
+            );
 
             if !quiet {
                 println!("  {}", plan.branch.cyan());
@@ -3902,12 +3906,13 @@ fn build_default_pr_body(
     template: Option<&str>,
     branch: &str,
     commit_messages: &[String],
+    commit_messages_in_body: bool,
 ) -> String {
     let commits_text = render_commit_list(commit_messages);
 
     let mut body = if let Some(template) = template {
         template.to_string()
-    } else if commits_text.is_empty() {
+    } else if commits_text.is_empty() || !commit_messages_in_body {
         String::new()
     } else {
         format!("## Summary\n\n{}", commits_text)

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -1,0 +1,159 @@
+use crate::config::Config;
+use anyhow::Result;
+use colored::Colorize;
+
+/// Print the current value of every `stax user` preference.
+pub fn run_default() -> Result<()> {
+    let config = Config::load_global()?;
+
+    println!("{}", "User preferences:".blue().bold());
+    println!(
+        "  branch-prefix       {}",
+        config.branch.prefix.as_deref().unwrap_or("(unset)")
+    );
+    println!("  branch-date         {}", bool_label(config.branch.date));
+    println!("  branch-replacement  {}", config.branch.replacement);
+    println!(
+        "  editor              {}",
+        config
+            .editor
+            .as_deref()
+            .unwrap_or("(unset, falls back to $EDITOR)")
+    );
+    println!("  tips                {}", bool_label(config.ui.tips));
+    println!(
+        "  submit-body         {}",
+        bool_label(config.submit.commit_messages_in_body)
+    );
+
+    Ok(())
+}
+
+pub fn branch_prefix(set: Option<String>, unset: bool) -> Result<()> {
+    if let Some(prefix) = set {
+        Config::set_branch_prefix(Some(prefix.clone()))?;
+        print_set("branch.prefix", &prefix);
+    } else if unset {
+        Config::set_branch_prefix(None)?;
+        print_unset("branch.prefix");
+    } else {
+        let config = Config::load_global()?;
+        print_current(
+            "branch.prefix",
+            config.branch.prefix.as_deref().unwrap_or("(unset)"),
+        );
+    }
+    Ok(())
+}
+
+pub fn branch_date(enable: bool, disable: bool) -> Result<()> {
+    if enable || disable {
+        Config::set_branch_date(enable)?;
+        print_bool("branch.date", enable);
+        warn_if_format_overrides_date()?;
+    } else {
+        let config = Config::load_global()?;
+        print_current("branch.date", bool_label(config.branch.date));
+    }
+    Ok(())
+}
+
+pub fn branch_replacement(set: Option<String>, set_dash: bool, set_underscore: bool) -> Result<()> {
+    let value = if set_dash {
+        Some("-".to_string())
+    } else if set_underscore {
+        Some("_".to_string())
+    } else {
+        set
+    };
+
+    if let Some(value) = value {
+        Config::set_branch_replacement(value.clone())?;
+        print_set("branch.replacement", &value);
+    } else {
+        let config = Config::load_global()?;
+        print_current("branch.replacement", &config.branch.replacement);
+    }
+    Ok(())
+}
+
+pub fn editor(set: Option<String>, unset: bool) -> Result<()> {
+    if let Some(editor) = set {
+        Config::set_editor(Some(editor.clone()))?;
+        print_set("editor", &editor);
+    } else if unset {
+        Config::set_editor(None)?;
+        print_unset("editor");
+    } else {
+        let config = Config::load_global()?;
+        print_current(
+            "editor",
+            config
+                .editor
+                .as_deref()
+                .unwrap_or("(unset, falls back to $EDITOR)"),
+        );
+    }
+    Ok(())
+}
+
+pub fn tips(enable: bool, disable: bool) -> Result<()> {
+    if enable || disable {
+        Config::set_tips(enable)?;
+        print_bool("ui.tips", enable);
+    } else {
+        let config = Config::load_global()?;
+        print_current("ui.tips", bool_label(config.ui.tips));
+    }
+    Ok(())
+}
+
+pub fn submit_body(enable: bool, disable: bool) -> Result<()> {
+    if enable || disable {
+        Config::set_submit_commit_messages_in_body(enable)?;
+        print_bool("submit.commit_messages_in_body", enable);
+    } else {
+        let config = Config::load_global()?;
+        print_current(
+            "submit.commit_messages_in_body",
+            bool_label(config.submit.commit_messages_in_body),
+        );
+    }
+    Ok(())
+}
+
+fn warn_if_format_overrides_date() -> Result<()> {
+    let config = Config::load_global()?;
+    if config.branch.format.is_some() {
+        println!(
+            "  {} branch.format is set, so branch.date has no effect until format is unset.",
+            "!".yellow()
+        );
+    }
+    Ok(())
+}
+
+fn bool_label(value: bool) -> &'static str {
+    if value { "true" } else { "false" }
+}
+
+fn print_set(key: &str, value: &str) {
+    println!("  {} Set {} = \"{}\"", "✓".green().bold(), key, value);
+}
+
+fn print_unset(key: &str) {
+    println!("  {} Cleared {}", "✓".green().bold(), key);
+}
+
+fn print_bool(key: &str, enabled: bool) {
+    println!(
+        "  {} Set {} = {}",
+        "✓".green().bold(),
+        key,
+        bool_label(enabled)
+    );
+}
+
+fn print_current(key: &str, value: &str) {
+    println!("  {} = {}", key, value);
+}

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -3,12 +3,18 @@
 # Omitted keys use the built-in defaults shown in each comment.
 # Docs: https://github.com/cesarferreira/stax/blob/main/docs/configuration/index.md
 
+# editor = "vim" # preferred editor for interactive edits (e.g. `stax pr --edit`); falls back to $EDITOR
+#   Set with: stax user editor --set <editor> | stax user editor --unset
+
 [branch]
 # format = "{user}/{date}/{message}"
 # user = "cesar"
 # date_format = "%m-%d"
-# replacement = "-"
+# replacement = "-" # stax user branch-replacement --set "_" | --set-dash | --set-underscore
 # stale_days = 30 # days without commits before `stax sweep` calls a branch stale
+#   prefix and date are legacy; prefer `format`. Set with:
+#   stax user branch-prefix --set "cesar/" | --unset
+#   stax user branch-date --enable | --disable
 
 [git]
 # rerere = true # auto-enable git rerere on `stax init`
@@ -24,6 +30,8 @@
 # single_stack = "on"     # "on" | "off" — when "off", skip stack-link sync while the stack has only one PR
 # native_stack = "auto"   # "auto" | "off" | "link" — GitHub gh-stack registration; use "off" to disable entirely
 # stack_links_when_native = "keep" # "keep" | "off" — stax PR links when native registration succeeds
+# commit_messages_in_body = true # include a `## Summary` commit-message list in the default PR body
+#   Set with: stax user submit-body --enable | --disable
 
 [ci]
 # alert = false
@@ -36,7 +44,7 @@
 # gh_hostname = "github.company.com"
 
 [ui]
-# tips = true
+# tips = true # stax user tips --enable | --disable
 
 [display]
 # worktree_glyph = "auto" # "auto" | "tree" (Nerd Font) | "wt" (ASCII)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,10 @@ use crate::remote::ForgeType;
 /// Main config (safe to commit to dotfiles)
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
+    /// Preferred editor for interactive text edits (e.g. `stax pr --edit`).
+    /// Falls back to `$EDITOR` when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub editor: Option<String>,
     #[serde(default)]
     pub branch: BranchConfig,
     #[serde(default)]
@@ -162,7 +166,7 @@ pub struct RemoteConfig {
     pub fork_remote: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubmitConfig {
     /// Where stax-managed stack links should be synced on submit.
     #[serde(default)]
@@ -180,6 +184,22 @@ pub struct SubmitConfig {
     /// PR exists, all PRs in the stack get links synced normally.
     #[serde(default)]
     pub single_stack: SingleStackMode,
+    /// Whether the default PR body (used when no template is picked) includes
+    /// a `## Summary` bullet list of commit messages (default: true).
+    #[serde(default = "default_true")]
+    pub commit_messages_in_body: bool,
+}
+
+impl Default for SubmitConfig {
+    fn default() -> Self {
+        Self {
+            stack_links: StackLinksMode::default(),
+            native_stack: NativeStackMode::default(),
+            stack_links_when_native: StackLinksWhenNative::default(),
+            single_stack: SingleStackMode::default(),
+            commit_messages_in_body: default_true(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -740,6 +760,55 @@ impl Config {
         let path = Self::path()?;
         let mut config = Self::load_path_or_default(&path)?;
         config.board.mine_only = mine_only;
+        config.save()
+    }
+
+    /// Persist the branch prefix preference (global config only).
+    pub fn set_branch_prefix(prefix: Option<String>) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.branch.prefix = prefix;
+        config.save()
+    }
+
+    /// Persist whether new branch names include a date (global config only).
+    pub fn set_branch_date(enabled: bool) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.branch.date = enabled;
+        config.save()
+    }
+
+    /// Persist the branch name replacement character (global config only).
+    pub fn set_branch_replacement(replacement: String) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.branch.replacement = replacement;
+        config.save()
+    }
+
+    /// Persist the preferred editor for interactive text edits (global config only).
+    pub fn set_editor(editor: Option<String>) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.editor = editor;
+        config.save()
+    }
+
+    /// Persist whether contextual tips/suggestions are shown (global config only).
+    pub fn set_tips(enabled: bool) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.ui.tips = enabled;
+        config.save()
+    }
+
+    /// Persist whether the default PR body includes a commit-message summary
+    /// (global config only).
+    pub fn set_submit_commit_messages_in_body(enabled: bool) -> Result<()> {
+        let path = Self::path()?;
+        let mut config = Self::load_path_or_default(&path)?;
+        config.submit.commit_messages_in_body = enabled;
         config.save()
     }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2248,3 +2248,98 @@ replacement = "-"
     // Legacy behavior should still work
     assert_eq!(config.format_branch_name("feature"), "cesar/feature");
 }
+
+// ---------------------------------------------------------------------------
+// `stax user` setters
+// ---------------------------------------------------------------------------
+
+fn with_isolated_config_dir<F: FnOnce()>(f: F) {
+    let _guard = env_lock();
+
+    let orig_stax = env::var("STAX_CONFIG_DIR").ok();
+    let temp_dir = tempfile::tempdir().unwrap();
+    unsafe { env::set_var("STAX_CONFIG_DIR", temp_dir.path()) };
+
+    f();
+
+    restore_env_var("STAX_CONFIG_DIR", orig_stax);
+}
+
+#[test]
+fn test_set_branch_prefix() {
+    with_isolated_config_dir(|| {
+        Config::set_branch_prefix(Some("cesar/".to_string())).unwrap();
+        assert_eq!(
+            Config::load_global().unwrap().branch.prefix,
+            Some("cesar/".to_string())
+        );
+
+        Config::set_branch_prefix(None).unwrap();
+        assert!(Config::load_global().unwrap().branch.prefix.is_none());
+    });
+}
+
+#[test]
+fn test_set_branch_date() {
+    with_isolated_config_dir(|| {
+        Config::set_branch_date(true).unwrap();
+        assert!(Config::load_global().unwrap().branch.date);
+
+        Config::set_branch_date(false).unwrap();
+        assert!(!Config::load_global().unwrap().branch.date);
+    });
+}
+
+#[test]
+fn test_set_branch_replacement() {
+    with_isolated_config_dir(|| {
+        Config::set_branch_replacement("_".to_string()).unwrap();
+        assert_eq!(Config::load_global().unwrap().branch.replacement, "_");
+    });
+}
+
+#[test]
+fn test_set_editor() {
+    with_isolated_config_dir(|| {
+        Config::set_editor(Some("vim".to_string())).unwrap();
+        assert_eq!(
+            Config::load_global().unwrap().editor,
+            Some("vim".to_string())
+        );
+
+        Config::set_editor(None).unwrap();
+        assert!(Config::load_global().unwrap().editor.is_none());
+    });
+}
+
+#[test]
+fn test_set_tips() {
+    with_isolated_config_dir(|| {
+        Config::set_tips(false).unwrap();
+        assert!(!Config::load_global().unwrap().ui.tips);
+
+        Config::set_tips(true).unwrap();
+        assert!(Config::load_global().unwrap().ui.tips);
+    });
+}
+
+#[test]
+fn test_set_submit_commit_messages_in_body() {
+    with_isolated_config_dir(|| {
+        Config::set_submit_commit_messages_in_body(false).unwrap();
+        assert!(
+            !Config::load_global()
+                .unwrap()
+                .submit
+                .commit_messages_in_body
+        );
+
+        Config::set_submit_commit_messages_in_body(true).unwrap();
+        assert!(
+            Config::load_global()
+                .unwrap()
+                .submit
+                .commit_messages_in_body
+        );
+    });
+}

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -170,6 +170,8 @@ mod track_plan_tests;
 mod tui_commands_tests;
 #[path = "upstack_onto_tests.rs"]
 mod upstack_onto_tests;
+#[path = "user_tests.rs"]
+mod user_tests;
 #[path = "validate_tests.rs"]
 mod validate_tests;
 #[path = "web_tests.rs"]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7933,6 +7933,21 @@ mod forge_mock_tests {
         fs::write(&config_path, config).expect("Failed to write config");
     }
 
+    fn write_test_config_with_submit_body(
+        home: &Path,
+        api_base_url: &str,
+        commit_messages_in_body: bool,
+    ) {
+        let config_dir = home.join(".config").join("stax");
+        std::fs::create_dir_all(&config_dir).expect("Failed to create config dir");
+        let config_path = config_dir.join("config.toml");
+        let config = format!(
+            "[remote]\napi_base_url = \"{}\"\n\n[submit]\nstack_links = \"off\"\ncommit_messages_in_body = {}\n",
+            api_base_url, commit_messages_in_body
+        );
+        fs::write(&config_path, config).expect("Failed to write config");
+    }
+
     fn write_test_config_with_ai(home: &Path, api_base_url: &str, stack_links: Option<&str>) {
         let config_dir = home.join(".config").join("stax");
         std::fs::create_dir_all(&config_dir).expect("Failed to create config dir");
@@ -10104,6 +10119,38 @@ mod forge_mock_tests {
         let payload: serde_json::Value = serde_json::from_slice(&pr_create.body).unwrap();
         assert_eq!(payload["title"], "Add AI fallback");
         assert_eq!(payload["body"], default_body);
+    }
+
+    #[tokio::test]
+    async fn test_submit_body_disabled_omits_commit_summary_for_new_pr() {
+        ensure_crypto_provider();
+        let mock_server = MockServer::start().await;
+        let home = super::test_tempdir();
+        write_test_config_with_submit_body(home.path(), &mock_server.uri(), false);
+        let repo = setup_branch_with_remote(home.path(), "feature-body-disabled");
+
+        mount_github_new_pr_flow(
+            &mock_server,
+            45,
+            "feature-body-disabled",
+            "Add feature-body-disabled",
+            "",
+        )
+        .await;
+
+        let output = run_stax_with_env(&repo, home.path(), &["submit", "--yes", "--no-prompt"]);
+        assert!(output.status.success(), "{}", TestRepo::stderr(&output));
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let pr_create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path() == "/repos/test/repo/pulls"
+            })
+            .expect("missing PR create request");
+        let payload: serde_json::Value = serde_json::from_slice(&pr_create.body).unwrap();
+        assert_eq!(payload["title"], "Add feature-body-disabled");
+        assert_eq!(payload["body"], "");
     }
 
     #[tokio::test]

--- a/tests/user_tests.rs
+++ b/tests/user_tests.rs
@@ -1,0 +1,168 @@
+//! Tests for the `stax user` preferences command.
+
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::PathBuf;
+
+fn config_path(repo: &TestRepo) -> PathBuf {
+    PathBuf::from(repo.clean_home())
+        .join(".config")
+        .join("stax")
+        .join("config.toml")
+}
+
+fn config_contents(repo: &TestRepo) -> String {
+    fs::read_to_string(config_path(repo)).unwrap_or_default()
+}
+
+#[test]
+fn user_default_prints_all_settings() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["user"]);
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+
+    assert!(stdout.contains("branch-prefix"), "stdout: {stdout}");
+    assert!(stdout.contains("branch-date"), "stdout: {stdout}");
+    assert!(stdout.contains("branch-replacement"), "stdout: {stdout}");
+    assert!(stdout.contains("editor"), "stdout: {stdout}");
+    assert!(stdout.contains("tips"), "stdout: {stdout}");
+    assert!(stdout.contains("submit-body"), "stdout: {stdout}");
+}
+
+#[test]
+fn user_branch_prefix_set_and_unset() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["user", "branch-prefix", "--set", "cesar/"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(
+        contents.contains("prefix = \"cesar/\""),
+        "config: {contents}"
+    );
+
+    repo.run_stax(&["user", "branch-prefix", "--unset"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(!contents.contains("prefix ="), "config: {contents}");
+}
+
+#[test]
+fn user_branch_date_enable_and_disable() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["user", "branch-date", "--enable"]);
+    output.assert_success();
+    let contents = config_contents(&repo);
+    assert!(contents.contains("date = true"), "config: {contents}");
+
+    repo.run_stax(&["user", "branch-date", "--disable"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(contents.contains("date = false"), "config: {contents}");
+}
+
+#[test]
+fn user_branch_date_warns_when_format_takes_precedence() {
+    let repo = TestRepo::new();
+
+    let config_dir = config_path(&repo).parent().unwrap().to_path_buf();
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_path(&repo),
+        "[branch]\nformat = \"{user}/{message}\"\n",
+    )
+    .unwrap();
+
+    let output = repo.run_stax(&["user", "branch-date", "--enable"]);
+    output.assert_success();
+    let stdout = TestRepo::stdout(&output);
+    assert!(
+        stdout.to_lowercase().contains("format"),
+        "expected a format-precedence warning, got: {stdout}"
+    );
+}
+
+#[test]
+fn user_branch_replacement_set_dash_and_underscore() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["user", "branch-replacement", "--set-underscore"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(
+        contents.contains("replacement = \"_\""),
+        "config: {contents}"
+    );
+
+    repo.run_stax(&["user", "branch-replacement", "--set-dash"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(
+        contents.contains("replacement = \"-\""),
+        "config: {contents}"
+    );
+
+    repo.run_stax(&["user", "branch-replacement", "--set", "~"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(
+        contents.contains("replacement = \"~\""),
+        "config: {contents}"
+    );
+}
+
+#[test]
+fn user_editor_set_and_unset() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["user", "editor", "--set", "vim"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(contents.contains("editor = \"vim\""), "config: {contents}");
+
+    repo.run_stax(&["user", "editor", "--unset"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(!contents.contains("editor ="), "config: {contents}");
+}
+
+#[test]
+fn user_tips_enable_and_disable() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["user", "tips", "--disable"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(contents.contains("tips = false"), "config: {contents}");
+
+    repo.run_stax(&["user", "tips", "--enable"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(contents.contains("tips = true"), "config: {contents}");
+}
+
+#[test]
+fn user_submit_body_enable_and_disable() {
+    let repo = TestRepo::new();
+
+    repo.run_stax(&["user", "submit-body", "--disable"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(
+        contents.contains("commit_messages_in_body = false"),
+        "config: {contents}"
+    );
+
+    repo.run_stax(&["user", "submit-body", "--enable"])
+        .assert_success();
+    let contents = config_contents(&repo);
+    assert!(
+        contents.contains("commit_messages_in_body = true"),
+        "config: {contents}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `stax user` subcommand family for personal preferences, matching (and rounding out) freephite/Graphite's `fp user` / `gt user`:

```bash
stax user                                      # show current values
stax user branch-prefix --set "cesar/" | --unset
stax user branch-date --enable | --disable
stax user branch-replacement --set "_" | --set-dash | --set-underscore
stax user editor --set vim | --unset
stax user tips --enable | --disable
stax user submit-body --enable | --disable
```

Three of these (`branch-prefix`, `branch-date`, `branch-replacement`) already existed as config fields but had no CLI — they could only be set by hand-editing `~/.config/stax/config.toml`. Checking upstream Graphite's `gt user` reference turned up two more worth matching:
- `tips` — also already existed as `config.ui.tips`, just with no setter command.
- `submit-body` — genuinely new. Toggles whether commit messages are auto-included in the default (non-template) PR body on submit (`config.submit.commit_messages_in_body`, default `true` to preserve current behavior).
- `editor` — genuinely new. `config.editor` is now consulted by `stax pr --edit` before falling back to `$EDITOR`.

Each mutating subcommand takes exactly one action flag (`--set`/`--unset`/`--enable`/`--disable`, enforced via clap `conflicts_with`) and persists straight to the global config file, following the existing `Config::set_skill_harnesses`/`Config::set_board_mine_only` setter pattern. Running `stax user branch-date --enable/--disable` while `branch.format` is already set prints a warning, since `format` takes precedence over the legacy date toggle.

## Test plan

- [x] `cargo check && cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo nextest run user_tests::` (new end-to-end CLI tests for all six settings, including the format-precedence warning)
- [x] `cargo nextest run config::tests::` (new setter unit tests)
- [x] `cargo nextest run command_coverage_tests::` (docs/commands/reference.md updated with the new `st user` row)
- [x] Full `make test` suite: 2646/2646 passing
- [x] Manually verified `stax user`, set/unset/enable/disable for each of the six settings, and that `stax create` picks up persisted prefix/replacement/date, and default PR body generation respects `submit-body --disable`