### PR TITLE
test(refresh): cover all-stacks delete merged

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -450,6 +450,37 @@ impl TestRepo {
             .expect("Failed to push merge");
     }
 
+    /// Squash-merge a branch into remote main, then remove its remote ref.
+    pub fn squash_merge_branch_on_remote(&self, branch: &str) {
+        let remote_path = self.remote_path().expect("No remote configured");
+        let clone_dir = test_tempdir();
+
+        let run = |args: &[&str]| {
+            let output = hermetic_git_command()
+                .args(args)
+                .current_dir(clone_dir.path())
+                .output()
+                .expect("Failed to run git in remote clone");
+            assert!(
+                output.status.success(),
+                "git {:?} failed\nstdout: {}\nstderr: {}",
+                args,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+
+        run(&["clone", remote_path.to_str().unwrap(), "."]);
+        run(&["checkout", "-B", "main", "origin/main"]);
+        run(&["config", "user.email", "merger@test.com"]);
+        run(&["config", "user.name", "Merger"]);
+        run(&["fetch", "origin", branch]);
+        run(&["merge", "--squash", &format!("origin/{branch}")]);
+        run(&["commit", "-m", &format!("Squash merge {branch}")]);
+        run(&["push", "origin", "main"]);
+        run(&["push", "origin", "--delete", branch]);
+    }
+
     /// List remote branches
     pub fn list_remote_branches(&self) -> Vec<String> {
         let output = hermetic_git_command()

--- a/tests/refresh_all_stacks_tests.rs
+++ b/tests/refresh_all_stacks_tests.rs
@@ -115,6 +115,87 @@ fn all_stacks_rejects_dirty_tree_without_auto_stash_pop() {
 }
 
 #[test]
+fn all_stacks_delete_merged_removes_squash_merged_branch_and_preserves_other_stack() {
+    let repo = TestRepo::new_with_remote();
+    let (stack_a, stack_b) = build_two_stacks(&repo);
+    let parent = &stack_a[0];
+    let child = &stack_a[1];
+    let unrelated = &stack_b[0];
+
+    for branch in stack_a.iter().chain(stack_b.iter()) {
+        repo.git(&["push", "-u", "origin", branch]).assert_success();
+    }
+    repo.squash_merge_branch_on_remote(parent);
+    repo.git(&["checkout", child]).assert_success();
+
+    repo.run_stax(&[
+        "refresh",
+        "--all-stacks",
+        "--no-submit",
+        "--force",
+        "--yes",
+        "--delete-merged",
+    ])
+    .assert_success();
+
+    let branches = repo.list_branches();
+    assert!(
+        !branches.contains(parent),
+        "--delete-merged should remove the squash-merged parent; branches: {branches:?}"
+    );
+    for branch in [child, unrelated] {
+        assert!(
+            branches.contains(branch),
+            "expected surviving branch {branch} to remain tracked locally; branches: {branches:?}"
+        );
+        repo.git(&["merge-base", "--is-ancestor", "main", branch])
+            .assert_success();
+    }
+    let novel_commit_count = repo.git(&["rev-list", "--count", &format!("main..{child}")]);
+    novel_commit_count.assert_success();
+    assert_eq!(
+        TestRepo::stdout(&novel_commit_count).trim(),
+        "1",
+        "the surviving child should retain only its novel commit"
+    );
+}
+
+#[test]
+fn all_stacks_delete_merged_is_a_noop_when_no_branches_are_merged() {
+    let repo = TestRepo::new_with_remote();
+    let (stack_a, stack_b) = build_two_stacks(&repo);
+    let before = stack_a
+        .iter()
+        .chain(stack_b.iter())
+        .map(|branch| (branch.clone(), repo.get_commit_sha(branch)))
+        .collect::<Vec<_>>();
+
+    repo.git(&["checkout", &stack_a[1]]).assert_success();
+    repo.run_stax(&[
+        "refresh",
+        "--all-stacks",
+        "--no-submit",
+        "--force",
+        "--yes",
+        "--delete-merged",
+    ])
+    .assert_success();
+
+    for (branch, sha) in before {
+        assert!(
+            repo.list_branches().contains(&branch),
+            "unmerged branch {branch} should not be deleted"
+        );
+        assert_eq!(
+            repo.get_commit_sha(&branch),
+            sha,
+            "{branch} should be a no-op"
+        );
+    }
+    assert_eq!(repo.current_branch(), stack_a[1]);
+}
+
+#[test]
 fn all_stacks_stops_at_conflict_and_retry_finishes_remaining_stacks() {
     let repo = TestRepo::new_with_remote();
 


### PR DESCRIPTION
## Summary
- cover `refresh --all-stacks --delete-merged` after a remote squash merge and branch prune
- assert the surviving child is restacked, the unrelated stack is processed, and no-merged cleanup is a no-op
- add a reusable hermetic remote squash-merge fixture helper

Closes #862

## Verification
- `make lint-fast`
- `cargo nextest run refresh_all_stacks_tests::all_stacks_delete_merged`
- `make test` — full local gate: 2679 passed, 0 skipped

Docs: not needed; this is test-only coverage.