### PR TITLE
fix(github): route GitHub API calls through the configured HTTP proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,8 @@ dependencies = [
  "fuzzy-matcher",
  "getrandom 0.4.3",
  "git2",
+ "http",
+ "http-body-util",
  "indicatif",
  "maud",
  "octocrab",
@@ -3607,6 +3609,7 @@ dependencies = [
  "termimad",
  "tokio",
  "toml",
+ "tower",
  "update-informer",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ git2 = { version = "0.21", default-features = false, features = ["https"] }
 
 # GitHub API
 octocrab = "0.54.1"
+# Proxy-aware GitHub transport (octocrab's own hyper client ignores HTTPS_PROXY;
+# see src/github/transport.rs). Versions match what octocrab/reqwest already pull in.
+http = "1"
+http-body-util = "0.1"
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "signal", "time"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-local-fast:
 		./scripts/native-tests.sh; \
 	else \
 		threads="$${NEXTEST_TEST_THREADS:-num-cpus}"; \
-		env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" TMPDIR="$$(pwd)/.test-tmp" NEXTEST_TEST_THREADS="$$threads" RUST_MIN_STACK=4194304 cargo nextest run --cargo-profile "$(NATIVE_CARGO_PROFILE)"; \
+		env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY -u NO_PROXY -u all_proxy -u https_proxy -u http_proxy -u no_proxy STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$$(pwd)/.test-tmp" TMPDIR="$$(pwd)/.test-tmp" NEXTEST_TEST_THREADS="$$threads" RUST_MIN_STACK=4194304 cargo nextest run --cargo-profile "$(NATIVE_CARGO_PROFILE)"; \
 	fi
 
 # Create a RAM disk for fast local test temp dirs (macOS only)
@@ -124,7 +124,7 @@ test-local-ramdisk: ramdisk-up
 	if [ -z "$$threads" ]; then \
 		threads="num-cpus"; \
 	fi; \
-	env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$(RAMDISK_MOUNT)/tmp" TMPDIR="$(RAMDISK_MOUNT)/tmp" NEXTEST_TEST_THREADS="$$threads" cargo nextest run
+	env -u GITHUB_TOKEN -u STAX_GITHUB_TOKEN -u GH_TOKEN -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY -u NO_PROXY -u all_proxy -u https_proxy -u http_proxy -u no_proxy STAX_DISABLE_UPDATE_CHECK=1 STAX_TEST_TMPDIR="$(RAMDISK_MOUNT)/tmp" TMPDIR="$(RAMDISK_MOUNT)/tmp" NEXTEST_TEST_THREADS="$$threads" cargo nextest run
 
 # Build the pre-baked Linux test image (nextest + mold linker).
 test-image:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -391,3 +391,29 @@ not an authentication problem.
 ```bash
 st auth status
 ```
+
+## HTTP proxies
+
+Stax routes forge API traffic through the proxy named by the standard
+environment variables, in this order: `ALL_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY`
+(both upper and lower case). `NO_PROXY` exclusions and `user:password@` proxy
+credentials are honoured, so the same values that work for `git` and `curl`
+work here.
+
+Nothing needs to be configured in `config.toml` — an exported proxy variable is
+enough:
+
+```bash
+export HTTPS_PROXY=http://proxy.example:8080
+export NO_PROXY=localhost,127.0.0.1,.internal.example
+```
+
+When a proxy variable is set, GitHub API calls run on a proxy-aware HTTP client
+(the GitHub client library stax builds on cannot speak to a proxy on its own)
+that verifies TLS against the operating system trust store, which also covers
+proxies that terminate TLS with a corporate CA. When no proxy variable is set,
+nothing changes.
+
+If the API is unreachable, stax says whether a proxy was in play and which
+variable named it (credentials redacted), so a connect timeout is not mistaken
+for an auth problem.

--- a/scripts/native-tests-tests.sh
+++ b/scripts/native-tests-tests.sh
@@ -14,6 +14,10 @@ if env | grep -Eq '^(GITHUB_TOKEN|STAX_GITHUB_TOKEN|GH_TOKEN)='; then
   echo "GitHub token environment leaked into cargo" >&2
   exit 90
 fi
+if env | grep -Eiq '^(ALL_PROXY|HTTPS_PROXY|HTTP_PROXY|NO_PROXY)='; then
+  echo "proxy environment leaked into cargo" >&2
+  exit 91
+fi
 printf '%s\n' "$*" >>"${STAX_NATIVE_TEST_LOG}"
 if [[ -n "${STAX_NATIVE_TEST_FAIL_MATCH:-}" ]] && \
   [[ "$*" == *"${STAX_NATIVE_TEST_FAIL_MATCH}"* ]]; then
@@ -25,6 +29,8 @@ chmod +x "${fake_cargo}"
 
 log="${tmp}/cargo.log"
 GITHUB_TOKEN=secret STAX_GITHUB_TOKEN=secret GH_TOKEN=secret \
+  HTTPS_PROXY=http://proxy.invalid:8080 https_proxy=http://proxy.invalid:8080 \
+  ALL_PROXY=http://proxy.invalid:8080 NO_PROXY=example.com \
   STAX_NATIVE_TEST_CARGO="${fake_cargo}" \
   STAX_NATIVE_TEST_LOG="${log}" \
   STAX_TEST_TMPDIR="${tmp}/test-tmp" \

--- a/scripts/native-tests.sh
+++ b/scripts/native-tests.sh
@@ -27,7 +27,12 @@ fi
 
 mkdir -p "${test_tmpdir}"
 
+# Tokens and proxy configuration both steer forge HTTP clients, so neither may
+# leak in from the developer's shell: a proxy would reroute the loopback mock
+# servers the tests talk to.
 unset GITHUB_TOKEN STAX_GITHUB_TOKEN GH_TOKEN
+unset ALL_PROXY HTTPS_PROXY HTTP_PROXY NO_PROXY
+unset all_proxy https_proxy http_proxy no_proxy
 export STAX_DISABLE_UPDATE_CHECK=1
 export STAX_TEST_TMPDIR="${test_tmpdir}"
 export TMPDIR="${TMPDIR:-${test_tmpdir}}"

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use crate::config::{Config, GitHubAuthSource};
 use crate::forge::{ForgeSignal, PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity};
+use crate::github::transport;
 
 const GITHUB_API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const GITHUB_API_READ_TIMEOUT: Duration = Duration::from_secs(30);
@@ -229,6 +230,39 @@ struct RepoListIssue {
     pull_request: Option<serde_json::Value>,
 }
 
+/// Connect-level failures never reach GitHub, so the auth hints below do not
+/// apply — what matters is whether traffic is supposed to go through a proxy.
+fn is_connect_error(msg: &str) -> bool {
+    const CONNECT_MARKERS: [&str; 6] = [
+        "(Connect)",
+        "deadline has elapsed",
+        "error trying to connect",
+        "dns error",
+        "operation timed out",
+        "Connection refused",
+    ];
+    CONNECT_MARKERS.iter().any(|marker| msg.contains(marker))
+}
+
+fn connect_failure_hint() -> String {
+    connect_failure_hint_for(transport::proxy_env_override())
+}
+
+fn connect_failure_hint_for(proxy: Option<(&str, String)>) -> String {
+    match proxy {
+        Some((name, value)) => format!(
+            "Could not reach the GitHub API. Requests use the proxy from {}={}; check that the \
+             proxy is up and permits CONNECT to the API host, or exclude the host via NO_PROXY.",
+            name,
+            transport::redact_proxy_url(&value),
+        ),
+        None => "Could not reach the GitHub API, and no HTTP proxy is configured. If this network \
+                 requires one, set HTTPS_PROXY (stax honours ALL_PROXY/HTTPS_PROXY/HTTP_PROXY and \
+                 NO_PROXY); otherwise check your VPN, DNS, or firewall."
+            .to_string(),
+    }
+}
+
 impl GitHubClient {
     /// Create a new GitHub client from config
     pub fn new(owner: &str, repo: &str, api_base_url: Option<String>) -> Result<Self> {
@@ -262,19 +296,32 @@ impl GitHubClient {
         auth_source: GitHubAuthSource,
         token: String,
     ) -> Result<Self> {
-        let mut builder = Octocrab::builder()
-            .personal_token(token)
-            .add_retry_config(RetryConfig::Simple(GITHUB_API_RETRY_COUNT))
-            .set_connect_timeout(Some(GITHUB_API_CONNECT_TIMEOUT))
-            .set_read_timeout(Some(GITHUB_API_READ_TIMEOUT))
-            .set_write_timeout(Some(GITHUB_API_WRITE_TIMEOUT));
-        if let Some(api_base) = api_base_url {
-            builder = builder
-                .base_uri(api_base)
-                .context("Failed to set GitHub API base URL")?;
-        }
+        // octocrab's own client cannot reach GitHub through an HTTP proxy, so
+        // when one is configured we swap in a reqwest-backed transport.
+        let octocrab = if transport::proxy_env_override().is_some() {
+            transport::build_proxy_aware_client(
+                &token,
+                api_base_url.as_deref(),
+                GITHUB_API_CONNECT_TIMEOUT,
+                GITHUB_API_READ_TIMEOUT,
+                GITHUB_API_RETRY_COUNT,
+            )
+            .context("Failed to create proxied GitHub client")?
+        } else {
+            let mut builder = Octocrab::builder()
+                .personal_token(token)
+                .add_retry_config(RetryConfig::Simple(GITHUB_API_RETRY_COUNT))
+                .set_connect_timeout(Some(GITHUB_API_CONNECT_TIMEOUT))
+                .set_read_timeout(Some(GITHUB_API_READ_TIMEOUT))
+                .set_write_timeout(Some(GITHUB_API_WRITE_TIMEOUT));
+            if let Some(api_base) = api_base_url {
+                builder = builder
+                    .base_uri(api_base)
+                    .context("Failed to set GitHub API base URL")?;
+            }
 
-        let octocrab = builder.build().context("Failed to create GitHub client")?;
+            builder.build().context("Failed to create GitHub client")?
+        };
 
         Ok(Self {
             octocrab,
@@ -310,6 +357,9 @@ impl GitHubClient {
     /// when the token lacks access, not 403).
     pub(crate) fn enrich_api_error(&self, err: anyhow::Error) -> anyhow::Error {
         let msg = format!("{:#}", err);
+        if is_connect_error(&msg) {
+            return err.context(connect_failure_hint());
+        }
         if msg.contains("Not Found")
             || msg.contains("404")
             || msg.contains("Unauthorized")
@@ -1487,6 +1537,60 @@ mod tests {
             "Non-auth errors should not get auth hint, got: {}",
             msg
         );
+    }
+
+    #[tokio::test]
+    async fn test_enrich_api_error_adds_connect_hint() {
+        ensure_crypto_provider();
+        let octocrab = Octocrab::builder()
+            .personal_token("token".to_string())
+            .build()
+            .unwrap();
+
+        let client = GitHubClient::with_octocrab(octocrab, "myorg", "myrepo");
+
+        let original = anyhow::anyhow!(
+            "Service Error: client error (Connect): client error (Connect): deadline has elapsed"
+        );
+        let msg = format!("{:#}", client.enrich_api_error(original));
+
+        assert!(
+            msg.contains("Could not reach the GitHub API"),
+            "Expected connect hint, got: {}",
+            msg
+        );
+        assert!(
+            !msg.contains("token is expired"),
+            "Connect errors should not get the auth hint, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_connect_hint_names_proxy_variable_without_credentials() {
+        let hint = connect_failure_hint_for(Some((
+            "HTTPS_PROXY",
+            "http://alice:s3cret@proxy.example:8080".to_string(),
+        )));
+
+        assert!(
+            hint.contains("HTTPS_PROXY=http://***@proxy.example:8080"),
+            "Expected redacted proxy in hint, got: {}",
+            hint
+        );
+        assert!(
+            !hint.contains("s3cret") && !hint.contains("alice"),
+            "Proxy credentials leaked into hint: {}",
+            hint
+        );
+    }
+
+    #[test]
+    fn test_connect_hint_without_proxy_points_at_env_vars() {
+        let hint = connect_failure_hint_for(None);
+
+        assert!(hint.contains("HTTPS_PROXY"), "got: {}", hint);
+        assert!(hint.contains("NO_PROXY"), "got: {}", hint);
     }
 
     #[tokio::test]

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -230,39 +230,6 @@ struct RepoListIssue {
     pull_request: Option<serde_json::Value>,
 }
 
-/// Connect-level failures never reach GitHub, so the auth hints below do not
-/// apply — what matters is whether traffic is supposed to go through a proxy.
-fn is_connect_error(msg: &str) -> bool {
-    const CONNECT_MARKERS: [&str; 6] = [
-        "(Connect)",
-        "deadline has elapsed",
-        "error trying to connect",
-        "dns error",
-        "operation timed out",
-        "Connection refused",
-    ];
-    CONNECT_MARKERS.iter().any(|marker| msg.contains(marker))
-}
-
-fn connect_failure_hint() -> String {
-    connect_failure_hint_for(transport::proxy_env_override())
-}
-
-fn connect_failure_hint_for(proxy: Option<(&str, String)>) -> String {
-    match proxy {
-        Some((name, value)) => format!(
-            "Could not reach the GitHub API. Requests use the proxy from {}={}; check that the \
-             proxy is up and permits CONNECT to the API host, or exclude the host via NO_PROXY.",
-            name,
-            transport::redact_proxy_url(&value),
-        ),
-        None => "Could not reach the GitHub API, and no HTTP proxy is configured. If this network \
-                 requires one, set HTTPS_PROXY (stax honours ALL_PROXY/HTTPS_PROXY/HTTP_PROXY and \
-                 NO_PROXY); otherwise check your VPN, DNS, or firewall."
-            .to_string(),
-    }
-}
-
 impl GitHubClient {
     /// Create a new GitHub client from config
     pub fn new(owner: &str, repo: &str, api_base_url: Option<String>) -> Result<Self> {
@@ -298,7 +265,7 @@ impl GitHubClient {
     ) -> Result<Self> {
         // octocrab's own client cannot reach GitHub through an HTTP proxy, so
         // when one is configured we swap in a reqwest-backed transport.
-        let octocrab = if transport::proxy_env_override().is_some() {
+        let octocrab = if transport::proxy_is_configured() {
             transport::build_proxy_aware_client(
                 &token,
                 api_base_url.as_deref(),
@@ -357,8 +324,8 @@ impl GitHubClient {
     /// when the token lacks access, not 403).
     pub(crate) fn enrich_api_error(&self, err: anyhow::Error) -> anyhow::Error {
         let msg = format!("{:#}", err);
-        if is_connect_error(&msg) {
-            return err.context(connect_failure_hint());
+        if let Some(hint) = transport::connect_failure_context(&msg) {
+            return err.context(hint);
         }
         if msg.contains("Not Found")
             || msg.contains("404")
@@ -1564,33 +1531,6 @@ mod tests {
             "Connect errors should not get the auth hint, got: {}",
             msg
         );
-    }
-
-    #[test]
-    fn test_connect_hint_names_proxy_variable_without_credentials() {
-        let hint = connect_failure_hint_for(Some((
-            "HTTPS_PROXY",
-            "http://alice:s3cret@proxy.example:8080".to_string(),
-        )));
-
-        assert!(
-            hint.contains("HTTPS_PROXY=http://***@proxy.example:8080"),
-            "Expected redacted proxy in hint, got: {}",
-            hint
-        );
-        assert!(
-            !hint.contains("s3cret") && !hint.contains("alice"),
-            "Proxy credentials leaked into hint: {}",
-            hint
-        );
-    }
-
-    #[test]
-    fn test_connect_hint_without_proxy_points_at_env_vars() {
-        let hint = connect_failure_hint_for(None);
-
-        assert!(hint.contains("HTTPS_PROXY"), "got: {}", hint);
-        assert!(hint.contains("NO_PROXY"), "got: {}", hint);
     }
 
     #[tokio::test]

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -4,5 +4,6 @@ pub mod client;
 pub mod gh_stack;
 pub mod pr;
 pub mod pr_template;
+mod transport;
 
 pub use client::{ForkTarget, GitHubClient};

--- a/src/github/transport.rs
+++ b/src/github/transport.rs
@@ -1,0 +1,363 @@
+//! Proxy-aware HTTP transport for the GitHub API.
+//!
+//! octocrab builds its own hyper client and that client has no notion of an
+//! HTTP proxy: `OctocrabBuilder::build()` hardcodes a TLS connector on top of
+//! hyper-util's `HttpConnector`, which never consults `HTTPS_PROXY` and
+//! friends. Behind a corporate CONNECT proxy that makes every GitHub API call
+//! fail on connect — `client error (Connect): deadline has elapsed` — while
+//! `git` (which honours `http_proxy`) keeps working, so `stax submit` fetches
+//! successfully and then dies on the first API request.
+//!
+//! When proxy environment variables are present we therefore run octocrab on
+//! top of `reqwest` instead — the same client stack the GitLab and Gitea
+//! forges already use. reqwest speaks CONNECT, honours `NO_PROXY` and proxy
+//! credentials, and verifies certificates through the platform verifier, which
+//! also covers proxies that terminate TLS with a CA from the OS trust store.
+//!
+//! `OctocrabBuilder::with_service()` bypasses octocrab's own layer stack, so
+//! the three layers that make an `Octocrab` behave like an `Octocrab` are
+//! reapplied here in octocrab's own order: extra headers (a `User-Agent` is
+//! mandatory for GitHub), base URI resolution, and the auth header. Retry is
+//! reimplemented as a loop because octocrab's `RetryConfig` policy is tied to
+//! `hyper_util::client::legacy::Error`, an error type we cannot produce.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use http::header::{HeaderValue, USER_AGENT};
+use http::{Request, Response, StatusCode};
+use http_body_util::BodyExt;
+use octocrab::service::middleware::auth_header::AuthHeaderLayer;
+use octocrab::service::middleware::base_uri::BaseUriLayer;
+use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+use octocrab::{AuthState, OctoBody, Octocrab, OctocrabBuilder};
+
+const GITHUB_API_BASE_URI: &str = "https://api.github.com";
+const GITHUB_UPLOAD_BASE_URI: &str = "https://uploads.github.com";
+
+/// Proxy environment variables, most specific first — the same set and order
+/// reqwest, curl and git resolve.
+const PROXY_ENV_VARS: [&str; 6] = [
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+];
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The proxy variable in effect for this process, as `(name, value)`.
+pub(crate) fn proxy_env_override() -> Option<(&'static str, String)> {
+    proxy_env_from(|name| std::env::var(name).ok())
+}
+
+fn proxy_env_from<F>(lookup: F) -> Option<(&'static str, String)>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    PROXY_ENV_VARS.iter().find_map(|name| {
+        let value = lookup(name)?;
+        let value = value.trim();
+        (!value.is_empty()).then(|| (*name, value.to_string()))
+    })
+}
+
+/// Strip any `user:password@` userinfo so a proxy URL is safe to print.
+pub(crate) fn redact_proxy_url(value: &str) -> String {
+    let (scheme, rest) = match value.split_once("://") {
+        Some((scheme, rest)) => (Some(scheme), rest),
+        None => (None, value),
+    };
+    let rest = match rest.rsplit_once('@') {
+        Some((_, host)) => format!("***@{host}"),
+        None => rest.to_string(),
+    };
+    match scheme {
+        Some(scheme) => format!("{scheme}://{rest}"),
+        None => rest,
+    }
+}
+
+/// Build an `Octocrab` that routes through the configured HTTP proxy.
+pub(crate) fn build_proxy_aware_client(
+    token: &str,
+    api_base_url: Option<&str>,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+    retries: usize,
+) -> Result<Octocrab> {
+    let base_uri: http::Uri = api_base_url
+        .unwrap_or(GITHUB_API_BASE_URI)
+        .parse()
+        .context("Failed to parse GitHub API base URL")?;
+    let upload_uri: http::Uri = GITHUB_UPLOAD_BASE_URI
+        .parse()
+        .expect("static GitHub upload URI is valid");
+
+    // reqwest is built with `rustls-no-provider`, so building a client panics
+    // unless a crypto provider is installed. `cli::run` installs one at
+    // startup; do it here too so a client built outside that entry point
+    // (tests, library use) cannot panic.
+    ensure_rustls_provider();
+
+    let http = reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .read_timeout(read_timeout)
+        // Match octocrab's redirect behaviour: cross-origin redirects are
+        // followed (GitHub sends them for artifact and log downloads) but
+        // reqwest strips `Authorization` when the origin changes, so the token
+        // never reaches another host.
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()
+        .context("Failed to build proxy-aware GitHub HTTP client")?;
+
+    let auth_header = HeaderValue::from_str(&format!("Bearer {}", token))
+        .context("GitHub token cannot be sent in an Authorization header")?;
+    let extra_headers = Arc::new(vec![(USER_AGENT, HeaderValue::from_static("stax"))]);
+
+    let service = tower::service_fn(move |request: Request<OctoBody>| {
+        let http = http.clone();
+        async move { send_with_retry(http, request, retries).await }
+    });
+
+    OctocrabBuilder::new_empty()
+        .with_service(service)
+        .with_layer(&ExtraHeadersLayer::new(extra_headers))
+        .with_layer(&BaseUriLayer::new(base_uri.clone()))
+        .with_layer(&AuthHeaderLayer::new(
+            Some(auth_header),
+            base_uri,
+            upload_uri,
+        ))
+        .with_auth(AuthState::None)
+        .build()
+        .context("Failed to build proxy-aware GitHub client")
+}
+
+/// Send one octocrab request through reqwest, retrying transport failures and
+/// the status codes octocrab's own `RetryConfig::Simple` retries.
+async fn send_with_retry(
+    http: reqwest::Client,
+    request: Request<OctoBody>,
+    retries: usize,
+) -> Result<Response<reqwest::Body>, BoxError> {
+    let (parts, body) = request.into_parts();
+    let body = body
+        .collect()
+        .await
+        .map_err(|err| -> BoxError {
+            format!("Failed to buffer GitHub request body: {err}").into()
+        })?
+        .to_bytes();
+
+    let mut attempts_left = retries;
+    loop {
+        let mut builder = http::Request::builder()
+            .method(parts.method.clone())
+            .uri(parts.uri.clone())
+            .version(parts.version);
+        for (name, value) in parts.headers.iter() {
+            builder = builder.header(name, value);
+        }
+        let attempt = builder
+            .body(reqwest::Body::from(body.clone()))
+            .map_err(BoxError::from)?;
+        let attempt = reqwest::Request::try_from(attempt).map_err(BoxError::from)?;
+
+        let result = http.execute(attempt).await;
+        let retryable = match &result {
+            Ok(response) => is_retryable_status(response.status()),
+            Err(_) => true,
+        };
+        if retryable && attempts_left > 0 {
+            attempts_left -= 1;
+            continue;
+        }
+
+        return result
+            .map(http::Response::<reqwest::Body>::from)
+            .map_err(BoxError::from);
+    }
+}
+
+fn ensure_rustls_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ensure_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    fn lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        move |name: &str| map.get(name).cloned()
+    }
+
+    fn test_client(server: &MockServer, retries: usize) -> Octocrab {
+        ensure_crypto_provider();
+        build_proxy_aware_client(
+            "test-token",
+            Some(&server.uri()),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            retries,
+        )
+        .expect("proxy-aware client builds")
+    }
+
+    #[test]
+    fn proxy_env_is_detected_in_resolution_order() {
+        assert_eq!(
+            proxy_env_from(lookup(&[
+                ("HTTPS_PROXY", "http://specific:8080"),
+                ("ALL_PROXY", "http://catch-all:8080"),
+            ])),
+            Some(("ALL_PROXY", "http://catch-all:8080".to_string()))
+        );
+        assert_eq!(
+            proxy_env_from(lookup(&[("http_proxy", "http://lower:8080")])),
+            Some(("http_proxy", "http://lower:8080".to_string()))
+        );
+    }
+
+    #[test]
+    fn blank_proxy_env_is_not_a_proxy() {
+        assert_eq!(proxy_env_from(lookup(&[("HTTPS_PROXY", "   ")])), None);
+        assert_eq!(proxy_env_from(lookup(&[])), None);
+    }
+
+    #[test]
+    fn proxy_url_credentials_are_redacted() {
+        assert_eq!(
+            redact_proxy_url("http://user:s3cret@proxy.example:8080"),
+            "http://***@proxy.example:8080"
+        );
+        assert_eq!(
+            redact_proxy_url("http://proxy.example:8080"),
+            "http://proxy.example:8080"
+        );
+        assert_eq!(redact_proxy_url("proxy.example:8080"), "proxy.example:8080");
+    }
+
+    #[tokio::test]
+    async fn proxy_aware_client_sends_octocrab_headers_and_resolves_base_uri() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .and(header("user-agent", "stax"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "login": "octocat",
+                "id": 1,
+                "node_id": "node",
+                "avatar_url": "https://example.com/a.png",
+                "gravatar_id": "",
+                "url": "https://example.com/users/octocat",
+                "html_url": "https://example.com/octocat",
+                "followers_url": "https://example.com/followers",
+                "following_url": "https://example.com/following",
+                "gists_url": "https://example.com/gists",
+                "starred_url": "https://example.com/starred",
+                "subscriptions_url": "https://example.com/subscriptions",
+                "organizations_url": "https://example.com/orgs",
+                "repos_url": "https://example.com/repos",
+                "events_url": "https://example.com/events",
+                "received_events_url": "https://example.com/received_events",
+                "type": "User",
+                "site_admin": false
+            })))
+            .mount(&server)
+            .await;
+
+        let octocrab = test_client(&server, 0);
+        let user = octocrab
+            .current()
+            .user()
+            .await
+            .expect("authenticated user request succeeds through the custom transport");
+
+        assert_eq!(user.login, "octocat");
+    }
+
+    #[tokio::test]
+    async fn proxy_aware_client_retries_server_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/probe"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "message": "server on fire"
+            })))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/probe"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "ok": true })),
+            )
+            .with_priority(2)
+            .mount(&server)
+            .await;
+
+        let octocrab = test_client(&server, 1);
+        let body: serde_json::Value = octocrab
+            .get("/probe", None::<&()>)
+            .await
+            .expect("retry recovers from a single 500");
+
+        assert_eq!(body["ok"], serde_json::json!(true));
+        assert_eq!(
+            server.received_requests().await.unwrap_or_default().len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_aware_client_surfaces_errors_without_retries() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/probe"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(serde_json::json!({ "message": "server on fire" })),
+            )
+            .mount(&server)
+            .await;
+
+        let octocrab = test_client(&server, 0);
+        let error = octocrab
+            .get::<serde_json::Value, _, ()>("/probe", None)
+            .await
+            .expect_err("a 500 without retries must surface");
+
+        let octocrab::Error::GitHub { source, .. } = &error else {
+            panic!("expected the 500 to surface as a GitHub API error, got: {error:?}");
+        };
+        assert_eq!(source.message, "server on fire");
+        assert_eq!(source.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            server.received_requests().await.unwrap_or_default().len(),
+            1
+        );
+    }
+}

--- a/src/github/transport.rs
+++ b/src/github/transport.rs
@@ -49,8 +49,13 @@ const PROXY_ENV_VARS: [&str; 6] = [
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
+/// Whether this process has an HTTP proxy configured for outbound requests.
+pub(crate) fn proxy_is_configured() -> bool {
+    proxy_env_override().is_some()
+}
+
 /// The proxy variable in effect for this process, as `(name, value)`.
-pub(crate) fn proxy_env_override() -> Option<(&'static str, String)> {
+fn proxy_env_override() -> Option<(&'static str, String)> {
     proxy_env_from(|name| std::env::var(name).ok())
 }
 
@@ -66,7 +71,7 @@ where
 }
 
 /// Strip any `user:password@` userinfo so a proxy URL is safe to print.
-pub(crate) fn redact_proxy_url(value: &str) -> String {
+fn redact_proxy_url(value: &str) -> String {
     let (scheme, rest) = match value.split_once("://") {
         Some((scheme, rest)) => (Some(scheme), rest),
         None => (None, value),
@@ -78,6 +83,47 @@ pub(crate) fn redact_proxy_url(value: &str) -> String {
     match scheme {
         Some(scheme) => format!("{scheme}://{rest}"),
         None => rest,
+    }
+}
+
+/// Guidance for an error that never got as far as talking to GitHub, or `None`
+/// when the error is not a connect failure.
+///
+/// A connect failure says nothing about the token, so it must not inherit the
+/// auth guidance `enrich_api_error` adds otherwise. What matters instead is
+/// whether the request was supposed to go through a proxy.
+pub(crate) fn connect_failure_context(message: &str) -> Option<String> {
+    const CONNECT_MARKERS: [&str; 6] = [
+        "(Connect)",
+        "deadline has elapsed",
+        "error trying to connect",
+        "dns error",
+        "operation timed out",
+        "Connection refused",
+    ];
+
+    if !CONNECT_MARKERS
+        .iter()
+        .any(|marker| message.contains(marker))
+    {
+        return None;
+    }
+
+    Some(connect_failure_hint(proxy_env_override()))
+}
+
+fn connect_failure_hint(proxy: Option<(&str, String)>) -> String {
+    match proxy {
+        Some((name, value)) => format!(
+            "Could not reach the GitHub API. Requests use the proxy from {}={}; check that the \
+             proxy is up and permits CONNECT to the API host, or exclude the host via NO_PROXY.",
+            name,
+            redact_proxy_url(&value),
+        ),
+        None => "Could not reach the GitHub API, and no HTTP proxy is configured. If this network \
+                 requires one, set HTTPS_PROXY (stax honours ALL_PROXY/HTTPS_PROXY/HTTP_PROXY and \
+                 NO_PROXY); otherwise check your VPN, DNS, or firewall."
+            .to_string(),
     }
 }
 
@@ -153,19 +199,15 @@ async fn send_with_retry(
         })?
         .to_bytes();
 
+    let request =
+        reqwest::Request::try_from(Request::from_parts(parts, reqwest::Body::from(body)))?;
+
     let mut attempts_left = retries;
     loop {
-        let mut builder = http::Request::builder()
-            .method(parts.method.clone())
-            .uri(parts.uri.clone())
-            .version(parts.version);
-        for (name, value) in parts.headers.iter() {
-            builder = builder.header(name, value);
-        }
-        let attempt = builder
-            .body(reqwest::Body::from(body.clone()))
-            .map_err(BoxError::from)?;
-        let attempt = reqwest::Request::try_from(attempt).map_err(BoxError::from)?;
+        // A buffered body always clones; this only fails if that stops holding.
+        let attempt = request
+            .try_clone()
+            .ok_or("GitHub request body cannot be replayed")?;
 
         let result = http.execute(attempt).await;
         let retryable = match &result {
@@ -177,9 +219,7 @@ async fn send_with_retry(
             continue;
         }
 
-        return result
-            .map(http::Response::<reqwest::Body>::from)
-            .map_err(BoxError::from);
+        return Ok(result?.into());
     }
 }
 
@@ -243,6 +283,42 @@ mod tests {
     fn blank_proxy_env_is_not_a_proxy() {
         assert_eq!(proxy_env_from(lookup(&[("HTTPS_PROXY", "   ")])), None);
         assert_eq!(proxy_env_from(lookup(&[])), None);
+    }
+
+    #[test]
+    fn connect_failure_context_ignores_unrelated_errors() {
+        assert_eq!(connect_failure_context("Bad credentials (401)"), None);
+        assert!(
+            connect_failure_context(
+                "Service Error: client error (Connect): client error (Connect): deadline has elapsed"
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn connect_failure_hint_names_the_proxy_variable_without_credentials() {
+        let hint = connect_failure_hint(Some((
+            "HTTPS_PROXY",
+            "http://alice:s3cret@proxy.example:8080".to_string(),
+        )));
+
+        assert!(
+            hint.contains("HTTPS_PROXY=http://***@proxy.example:8080"),
+            "expected redacted proxy in hint: {hint}"
+        );
+        assert!(
+            !hint.contains("s3cret") && !hint.contains("alice"),
+            "proxy credentials leaked into hint: {hint}"
+        );
+    }
+
+    #[test]
+    fn connect_failure_hint_without_a_proxy_points_at_the_env_vars() {
+        let hint = connect_failure_hint(None);
+
+        assert!(hint.contains("HTTPS_PROXY"), "got: {hint}");
+        assert!(hint.contains("NO_PROXY"), "got: {hint}");
     }
 
     #[test]


### PR DESCRIPTION
## The problem

On a network where egress requires an HTTP `CONNECT` proxy, every GitHub API call fails at connect time:

```
$ st ss
Submitting stack...
  ✓ Fetching from origin...             done 2.977s
Error: Failed to list PRs by head: Service Error: client error (Connect): client error (Connect): deadline has elapsed
```

The fetch succeeds because git honours `http_proxy`. The API call immediately after it does not, because octocrab has no proxy support: `build()` hardcodes `HttpsConnectorBuilder` over hyper-util's `HttpConnector`, which never consults proxy configuration, and `grep -ri proxy` over the crate returns nothing. No env var or `config.toml` key can fix that from outside — a client with no proxy code cannot use a proxy.

The GitLab and Gitea paths were unaffected: they use `reqwest`, which does read `HTTPS_PROXY`/`NO_PROXY`.

## The fix

When `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` (either case) is set, `GitHubClient::new_with_auth` builds the `Octocrab` on a reqwest-backed `tower` service — the same client stack the other forges already use. reqwest handles `CONNECT` tunnelling, `NO_PROXY` exclusions, proxy credentials, and platform certificate verification, which also covers proxies that terminate TLS with a CA from the OS trust store.

**With no proxy variable set, nothing changes** — the existing octocrab builder path is taken verbatim, so unproxied users are unaffected.

`with_service()` moves the builder into the `NoConfig` type state, whose `build()` applies nothing but `MapResponseBodyLayer`, so `src/github/transport.rs` reapplies octocrab's own layers in octocrab's order:

| Layer | Why it can't be skipped |
|---|---|
| `ExtraHeadersLayer` | GitHub rejects requests without a `User-Agent` |
| `BaseUriLayer` | handlers build relative URIs |
| `AuthHeaderLayer` | `Authorization`, plus the authority check that keeps the token from following a redirect off-host |

Retry is a loop over the buffered request body rather than `RetryConfig`, whose `Policy` impl is bound to `hyper_util::client::legacy::Error` — an error type a non-hyper service cannot construct. Filed upstream as [XAMPPRocky/octocrab#936](https://github.com/XAMPPRocky/octocrab/issues/936), asking for connector injection so this module can shrink to a few lines.

## Also in here

- **Better connect diagnostics.** A connect failure previously fell through to the auth branch of `enrich_api_error` and suggested the token was expired. It now reports whether a proxy was in play and which variable named it, with `user:password@` redacted.
- **A latent panic fixed.** reqwest is built with `rustls-no-provider`, which panics unless a crypto provider is installed. `cli::run` installs one, so the CLI was fine, but a client built outside that entry point (tests, library use) panicked. The transport now installs one defensively.
- **Deterministic tests.** `scripts/native-tests.sh` and the Makefile's native runs now scrub proxy variables alongside the tokens, because a proxy inherited from the developer's shell reroutes the loopback mock servers the tests talk to. `scripts/native-tests-tests.sh` asserts the scrub.
- **Docs.** New "HTTP proxies" section in `docs/configuration/index.md`.

## Tests

Six new tests in `src/github/transport.rs` and `src/github/client.rs`:

- a wiremock round trip through the custom transport, asserting `User-Agent` and `Authorization` arrive and the relative URI resolves against the base — i.e. the hand-built layer stack behaves like octocrab's;
- retry recovers from a single 500 (2 requests), and surfaces the error with retries disabled (1 request);
- proxy-variable resolution order and blank-value handling;
- credential redaction in the hint;
- connect errors get the proxy hint and not the auth hint.

Verified end-to-end against real GitHub through an HTTP `CONNECT` proxy: REST reads and a GraphQL POST both succeed where they previously died at connect.

`cargo check --all-targets`, `./scripts/lint.sh full` and `cargo fmt --check` are clean. The full suite was run natively with a proxy deliberately left set, so the new transport was the one under test: **2649/2655 pass**. The 6 failures are pre-existing and unrelated — they fail identically on `main` at this commit: 4 PTY-driven tests need Linux `script` semantics (which is why `make test` prefers Docker on macOS), and 2 read a global `remote.base_url` from the developer's own stax config. CI, which runs the suite in the Linux image with a clean environment, should be green.

## Follow-up, deliberately not in this PR

Collapsing GitHub onto the same reqwest stack as the other forges would delete the dual transport and the small divergences it carries (user-agent `stax` vs `octocrab`; no write timeout on the proxy path). Bigger blast radius, so it belongs in its own change.
