### PR TITLE
refactor(github): make the reqwest transport the only GitHub transport (stacked on #852)

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1,21 +1,14 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use octocrab::Octocrab;
-use octocrab::service::middleware::retry::RetryConfig;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use crate::config::{Config, GitHubAuthSource};
 use crate::forge::{ForgeSignal, PrActivity, RepoIssueListItem, RepoPrListItem, ReviewActivity};
 use crate::github::transport;
-
-const GITHUB_API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-const GITHUB_API_READ_TIMEOUT: Duration = Duration::from_secs(30);
-const GITHUB_API_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
-const GITHUB_API_RETRY_COUNT: usize = 1;
 
 pub struct GitHubClient {
     pub octocrab: Octocrab,
@@ -263,32 +256,8 @@ impl GitHubClient {
         auth_source: GitHubAuthSource,
         token: String,
     ) -> Result<Self> {
-        // octocrab's own client cannot reach GitHub through an HTTP proxy, so
-        // when one is configured we swap in a reqwest-backed transport.
-        let octocrab = if transport::proxy_is_configured() {
-            transport::build_proxy_aware_client(
-                &token,
-                api_base_url.as_deref(),
-                GITHUB_API_CONNECT_TIMEOUT,
-                GITHUB_API_READ_TIMEOUT,
-                GITHUB_API_RETRY_COUNT,
-            )
-            .context("Failed to create proxied GitHub client")?
-        } else {
-            let mut builder = Octocrab::builder()
-                .personal_token(token)
-                .add_retry_config(RetryConfig::Simple(GITHUB_API_RETRY_COUNT))
-                .set_connect_timeout(Some(GITHUB_API_CONNECT_TIMEOUT))
-                .set_read_timeout(Some(GITHUB_API_READ_TIMEOUT))
-                .set_write_timeout(Some(GITHUB_API_WRITE_TIMEOUT));
-            if let Some(api_base) = api_base_url {
-                builder = builder
-                    .base_uri(api_base)
-                    .context("Failed to set GitHub API base URL")?;
-            }
-
-            builder.build().context("Failed to create GitHub client")?
-        };
+        let octocrab = transport::build_client(&token, api_base_url.as_deref())
+            .context("Failed to create GitHub client")?;
 
         Ok(Self {
             octocrab,

--- a/src/github/transport.rs
+++ b/src/github/transport.rs
@@ -20,6 +20,12 @@
 //! mandatory for GitHub), base URI resolution, and the auth header. Retry is
 //! reimplemented as a loop because octocrab's `RetryConfig` policy is tied to
 //! `hyper_util::client::legacy::Error`, an error type we cannot produce.
+//!
+//! This is the only GitHub transport: it runs whether or not a proxy is
+//! configured, so the proxied and unproxied paths cannot drift apart, and
+//! GitHub now reaches the network exactly the way GitLab and Gitea already do
+//! (`forge::build_http_client`) — same client, same timeout shape, same
+//! `stax` user-agent.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -36,6 +42,14 @@ use octocrab::{AuthState, OctoBody, Octocrab, OctocrabBuilder};
 const GITHUB_API_BASE_URI: &str = "https://api.github.com";
 const GITHUB_UPLOAD_BASE_URI: &str = "https://uploads.github.com";
 
+/// Timeouts and retry budget for GitHub API requests. The shape matches
+/// `forge::build_http_client`, so every forge behaves the same way on a slow
+/// or half-open connection.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+const TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
+const RETRY_COUNT: usize = 1;
+
 /// Proxy environment variables, most specific first — the same set and order
 /// reqwest, curl and git resolve.
 const PROXY_ENV_VARS: [&str; 6] = [
@@ -48,11 +62,6 @@ const PROXY_ENV_VARS: [&str; 6] = [
 ];
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
-
-/// Whether this process has an HTTP proxy configured for outbound requests.
-pub(crate) fn proxy_is_configured() -> bool {
-    proxy_env_override().is_some()
-}
 
 /// The proxy variable in effect for this process, as `(name, value)`.
 fn proxy_env_override() -> Option<(&'static str, String)> {
@@ -127,12 +136,30 @@ fn connect_failure_hint(proxy: Option<(&str, String)>) -> String {
     }
 }
 
-/// Build an `Octocrab` that routes through the configured HTTP proxy.
-pub(crate) fn build_proxy_aware_client(
+/// Build the `Octocrab` stax talks to GitHub through.
+pub(crate) fn build_client(token: &str, api_base_url: Option<&str>) -> Result<Octocrab> {
+    build_client_with(
+        token,
+        api_base_url,
+        Timeouts {
+            connect: CONNECT_TIMEOUT,
+            read: READ_TIMEOUT,
+            total: TOTAL_TIMEOUT,
+        },
+        RETRY_COUNT,
+    )
+}
+
+struct Timeouts {
+    connect: Duration,
+    read: Duration,
+    total: Duration,
+}
+
+fn build_client_with(
     token: &str,
     api_base_url: Option<&str>,
-    connect_timeout: Duration,
-    read_timeout: Duration,
+    timeouts: Timeouts,
     retries: usize,
 ) -> Result<Octocrab> {
     let base_uri: http::Uri = api_base_url
@@ -150,8 +177,9 @@ pub(crate) fn build_proxy_aware_client(
     ensure_rustls_provider();
 
     let http = reqwest::Client::builder()
-        .connect_timeout(connect_timeout)
-        .read_timeout(read_timeout)
+        .connect_timeout(timeouts.connect)
+        .read_timeout(timeouts.read)
+        .timeout(timeouts.total)
         // Match octocrab's redirect behaviour: cross-origin redirects are
         // followed (GitHub sends them for artifact and log downloads) but
         // reqwest strips `Authorization` when the origin changes, so the token
@@ -254,14 +282,17 @@ mod tests {
 
     fn test_client(server: &MockServer, retries: usize) -> Octocrab {
         ensure_crypto_provider();
-        build_proxy_aware_client(
+        build_client_with(
             "test-token",
             Some(&server.uri()),
-            Duration::from_secs(5),
-            Duration::from_secs(5),
+            Timeouts {
+                connect: Duration::from_secs(5),
+                read: Duration::from_secs(5),
+                total: Duration::from_secs(5),
+            },
             retries,
         )
-        .expect("proxy-aware client builds")
+        .expect("GitHub client builds")
     }
 
     #[test]
@@ -335,7 +366,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proxy_aware_client_sends_octocrab_headers_and_resolves_base_uri() {
+    async fn client_sends_octocrab_headers_and_resolves_base_uri() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/user"))
@@ -375,7 +406,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proxy_aware_client_retries_server_errors() {
+    async fn client_retries_server_errors() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/probe"))
@@ -409,7 +440,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proxy_aware_client_surfaces_errors_without_retries() {
+    async fn client_surfaces_errors_without_retries() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/probe"))


### PR DESCRIPTION
> ## ⚠️ Merge #852 first
>
> This is a follow-up to **#852** and depends on it. Please do not merge this one until #852 has landed.
>
> Because the base branch of #852 lives on a fork (I have no push access here, so it could not be used as a base branch in this repo), GitHub cannot show this as a true stacked PR. **The diff below therefore contains #852's two commits as well.** Only the final commit — `refactor(github): make the reqwest transport the only GitHub transport` — is new work here.
>
> - Isolated diff for just this change (51 lines, 2 files): geoHeil/stax#2
> - After #852 merges I will rebase this branch onto `main` and force-push, and this PR will then show only the refactor commit.

## Why

#852 fixed GitHub API calls failing behind an HTTP `CONNECT` proxy, but it deliberately kept **two** transports: reqwest when a proxy is configured, octocrab's own hyper client otherwise. That was the right scope for a bug fix — the blast radius stayed on the users who were already broken — but it leaves a codebase where:

- the path **most** users take is not the path #852's new tests cover;
- a future transport fix has to be made twice, or silently applies to only half the users;
- GitHub reaches the network differently from GitLab and Gitea, which have used `reqwest` via `forge::build_http_client` all along.

## What changes

`GitHubClient::new_with_auth` always builds on the reqwest-backed service, and the branch goes away:

```rust
let octocrab = transport::build_client(&token, api_base_url.as_deref())
    .context("Failed to create GitHub client")?;
```

The transport also takes ownership of its own timeout and retry constants, since nothing else needed them once the octocrab builder was gone, and `build_client` takes only what the caller actually knows: a token and an optional API base.

## Two visible consequences

Both look like corrections rather than regressions, but they *are* behaviour changes for unproxied users and deserve your eye:

| | Before (unproxied users) | After |
|---|---|---|
| `User-Agent` | `octocrab` | `stax` — same as the other forges send |
| Timeouts | connect 10s, read 30s, **write 30s** | connect 10s, read 30s, **total 60s** — same shape as `forge::build_http_client` |

reqwest has no write-timeout equivalent. A total timeout is arguably the stronger guarantee anyway: it also bounds a response that trickles in indefinitely without ever going idle long enough to trip a read timeout. Happy to revisit either row if you would rather preserve the old values exactly.

Behaviour that comes from the `Octocrab` type rather than its service stack is untouched — notably the `X-GitHub-Api-Version` header, which `build_request` adds per request, not via a layer.

## Tests

No new tests: this deletes a path rather than adding one, and #852's transport tests now cover every user instead of only proxied ones. The wiremock tests exercise the unproxied path directly — the mock servers are on loopback, which `NO_PROXY` excludes, so those requests go straight out with no proxy in between.

`cargo check --all-targets`, `./scripts/clippy-lint.sh full` and `cargo fmt --check` are clean. Full suite run natively: **2650/2656 pass**. The 6 failures are pre-existing and unrelated — they fail identically on `main` at this commit (verified by stashing): 4 PTY-driven tests need Linux `script` semantics, which is why `make test` prefers Docker on macOS, and 2 read a global `remote.base_url` from the developer's own stax config. CI, which runs the suite in the Linux image with a clean environment, should be green.

Also smoke-tested against real GitHub through a corporate `CONNECT` proxy — REST reads and a GraphQL POST both succeed on the collapsed transport.

## Unrelated bug spotted while testing

`stax standup`'s reviews-given signal fails for everyone, proxy or not:

```
Failed to query authored review contributions:
GraphQL error: InputObject 'ContributionOrder' doesn't accept argument 'field'
```

`src/github/client.rs` sends `orderBy: { field: OCCURRED_AT, direction: DESC }`, but GitHub's `ContributionOrder` only accepts `direction`. Deleting `field: OCCURRED_AT` is the whole fix. Not touched here — unrelated to the transport, so it belongs in its own PR off `main`. Happy to send that separately.
