### PR TITLE
feat(refresh): add opt-in --delete-merged flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` removes merged branches (including tracked merged PRs) and upstream-gone branches with no unique work |
-| `st refresh` / `st r` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs |
+| `st refresh` / `st r` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs (pass `--delete-merged` to opt into `sync`-style cleanup) |
 | `st refresh --all-stacks` | Sync trunk once, then restack and submit every independent stack; needs a clean tree unless `--auto-stash-pop` is set and stops at the first conflict |
 | `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |
 | `st refresh --verbose` | Include detailed sync/restack/submit timing |

--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -66,7 +66,7 @@ On GitHub repos with native Stacked PRs enabled, `st ss`/`st bs` auto-register t
 | `st rs --json` | Run sync and emit the result as a versioned JSON document (`kind: "sync"`, schema version 1); implies non-interactive; failures still emit JSON and exit non-zero |
 | `st rs --json --force` | Same as `--json` but also auto-confirms branch deletions |
 | `st restack` | Rebase current stack onto parents locally (no fetch) |
-| `st refresh` | Sync trunk without merged-branch cleanup, restack, then push and update PRs; **does not** show the interactive Sync plan prompt (you already chose this workflow) |
+| `st refresh` | Sync trunk without merged-branch cleanup, restack, then push and update PRs; **does not** show the interactive Sync plan prompt (you already chose this workflow) (pass `--delete-merged` to opt into `sync`-style cleanup) |
 | `st refresh --all-stacks` | Sync trunk once, then restack and submit every independent stack; requires a clean tree unless `--auto-stash-pop` is set, and stops at the first conflict |
 | `st refresh --force --yes --no-prompt` | Full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | Same as `st refresh`, with detailed sync/restack/submit timing |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -38,7 +38,7 @@ st --trace status --json >/dev/null
 | `st sweep --delete --force` | | Skip confirmation prompt |
 | `st sweep --stale-days <N>` | | Override stale threshold in days (default: 30) |
 | `st sweep --json` | | Machine-readable branch classification (conflicts with `--delete`) |
-| `st refresh` | `r` | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack |
+| `st refresh` | `r` | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack (pass `--delete-merged` to opt into `sync`-style cleanup) |
 | `st refresh --force --yes --no-prompt` | | Run the full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
 | `st refresh --all-stacks` | | Refresh every stack in the repo (fetch/trunk sync once, then restack + submit each stack); stops at the first conflict |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -601,6 +601,9 @@ pub(crate) enum Commands {
         /// Refresh every stack in the repo, not just the current one
         #[arg(long)]
         all_stacks: bool,
+        /// Delete local branches whose PRs were merged (off by default, unlike `stax sync`)
+        #[arg(long)]
+        delete_merged: bool,
     },
 
     /// Checkout a branch in the stack

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -490,6 +490,7 @@ pub fn run() -> Result<()> {
             no_prompt,
             auto_stash_pop,
             all_stacks,
+            delete_merged,
         } => commands::refresh::run(
             no_pr,
             no_submit,
@@ -500,6 +501,7 @@ pub fn run() -> Result<()> {
             no_prompt,
             auto_stash_pop,
             all_stacks,
+            delete_merged,
         ),
         Commands::Checkout {
             branch,

--- a/src/commands/continue_cmd.rs
+++ b/src/commands/continue_cmd.rs
@@ -6,14 +6,34 @@ use crate::ops::receipt::{OpKind, OpReceipt, OpStatus};
 use anyhow::Result;
 use colored::Colorize;
 
+/// Resolve the parent branch that metadata should record after a rebase.
+///
+/// The parent recorded on disk may no longer exist locally (e.g. it was merged
+/// upstream and pruned before the sync that started this rebase). `Stack::load`
+/// already reparents such orphans onto trunk in memory, and `restack` rebases
+/// them onto trunk — so mirror that here instead of failing on a branch that is
+/// gone. When the recorded parent still exists, this is a no-op.
+pub(crate) fn effective_parent_branch(repo: &GitRepo, recorded_parent: &str) -> Result<String> {
+    if repo
+        .inner()
+        .find_branch(recorded_parent, git2::BranchType::Local)
+        .is_ok()
+    {
+        return Ok(recorded_parent.to_string());
+    }
+    repo.trunk_branch()
+}
+
 pub(crate) fn continue_rebase_and_update_metadata(repo: &GitRepo) -> Result<RebaseResult> {
     match repo.rebase_continue()? {
         RebaseResult::Success => {
             // Update metadata for current branch
             let current = repo.current_branch()?;
             if let Some(meta) = BranchMetadata::read(repo.inner(), &current)? {
-                let new_parent_rev = repo.branch_commit(&meta.parent_branch_name)?;
+                let parent_name = effective_parent_branch(repo, &meta.parent_branch_name)?;
+                let new_parent_rev = repo.branch_commit(&parent_name)?;
                 let updated_meta = BranchMetadata {
+                    parent_branch_name: parent_name,
                     parent_branch_revision: new_parent_rev,
                     ..meta
                 };

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -18,6 +18,7 @@ pub fn run(
     no_prompt: bool,
     auto_stash_pop: bool,
     all_stacks: bool,
+    delete_merged: bool,
 ) -> Result<()> {
     if all_stacks {
         return run_all_stacks(
@@ -29,6 +30,7 @@ pub fn run(
             yes,
             no_prompt,
             auto_stash_pop,
+            delete_merged,
         );
     }
 
@@ -64,7 +66,7 @@ pub fn run(
     commands::sync::run(
         true,  // restack
         false, // full
-        false, // delete_merged
+        delete_merged,
         false, // delete_upstream_gone
         force,
         safe,
@@ -229,6 +231,7 @@ fn run_all_stacks(
     yes: bool,
     no_prompt: bool,
     auto_stash_pop: bool,
+    delete_merged: bool,
 ) -> Result<()> {
     let repo = GitRepo::open()?;
     let original = repo.current_branch()?;
@@ -270,7 +273,7 @@ fn run_all_stacks(
     if let Err(error) = commands::sync::run(
         true,  // restack
         false, // full
-        false, // delete_merged
+        delete_merged,
         false, // delete_upstream_gone
         force,
         safe,

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -54,25 +54,36 @@ pub fn run(
                 .as_ref()
                 .and_then(|e| e.failed_branch.as_deref())
             {
-                if let Some(meta) = BranchMetadata::read(repo.inner(), failed_branch)?
-                    && let Ok(actual_parent_rev) = repo.branch_commit(&meta.parent_branch_name)
-                {
-                    // `actual_parent_rev` is only a valid boundary if `failed_branch` was
-                    // actually rebased onto it. If the parent advanced again during the
-                    // pause window (between the conflict and a manual `git rebase
-                    // --continue`), it wasn't -- verify ancestry before trusting it, else
-                    // keep the previously recorded (still-valid) boundary (see #830).
-                    let resolved = repo.resolve_child_parent_boundary(
-                        failed_branch,
-                        &[Some(actual_parent_rev.as_str())],
-                        &meta.parent_branch_revision,
-                    );
-                    if resolved != meta.parent_branch_revision {
-                        let updated = BranchMetadata {
-                            parent_branch_revision: resolved,
-                            ..meta
-                        };
-                        updated.write(repo.inner(), failed_branch)?;
+                if let Some(meta) = BranchMetadata::read(repo.inner(), failed_branch)? {
+                    // The recorded parent may no longer exist locally (e.g. it was merged
+                    // upstream and pruned before the restack started) -- mirror the same
+                    // orphan-to-trunk fallback `stax continue` uses instead of failing on a
+                    // branch that is gone.
+                    let parent_name = crate::commands::continue_cmd::effective_parent_branch(
+                        &repo,
+                        &meta.parent_branch_name,
+                    )?;
+                    if let Ok(actual_parent_rev) = repo.branch_commit(&parent_name) {
+                        // `actual_parent_rev` is only a valid boundary if `failed_branch` was
+                        // actually rebased onto it. If the parent advanced again during the
+                        // pause window (between the conflict and a manual `git rebase
+                        // --continue`), it wasn't -- verify ancestry before trusting it, else
+                        // keep the previously recorded (still-valid) boundary (see #830).
+                        let resolved = repo.resolve_child_parent_boundary(
+                            failed_branch,
+                            &[Some(actual_parent_rev.as_str())],
+                            &meta.parent_branch_revision,
+                        );
+                        if resolved != meta.parent_branch_revision
+                            || parent_name != meta.parent_branch_name
+                        {
+                            let updated = BranchMetadata {
+                                parent_branch_name: parent_name,
+                                parent_branch_revision: resolved,
+                                ..meta
+                            };
+                            updated.write(repo.inner(), failed_branch)?;
+                        }
                     }
                 }
                 completed_from_receipt.insert(failed_branch.to_string());

--- a/tests/continue_tests.rs
+++ b/tests/continue_tests.rs
@@ -336,6 +336,88 @@ fn restack_continue_after_manual_rebase_continue_and_parent_advance_keeps_ancest
     );
 }
 
+#[test]
+fn restack_continue_after_manual_rebase_continue_reparents_orphaned_branch_onto_trunk() {
+    let repo = TestRepo::new();
+
+    // main -> branch-a -> branch-b -> branch-c
+    repo.run_stax(&["bc", "branch-a"]);
+    let branch_a = repo.current_branch();
+    repo.create_file("a.txt", "a\n");
+    repo.commit("A commit");
+
+    repo.run_stax(&["bc", "branch-b"]);
+    let branch_b = repo.current_branch();
+    repo.create_file("b.txt", "b\n");
+    repo.commit("B commit");
+
+    repo.run_stax(&["bc", "branch-c"]);
+    let branch_c = repo.current_branch();
+    repo.create_file("shared.txt", "c\n");
+    repo.commit("C commit touches shared.txt");
+
+    // Simulate branch-a and branch-b having been squash-merged into main and
+    // pruned locally, with the merge including a conflicting edit to shared.txt.
+    repo.run_stax(&["checkout", "main"]);
+    repo.create_file("a.txt", "a\n");
+    repo.create_file("b.txt", "b\n");
+    repo.create_file("shared.txt", "main-side-fix\n");
+    repo.commit("squash merge branch-a + branch-b (#1)");
+    repo.git(&["branch", "-D", &branch_a, &branch_b])
+        .assert_success();
+
+    repo.run_stax(&["checkout", &branch_c]);
+    let output = repo.run_stax(&["restack"]);
+    assert!(
+        !output.status.success(),
+        "expected restack to conflict\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(repo.has_rebase_in_progress());
+
+    // Resolve and complete the rebase MANUALLY (git rebase --continue), not via
+    // `stax continue` -- this exercises restack's own receipt-recovery metadata
+    // fixup (src/commands/restack.rs), the parallel path to `continue_cmd.rs`.
+    repo.resolve_conflicts_ours();
+    let manual_continue = repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")]);
+    assert!(
+        manual_continue.status.success(),
+        "manual git rebase --continue should complete: {}",
+        TestRepo::stderr(&manual_continue)
+    );
+    assert!(!repo.has_rebase_in_progress());
+
+    let recovery = repo.run_stax(&["restack", "--continue"]);
+    assert!(
+        recovery.status.success(),
+        "restack --continue recovery should succeed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&recovery),
+        TestRepo::stderr(&recovery)
+    );
+
+    let meta_output = repo.git(&["show", &format!("refs/branch-metadata/{}", branch_c)]);
+    let meta: serde_json::Value =
+        serde_json::from_str(&TestRepo::stdout(&meta_output)).expect("valid JSON");
+    assert_eq!(
+        meta["parentBranchName"].as_str(),
+        Some("main"),
+        "expected orphaned branch-c (parent branch-b deleted) to be reparented onto trunk: {meta}"
+    );
+
+    let boundary = meta["parentBranchRevision"]
+        .as_str()
+        .expect("parentBranchRevision missing")
+        .to_string();
+    let ancestry_check = repo.git(&["merge-base", "--is-ancestor", &boundary, &branch_c]);
+    assert!(
+        ancestry_check.status.success(),
+        "Recorded boundary {} is not an ancestor of {}",
+        boundary,
+        branch_c
+    );
+}
+
 // =============================================================================
 // Sync Continue Tests
 // =============================================================================
@@ -445,6 +527,48 @@ fn test_continue_on_untracked_branch() {
             || !output.status.success(),
         "Expected graceful handling on untracked branch, got: {}",
         combined
+    );
+}
+
+#[test]
+fn continue_after_conflict_reparents_orphaned_branch_onto_trunk() {
+    let repo = TestRepo::new_with_remote();
+    let branches = repo.create_stack(&["json-output", "conflict-report", "dual-role-keys"]);
+    // give dual-role-keys a change that will conflict with the squashed trunk content
+    repo.create_file("shared.txt", "dual\n");
+    repo.commit("dual role keys touches shared.txt");
+    repo.git(&["push", "origin", "--all"]).assert_success();
+
+    // squash-merge the bottom two into trunk, with content that conflicts with dual-role-keys' change
+    repo.simulate_remote_commit(
+        "shared.txt",
+        "conflict-with-review-fix\n",
+        "squash merge json-output + conflict-report (#1)",
+    );
+
+    // the local branches are already gone before refresh runs (merged PRs pruned locally)
+    repo.git(&["fetch", "--prune", "origin"]).assert_success();
+    repo.git(&["checkout", &branches[2]]).assert_success();
+    repo.git(&["branch", "-D", &branches[0], &branches[1]])
+        .assert_success();
+
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force"]);
+    assert!(
+        repo.has_rebase_in_progress(),
+        "{}",
+        TestRepo::stdout(&output)
+    );
+
+    repo.resolve_conflicts_ours();
+    repo.run_stax(&["continue"]).assert_success();
+
+    let meta =
+        TestRepo::stdout(&repo.git(&["show", &format!("refs/branch-metadata/{}", branches[2])]));
+    let main_sha = repo.get_commit_sha("main");
+    assert!(meta.contains(r#""parentBranchName":"main""#), "{meta}");
+    assert!(
+        meta.contains(&format!(r#""parentBranchRevision":"{main_sha}""#)),
+        "expected fresh trunk tip {main_sha}, got:\n{meta}"
     );
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2796,6 +2796,80 @@ fn test_refresh_no_submit_preserves_squash_merged_middle_branch() {
 }
 
 #[test]
+fn test_refresh_delete_merged_removes_squash_merged_middle_branch() {
+    let repo = TestRepo::new_with_remote();
+
+    repo.run_stax(&["bc", "refresh-squash-parent"]);
+    let parent = repo.current_branch();
+    repo.create_file("parent.txt", "parent 1\n");
+    repo.commit("Parent commit 1");
+    repo.create_file("parent.txt", "parent 1\nparent 2\n");
+    repo.commit("Parent commit 2");
+    repo.git(&["push", "-u", "origin", &parent]);
+
+    repo.run_stax(&["bc", "refresh-squash-child"]);
+    let child = repo.current_branch();
+    repo.create_file("child.txt", "child change\n");
+    repo.commit("Child commit");
+    repo.git(&["push", "-u", "origin", &child]);
+
+    let remote_path = repo.remote_path().expect("No remote configured");
+    let clone_dir = test_tempdir();
+    let run_remote_git = |args: &[&str]| {
+        let output = hermetic_git_command()
+            .args(args)
+            .current_dir(clone_dir.path())
+            .output()
+            .expect("Failed to run git in remote clone");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run_remote_git(&["clone", remote_path.to_str().unwrap(), "."]);
+    run_remote_git(&["checkout", "-B", "main", "origin/main"]);
+    run_remote_git(&["config", "user.email", "merger@test.com"]);
+    run_remote_git(&["config", "user.name", "Merger"]);
+    run_remote_git(&["fetch", "origin", &parent]);
+    run_remote_git(&["merge", "--squash", &format!("origin/{}", parent)]);
+    run_remote_git(&["commit", "-m", "Squash merge parent"]);
+    run_remote_git(&["push", "origin", "main"]);
+    run_remote_git(&["push", "origin", "--delete", &parent]);
+
+    repo.run_stax(&["checkout", &child]);
+
+    let output = repo.run_stax(&["refresh", "--no-submit", "--force", "--delete-merged"]);
+    assert!(
+        output.status.success(),
+        "refresh --no-submit --delete-merged failed\nstdout: {}\nstderr: {}",
+        TestRepo::stdout(&output),
+        TestRepo::stderr(&output)
+    );
+    assert!(
+        !TestRepo::stdout(&output).contains("conflict"),
+        "Expected refresh to use provenance-aware sync restack without conflict.\nstdout: {}",
+        TestRepo::stdout(&output)
+    );
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.iter().any(|b| b == &parent),
+        "Expected --delete-merged to remove merged parent branch"
+    );
+
+    let count_output = repo.git(&["rev-list", "--count", &format!("main..{}", child)]);
+    assert!(count_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&count_output.stdout).trim(),
+        "1",
+        "Expected child to keep only novel commits after refresh restack"
+    );
+}
+
+#[test]
 fn test_refresh_auto_stash_pop_restores_dirty_linked_worktree() {
     let repo = TestRepo::new_with_remote();
 


### PR DESCRIPTION
## Summary

Stacked on #856.

`stax refresh`/`stax update` deliberately never cleans up merged branches (PR #415, intentional command-boundary decision vs. `stax sync`, which cleans up by default). That's fine, but it meant the *only* way to get that cleanup was to switch to a separate `stax sync` run — there was no way to opt into it from `refresh` itself.

This adds an opt-in `--delete-merged` flag to `stax refresh` that threads through to the same merged-branch detection/cleanup `stax sync` uses, without changing refresh's default (non-destructive) behavior. `--delete-merged` is plumbed through both the single-stack and `--all-stacks` refresh paths.

## Note on scope

This started as an investigation into "I merged the bottom PR of a 3-stack, then hit a conflict running `refresh` on the second branch — how is that even possible?" I ran an empirical repro across 12 variants (branch kept vs. deleted locally, drifted boundaries, multi-commit squashes, external rebases, repeated refresh runs) and could not reproduce a spurious conflict — `Stack::load`'s orphan-branch handling turned out to be correct by construction, and every conflict I could produce was a genuine content clash that any correct tool must raise. So this PR is **not** a confirmed fix for that specific report — it's a real, independently-useful CLI gap this investigation surfaced along the way. If the original conflict recurs, capturing the actual `refs/branch-metadata/<branch>` JSON and conflicted file diff would be the fastest way to pin it down further.

## Test plan

- [x] Added `test_refresh_delete_merged_removes_squash_merged_middle_branch` (`tests/integration_tests.rs`) — confirmed it fails on pre-flag code (`error: unexpected argument '--delete-merged'`), passes after.
- [x] Confirmed no regression in `test_refresh_no_submit_preserves_squash_merged_middle_branch` (the PR #415 non-destructive-default guard) and the related squash-merge boundary tests.
- [x] `cargo check && cargo clippy -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `make test` — full suite, 2677/2677 passed.