### PR TITLE
feat(merge): add --ignore-failed-ci to override a red CI rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ st merge --stack          # GitHub/GitLab: preserve lower PR/MR merged state thr
 st merge --stack --full   # stack-merge the full stack even from the middle
 st merge --remote         # merge remotely on GitHub while you keep working
 st merge --all            # merge the whole stack regardless of position
+st merge --ignore-failed-ci  # merge despite a red CI rollup (e.g. only optional checks failed)
 ```
 
 On GitHub, if the current stack is a confirmed-enabled native GitHub Stack and
@@ -366,7 +367,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st upstack submit` | Submit current branch and descendants, chaining temporary publish heads when needed |
 | `st reviews --stack [--json]` | Stack-wide review/comment inbox, including inline file/line locations on GitHub (`st comments` remains the current-PR view) |
 | `st next` | Move to the next unmerged branch upstack; fork choices are deterministic |
-| `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--stack`, `--stack --full`, `--remote`, `--all`) |
+| `st merge` | Cascade-merge from bottom to current (`--when-ready`, `--downstack-only`/`--ds`, `--stack`, `--stack --full`, `--remote`, `--all`, `--ignore-failed-ci`) |
 | `st ready` | Interactive PR readiness TUI — CI, review approval, and merge state for unmerged tracked PRs; auto-refreshes every 15s and drops remotely merged PRs without cleaning up their local branches (`--current`/`--stack` for current stack, `--plain` for a static table, `--json` for machine-readable readiness schema) |
 | `st board` / `st home` | Interactive repository dashboard (GitHub only) — PULL REQUESTS / ISSUES tabs with a detail pane, inline diff/comments, label editing, draft toggle, and API-only merge (`--limit`, `--tab`, `--interval`, `--plain` for static tables) |
 | `st ci` / `st ci --oneline` | Live CI status for each PR head — full per-check table, or one compact line per branch across the stack; GitHub statuses and check runs are fetched across all pages before roll-up |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -334,6 +334,7 @@ st completions elvish
 - `--timeout <minutes>` — positive whole minutes (default: 30); zero is rejected
 - `--interval <seconds>` — positive whole seconds (default: 15) for `--when-ready`, `--remote`, `--queue`, and `--stack --when-ready`; zero is rejected
 - `--no-wait` / `--no-sync` / `--no-delete` / `--quiet`
+- `--ignore-failed-ci` — merge even when CI checks have failed; still blocks on draft, changes-requested, conflicts, and closed. Incompatible with `--queue`. Use when only optional checks failed and branch protection does not require them.
 
 For `--queue`, the timeout is a real deadline: stax caps the final sleep to the remaining budget and does not start another forge status poll once the deadline is reached.
 

--- a/docs/workflows/merge-and-cascade.md
+++ b/docs/workflows/merge-and-cascade.md
@@ -6,7 +6,7 @@ How to merge an entire stack safely.
 
 Cascade-merges PRs from the bottom of your stack up to your current branch. For each PR, stax:
 
-1. Waits for readiness (CI + approvals + mergeability) unless `--no-wait`
+1. Waits for readiness (CI + approvals + mergeability) unless `--no-wait`, or `--ignore-failed-ci` to proceed despite a red CI rollup
 2. Merges with the selected strategy
 3. Rebases the next branch onto updated trunk
 4. Updates the next PR base
@@ -31,6 +31,7 @@ st merge --when-ready                       # wait for readiness explicitly
 st merge --when-ready --interval 10
 st merge --no-wait --no-delete --no-sync
 st merge --timeout 60 --yes
+st merge --ignore-failed-ci               # override a failed CI rollup (still blocks on draft/conflicts)
 ```
 
 `--downstack-only` (`--ds`) merges only ancestors below the current branch, then rebases the current branch onto trunk and keeps descendants stacked above it. It composes with `--stack`, and is incompatible with `--all`, `--full`, `--remote`, and `--queue`.
@@ -38,6 +39,8 @@ st merge --timeout 60 --yes
 `--full` is only valid with `--stack`; it includes descendants above the current branch in the selected stack merge.
 
 `--when-ready` is incompatible with `--dry-run`, `--no-wait`, `--remote`, and `--queue`. With `--stack`, it waits only for the selected tip PR/MR.
+
+`--ignore-failed-ci` merges even when the forge reports the CI rollup as failed. Use it when only optional checks are red — a preview deployment, say — and branch protection does not require them. It waives nothing else: draft PRs, requested changes, merge conflicts, and closed PRs still block, and a *pending* rollup is still waited on (that is `--no-wait`'s job, not this flag's). stax prints a warning whenever the override actually skips a red rollup, and the forge's own branch protection remains the final gate — if it refuses the merge, you get that error instead. Works with the default cascade, `--stack`, `--remote`, and `--when-ready`; incompatible with `--queue`, where the forge's merge queue makes the readiness decision.
 
 ### Partial stack merge
 

--- a/skills.md
+++ b/skills.md
@@ -327,6 +327,7 @@ stax merge --remote                # Merge via GitHub API only — no local chec
 stax merge --remote --all          # Include full stack (GitHub only)
 stax merge --interval 30           # Positive poll seconds for --when-ready / --remote / --queue / --stack --when-ready
 stax merge --no-wait               # Fail fast if CI is pending
+stax merge --ignore-failed-ci      # Merge even when CI failed (still blocks draft/conflicts/changes-requested); incompatible with --queue
 stax merge --timeout 60            # Positive max-wait minutes (default 30; zero is rejected)
 stax merge --no-delete             # Keep branches after merge
 stax merge --no-sync               # Skip post-merge sync

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -395,6 +395,9 @@ pub(crate) enum Commands {
         /// Fail if CI pending (don't poll/wait)
         #[arg(long)]
         no_wait: bool,
+        /// Merge even when CI checks failed (still blocks on draft, changes requested, and conflicts)
+        #[arg(long)]
+        ignore_failed_ci: bool,
         /// Max wait time for CI per PR in minutes
         #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..))]
         timeout: u64,
@@ -409,7 +412,7 @@ pub(crate) enum Commands {
         stack: bool,
         /// Enqueue PRs into the forge's merge queue instead of merging one-by-one.
         /// Supported on GitHub (merge queue) and GitLab (merge trains). Not available on Gitea.
-        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote", "stack"])]
+        #[arg(long, conflicts_with_all = ["dry_run", "no_wait", "when_ready", "remote", "stack", "ignore_failed_ci"])]
         queue: bool,
         /// Polling interval in seconds for --when-ready, --remote, --queue, and --stack --when-ready
         #[arg(long, default_value_t = 15, value_parser = clap::value_parser!(u64).range(1..))]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+use crate::github::pr::ReadinessPolicy;
 use crate::{commands, config::Config, git::GitRepo, tui, update};
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
@@ -293,6 +294,7 @@ pub fn run() -> Result<()> {
             method,
             no_delete,
             no_wait,
+            ignore_failed_ci,
             timeout,
             when_ready,
             remote,
@@ -305,6 +307,11 @@ pub fn run() -> Result<()> {
         } => {
             let default_method = if stack { "merge" } else { "squash" };
             let merge_method = method.as_deref().unwrap_or(default_method).parse()?;
+            let readiness = if ignore_failed_ci {
+                ReadinessPolicy::ignoring_failed_ci()
+            } else {
+                ReadinessPolicy::strict()
+            };
             if queue {
                 commands::merge_queue::run(all, timeout, interval, no_sync, yes, quiet)
             } else if remote {
@@ -313,6 +320,7 @@ pub fn run() -> Result<()> {
                     merge_method,
                     timeout,
                     interval,
+                    readiness,
                     no_delete,
                     no_sync,
                     yes,
@@ -327,6 +335,7 @@ pub fn run() -> Result<()> {
                     merge_method,
                     timeout,
                     interval,
+                    readiness,
                     no_delete,
                     no_sync,
                     yes,
@@ -339,6 +348,7 @@ pub fn run() -> Result<()> {
                     merge_method,
                     timeout,
                     interval,
+                    readiness,
                     no_delete,
                     no_sync,
                     yes,
@@ -352,6 +362,7 @@ pub fn run() -> Result<()> {
                     merge_method,
                     no_delete,
                     no_wait,
+                    readiness,
                     timeout,
                     no_sync,
                     yes,
@@ -377,6 +388,7 @@ pub fn run() -> Result<()> {
                 merge_method,
                 timeout,
                 interval,
+                ReadinessPolicy::strict(),
                 no_delete,
                 no_sync,
                 yes,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -516,3 +516,23 @@ fn merge_accepts_timeout_of_one() {
         Some(Commands::Merge { timeout: 1, .. })
     ));
 }
+
+#[test]
+fn merge_accepts_ignore_failed_ci() {
+    let cli = parse_cli(&["stax", "merge", "--ignore-failed-ci"]);
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Merge {
+            ignore_failed_ci: true,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn merge_queue_rejects_ignore_failed_ci() {
+    assert!(
+        try_parse_cli(&["stax", "merge", "--queue", "--ignore-failed-ci"]).is_err(),
+        "--queue and --ignore-failed-ci should be mutually exclusive"
+    );
+}

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -4,13 +4,13 @@ use crate::commands::merge_rebase::{
 use crate::commands::merge_shared::{
     BlockedReasonStyle, PrBaseUpdate, WaitResult, blocked_reason, print_native_stack_locked_note,
     rebase_and_finalize_remaining_branch, record_ci_history_for_branch, sync_head_after_push,
-    update_pr_base_unless_current, wait_for_pr_ready,
+    update_pr_base_unless_current, wait_for_pr_ready, warn_ignored_ci_failure,
 };
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::{GitRepo, RebaseResult};
-use crate::github::pr::{MergeMethod, PrMergeStatus};
+use crate::github::pr::{MergeMethod, PrMergeStatus, ReadinessPolicy};
 use crate::progress::LiveTimer;
 use crate::remote::RemoteInfo;
 use anyhow::{Context, Result};
@@ -53,6 +53,7 @@ pub fn run(
     method: MergeMethod,
     no_delete: bool,
     no_wait: bool,
+    readiness: ReadinessPolicy,
     timeout_mins: u64,
     no_sync: bool,
     yes: bool,
@@ -220,9 +221,12 @@ pub fn run(
                     timeout,
                     Duration::from_secs(10),
                     BlockedReasonStyle::Detailed,
+                    readiness,
                     quiet,
                 )? {
-                    WaitResult::Ready(_) => {}
+                    WaitResult::Ready(status) => {
+                        warn_ignored_ci_failure(&status, readiness, quiet);
+                    }
                     WaitResult::Failed(reason) => {
                         failed_pr = Some((branch_info.branch.clone(), pr_number, reason));
                         break;
@@ -239,15 +243,16 @@ pub fn run(
             } else {
                 // Check if ready without waiting
                 let status = rt.block_on(async { client.get_pr_merge_status(pr_number).await })?;
-                if !status.is_ready() {
-                    let reason = if status.is_blocked() {
-                        blocked_reason(&status)
+                if !status.is_ready(readiness) {
+                    let reason = if status.is_blocked(readiness) {
+                        blocked_reason(&status, readiness)
                     } else {
-                        format!("PR not ready: {}", status.status_text())
+                        format!("PR not ready: {}", status.status_text(readiness))
                     };
                     failed_pr = Some((branch_info.branch.clone(), pr_number, reason));
                     break;
                 }
+                warn_ignored_ci_failure(&status, readiness, quiet);
             }
 
             // Merge the PR
@@ -466,6 +471,12 @@ pub fn run(
 
     if let Some((branch, pr, reason)) = failed_pr {
         println!("  {} #{} {} → {}", "✗".red(), pr, branch, reason);
+        if reason == "CI failed" && !readiness.ignore_failed_ci {
+            println!(
+                "{}",
+                "If only optional checks failed, re-run with --ignore-failed-ci.".dimmed()
+            );
+        }
         println!("{}", "Fix the issue and run 'stax merge' again.".dimmed());
     } else {
         let pr_word = if merged_prs.len() == 1 { "PR" } else { "PRs" };

--- a/src/commands/merge_remote.rs
+++ b/src/commands/merge_remote.rs
@@ -6,12 +6,13 @@ use crate::commands::merge_shared::{
     BlockedReasonStyle, PrBaseUpdate, WaitResult, calculate_scope, print_header,
     print_header_error, print_header_success, print_native_stack_locked_note,
     record_ci_history_for_branch, update_pr_base_unless_current, wait_for_pr_ready,
+    warn_ignored_ci_failure,
 };
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
-use crate::github::pr::MergeMethod;
+use crate::github::pr::{MergeMethod, ReadinessPolicy};
 use crate::progress::LiveTimer;
 use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
@@ -43,6 +44,7 @@ pub fn run(
     method: MergeMethod,
     timeout_mins: u64,
     interval_secs: u64,
+    readiness: ReadinessPolicy,
     no_delete: bool,
     no_sync: bool,
     yes: bool,
@@ -255,9 +257,12 @@ pub fn run(
                 timeout,
                 poll_interval,
                 BlockedReasonStyle::StatusText,
+                readiness,
                 quiet,
             )? {
-                WaitResult::Ready(_) => {}
+                WaitResult::Ready(status) => {
+                    warn_ignored_ci_failure(&status, readiness, quiet);
+                }
                 WaitResult::Failed(reason) => {
                     failed_pr = Some((branch_name, pr_number, reason));
                     break;

--- a/src/commands/merge_shared.rs
+++ b/src/commands/merge_shared.rs
@@ -12,7 +12,7 @@ use crate::commands::merge_rebase::{
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::{GitRepo, RebaseResult};
-use crate::github::pr::{PrMergeStatus, is_native_stack_base_locked_error};
+use crate::github::pr::{PrMergeStatus, ReadinessPolicy, is_native_stack_base_locked_error};
 use crate::progress::LiveTimer;
 use anyhow::{Context, Result};
 use colored::Colorize;
@@ -98,14 +98,37 @@ pub(crate) fn calculate_scope(
 }
 
 /// Map a blocked `PrMergeStatus` to a descriptive, actionable message.
-pub(crate) fn blocked_reason(status: &PrMergeStatus) -> String {
+pub(crate) fn blocked_reason(status: &PrMergeStatus, policy: ReadinessPolicy) -> String {
     if status.is_draft {
         return "PR is in Draft state — remove Draft status before merging".to_string();
     }
-    status.status_text().to_string()
+    status.status_text(policy).to_string()
+}
+
+/// Warn when `--ignore-failed-ci` waived a real CI failure, so overriding is
+/// never silent. The forge's branch protection remains the final gate.
+pub(crate) fn warn_ignored_ci_failure(
+    status: &PrMergeStatus,
+    policy: ReadinessPolicy,
+    quiet: bool,
+) {
+    if quiet || !policy.ignore_failed_ci || !status.ci_status.is_failure() {
+        return;
+    }
+    println!(
+        "  {} {}",
+        "warning:".yellow().bold(),
+        format!(
+            "#{} has failing CI — merging anyway because --ignore-failed-ci was passed; \
+             the forge's branch protection is still the final gate",
+            status.number
+        )
+        .yellow()
+    );
 }
 
 /// Wait for a PR to be ready to merge (CI passed, approved).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn wait_for_pr_ready(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
@@ -113,6 +136,7 @@ pub(crate) fn wait_for_pr_ready(
     timeout: Duration,
     poll_interval: Duration,
     blocked_style: BlockedReasonStyle,
+    policy: ReadinessPolicy,
     quiet: bool,
 ) -> Result<WaitResult> {
     let start = Instant::now();
@@ -122,7 +146,7 @@ pub(crate) fn wait_for_pr_ready(
         let status = rt.block_on(async { client.get_pr_merge_status(pr_number).await })?;
 
         // Check if ready
-        if status.is_ready() {
+        if status.is_ready(policy) {
             if !quiet && last_status.is_some() {
                 println!(); // End the waiting line
             }
@@ -130,13 +154,13 @@ pub(crate) fn wait_for_pr_ready(
         }
 
         // Check if blocked (won't become ready)
-        if status.is_blocked() {
+        if status.is_blocked(policy) {
             if !quiet && last_status.is_some() {
                 println!(); // End the waiting line
             }
             let reason = match blocked_style {
-                BlockedReasonStyle::Detailed => blocked_reason(&status),
-                BlockedReasonStyle::StatusText => status.status_text().to_string(),
+                BlockedReasonStyle::Detailed => blocked_reason(&status, policy),
+                BlockedReasonStyle::StatusText => status.status_text(policy).to_string(),
             };
             return Ok(WaitResult::Failed(reason));
         }
@@ -155,7 +179,7 @@ pub(crate) fn wait_for_pr_ready(
             let status_text = format!(
                 "      {} Waiting for {}... ({}s)",
                 "⏳".yellow(),
-                status.status_text().to_lowercase(),
+                status.status_text(policy).to_lowercase(),
                 elapsed
             );
 
@@ -590,7 +614,7 @@ pub(crate) fn print_header_error(title: &str) {
 mod tests {
     use super::*;
     use crate::engine::stack::StackBranch;
-    use crate::github::pr::CiStatus;
+    use crate::github::pr::{CiStatus, ReadinessPolicy};
     use std::collections::HashMap;
 
     fn create_test_stack() -> Stack {
@@ -772,7 +796,7 @@ mod tests {
         let mut status = merge_status("open");
         status.is_draft = true;
 
-        let reason = blocked_reason(&status);
+        let reason = blocked_reason(&status, ReadinessPolicy::strict());
         assert!(reason.contains("Draft"));
         assert!(reason.contains("remove Draft"));
     }
@@ -782,7 +806,10 @@ mod tests {
         let mut status = merge_status("open");
         status.changes_requested = true;
 
-        assert_eq!(blocked_reason(&status), "Changes requested");
+        assert_eq!(
+            blocked_reason(&status, ReadinessPolicy::strict()),
+            "Changes requested"
+        );
     }
 
     #[test]
@@ -790,7 +817,22 @@ mod tests {
         let mut status = merge_status("open");
         status.ci_status = CiStatus::Failure;
 
-        assert_eq!(blocked_reason(&status), "CI failed");
+        assert_eq!(
+            blocked_reason(&status, ReadinessPolicy::strict()),
+            "CI failed"
+        );
+    }
+
+    #[test]
+    fn blocked_reason_under_override_reports_conflicts_not_ci() {
+        let mut status = merge_status("open");
+        status.ci_status = CiStatus::Failure;
+        status.mergeable = Some(false);
+
+        assert_eq!(
+            blocked_reason(&status, ReadinessPolicy::ignoring_failed_ci()),
+            "Has conflicts"
+        );
     }
 
     #[test]

--- a/src/commands/merge_stack.rs
+++ b/src/commands/merge_stack.rs
@@ -6,14 +6,14 @@
 
 use crate::commands::merge_shared::{
     PrBaseUpdate, WaitResult, print_header, print_header_success,
-    rebase_and_finalize_remaining_branch, update_pr_base_unless_current,
+    rebase_and_finalize_remaining_branch, update_pr_base_unless_current, warn_ignored_ci_failure,
 };
 use crate::config::{Config, NativeStackMode};
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::GitRepo;
 use crate::github::gh_stack::{self, FeatureState, StackMergeOutcome};
-use crate::github::pr::{CiStatus, MergeMethod, PrMergeStatus};
+use crate::github::pr::{CiStatus, MergeMethod, PrMergeStatus, ReadinessPolicy};
 use crate::progress::LiveTimer;
 use crate::remote::{ForgeType, RemoteInfo};
 use anyhow::{Context, Result};
@@ -152,6 +152,7 @@ pub fn run(
     method: MergeMethod,
     timeout_mins: u64,
     interval_secs: u64,
+    readiness: ReadinessPolicy,
     no_delete: bool,
     no_sync: bool,
     yes: bool,
@@ -260,7 +261,7 @@ pub fn run(
     let tip = resolved.last().context("stack merge scope is empty")?;
     let mut tip_status = statuses.last().context("missing tip status")?.clone();
 
-    if !when_ready && let Some(reason) = tip_blocker(&tip_status) {
+    if !when_ready && let Some(reason) = tip_blocker(&tip_status, readiness) {
         anyhow::bail!(
             "Selected tip {} ({}) is not ready: {}.\n\nRun `stax merge --stack --when-ready` to wait.",
             item_label(forge, tip.pr_number),
@@ -328,10 +329,14 @@ pub fn run(
             tip.pr_number,
             timeout,
             poll_interval,
+            readiness,
             quiet,
             forge,
         )? {
-            WaitResult::Ready(status) => tip_status = status,
+            WaitResult::Ready(status) => {
+                warn_ignored_ci_failure(&status, readiness, quiet);
+                tip_status = status;
+            }
             WaitResult::Failed(reason) => {
                 anyhow::bail!(
                     "Selected tip {} ({}) is not ready: {}",
@@ -348,6 +353,8 @@ pub fn run(
                 )
             }
         }
+    } else {
+        warn_ignored_ci_failure(&tip_status, readiness, quiet);
     }
 
     verify_tip_head_matches_local(&repo, tip, &tip_status, forge)?;
@@ -725,11 +732,11 @@ fn downstack_blocker(status: &PrMergeStatus) -> Option<&'static str> {
     None
 }
 
-fn tip_blocker(status: &PrMergeStatus) -> Option<&'static str> {
+fn tip_blocker(status: &PrMergeStatus, policy: ReadinessPolicy) -> Option<&'static str> {
     downstack_blocker(status).or_else(|| match status.ci_status {
-        CiStatus::Failure => Some("CI failed"),
+        CiStatus::Failure if !policy.ignore_failed_ci => Some("CI failed"),
         CiStatus::Pending => Some("CI is still pending"),
-        CiStatus::Success | CiStatus::NoCi => {
+        CiStatus::Failure | CiStatus::Success | CiStatus::NoCi => {
             if status.mergeable.is_none() {
                 Some("mergeability is still being checked")
             } else {
@@ -739,12 +746,14 @@ fn tip_blocker(status: &PrMergeStatus) -> Option<&'static str> {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn wait_for_tip_ready(
     rt: &tokio::runtime::Runtime,
     client: &ForgeClient,
     pr_number: u64,
     timeout: Duration,
     poll_interval: Duration,
+    policy: ReadinessPolicy,
     quiet: bool,
     forge: ForgeType,
 ) -> Result<WaitResult> {
@@ -753,7 +762,7 @@ fn wait_for_tip_ready(
 
     loop {
         let status = rt.block_on(async { client.get_pr_merge_status(pr_number).await })?;
-        if let Some(reason) = tip_blocker(&status) {
+        if let Some(reason) = tip_blocker(&status, policy) {
             if matches!(
                 reason,
                 "CI is still pending" | "mergeability is still being checked"
@@ -1372,6 +1381,7 @@ fn print_stack_preview(
 mod tests {
     use super::*;
     use crate::engine::stack::StackBranch;
+    use crate::github::pr::ReadinessPolicy;
     use std::collections::HashMap;
 
     #[test]
@@ -1573,11 +1583,49 @@ mod tests {
     #[test]
     fn tip_blocker_checks_tip_ci() {
         assert_eq!(
-            tip_blocker(&status(CiStatus::Pending)),
+            tip_blocker(&status(CiStatus::Pending), ReadinessPolicy::strict()),
             Some("CI is still pending")
         );
-        assert_eq!(tip_blocker(&status(CiStatus::Failure)), Some("CI failed"));
-        assert_eq!(tip_blocker(&status(CiStatus::Success)), None);
+        assert_eq!(
+            tip_blocker(&status(CiStatus::Failure), ReadinessPolicy::strict()),
+            Some("CI failed")
+        );
+        assert_eq!(
+            tip_blocker(&status(CiStatus::Success), ReadinessPolicy::strict()),
+            None
+        );
+    }
+
+    #[test]
+    fn tip_blocker_ignores_ci_failure_under_override() {
+        assert_eq!(
+            tip_blocker(
+                &status(CiStatus::Failure),
+                ReadinessPolicy::ignoring_failed_ci()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn tip_blocker_still_blocks_pending_ci_under_override() {
+        assert_eq!(
+            tip_blocker(
+                &status(CiStatus::Pending),
+                ReadinessPolicy::ignoring_failed_ci()
+            ),
+            Some("CI is still pending")
+        );
+    }
+
+    #[test]
+    fn tip_blocker_still_blocks_draft_under_override() {
+        let mut s = status(CiStatus::Failure);
+        s.is_draft = true;
+        assert_eq!(
+            tip_blocker(&s, ReadinessPolicy::ignoring_failed_ci()),
+            Some("item is draft")
+        );
     }
 
     #[test]

--- a/src/commands/merge_when_ready.rs
+++ b/src/commands/merge_when_ready.rs
@@ -5,13 +5,13 @@ use crate::commands::merge_shared::{
     BlockedReasonStyle, PrBaseUpdate, WaitResult, calculate_scope, print_header,
     print_header_error, print_header_success, print_native_stack_locked_note,
     rebase_and_finalize_remaining_branch, record_ci_history_for_branch, sync_head_after_push,
-    update_pr_base_unless_current, wait_for_pr_ready,
+    update_pr_base_unless_current, wait_for_pr_ready, warn_ignored_ci_failure,
 };
 use crate::config::Config;
 use crate::engine::Stack;
 use crate::forge::ForgeClient;
 use crate::git::{GitRepo, RebaseResult};
-use crate::github::pr::MergeMethod;
+use crate::github::pr::{MergeMethod, ReadinessPolicy};
 use crate::ops::receipt::{OpKind, PlanSummary};
 use crate::ops::tx::{self, Transaction};
 use crate::progress::LiveTimer;
@@ -90,6 +90,7 @@ pub fn run(
     method: MergeMethod,
     timeout_mins: u64,
     interval_secs: u64,
+    readiness: ReadinessPolicy,
     no_delete: bool,
     no_sync: bool,
     yes: bool,
@@ -284,9 +285,12 @@ pub fn run(
                 timeout,
                 poll_interval,
                 BlockedReasonStyle::StatusText,
+                readiness,
                 quiet,
             )? {
-                WaitResult::Ready(_) => {}
+                WaitResult::Ready(status) => {
+                    warn_ignored_ci_failure(&status, readiness, quiet);
+                }
                 WaitResult::Failed(reason) => {
                     branches[idx].status = LandStatus::Failed(reason.clone());
                     failed_pr = Some((branch_name, pr_number, reason));

--- a/src/forge/model.rs
+++ b/src/forge/model.rs
@@ -184,10 +184,34 @@ pub struct PrMergeStatus {
     pub head_sha: String,
 }
 
+/// Which merge-readiness signals the caller is willing to waive.
+///
+/// The default waives nothing. `stax merge --ignore-failed-ci` waives only a
+/// failed CI rollup; draft, changes-requested, conflict, and closed gates stay
+/// in force, and a *pending* rollup is still waited on rather than waived.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReadinessPolicy {
+    pub ignore_failed_ci: bool,
+}
+
+impl ReadinessPolicy {
+    /// Block on every readiness signal — the default `stax merge` behaviour.
+    pub fn strict() -> Self {
+        Self::default()
+    }
+
+    /// Waive a failed CI rollup only (`stax merge --ignore-failed-ci`).
+    pub fn ignoring_failed_ci() -> Self {
+        Self {
+            ignore_failed_ci: true,
+        }
+    }
+}
+
 impl PrMergeStatus {
     /// Check if PR is ready to merge (approved + CI passed + mergeable)
-    pub fn is_ready(&self) -> bool {
-        self.ci_status.is_success()
+    pub fn is_ready(&self, policy: ReadinessPolicy) -> bool {
+        (self.ci_status.is_success() || (policy.ignore_failed_ci && self.ci_status.is_failure()))
             && !self.is_draft
             && self.mergeable.unwrap_or(false)
             && !self.changes_requested
@@ -200,15 +224,15 @@ impl PrMergeStatus {
     }
 
     /// Check if PR has a blocking issue
-    pub fn is_blocked(&self) -> bool {
-        self.ci_status.is_failure()
+    pub fn is_blocked(&self, policy: ReadinessPolicy) -> bool {
+        (self.ci_status.is_failure() && !policy.ignore_failed_ci)
             || self.changes_requested
             || self.is_draft
             || self.mergeable == Some(false)
     }
 
     /// Get human-readable status
-    pub fn status_text(&self) -> &'static str {
+    pub fn status_text(&self, policy: ReadinessPolicy) -> &'static str {
         if self.state.to_lowercase() != "open" {
             return "Closed";
         }
@@ -218,7 +242,7 @@ impl PrMergeStatus {
         if self.changes_requested {
             return "Changes requested";
         }
-        if self.ci_status.is_failure() {
+        if self.ci_status.is_failure() && !policy.ignore_failed_ci {
             return "CI failed";
         }
         if self.mergeable == Some(false) {
@@ -230,7 +254,7 @@ impl PrMergeStatus {
         if self.mergeable.is_none() {
             return "mergeability check";
         }
-        if self.is_ready() {
+        if self.is_ready(policy) {
             return "Ready";
         }
         "Ready" // Default to ready if nothing is blocking

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -37,7 +37,7 @@ pub(crate) fn is_native_stack_base_locked_error(err: &anyhow::Error) -> bool {
 
 pub use crate::forge::{
     CiStatus, EnqueueResult, IssueComment, MergeMethod, MergeQueueEntry, PrComment, PrInfo,
-    PrInfoWithHead, PrMergeStatus, ReviewComment,
+    PrInfoWithHead, PrMergeStatus, ReadinessPolicy, ReviewComment,
 };
 
 #[derive(Debug, Deserialize)]
@@ -1574,9 +1574,9 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(status.is_ready());
+        assert!(status.is_ready(ReadinessPolicy::strict()));
         assert!(!status.is_waiting());
-        assert!(!status.is_blocked());
+        assert!(!status.is_blocked(ReadinessPolicy::strict()));
     }
 
     #[test]
@@ -1596,10 +1596,10 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(!status.is_ready());
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
         assert!(status.is_waiting());
-        assert!(!status.is_blocked());
-        assert_eq!(status.status_text(), "CI checks");
+        assert!(!status.is_blocked(ReadinessPolicy::strict()));
+        assert_eq!(status.status_text(ReadinessPolicy::strict()), "CI checks");
     }
 
     #[test]
@@ -1619,9 +1619,12 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(!status.is_ready());
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
         assert!(status.is_waiting());
-        assert_eq!(status.status_text(), "mergeability check");
+        assert_eq!(
+            status.status_text(ReadinessPolicy::strict()),
+            "mergeability check"
+        );
     }
 
     #[test]
@@ -1641,8 +1644,8 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(!status.is_ready());
-        assert!(status.is_blocked());
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
+        assert!(status.is_blocked(ReadinessPolicy::strict()));
     }
 
     #[test]
@@ -1662,8 +1665,8 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(!status.is_ready());
-        assert!(status.is_blocked());
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
+        assert!(status.is_blocked(ReadinessPolicy::strict()));
     }
 
     #[test]
@@ -1683,8 +1686,8 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(!status.is_ready());
-        assert!(status.is_blocked());
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
+        assert!(status.is_blocked(ReadinessPolicy::strict()));
     }
 
     #[test]
@@ -1704,8 +1707,8 @@ mod tests {
             head_sha: "abc123".to_string(),
         };
 
-        assert!(!status.is_ready());
-        assert!(status.is_blocked());
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
+        assert!(status.is_blocked(ReadinessPolicy::strict()));
     }
 
     #[test]
@@ -1725,14 +1728,14 @@ mod tests {
             changes_requested: false,
             head_sha: "abc123".to_string(),
         };
-        assert_eq!(status.status_text(), "Ready");
+        assert_eq!(status.status_text(ReadinessPolicy::strict()), "Ready");
 
         // Draft
         let status = PrMergeStatus {
             is_draft: true,
             ..status.clone()
         };
-        assert_eq!(status.status_text(), "Draft");
+        assert_eq!(status.status_text(ReadinessPolicy::strict()), "Draft");
 
         // CI Failed
         let status = PrMergeStatus {
@@ -1740,7 +1743,7 @@ mod tests {
             ci_status: CiStatus::Failure,
             ..status.clone()
         };
-        assert_eq!(status.status_text(), "CI failed");
+        assert_eq!(status.status_text(ReadinessPolicy::strict()), "CI failed");
 
         // Changes requested
         let status = PrMergeStatus {
@@ -1748,7 +1751,10 @@ mod tests {
             changes_requested: true,
             ..status.clone()
         };
-        assert_eq!(status.status_text(), "Changes requested");
+        assert_eq!(
+            status.status_text(ReadinessPolicy::strict()),
+            "Changes requested"
+        );
 
         // Has conflicts
         let status = PrMergeStatus {
@@ -1756,7 +1762,10 @@ mod tests {
             mergeable: Some(false),
             ..status.clone()
         };
-        assert_eq!(status.status_text(), "Has conflicts");
+        assert_eq!(
+            status.status_text(ReadinessPolicy::strict()),
+            "Has conflicts"
+        );
 
         // Closed
         let status = PrMergeStatus {
@@ -1764,7 +1773,148 @@ mod tests {
             state: "Closed".to_string(),
             ..status.clone()
         };
-        assert_eq!(status.status_text(), "Closed");
+        assert_eq!(status.status_text(ReadinessPolicy::strict()), "Closed");
+    }
+
+    #[test]
+    fn ignore_failed_ci_makes_ci_failed_pr_ready() {
+        let status = PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "open".to_string(),
+            updated_at: None,
+            is_draft: false,
+            mergeable: Some(true),
+            mergeable_state: "clean".to_string(),
+            ci_status: CiStatus::Failure,
+            review_decision: Some("APPROVED".to_string()),
+            approvals: 1,
+            changes_requested: false,
+            head_sha: "abc123".to_string(),
+        };
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
+        assert!(status.is_ready(ReadinessPolicy::ignoring_failed_ci()));
+        assert!(!status.is_blocked(ReadinessPolicy::ignoring_failed_ci()));
+        assert_eq!(
+            status.status_text(ReadinessPolicy::ignoring_failed_ci()),
+            "Ready"
+        );
+    }
+
+    #[test]
+    fn ignore_failed_ci_does_not_waive_draft() {
+        let status = PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "open".to_string(),
+            updated_at: None,
+            is_draft: true,
+            mergeable: Some(true),
+            mergeable_state: "clean".to_string(),
+            ci_status: CiStatus::Failure,
+            review_decision: Some("APPROVED".to_string()),
+            approvals: 1,
+            changes_requested: false,
+            head_sha: "abc123".to_string(),
+        };
+        assert!(!status.is_ready(ReadinessPolicy::ignoring_failed_ci()));
+        assert!(status.is_blocked(ReadinessPolicy::ignoring_failed_ci()));
+        assert_eq!(
+            status.status_text(ReadinessPolicy::ignoring_failed_ci()),
+            "Draft"
+        );
+    }
+
+    #[test]
+    fn ignore_failed_ci_does_not_waive_changes_requested() {
+        let status = PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "open".to_string(),
+            updated_at: None,
+            is_draft: false,
+            mergeable: Some(true),
+            mergeable_state: "clean".to_string(),
+            ci_status: CiStatus::Failure,
+            review_decision: Some("CHANGES_REQUESTED".to_string()),
+            approvals: 0,
+            changes_requested: true,
+            head_sha: "abc123".to_string(),
+        };
+        assert!(!status.is_ready(ReadinessPolicy::ignoring_failed_ci()));
+        assert!(status.is_blocked(ReadinessPolicy::ignoring_failed_ci()));
+        assert_eq!(
+            status.status_text(ReadinessPolicy::ignoring_failed_ci()),
+            "Changes requested"
+        );
+    }
+
+    #[test]
+    fn ignore_failed_ci_does_not_waive_conflicts() {
+        let status = PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "open".to_string(),
+            updated_at: None,
+            is_draft: false,
+            mergeable: Some(false),
+            mergeable_state: "dirty".to_string(),
+            ci_status: CiStatus::Failure,
+            review_decision: Some("APPROVED".to_string()),
+            approvals: 1,
+            changes_requested: false,
+            head_sha: "abc123".to_string(),
+        };
+        assert!(!status.is_ready(ReadinessPolicy::ignoring_failed_ci()));
+        assert!(status.is_blocked(ReadinessPolicy::ignoring_failed_ci()));
+        assert_eq!(
+            status.status_text(ReadinessPolicy::ignoring_failed_ci()),
+            "Has conflicts"
+        );
+    }
+
+    #[test]
+    fn ignore_failed_ci_does_not_waive_closed_pr() {
+        let status = PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "closed".to_string(),
+            updated_at: None,
+            is_draft: false,
+            mergeable: Some(true),
+            mergeable_state: "clean".to_string(),
+            ci_status: CiStatus::Failure,
+            review_decision: None,
+            approvals: 0,
+            changes_requested: false,
+            head_sha: "abc123".to_string(),
+        };
+        assert!(!status.is_ready(ReadinessPolicy::ignoring_failed_ci()));
+        assert_eq!(
+            status.status_text(ReadinessPolicy::ignoring_failed_ci()),
+            "Closed"
+        );
+    }
+
+    #[test]
+    fn ignore_failed_ci_still_waits_on_pending_ci() {
+        let status = PrMergeStatus {
+            number: 1,
+            title: "Test".to_string(),
+            state: "open".to_string(),
+            updated_at: None,
+            is_draft: false,
+            mergeable: Some(true),
+            mergeable_state: "clean".to_string(),
+            ci_status: CiStatus::Pending,
+            review_decision: Some("APPROVED".to_string()),
+            approvals: 1,
+            changes_requested: false,
+            head_sha: "abc123".to_string(),
+        };
+        assert!(!status.is_ready(ReadinessPolicy::ignoring_failed_ci()));
+        assert!(!status.is_blocked(ReadinessPolicy::ignoring_failed_ci()));
+        assert!(status.is_waiting());
     }
 
     #[test]
@@ -2878,8 +3028,8 @@ mod tests {
         let client = create_test_client(&mock_server).await;
         let status = client.get_pr_merge_status(11).await.unwrap();
 
-        assert_eq!(status.status_text(), "Closed");
-        assert!(!status.is_ready());
+        assert_eq!(status.status_text(ReadinessPolicy::strict()), "Closed");
+        assert!(!status.is_ready(ReadinessPolicy::strict()));
         assert_eq!(status.review_decision, None);
         assert_eq!(status.approvals, 0);
         assert_eq!(status.ci_status, CiStatus::Success);

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -88,6 +88,8 @@ mod github_list_tests;
 mod guard_rail_tests;
 #[path = "integration_tests.rs"]
 mod integration_tests;
+#[path = "merge_ignore_failed_ci_tests.rs"]
+mod merge_ignore_failed_ci_tests;
 #[path = "navigation_tests.rs"]
 mod navigation_tests;
 #[path = "performance_tests.rs"]

--- a/tests/flag_validation_tests.rs
+++ b/tests/flag_validation_tests.rs
@@ -119,3 +119,13 @@ fn lane_tmux_session_requires_explicit_lane_name() {
         .assert_failure()
         .assert_stderr_contains("--tmux-session requires an explicit lane name");
 }
+
+#[test]
+fn merge_queue_and_ignore_failed_ci_are_mutually_exclusive() {
+    let repo = TestRepo::new();
+
+    let output = repo.run_stax(&["merge", "--queue", "--ignore-failed-ci"]);
+    output
+        .assert_failure()
+        .assert_stderr_contains("cannot be used with");
+}

--- a/tests/merge_ignore_failed_ci_tests.rs
+++ b/tests/merge_ignore_failed_ci_tests.rs
@@ -1,0 +1,393 @@
+//! Integration tests for `stax merge --ignore-failed-ci`.
+
+use crate::common::{OutputAssertions, TestRepo};
+use std::fs;
+use std::path::PathBuf;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const REMOTE_URL: &str = "https://github.com/test-owner/test-repo.git";
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn setup_github_repo(repo: &TestRepo, api_base_url: &str) {
+    let config_dir = PathBuf::from(repo.clean_home())
+        .join(".config")
+        .join("stax");
+    fs::create_dir_all(&config_dir).expect("config directory");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("[remote]\napi_base_url = \"{api_base_url}\"\n"),
+    )
+    .expect("test config");
+    repo.git(&["remote", "add", "origin", REMOTE_URL])
+        .assert_success();
+}
+
+fn write_branch_pr_metadata(repo: &TestRepo, branch: &str, parent: &str, pr_number: u64) {
+    let metadata = serde_json::json!({
+        "parentBranchName": parent,
+        "parentBranchRevision": repo.get_commit_sha(parent),
+        "prInfo": { "number": pr_number, "state": "OPEN" }
+    });
+    let file = tempfile::NamedTempFile::new().expect("metadata file");
+    fs::write(file.path(), metadata.to_string()).expect("metadata contents");
+    let hash = repo.git(&["hash-object", "-w", file.path().to_str().unwrap()]);
+    hash.assert_success();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{branch}"),
+        TestRepo::stdout(&hash).trim(),
+    ])
+    .assert_success();
+}
+
+fn auth_env() -> [(&'static str, &'static str); 1] {
+    [("STAX_GITHUB_TOKEN", "mock-token")]
+}
+
+/// Build the GraphQL `pullRequest` body returned by `get_pr_merge_status`.
+fn merge_status_graphql(
+    number: u64,
+    sha: &str,
+    rollup_state: &str,
+    mergeable: &str,
+    is_draft: bool,
+    review_decision: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "data": { "repository": { "pullRequest": {
+            "number": number,
+            "title": "Test PR",
+            "state": "OPEN",
+            "updatedAt": "2026-09-01T10:00:00Z",
+            "isDraft": is_draft,
+            "mergeable": mergeable,
+            "reviewDecision": review_decision,
+            "headRefOid": sha,
+            "statusCheckRollup": { "state": rollup_state, "contexts": { "nodes": [] } },
+            "reviews": { "nodes": [
+                { "state": "APPROVED", "author": { "login": "reviewer" } }
+            ] }
+        } } }
+    })
+}
+
+/// Mount the GraphQL merge-status mock for PR `number`.
+async fn mount_merge_status(
+    server: &MockServer,
+    number: u64,
+    sha: &str,
+    rollup_state: &str,
+    mergeable: &str,
+    is_draft: bool,
+    review_decision: &str,
+) {
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_string_contains(format!(
+            "pullRequest(number: {number})"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(merge_status_graphql(
+                number,
+                sha,
+                rollup_state,
+                mergeable,
+                is_draft,
+                review_decision,
+            )),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Mount `GET /repos/.../pulls/N` — backs `is_pr_merged` (checks `merged_at`).
+async fn mount_pr_get(server: &MockServer, number: u64, sha: &str) {
+    let pr_body = serde_json::json!({
+        "url": format!("https://api.github.com/repos/test-owner/test-repo/pulls/{number}"),
+        "id": number,
+        "number": number,
+        "state": "open",
+        "title": "Test PR",
+        "body": "",
+        "draft": false,
+        "merged_at": null,
+        "head": { "ref": "feat", "sha": sha, "label": "test-owner:feat" },
+        "base": { "ref": "main", "sha": "0000" },
+        "html_url": format!("https://github.com/test-owner/test-repo/pull/{number}")
+    });
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/test-owner/test-repo/pulls/{number}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(pr_body))
+        .mount(server)
+        .await;
+}
+
+/// Mount `PUT /repos/.../pulls/N/merge` → 200 merged.
+async fn mount_merge_endpoint(server: &MockServer, number: u64) {
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "/repos/test-owner/test-repo/pulls/{number}/merge"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "cafe",
+            "merged": true,
+            "message": "Pull Request successfully merged"
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn merge_without_override_stops_on_failed_ci() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(&server, 1, &sha, "FAILURE", "MERGEABLE", false, "APPROVED").await;
+    mount_pr_get(&server, 1, &sha).await;
+
+    let output = repo.run_stax_with_env(
+        &["merge", "--no-wait", "--yes", "--no-delete", "--no-sync"],
+        &auth_env(),
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let combined = format!("{}{}", stdout, TestRepo::stderr(&output));
+
+    assert!(
+        combined.contains("CI failed"),
+        "expected 'CI failed' in output; got: {combined}"
+    );
+    assert!(
+        combined.contains("--ignore-failed-ci"),
+        "expected --ignore-failed-ci hint in output; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let had_merge = requests.iter().any(|r| {
+        r.method == wiremock::http::Method::PUT
+            && r.url
+                .path()
+                .contains("/repos/test-owner/test-repo/pulls/1/merge")
+    });
+    assert!(
+        !had_merge,
+        "merge endpoint must NOT be called when CI failed without override"
+    );
+}
+
+#[tokio::test]
+async fn merge_with_override_merges_failed_ci_pr() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(&server, 1, &sha, "FAILURE", "MERGEABLE", false, "APPROVED").await;
+    mount_pr_get(&server, 1, &sha).await;
+    mount_merge_endpoint(&server, 1).await;
+
+    let output = repo.run_stax_with_env(
+        &[
+            "merge",
+            "--no-wait",
+            "--yes",
+            "--no-delete",
+            "--no-sync",
+            "--ignore-failed-ci",
+        ],
+        &auth_env(),
+    );
+
+    let stdout = TestRepo::stdout(&output);
+    let combined = format!("{}{}", stdout, TestRepo::stderr(&output));
+
+    assert!(
+        combined.contains("warning:"),
+        "expected warning about CI failure override; got: {combined}"
+    );
+    assert!(
+        combined.contains("--ignore-failed-ci"),
+        "expected --ignore-failed-ci in warning text; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let had_merge = requests.iter().any(|r| {
+        r.method == wiremock::http::Method::PUT
+            && r.url
+                .path()
+                .contains("/repos/test-owner/test-repo/pulls/1/merge")
+    });
+    assert!(
+        had_merge,
+        "merge endpoint MUST be called with --ignore-failed-ci"
+    );
+}
+
+#[tokio::test]
+async fn merge_with_override_still_blocks_draft() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(&server, 1, &sha, "FAILURE", "MERGEABLE", true, "APPROVED").await;
+    mount_pr_get(&server, 1, &sha).await;
+
+    let output = repo.run_stax_with_env(
+        &[
+            "merge",
+            "--no-wait",
+            "--yes",
+            "--no-delete",
+            "--no-sync",
+            "--ignore-failed-ci",
+        ],
+        &auth_env(),
+    );
+
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+
+    assert!(
+        combined.contains("Draft"),
+        "expected Draft block message; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let had_merge = requests.iter().any(|r| {
+        r.method == wiremock::http::Method::PUT
+            && r.url
+                .path()
+                .contains("/repos/test-owner/test-repo/pulls/1/merge")
+    });
+    assert!(
+        !had_merge,
+        "merge endpoint must NOT be called for a draft PR"
+    );
+}
+
+#[tokio::test]
+async fn merge_with_override_still_blocks_changes_requested() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(
+        &server,
+        1,
+        &sha,
+        "FAILURE",
+        "MERGEABLE",
+        false,
+        "CHANGES_REQUESTED",
+    )
+    .await;
+    mount_pr_get(&server, 1, &sha).await;
+
+    let output = repo.run_stax_with_env(
+        &[
+            "merge",
+            "--no-wait",
+            "--yes",
+            "--no-delete",
+            "--no-sync",
+            "--ignore-failed-ci",
+        ],
+        &auth_env(),
+    );
+
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+
+    assert!(
+        combined.contains("Changes requested"),
+        "expected 'Changes requested' block; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let had_merge = requests.iter().any(|r| {
+        r.method == wiremock::http::Method::PUT
+            && r.url
+                .path()
+                .contains("/repos/test-owner/test-repo/pulls/1/merge")
+    });
+    assert!(
+        !had_merge,
+        "merge endpoint must NOT be called when changes requested"
+    );
+}
+
+#[tokio::test]
+async fn merge_with_override_still_blocks_conflicts() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(
+        &server,
+        1,
+        &sha,
+        "FAILURE",
+        "CONFLICTING",
+        false,
+        "APPROVED",
+    )
+    .await;
+    mount_pr_get(&server, 1, &sha).await;
+
+    let output = repo.run_stax_with_env(
+        &[
+            "merge",
+            "--no-wait",
+            "--yes",
+            "--no-delete",
+            "--no-sync",
+            "--ignore-failed-ci",
+        ],
+        &auth_env(),
+    );
+
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+
+    assert!(
+        combined.contains("Has conflicts"),
+        "expected 'Has conflicts' block (not 'CI failed'); got: {combined}"
+    );
+    assert!(
+        !combined.contains("CI failed"),
+        "must not report 'CI failed' when conflict is the actual blocker; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let had_merge = requests.iter().any(|r| {
+        r.method == wiremock::http::Method::PUT
+            && r.url
+                .path()
+                .contains("/repos/test-owner/test-repo/pulls/1/merge")
+    });
+    assert!(
+        !had_merge,
+        "merge endpoint must NOT be called for a conflicting PR"
+    );
+}


### PR DESCRIPTION
## Motivation

Closes #851.

`stax merge` refused to merge whenever the forge reported the CI rollup as failed, even when the failing check was optional and GitHub itself considered the PR mergeable (`mergeStateStatus: UNSTABLE`, not `BLOCKED`). The reporter hit this with a Vercel preview deployment that reported "Deployment was blocked" while every required check passed. There was no escape hatch: `--no-wait` only changes pending-check handling, `--yes` only skips the confirmation prompt, and `--remote` only changes where the merge executes. The run just died with:

```
CI failed
Fix the issue and run stax merge again.
```

## What changed

Adds `stax merge --ignore-failed-ci`, an explicit, narrowly-scoped override.

The readiness gate lived in `PrMergeStatus::is_ready()` / `is_blocked()` / `status_text()`, which conflated "CI is red" with "this PR must not merge". Rather than duplicate that logic per merge mode or mutate status objects in place, this introduces a `ReadinessPolicy { ignore_failed_ci: bool }` value that those three methods now take, and threads it from the CLI down through the merge family:

- `src/forge/model.rs` — new `ReadinessPolicy` (`Copy`, `Default` = waive nothing) with `strict()` / `ignoring_failed_ci()`; the three gate methods take it.
- `src/commands/merge_shared.rs` — `blocked_reason` and `wait_for_pr_ready` take the policy; new `warn_ignored_ci_failure` helper.
- `src/commands/merge_stack.rs` — `tip_blocker` and `wait_for_tip_ready` take the policy. `downstack_blocker` is deliberately unchanged: it already ignores CI by design, because lower PRs in a `--stack` range land indirectly through the tip merge.
- `src/commands/{merge,merge_stack,merge_when_ready,merge_remote}.rs` — `run()` accepts and forwards the policy.

The flag applies to the default cascade, `--stack`, `--remote`, and `--when-ready` — every mode where stax gates locally.

### Semantics, deliberately narrow

`--ignore-failed-ci` waives exactly one thing: a **failed** CI rollup. It still blocks on draft PRs, requested changes, merge conflicts, and closed PRs. A **pending** rollup is still waited on rather than waived — that is `--no-wait`'s job, and conflating the two would make the flag a blunt "merge anything" instrument. If a run turns red while stax is waiting, the next poll now returns `Ready` instead of `Failed`.

Making `status_text()` policy-aware is load-bearing, not cosmetic. It checks CI failure *before* the conflict branch, so without the policy a conflicting PR merged with `--ignore-failed-ci` would have reported "CI failed" — telling the user to fix the exact thing they just overrode. There is a unit test and an integration test pinning that it says `Has conflicts` instead.

The override is never silent: when it actually skips a red rollup, stax prints a warning naming the flag and noting that the forge's branch protection is still the final gate. If GitHub refuses the merge, the existing `merge_pr` error path surfaces that unchanged. Conversely, when CI failure *does* block a merge, the failure summary now points at the flag, so the escape hatch is discoverable at the moment it is needed.

`--queue` rejects the flag at parse time via `conflicts_with_all`. `merge_queue.rs` has no local readiness gate at all — the forge's merge queue decides — so a silently-ignored flag would be worse than a clap error.

### Why not required-vs-optional check detection

Issue #851 asked for either (a) distinguishing GitHub-required from optional checks, or (b) an explicit override. This implements (b).

Option (a) is a materially larger change and is not attempted here. stax never fetches `mergeStateStatus` — `src/github/pr.rs` maps only `mergeable` (`MERGEABLE` / `CONFLICTING` / `UNKNOWN`) via `graphql_mergeable_state`. Reading `UNSTABLE` vs `BLOCKED` needs a GitHub preview `Accept` header and has no GitLab or Gitea equivalent, so it would fork readiness semantics per forge. `--ignore-failed-ci` is the forge-agnostic fix, and it composes with (a) later: required-check awareness would shrink how often the flag is needed without changing what it means.

## Verification

Evidence is from the **full local gate** on Linux, not the scoped draft gate — the change touches `src/forge/model.rs`, shared core readiness logic consumed by the whole merge family, which triggers the high-risk exception in `AGENTS.md`.

- `cargo check`, `cargo fmt --check`, `git diff --check` — clean.
- `make lint` (full, `--all-targets --all-features`) — clean.
- `make test` — **2674 passed, 0 failed, 0 skipped**.

New tests:

- **Unit** (`src/github/pr.rs`): override makes a CI-failed-but-clean PR ready; does not waive draft / changes-requested / conflicts / closed; pending CI is neither ready nor blocked under the override.
- **Unit** (`src/commands/merge_stack.rs`): `tip_blocker` ignores CI failure under the override, still blocks pending CI and drafts.
- **Unit** (`src/commands/merge_shared.rs`): `blocked_reason` reports `Has conflicts`, not `CI failed`, under the override.
- **Integration** (`tests/merge_ignore_failed_ci_tests.rs`, 5 end-to-end tests via the real binary against a wiremock forge): each asserts on whether `PUT /pulls/1/merge` was actually called, so a passing assertion means the merge really did or did not happen. Covers the happy path, the no-flag regression (still blocks, and surfaces the hint), and the three bad paths (draft, changes-requested, conflicts).
- **Clap surface**: flag parses; `--queue --ignore-failed-ci` is rejected.

## Risk

Low, and the risk is concentrated in the signature change rather than the behavior change. Default behavior is unchanged by construction: `ReadinessPolicy::default()` waives nothing, and every existing caller passes `strict()`, so a red CI rollup blocks exactly as before unless the user opts in.

The three `PrMergeStatus` methods gained a parameter. They had no callers outside the merge family and their own tests (`src/commands/ready.rs` and the TUI read `PrMergeStatus` fields directly), so this is contained — and the compiler enforces that every future call site makes a policy decision, rather than leaving a policy-free overload that silently reintroduces this bug.

The genuine residual risk is behavioral, not mechanical: a user can now merge a PR with failing required checks if branch protection does not enforce them. That is the requested capability, it requires an explicit flag, it warns on use, and the forge remains the final authority.

## Docs

Updated `README.md`, `docs/workflows/merge-and-cascade.md` (including what the flag does *not* waive), `docs/commands/reference.md`, and `skills.md`. `CHANGELOG.md` is untouched — it is generated by git-cliff.
