### PR TITLE
fix(board): commit label state after mutation succeeds

### DIFF
--- a/src/tui/board/app.rs
+++ b/src/tui/board/app.rs
@@ -68,6 +68,12 @@ pub enum BoardUpdate {
         message: String,
         refresh: bool,
     },
+    LabelMutation {
+        target: BoardTarget,
+        label: String,
+        added: bool,
+        message: String,
+    },
     DetailError {
         target: BoardTarget,
         message: String,
@@ -443,6 +449,37 @@ impl BoardApp {
             BoardUpdate::ActionDone { message, .. } => {
                 self.status_message = Some(message);
             }
+            BoardUpdate::LabelMutation {
+                target,
+                label,
+                added,
+                message,
+            } => {
+                match target {
+                    BoardTarget::Pr(number) => {
+                        if let Some(pr) = self.prs.iter_mut().find(|pr| pr.number == number) {
+                            update_labels(&mut pr.labels, &label, added);
+                        }
+                        if let Some(detail) = self.pr_details.get_mut(&number) {
+                            update_labels(&mut detail.labels, &label, added);
+                        }
+                    }
+                    BoardTarget::Issue(number) => {
+                        if let Some(issue) =
+                            self.issues.iter_mut().find(|issue| issue.number == number)
+                        {
+                            update_labels(&mut issue.labels, &label, added);
+                        }
+                        if let Some(detail) = self.issue_details.get_mut(&number) {
+                            update_labels(&mut detail.labels, &label, added);
+                        }
+                    }
+                }
+                if self.selected_target() == Some(target) {
+                    update_labels(&mut self.active_labels, &label, added);
+                }
+                self.status_message = Some(message);
+            }
             BoardUpdate::DetailError { target, message } => {
                 if self.loading_detail == Some(target) {
                     self.loading_detail = None;
@@ -458,6 +495,16 @@ impl BoardApp {
                 self.loading_comments = None;
             }
         }
+    }
+}
+
+fn update_labels(labels: &mut Vec<String>, label: &str, added: bool) {
+    if added {
+        if !labels.iter().any(|existing| existing == label) {
+            labels.push(label.to_string());
+        }
+    } else {
+        labels.retain(|existing| existing != label);
     }
 }
 
@@ -685,6 +732,55 @@ mod tests {
         });
 
         assert!(!app.detail_error.contains_key(&BoardTarget::Pr(1)));
+    }
+
+    #[test]
+    fn label_mutation_updates_cached_pr_and_picker_state_without_refresh() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, "a", &["bug"])];
+        app.pr_selected = 0;
+        app.active_labels = vec!["bug".to_string()];
+        let mut detail = pr_detail(1, false);
+        detail.labels = vec!["bug".to_string()];
+        app.pr_details.insert(1, detail);
+
+        app.apply_update(BoardUpdate::LabelMutation {
+            target: BoardTarget::Pr(1),
+            label: "feature".to_string(),
+            added: true,
+            message: "Added label \"feature\"".to_string(),
+        });
+
+        assert_eq!(app.prs[0].labels, vec!["bug", "feature"]);
+        assert_eq!(app.pr_details[&1].labels, vec!["bug", "feature"]);
+        assert_eq!(app.active_labels, vec!["bug", "feature"]);
+
+        app.apply_update(BoardUpdate::LabelMutation {
+            target: BoardTarget::Pr(1),
+            label: "bug".to_string(),
+            added: false,
+            message: "Removed label \"bug\"".to_string(),
+        });
+
+        assert_eq!(app.prs[0].labels, vec!["feature"]);
+        assert_eq!(app.pr_details[&1].labels, vec!["feature"]);
+        assert_eq!(app.active_labels, vec!["feature"]);
+    }
+
+    #[test]
+    fn failed_label_mutation_keeps_picker_selection_unchanged() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.active_labels = vec!["bug".to_string()];
+
+        app.apply_update(BoardUpdate::Error(
+            "Failed to remove label: forbidden".to_string(),
+        ));
+
+        assert_eq!(app.active_labels, vec!["bug"]);
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Failed to remove label: forbidden")
+        );
     }
 
     #[test]

--- a/src/tui/board/mod.rs
+++ b/src/tui/board/mod.rs
@@ -322,10 +322,8 @@ fn toggle_label(app: &mut BoardApp, req_tx: &Sender<BoardRequest>) {
     };
 
     if app.active_labels.contains(&label) {
-        app.active_labels.retain(|active| active != &label);
         let _ = req_tx.send(BoardRequest::RemoveLabel { target, label });
     } else {
-        app.active_labels.push(label.clone());
         let _ = req_tx.send(BoardRequest::AddLabel { target, label });
     }
 }
@@ -704,9 +702,11 @@ async fn handle_request(
                 .await
             {
                 Ok(()) => {
-                    let _ = tx.send(BoardUpdate::ActionDone {
+                    let _ = tx.send(BoardUpdate::LabelMutation {
+                        target,
+                        label: label.clone(),
+                        added: true,
                         message: format!("Added label \"{label}\""),
-                        refresh: false,
                     });
                 }
                 Err(error) => {
@@ -718,9 +718,11 @@ async fn handle_request(
             let number = target_number(target);
             match client.remove_label(number, &label).await {
                 Ok(()) => {
-                    let _ = tx.send(BoardUpdate::ActionDone {
+                    let _ = tx.send(BoardUpdate::LabelMutation {
+                        target,
+                        label: label.clone(),
+                        added: false,
                         message: format!("Removed label \"{label}\""),
-                        refresh: false,
                     });
                 }
                 Err(error) => {
@@ -804,11 +806,45 @@ async fn fetch_pr_checks(
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::github::board::BoardPrSummary;
     use crate::remote::{ForgeType, RemoteInfo};
+    use chrono::Utc;
     use std::env;
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn pr(number: u64, labels: &[&str]) -> BoardPrSummary {
+        BoardPrSummary {
+            number,
+            title: "title".to_string(),
+            author: "octocat".to_string(),
+            head_branch: "feature".to_string(),
+            base_branch: "main".to_string(),
+            is_draft: false,
+            labels: labels.iter().map(|label| label.to_string()).collect(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            url: format!("https://github.com/o/r/pull/{number}"),
+        }
+    }
+
+    #[test]
+    fn label_picker_waits_for_success_before_changing_active_labels() {
+        let mut app = BoardApp::new("o/r".to_string(), BoardTabSelection::PullRequests, false);
+        app.prs = vec![pr(1, &["bug"])];
+        app.active_labels = vec!["bug".to_string()];
+        app.repo_labels = vec!["bug".to_string()];
+        let (tx, rx) = mpsc::channel();
+
+        toggle_label(&mut app, &tx);
+
+        assert!(matches!(
+            rx.recv().expect("label request"),
+            BoardRequest::RemoveLabel { target: BoardTarget::Pr(1), label } if label == "bug"
+        ));
+        assert_eq!(app.active_labels, vec!["bug"]);
+    }
 
     #[test]
     fn board_worker_constructs_github_client_with_entered_runtime() {


### PR DESCRIPTION
## Motivation

The board label picker updated its local selection before GitHub confirmed a mutation, leaving stale UI state after rejected requests and stale board caches after successful ones.

## Changes

- defer label-picker state changes until the worker confirms the GitHub mutation
- carry successful label mutation context to `BoardApp` and update matching list/detail caches immediately
- preserve picker state when the worker reports an error
- add focused regression coverage for success, failure, and request-state behavior

## Verification

- Full local gate: `make test` — **2,649 passed, 0 skipped**
- `make lint-fast` — passed
- Focused `cargo nextest run` coverage for successful cache updates, failed mutation state, and picker behavior — passed
- `git diff --check` — passed

Closes #848

## Documentation

No README/docs/skills update: this fixes internal TUI state consistency without changing commands, flags, or documented behavior.