### PR TITLE
test(merge): cover ignore failed CI merge modes

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8507,6 +8507,27 @@ mod forge_mock_tests {
         decision: &str,
         head_sha: &str,
     ) {
+        mount_github_merge_status_with_rollup(
+            mock_server,
+            number,
+            state,
+            decision,
+            head_sha,
+            "SUCCESS",
+            5,
+        )
+        .await;
+    }
+
+    async fn mount_github_merge_status_with_rollup(
+        mock_server: &MockServer,
+        number: u64,
+        state: &str,
+        decision: &str,
+        head_sha: &str,
+        rollup_state: &str,
+        priority: u8,
+    ) {
         let nodes = if decision == "APPROVED" {
             serde_json::json!([{ "state": "APPROVED" }])
         } else {
@@ -8532,12 +8553,13 @@ mod forge_mock_tests {
                             "mergeable": "MERGEABLE",
                             "reviewDecision": decision,
                             "headRefOid": head_sha,
-                            "statusCheckRollup": { "state": "SUCCESS" },
+                            "statusCheckRollup": { "state": rollup_state },
                             "reviews": { "nodes": nodes }
                         }
                     }
                 }
             })))
+            .with_priority(priority)
             .mount(mock_server)
             .await;
     }
@@ -12820,6 +12842,54 @@ mod forge_mock_tests {
                 && combined.contains("Fix the issue and run 'stax merge' again."),
             "Expected duplicate PR base error to surface. Output:\n{}",
             combined
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_stack_ignore_failed_ci_merges_failed_selected_tip_and_warns() {
+        let fixture = setup_three_branch_stack_merge_fixture(
+            StackMergeForge::GitHub,
+            StackMergeScenario::LowerPending,
+        )
+        .await;
+        mount_github_merge_status_with_rollup(
+            &fixture.mock_server,
+            603,
+            "OPEN",
+            "APPROVED",
+            &fixture.tip_sha,
+            "FAILURE",
+            1,
+        )
+        .await;
+
+        let output = run_stax_with_env(
+            &fixture.repo,
+            fixture.home.path(),
+            &[
+                "merge",
+                "--stack",
+                "--ignore-failed-ci",
+                "--yes",
+                "--no-delete",
+                "--no-sync",
+            ],
+        );
+        let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+        assert!(output.status.success(), "merge --stack failed: {combined}");
+        assert!(
+            combined.contains("warning:"),
+            "expected override warning; got: {combined}"
+        );
+        assert!(
+            combined.contains("--ignore-failed-ci"),
+            "expected override flag in warning; got: {combined}"
+        );
+
+        let requests = fixture.mock_server.received_requests().await.unwrap();
+        assert!(
+            !find_request_indices(&requests, "PUT", "/repos/test/repo/pulls/603/merge").is_empty(),
+            "merge --stack must merge the selected tip after waiving failed CI"
         );
     }
 

--- a/tests/merge_ignore_failed_ci_tests.rs
+++ b/tests/merge_ignore_failed_ci_tests.rs
@@ -236,6 +236,103 @@ async fn merge_with_override_merges_failed_ci_pr() {
 }
 
 #[tokio::test]
+async fn merge_remote_with_override_merges_failed_ci_pr_and_warns() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(&server, 1, &sha, "FAILURE", "MERGEABLE", false, "APPROVED").await;
+    mount_pr_get(&server, 1, &sha).await;
+    mount_merge_endpoint(&server, 1).await;
+
+    let output = repo.run_stax_with_env(
+        &[
+            "merge",
+            "--remote",
+            "--yes",
+            "--no-delete",
+            "--no-sync",
+            "--ignore-failed-ci",
+        ],
+        &auth_env(),
+    );
+
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(output.status.success(), "merge --remote failed: {combined}");
+    assert!(
+        combined.contains("warning:"),
+        "expected override warning; got: {combined}"
+    );
+    assert!(
+        combined.contains("--ignore-failed-ci"),
+        "expected override flag in warning; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.iter().any(|r| {
+            r.method == wiremock::http::Method::PUT
+                && r.url.path() == "/repos/test-owner/test-repo/pulls/1/merge"
+        }),
+        "merge --remote must call the merge endpoint after waiving failed CI"
+    );
+}
+
+#[tokio::test]
+async fn merge_when_ready_with_override_merges_failed_ci_pr_and_warns() {
+    ensure_crypto_provider();
+    let server = MockServer::start().await;
+    let repo = TestRepo::new();
+    setup_github_repo(&repo, &server.uri());
+    let branches = repo.create_stack(&["feat"]);
+    let sha = repo.get_commit_sha(&branches[0]);
+    write_branch_pr_metadata(&repo, &branches[0], "main", 1);
+
+    mount_merge_status(&server, 1, &sha, "FAILURE", "MERGEABLE", false, "APPROVED").await;
+    mount_pr_get(&server, 1, &sha).await;
+    mount_merge_endpoint(&server, 1).await;
+
+    let output = repo.run_stax_with_env(
+        &[
+            "merge",
+            "--when-ready",
+            "--yes",
+            "--no-delete",
+            "--no-sync",
+            "--ignore-failed-ci",
+        ],
+        &auth_env(),
+    );
+
+    let combined = format!("{}{}", TestRepo::stdout(&output), TestRepo::stderr(&output));
+    assert!(
+        output.status.success(),
+        "merge --when-ready failed: {combined}"
+    );
+    assert!(
+        combined.contains("warning:"),
+        "expected override warning; got: {combined}"
+    );
+    assert!(
+        combined.contains("--ignore-failed-ci"),
+        "expected override flag in warning; got: {combined}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.iter().any(|r| {
+            r.method == wiremock::http::Method::PUT
+                && r.url.path() == "/repos/test-owner/test-repo/pulls/1/merge"
+        }),
+        "merge --when-ready must call the merge endpoint after waiving failed CI"
+    );
+}
+
+#[tokio::test]
 async fn merge_with_override_still_blocks_draft() {
     ensure_crypto_provider();
     let server = MockServer::start().await;


### PR DESCRIPTION
## Motivation

`--ignore-failed-ci` is threaded through remote, stack, and when-ready merge paths, but integration coverage previously exercised only the default local cascade.

## Changes

- add wiremock coverage that `merge --remote --ignore-failed-ci` emits the explicit warning and reaches the merge endpoint
- add the equivalent `merge --when-ready` coverage
- extend the stack mock helper to set a rollup state and add selected-tip failed-CI coverage for `merge --stack --ignore-failed-ci`
- assert each mode preserves the user-visible override warning and actually attempts the merge

## Verification

- Full local gate: `make test` — **2,680 passed, 0 skipped**
- `make lint-fast` — passed
- Focused `cargo nextest run` for the three new mode tests — **3 passed**
- `git diff --check` — passed

Closes #857

## Documentation

No documentation update: this adds regression coverage only and does not change user-visible behavior, commands, flags, or defaults.