### PR TITLE
fix(continue): reparent orphaned branches onto trunk when recorded parent is gone

### DIFF
--- a/src/commands/continue_cmd.rs
+++ b/src/commands/continue_cmd.rs
@@ -6,14 +6,34 @@ use crate::ops::receipt::{OpKind, OpReceipt, OpStatus};
 use anyhow::Result;
 use colored::Colorize;
 
+/// Resolve the parent branch that metadata should record after a rebase.
+///
+/// The parent recorded on disk may no longer exist locally (e.g. it was merged
+/// upstream and pruned before the sync that started this rebase). `Stack::load`
+/// already reparents such orphans onto trunk in memory, and `restack` rebases
+/// them onto trunk — so mirror that here instead of failing on a branch that is
+/// gone. When the recorded parent still exists, this is a no-op.
+pub(crate) fn effective_parent_branch(repo: &GitRepo, recorded_parent: &str) -> Result<String> {
+    if repo
+        .inner()
+        .find_branch(recorded_parent, git2::BranchType::Local)
+        .is_ok()
+    {
+        return Ok(recorded_parent.to_string());
+    }
+    repo.trunk_branch()
+}
+
 pub(crate) fn continue_rebase_and_update_metadata(repo: &GitRepo) -> Result<RebaseResult> {
     match repo.rebase_continue()? {
         RebaseResult::Success => {
             // Update metadata for current branch
             let current = repo.current_branch()?;
             if let Some(meta) = BranchMetadata::read(repo.inner(), &current)? {
-                let new_parent_rev = repo.branch_commit(&meta.parent_branch_name)?;
+                let parent_name = effective_parent_branch(repo, &meta.parent_branch_name)?;
+                let new_parent_rev = repo.branch_commit(&parent_name)?;
                 let updated_meta = BranchMetadata {
+                    parent_branch_name: parent_name,
                     parent_branch_revision: new_parent_rev,
                     ..meta
                 };

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -54,25 +54,36 @@ pub fn run(
                 .as_ref()
                 .and_then(|e| e.failed_branch.as_deref())
             {
-                if let Some(meta) = BranchMetadata::read(repo.inner(), failed_branch)?
-                    && let Ok(actual_parent_rev) = repo.branch_commit(&meta.parent_branch_name)
-                {
-                    // `actual_parent_rev` is only a valid boundary if `failed_branch` was
-                    // actually rebased onto it. If the parent advanced again during the
-                    // pause window (between the conflict and a manual `git rebase
-                    // --continue`), it wasn't -- verify ancestry before trusting it, else
-                    // keep the previously recorded (still-valid) boundary (see #830).
-                    let resolved = repo.resolve_child_parent_boundary(
-                        failed_branch,
-                        &[Some(actual_parent_rev.as_str())],
-                        &meta.parent_branch_revision,
-                    );
-                    if resolved != meta.parent_branch_revision {
-                        let updated = BranchMetadata {
-                            parent_branch_revision: resolved,
-                            ..meta
-                        };
-                        updated.write(repo.inner(), failed_branch)?;
+                if let Some(meta) = BranchMetadata::read(repo.inner(), failed_branch)? {
+                    // The recorded parent may no longer exist locally (e.g. it was merged
+                    // upstream and pruned before the restack started) -- mirror the same
+                    // orphan-to-trunk fallback `stax continue` uses instead of failing on a
+                    // branch that is gone.
+                    let parent_name = crate::commands::continue_cmd::effective_parent_branch(
+                        &repo,
+                        &meta.parent_branch_name,
+                    )?;
+                    if let Ok(actual_parent_rev) = repo.branch_commit(&parent_name) {
+                        // `actual_parent_rev` is only a valid boundary if `failed_branch` was
+                        // actually rebased onto it. If the parent advanced again during the
+                        // pause window (between the conflict and a manual `git rebase
+                        // --continue`), it wasn't -- verify ancestry before trusting it, else
+                        // keep the previously recorded (still-valid) boundary (see #830).
+                        let resolved = repo.resolve_child_parent_boundary(
+                            failed_branch,
+                            &[Some(actual_parent_rev.as_str())],
+                            &meta.parent_branch_revision,
+                        );
+                        if resolved != meta.parent_branch_revision
+                            || parent_name != meta.parent_branch_name
+                        {
+                            let updated = BranchMetadata {
+                                parent_branch_name: parent_name,
+                                parent_branch_revision: resolved,
+                                ..meta
+                            };
+                            updated.write(repo.inner(), failed_branch)?;
+                        }
                     }
                 }
                 completed_from_receipt.insert(failed_branch.to_string());

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -336,6 +336,88 @@ fn restack_continue_after_manual_rebase_continue_and_parent_advance_keeps_ancest
     );
 }
 
+#[test]
+fn restack_continue_after_manual_rebase_continue_reparents_orphaned_branch_onto_trunk() {
+    let repo = TestRepo::new();
+
+    // main -> branch-a -> branch-b -> branch-c
+    repo.run_stax(&["bc", "branch-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a\n");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "branch-b"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("b.txt", "b\n");
+    repo.commit("B commit");
+
+    repo.run_stax(&["bc", "branch-c"]);
+    let branch_c = repo.current_branch();
+    repo.create_file("shared.txt", "c\n");
+    repo.commit("C commit touches shared.txt");
+
+    // Simulate branch-a and branch-b having been squash-merged into main and
+    // pruned locally, with the merge including a conflicting edit to shared.txt.
+    repo.run_stax(&["checkout", "main"]);
+    repo.create_file("a.txt", "a\n");
+    repo.create_file("b.txt", "b\n");
+    repo.create_file("shared.txt", "main-side-fix\n");
+    repo.commit("squash merge branch-a + branch-b (#1)");
+    repo.git(&["branch", "-D", &branch_a, &branch_b])
+        .assert_success();
+
+    repo.run_stax(&["checkout", &branch_c]);
+    let output = repo.run_stax(&["restack"]);
+    assert!(
+        !output.status.success(),
+        "expected restack to conflict\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(repo.has_rebase_in_progress());
+
+    // Resolve and complete the rebase MANUALLY (git rebase --continue), not via
+    // `stax continue` -- this exercises restack's own receipt-recovery metadata
+    // fixup (src/commands/restack.rs), the parallel path to `continue_cmd.rs`.
+    repo.resolve_conflicts_ours();
+    let manual_continue = repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")]);
+    assert!(
+        manual_continue.status.success(),
+        "manual git rebase --continue should complete: {}",
+        TestRepo::stderr(&manual_continue)
+    );
+    assert!(!repo.has_rebase_in_progress());
+
+    let recovery = repo.run_stax(&["restack", "--continue"]);
+    assert!(
+        recovery.status.success(),
+        "restack --continue recovery should succeed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&recovery),
+        TestRepo::stderr(&recovery)
+    );
+
+    let meta_output = repo.git(&["show", &format!("refs/branch-metadata/{}", branch_c)]);
+    let meta: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&meta_output)).expect("valid JSON");
+    assert_eq!(
+        meta["parentBranchName"].as_str(),
+        Some("main"),
+        "expected orphaned branch-c (parent branch-b deleted) to be reparented onto trunk: {meta}"
+    );
+
+    let boundary = meta["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &branch_c]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {}",
+        boundary,
+        branch_c
+    );
+}
+
 // =============================================================================
 // Sync Continue Tests
 // =============================================================================
@@ -445,6 +527,48 @@ fn test_continue_on_untracked_branch() {
             || !output.status.success(),
         "Expected graceful handling on untracked branch, got: {}",
         combined
+    );
+}
+
+#[test]
+fn continue_after_conflict_reparents_orphaned_branch_onto_trunk() {
+    let repo = TestRepo::new_with_remote();
+    let branches = repo.create_stack(&["json-output", "conflict-report", "dual-role-keys"]);
+    // give dual-role-keys a change that will conflict with the squashed trunk content
+    repo.create_file("shared.txt", "dual\n");
+    repo.commit("dual role keys touches shared.txt");
+    repo.git(&["push", "origin", "--all"]).assert_success();
+
+    // squash-merge the bottom two into trunk, with content that conflicts with dual-role-keys' change
+    repo.simulate_remote_commit(
+        "shared.txt",
+        "conflict-with-review-fix\n",
+        "squash merge json-output + conflict-report (#1)",
+    );
+
+    // the local branches are already gone before refresh runs (merged PRs pruned locally)
+    repo.git(&["fetch", "--prune", "origin"]).assert_success();
+    repo.git(&["checkout", &branches[2]]).assert_success();
+    repo.git(&["branch", "-D", &branches[0], &branches[1]])
+        .assert_success();
+
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
+    assert!(
+        repo.has_rebase_in_progress(),
+        "{}",
+        TestRepo::stdout(&output)
+    );
+
+    repo.resolve_conflicts_ours();
+    repo.run_stax(&["continue"]).assert_success();
+
+    let meta =
+        TestRepo::stdout(&repo.git(&["show", &format!("refs/branch-metadata/{}", branches[2])]));
+    let main_sha = repo.get_commit_sha("main");
+    assert!(meta.contains(r#""parentBranchName":"main""#), "{meta}");
+    assert!(
+        meta.contains(&format!(r#""parentBranchRevision":"{main_sha}""#)),
+        "expected fresh trunk tip {main_sha}, got:\n{meta}"
     );
 }
 


### PR DESCRIPTION
## Summary

After merged bottom-of-stack PRs get pruned locally, `stax refresh`/`sync --restack` can hit a rebase conflict for a descendant whose recorded parent branch no longer exists. Resolving that conflict via `stax continue` (or a manual `git rebase --continue` followed by `stax restack --continue`) trusted the on-disk `parentBranchName` verbatim when looking up the fresh parent tip. Since that branch was already deleted, the lookup failed, the metadata write was skipped entirely, and the branch stayed flagged as needing a restack with a stale recorded parent — only self-healing on some later, unrelated sync that happened to succeed cleanly, by which point trunk had already moved on. That's what produced the observed "parentBranchName correct, parentBranchRevision stale/inherited-from-further-up-the-chain" symptom, and the stale boundary made subsequent restacks replay already-merged patches and conflict.

- Added `effective_parent_branch` in `src/commands/continue_cmd.rs`, mirroring the orphan-to-trunk fallback `Stack::load` already applies in memory.
- Used it in both `continue_rebase_and_update_metadata` (the `stax continue` path) and the manual-`git rebase --continue` receipt-recovery path in `src/commands/restack.rs` (`stax restack --continue`), since both trusted the stale on-disk parent name the same way.

## Repro chain (confirmed empirically before the fix)

Stack `main <- json-output <- conflict-report <- dual-role-keys`; `json-output` and `conflict-report` squash-merged into `main` and locally deleted; `stax refresh` hits a real conflict restacking `dual-role-keys`; `stax continue` previously errored with `Branch 'conflict-report' not found` and left metadata stuck at the deleted branch, despite the underlying rebase having already succeeded.

## Test plan

- [x] Added `continue_after_conflict_reparents_orphaned_branch_onto_trunk` (`tests/continue_tests.rs`) — confirmed it fails on pre-fix code with the exact error above, passes after the fix.
- [x] Added `restack_continue_after_manual_rebase_continue_reparents_orphaned_branch_onto_trunk` (`tests/continue_tests.rs`) — covers the parallel `stax restack --continue` recovery path found during review; confirmed it fails on pre-fix code, passes after.
- [x] `cargo check && cargo clippy -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `make test` — full suite, 2676/2676 passed.