### PR TITLE
fix(sweep): stop parsing the worktree marker into branch names

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -3363,7 +3363,13 @@ pub(super) fn find_merged_branches(
 
     // Method 1: git branch --merged (finds local branches merged into trunk)
     let output = Command::new("git")
-        .args(["branch", "--merged", &stack.trunk])
+        .args([
+            "for-each-ref",
+            "--merged",
+            &stack.trunk,
+            "--format=%(refname:short)",
+            "refs/heads",
+        ])
         .current_dir(workdir)
         .output()
         .context("Failed to list merged branches")?;
@@ -3371,7 +3377,7 @@ pub(super) fn find_merged_branches(
     let merged_output = String::from_utf8_lossy(&output.stdout);
 
     for line in merged_output.lines() {
-        let branch = branch_name_from_merged_output(line);
+        let branch = line.trim();
 
         // Skip trunk itself and any non-tracked branches
         if branch == stack.trunk || branch.is_empty() {
@@ -3391,7 +3397,13 @@ pub(super) fn find_merged_branches(
 
     // Method 1b: git branch --merged origin/trunk (handles stale/diverged local trunk)
     let output = Command::new("git")
-        .args(["branch", "--merged", &remote_trunk_ref])
+        .args([
+            "for-each-ref",
+            "--merged",
+            &remote_trunk_ref,
+            "--format=%(refname:short)",
+            "refs/heads",
+        ])
         .current_dir(workdir)
         .output();
 
@@ -3399,7 +3411,7 @@ pub(super) fn find_merged_branches(
         let merged_output = String::from_utf8_lossy(&output.stdout);
 
         for line in merged_output.lines() {
-            let branch = branch_name_from_merged_output(line);
+            let branch = line.trim();
 
             // Skip trunk itself and any non-tracked branches
             if branch == stack.trunk || branch.is_empty() {
@@ -3730,14 +3742,6 @@ fn count_extra_commits(workdir: &Path, branch: &str, bases: &[&str]) -> Result<u
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(stdout.trim().parse::<usize>().unwrap_or(0))
-}
-
-fn branch_name_from_merged_output(line: &str) -> &str {
-    let branch = line.trim();
-    branch
-        .strip_prefix("* ")
-        .or_else(|| branch.strip_prefix("+ "))
-        .unwrap_or(branch)
 }
 
 pub(super) fn find_upstream_gone_branches(

--- a/src/engine/branch_detect.rs
+++ b/src/engine/branch_detect.rs
@@ -50,13 +50,19 @@ pub fn find_merged_branches_all(
 
     // Method 1: git branch --merged <trunk>
     let output = Command::new("git")
-        .args(["branch", "--merged", trunk])
+        .args([
+            "for-each-ref",
+            "--merged",
+            trunk,
+            "--format=%(refname:short)",
+            "refs/heads",
+        ])
         .current_dir(workdir)
         .output()
         .context("Failed to list merged branches")?;
 
     for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let branch = line.trim().trim_start_matches("* ");
+        let branch = line.trim();
         if branch.is_empty() || branch == trunk {
             continue;
         }
@@ -69,12 +75,18 @@ pub fn find_merged_branches_all(
     // Method 1b: git branch --merged <remote/trunk> (handles stale local trunk)
     if let Some(remote_ref) = remote_trunk_ref {
         let output = Command::new("git")
-            .args(["branch", "--merged", remote_ref])
+            .args([
+                "for-each-ref",
+                "--merged",
+                remote_ref,
+                "--format=%(refname:short)",
+                "refs/heads",
+            ])
             .current_dir(workdir)
             .output();
         if let Ok(output) = output {
             for line in String::from_utf8_lossy(&output.stdout).lines() {
-                let branch = line.trim().trim_start_matches("* ");
+                let branch = line.trim();
                 if branch.is_empty() || branch == trunk {
                     continue;
                 }

--- a/tests/sweep_tests.rs
+++ b/tests/sweep_tests.rs
@@ -744,3 +744,45 @@ fn sweep_reparents_tracked_children_on_delete() {
     let status_out = repo.run_stax(&["status"]);
     status_out.assert_success();
 }
+
+#[test]
+fn sweep_ignores_worktree_checkout_marker() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["bc", "side"]).assert_success();
+    repo.create_file("side.txt", "side");
+    repo.commit("side commit");
+
+    let worktree_path = repo.path().join("wt-main");
+    let out = repo.git(&[
+        "worktree",
+        "add",
+        worktree_path.to_str().expect("worktree path"),
+        "main",
+    ]);
+    assert!(
+        out.status.success(),
+        "failed to add worktree: {}",
+        TestRepo::stderr(&out)
+    );
+
+    let out = repo.run_stax(&["sweep", "--json"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("sweep --json should output valid JSON: {}\n{}", e, stdout));
+
+    let names: Vec<&str> = parsed["branches"]
+        .as_array()
+        .expect("JSON should have branches array")
+        .iter()
+        .filter_map(|b| b["name"].as_str())
+        .collect();
+
+    assert!(
+        !names.iter().any(|n| n.starts_with('+') || *n == "main"),
+        "trunk checked out in another worktree must not be swept: {:?}",
+        names
+    );
+}


### PR DESCRIPTION
## Motivation

`stax sweep` lists trunk as a deletion candidate in any repo with linked worktrees.

`git branch --merged` prefixes `+ ` for a branch that is checked out in another worktree, but `branch_detect.rs` strips only `* `. The marker ends up inside the branch name, so sweep reports a phantom `+ main` as **merged** and offers it under `--delete`:

```
Will delete 1 branch:
  ▸ + main
```

Trunk and current-branch guards compare raw names (`branch != trunk`), and `"+ main"` never equals `"main"`, so every protection is bypassed. The deletion itself fails at the git level — there is no ref by that name — so no branch is actually lost, but the prompt says stax is about to delete `main`, and the deletion loop reports it as a skip rather than as a parse bug.

`sync` already handled `+ ` (#638, "Keep linked worktrees during sync cleanup"); `sweep` (#468) has its own parser that never got the fix.

Fixes #860

## Description of changes / notes for reviewers

- `src/engine/branch_detect.rs` — both `--merged` passes now use `git for-each-ref --merged <ref> --format=%(refname:short) refs/heads`. Listing refs sidesteps decorated output entirely: no `* `/`+ ` markers, and no `(HEAD detached at …)` pseudo-entry, which the old parsers also mistook for a branch name.
- `src/commands/sync.rs` — same change to its two call sites, which retires `branch_name_from_merged_output` (it patched the markers but still let the detached-HEAD line through).
- `tests/sweep_tests.rs` — `sweep_ignores_worktree_checkout_marker` adds a worktree checkout of trunk and asserts sweep emits no `+`-prefixed name and no trunk entry.

Verified: the new test fails on `main` (`+ main` classified merged) and passes with the fix; `cargo test --test all_tests sweep_` 22 passed, `sync` 137 passed; `cargo fmt --check` clean; no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx7ypGdwjXopRcFMwvvjPT

> AGENT GENERATED
