### PR TITLE
feat(stats): add local stacking health snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ These rules apply to AI-generated PR titles and bodies from `generate` and `subm
 | `st ci -w --strict` | Watch CI but exit as soon as any check fails |
 | `st rs` / `st rs --restack` | Sync trunk, clean merged branches, optionally rebase |
 | `st sweep` | Classify all local branches (merged/gone/stale/active); `--delete` removes merged branches (including tracked merged PRs) and upstream-gone branches with no unique work |
+| `st stats` | Single-screen, local-only snapshot of stacking health (stack shape, PR mix, restack/parent/dirty health, worktree lanes, hygiene, next action); `--current` scopes to the current stack, `--json` for machine output, `--ci` adds an opt-in CI roll-up |
 | `st refresh` / `st r` | Sync trunk without merged-branch cleanup, restack current stack, then push/update PRs (pass `--delete-merged` to opt into `sync`-style cleanup) |
 | `st refresh --all-stacks` | Sync trunk once, then restack and submit every independent stack; needs a clean tree unless `--auto-stash-pop` is set and stops at the first conflict |
 | `st refresh --force --yes --no-prompt` | Run refresh without sync or submit prompts |

--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -38,6 +38,9 @@ st --trace status --json >/dev/null
 | `st sweep --delete --force` | | Skip confirmation prompt |
 | `st sweep --stale-days <N>` | | Override stale threshold in days (default: 30) |
 | `st sweep --json` | | Machine-readable branch classification (conflicts with `--delete`) |
+| `st stats` | | Single-screen, local-only snapshot of stacking health (stack shape, PR mix, health, worktrees, hygiene, next action); `--current` scopes to the current stack |
+| `st stats --json` | | Machine-readable `RepoStats` document |
+| `st stats --ci` | | Add an opt-in CI roll-up (network call, reuses the standup CI pattern); omitted (and non-fatal) without forge auth |
 | `st refresh` | `r` | Sync trunk without merged-branch cleanup, restack, then push and create/update PRs for the current stack (pass `--delete-merged` to opt into `sync`-style cleanup) |
 | `st refresh --force --yes --no-prompt` | | Run the full refresh flow without sync or submit prompts |
 | `st refresh --verbose` | | Same as `st refresh`, with detailed sync/restack/submit timing |
@@ -502,6 +505,17 @@ Restack the stack and submit updates, without fetching trunk (offline-friendly).
 - `--ci` checks only the selected branches and may add network latency; combine it with `--all` to check all tracked branches.
 - GitHub authored reviews come from one time-bounded, maximum-100 GraphQL query. GitLab and Gitea mark that signal unsupported rather than scanning every MR/PR.
 - JSON preserves `reviews_given` and `needs_attention.ci_failing`; use `signals.<name>.status` (`available`, `unsupported`, `unavailable`, or `not_requested`) to interpret empty arrays.
+
+### `st stats`
+
+- `--current` scopes to the current stack (ancestors + current + descendants); when the current branch is untracked, the scope is empty and the command still exits `0`.
+- `--json` emits a single `RepoStats` document with top-level keys: `scope` (`"all"` or `"current"`), `trunk`, `current`, `repo` (project slug, omitted with no forge remote), `trunk_ahead` / `trunk_behind` (omitted with no remote-tracking branch), `stack_shape`, `pr_mix`, `health`, `worktrees`, `ci` (omitted unless `--ci` produced counts), `ci_unavailable_reason` (present when `--ci` was requested but unavailable), `attention`, `biggest_stacks`, `hygiene`, `next_actions`.
+- `stack_shape`: `tracked`, `independent`, `deepest`, `avg_height`.
+- `pr_mix`: `open` (includes drafts), `draft`, `ready` (`open - draft`), `no_pr`, `merged`, `closed`, `frozen`.
+- `health`: `need_restack`, `missing_parent`, `dirty_worktrees` (repo-wide, not scoped by `--current`; `null` when the dirty check was skipped for having too many worktrees).
+- `worktrees`: `linked`, `idle_slots`.
+- `hygiene`: `merged_but_local`, `upstream_gone`, `stale`, `stale_days` — same ancestry-based classification `st sweep` uses.
+- `--ci` is opt-in because it makes a network call; without forge auth configured, `ci` is omitted and `ci_unavailable_reason` explains why. `st stats` always exits `0` regardless of CI availability.
 
 ### `st pr` / `st issue`
 

--- a/docs/commands/stack-health.md
+++ b/docs/commands/stack-health.md
@@ -25,11 +25,17 @@ st stats --ci           # add an opt-in CI roll-up (network call, reuses the sta
   branches without a PR, branches with missing parent metadata, and dirty/clean
   worktree lanes.
 - **Biggest stacks** — the largest (by height) independent stacks, with
-  commits-ahead and PR range.
+  commits-ahead and PR range. Shown only when there are at least two stacks to
+  compare.
+- **PR mix** chart — a bar chart of ready/draft/no-PR, shown only when at least
+  two of those categories are non-zero.
 - **Hygiene** — merged-but-local, upstream-gone, and stale branch counts (same
   classification as `st sweep`), with a hint to run `st sweep --delete`.
 - **Next** — one or two suggested follow-up commands (e.g. `st restack --all`
   then `st ss`, or `st sweep`).
+
+Counters with a zero value are omitted rather than printed as `0`, and the
+health row collapses to `✓ all clear` when nothing needs attention.
 
 `--ci` is opt-in because it makes a network call; without it (or without forge
 auth configured), the CI line is omitted and `st stats` still exits `0`.

--- a/docs/commands/stack-health.md
+++ b/docs/commands/stack-health.md
@@ -2,6 +2,38 @@
 
 Commands to validate, repair, and test your stack metadata.
 
+## `st stats`
+
+Single-screen, local-only snapshot of stacking health: stack shape, PR mix,
+restack/parent/dirty health, worktree lanes, local branch hygiene, and a
+next-action hint. Read-only and safe to run at any time.
+
+```bash
+st stats              # all tracked branches
+st stats --current    # scope to the current stack only
+st stats --json        # machine-readable output
+st stats --ci           # add an opt-in CI roll-up (network call, reuses the standup CI pattern)
+```
+
+- **Stack shape** — tracked branch count, number of independent stacks, deepest
+  stack, and average stack height.
+- **PR mix** — open/draft/ready/no-PR/frozen counts across the scoped branches.
+- **Health** — branches needing restack, branches with missing parent
+  metadata, and (repo-wide, not scoped by `--current`) dirty linked worktrees.
+- **Worktrees** — linked worktree count and idle pool slots.
+- **Attention** — up to a few highlighted items: stacks needing restack,
+  branches without a PR, branches with missing parent metadata, and dirty/clean
+  worktree lanes.
+- **Biggest stacks** — the largest (by height) independent stacks, with
+  commits-ahead and PR range.
+- **Hygiene** — merged-but-local, upstream-gone, and stale branch counts (same
+  classification as `st sweep`), with a hint to run `st sweep --delete`.
+- **Next** — one or two suggested follow-up commands (e.g. `st restack --all`
+  then `st ss`, or `st sweep`).
+
+`--ci` is opt-in because it makes a network call; without it (or without forge
+auth configured), the CI line is omitted and `st stats` still exits `0`.
+
 ## `st validate`
 
 Check that all branch metadata is consistent.

--- a/skills.md
+++ b/skills.md
@@ -30,6 +30,7 @@ stax stack unlink <stack-number> # Unstack a native GitHub Stack remotely; omit 
 stax merge                     # Merge PRs from stack bottom upward
 stax sync|rs                   # Sync trunk + clean merged branches
 stax sweep                     # Classify + optionally delete merged/gone/stale branches
+stax stats                     # Single-screen local stacking health snapshot (--current, --json, --ci)
 stax restack                   # Rebase branch/stack onto parents
 stax cascade                   # Restack bottom-up and submit updates (no trunk fetch; offline-friendly)
 
@@ -372,6 +373,11 @@ stax sweep --delete --include-stale  # Also delete stale branches
 stax sweep --delete --force        # Skip confirmation prompt
 stax sweep --stale-days 60         # Override stale threshold in days (default 30, or branch.stale_days config)
 stax sweep --json                  # Machine-readable branch classification (conflicts with --delete)
+
+stax stats                          # Single-screen local-only stacking health snapshot (stack shape, PR mix, health, worktrees, hygiene, next action)
+stax stats --current                # Scope to the current stack only
+stax stats --json                   # Machine-readable RepoStats document
+stax stats --ci                     # Add an opt-in CI roll-up (network call); omitted (non-fatal) without forge auth — always exits 0
 
 stax refresh|r                      # Sync trunk, restack, then submit (no merged cleanup; no Sync plan prompt)
 stax refresh --no-pr                # Push only after trunk sync/restack

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1182,6 +1182,19 @@ pub(crate) enum Commands {
     /// Interactive tutorial (no auth or repo needed)
     Demo,
 
+    /// Single-screen snapshot of local stacking health
+    Stats {
+        /// Output raw JSON
+        #[arg(long)]
+        json: bool,
+        /// Scope to the current stack only (default: all tracked branches)
+        #[arg(long)]
+        current: bool,
+        /// Include a CI roll-up (may add network latency)
+        #[arg(long)]
+        ci: bool,
+    },
+
     /// Generate standup summary of recent activity
     Standup {
         /// Output raw JSON (standup data, or summary JSON when combined with --ai)
@@ -2018,7 +2031,8 @@ impl Commands {
             | Commands::Web(_)
             | Commands::W
             | Commands::Wtll { .. }
-            | Commands::Wtls => CommandPolicy::RebaseSafe,
+            | Commands::Wtls
+            | Commands::Stats { .. } => CommandPolicy::RebaseSafe,
             Commands::Issue { command } => match command {
                 None | Some(IssueCommands::List { .. }) => CommandPolicy::RebaseSafe,
             },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -711,6 +711,7 @@ pub fn run() -> Result<()> {
         } => commands::stack_cmd::run_test(cmd, all, stack, fail_fast, parallel, jobs),
         Commands::Demo => unreachable!(),        // Handled above
         Commands::UpdateCheck => unreachable!(), // Handled before setup/config work
+        Commands::Stats { json, current, ci } => commands::stats::run(json, current, ci),
         Commands::Standup {
             json,
             all,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -53,6 +53,7 @@ pub mod stack_cmd;
 pub(crate) mod stack_palette;
 pub mod staging;
 pub mod standup;
+pub mod stats;
 pub mod status;
 pub mod submit;
 pub(crate) mod submit_plan;

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -1,0 +1,489 @@
+use crate::config::Config;
+use crate::engine::branch_detect::{
+    find_ancestor_merged_branches, find_stale_branches, find_upstream_gone_branches,
+    has_unique_commits_since_any_base,
+};
+use crate::engine::stats::{self, CiFacts, HygieneFacts, RepoStats, StatsFacts, WorktreeFact};
+use crate::engine::{Stack, StackSnapshot, TrackedFacts, collect_tracked_facts};
+use crate::forge::ForgeClient;
+use crate::git::GitRepo;
+use crate::progress::LiveTimer;
+use crate::remote::RemoteInfo;
+use anyhow::Result;
+use colored::Colorize;
+use std::collections::{HashMap, HashSet};
+
+/// Above this many non-prunable worktrees, skip the per-worktree dirty check
+/// (each check is a `git status` subprocess) and report `dirty_worktrees: None`.
+const DIRTY_CHECK_LIMIT: usize = 16;
+
+/// Above this many upstream-gone candidates, skip the unique-commits refine
+/// pass (each check is a `git rev-list` subprocess).
+const HYGIENE_GONE_REFINE_LIMIT: usize = 32;
+
+pub fn run(json: bool, current: bool, ci: bool) -> Result<()> {
+    let repo = GitRepo::open()?;
+    let snapshot = StackSnapshot::load(&repo)?;
+    let stack = snapshot.stack;
+    let current_branch = snapshot.current_branch;
+    let config = Config::load()?;
+
+    let scope = compute_scope(&stack, &current_branch, current);
+    let mut scope_vec: Vec<String> = scope.iter().cloned().collect();
+    scope_vec.sort();
+
+    let remote_info = RemoteInfo::from_repo(&repo, &config).ok();
+    let repo_slug = remote_info.as_ref().map(|r| r.project_path());
+    let trunk_divergence = repo.commits_vs_remote_named(config.remote_name(), &stack.trunk);
+    let tracked: TrackedFacts = collect_tracked_facts(&repo, &stack);
+
+    let ahead_behind = gather_ahead_behind(&repo, &stack, &scope_vec);
+    let (worktrees, dirty_worktrees) = gather_worktree_facts(&repo)?;
+    let idle_slots = gather_idle_slots(&repo, &config);
+    let hygiene = gather_hygiene(&repo, &stack, &current_branch, &config)?;
+
+    let (ci_facts, ci_unavailable_reason) =
+        gather_ci_facts(ci, json, &repo, &stack, &scope_vec, &remote_info);
+
+    let facts = StatsFacts {
+        stack,
+        current: current_branch,
+        current_only: current,
+        repo_slug,
+        trunk_divergence,
+        tracked,
+        ahead_behind,
+        worktrees,
+        dirty_worktrees,
+        idle_slots,
+        hygiene,
+        ci: ci_facts,
+        ci_unavailable_reason,
+    };
+
+    let result = stats::compute(&facts);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    render_human(&result);
+    Ok(())
+}
+
+fn compute_scope(stack: &Stack, current: &str, current_only: bool) -> HashSet<String> {
+    if current_only {
+        stack
+            .current_stack(current)
+            .into_iter()
+            .filter(|b| b != &stack.trunk)
+            .collect()
+    } else {
+        stack
+            .branches
+            .keys()
+            .filter(|b| *b != &stack.trunk)
+            .cloned()
+            .collect()
+    }
+}
+
+fn gather_ahead_behind(
+    repo: &GitRepo,
+    stack: &Stack,
+    scope: &[String],
+) -> HashMap<String, (usize, usize)> {
+    let pairs: Vec<(String, String)> = scope
+        .iter()
+        .map(|name| {
+            let base = stack
+                .branches
+                .get(name)
+                .and_then(|b| b.parent.clone())
+                .unwrap_or_else(|| stack.trunk.clone());
+            (base, name.clone())
+        })
+        .collect();
+    let results = repo.commits_ahead_behind_many(&pairs);
+    scope
+        .iter()
+        .cloned()
+        .zip(results.into_iter().map(|r| r.unwrap_or((0, 0))))
+        .collect()
+}
+
+fn gather_worktree_facts(repo: &GitRepo) -> Result<(Vec<WorktreeFact>, Option<usize>)> {
+    let infos = repo.list_worktrees()?;
+    let non_prunable_paths: Vec<std::path::PathBuf> = infos
+        .iter()
+        .filter(|w| !w.is_prunable)
+        .map(|w| w.path.clone())
+        .collect();
+
+    let dirty_by_path: Option<HashMap<std::path::PathBuf, bool>> =
+        if non_prunable_paths.len() <= DIRTY_CHECK_LIMIT {
+            let results =
+                crate::parallel::map_ordered(&non_prunable_paths, |path| worktree_is_dirty(path));
+            Some(non_prunable_paths.iter().cloned().zip(results).collect())
+        } else {
+            None
+        };
+
+    let facts: Vec<WorktreeFact> = infos
+        .iter()
+        .map(|w| {
+            let is_dirty = if w.is_prunable {
+                None
+            } else {
+                dirty_by_path.as_ref().and_then(|m| m.get(&w.path).copied())
+            };
+            WorktreeFact {
+                name: w.name.clone(),
+                is_main: w.is_main,
+                is_prunable: w.is_prunable,
+                is_dirty,
+            }
+        })
+        .collect();
+
+    let dirty_worktrees = dirty_by_path.map(|m| m.values().filter(|d| **d).count());
+
+    Ok((facts, dirty_worktrees))
+}
+
+/// Thread-safe dirty check (subprocess-based, unlike `GitRepo::is_dirty_at`
+/// which holds a non-`Sync` `git2::Repository`).
+fn worktree_is_dirty(path: &std::path::Path) -> bool {
+    crate::git::command::output(path, &["status", "--porcelain"])
+        .map(|output| output.status.success() && !output.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn gather_idle_slots(repo: &GitRepo, config: &Config) -> usize {
+    crate::commands::worktree::shared::managed_worktrees_dir(repo, config)
+        .ok()
+        .and_then(|dir| crate::commands::worktree::pool::load(&dir).ok())
+        .map(|pool| pool.idle_count())
+        .unwrap_or(0)
+}
+
+fn gather_hygiene(
+    repo: &GitRepo,
+    stack: &Stack,
+    current: &str,
+    config: &Config,
+) -> Result<HygieneFacts> {
+    let workdir = repo.workdir()?.to_path_buf();
+    let trunk = &stack.trunk;
+    let remote_trunk_ref = format!("{}/{}", config.remote_name(), trunk);
+    let stale_days = config.branch.stale_days;
+
+    let merged: HashSet<String> =
+        find_ancestor_merged_branches(&workdir, trunk, Some(remote_trunk_ref.as_str()))?
+            .into_iter()
+            .filter(|b| b != current)
+            .collect();
+
+    let gone_candidates: Vec<String> = find_upstream_gone_branches(&workdir, trunk)?
+        .into_iter()
+        .filter(|b| b != trunk && b != current && !merged.contains(b))
+        .collect();
+
+    let gone: HashSet<String> = if gone_candidates.len() <= HYGIENE_GONE_REFINE_LIMIT {
+        gone_candidates
+            .into_iter()
+            .filter(|b| {
+                !has_unique_commits_since_any_base(&workdir, b, &[trunk, remote_trunk_ref.as_str()])
+                    .unwrap_or(false)
+            })
+            .collect()
+    } else {
+        gone_candidates.into_iter().collect()
+    };
+
+    let already_classified: HashSet<String> = merged.iter().chain(gone.iter()).cloned().collect();
+    let stale = find_stale_branches(&workdir, trunk, current, stale_days, &already_classified)?;
+
+    Ok(HygieneFacts {
+        merged_but_local: merged.len(),
+        upstream_gone: gone.len(),
+        stale: stale.len(),
+        stale_days,
+    })
+}
+
+fn gather_ci_facts(
+    requested: bool,
+    json: bool,
+    repo: &GitRepo,
+    stack: &Stack,
+    scope: &[String],
+    remote_info: &Option<RemoteInfo>,
+) -> (Option<CiFacts>, Option<String>) {
+    if !requested {
+        return (None, None);
+    }
+
+    let Some(remote) = remote_info else {
+        return (
+            None,
+            Some("no supported forge remote configured".to_string()),
+        );
+    };
+    if crate::forge::forge_token(remote.forge).is_none() {
+        return (
+            None,
+            Some("forge authentication is not configured".to_string()),
+        );
+    }
+
+    let timer = LiveTimer::maybe_new_stderr(!json, "Checking CI...");
+    let result = (|| -> Result<CiFacts> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let statuses = rt.block_on(async {
+            let client = ForgeClient::new(remote)?;
+            crate::commands::ci::fetch_ci_statuses_async(repo, &client, stack, scope).await
+        })?;
+        let failing = statuses
+            .iter()
+            .filter(|s| s.overall_status.as_deref() == Some("failure"))
+            .count();
+        let pending = statuses
+            .iter()
+            .filter(|s| s.overall_status.as_deref() == Some("pending"))
+            .count();
+        let passing = statuses
+            .iter()
+            .filter(|s| s.overall_status.as_deref() == Some("success"))
+            .count();
+        Ok(CiFacts {
+            failing,
+            pending,
+            passing,
+        })
+    })();
+
+    match result {
+        Ok(facts) => {
+            LiveTimer::maybe_finish_ok(timer, "done");
+            (Some(facts), None)
+        }
+        Err(err) => {
+            LiveTimer::maybe_finish_warn(timer, "unavailable");
+            (None, Some(format!("{err:#}")))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+fn divergence_arrows(ahead: usize, behind: usize) -> String {
+    let mut parts = Vec::new();
+    if ahead > 0 {
+        parts.push(format!("{}", format!("{}↑", ahead).green()));
+    }
+    if behind > 0 {
+        parts.push(format!("{}", format!("{}↓", behind).red()));
+    }
+    parts.join(" ")
+}
+
+fn attention_label(kind: &str) -> &'static str {
+    match kind {
+        "restack" => "restack",
+        "no_pr" => "no PR",
+        "missing_parent" => "parent",
+        "lanes" => "lanes",
+        _ => "item",
+    }
+}
+
+fn render_human(stats: &RepoStats) {
+    // --- Header ---
+    let mut header_parts: Vec<String> = Vec::new();
+    if let Some(repo) = &stats.repo {
+        header_parts.push(repo.clone());
+    }
+    header_parts.push(stats.trunk.clone());
+    if let (Some(ahead), Some(behind)) = (stats.trunk_ahead, stats.trunk_behind) {
+        if ahead == 0 && behind == 0 {
+            header_parts.push("in sync".to_string());
+        } else {
+            header_parts.push(divergence_arrows(ahead, behind));
+        }
+    }
+    println!(
+        "{}{}",
+        format!("{:<6}", "Stats").bold(),
+        header_parts.join(" · ")
+    );
+    println!("{}{}", format!("{:<6}", "You").bold(), stats.current.cyan());
+    println!();
+
+    // --- Counters ---
+    let shape = &stats.stack_shape;
+    let mut counter_lines: Vec<(&str, String)> = Vec::new();
+
+    if shape.tracked > 0 || shape.independent > 0 || shape.deepest > 0 {
+        counter_lines.push((
+            "Stacks",
+            format!(
+                "{} tracked  ·  {} independent  ·  deepest {}  ·  avg {:.1}",
+                shape.tracked, shape.independent, shape.deepest, shape.avg_height
+            ),
+        ));
+    }
+
+    let pr = &stats.pr_mix;
+    if pr.open > 0 || pr.no_pr > 0 || pr.frozen > 0 {
+        let mut parts = vec![
+            format!("{} open", pr.open),
+            format!("{} draft", pr.draft),
+            format!("{} no PR", pr.no_pr),
+        ];
+        if pr.frozen > 0 {
+            parts.push(format!("{} frozen", pr.frozen));
+        }
+        counter_lines.push(("PRs", parts.join("  ·  ")));
+    }
+
+    let health = &stats.health;
+    if health.need_restack > 0
+        || health.missing_parent > 0
+        || health.dirty_worktrees.unwrap_or(0) > 0
+    {
+        let mut parts = vec![
+            format!("{} need restack", health.need_restack),
+            format!("{} missing parent", health.missing_parent),
+        ];
+        if let Some(dirty) = health.dirty_worktrees {
+            parts.push(format!("{} dirty", dirty));
+        }
+        counter_lines.push(("Health", parts.join("  ·  ")));
+    }
+
+    let wt = &stats.worktrees;
+    if wt.linked > 0 || wt.idle_slots > 0 {
+        counter_lines.push((
+            "Worktrees",
+            format!("{} linked  ·  {} idle", wt.linked, wt.idle_slots),
+        ));
+    }
+
+    if let Some(ci) = &stats.ci {
+        if ci.failing > 0 || ci.pending > 0 || ci.passing > 0 {
+            counter_lines.push((
+                "CI",
+                format!(
+                    "{} failing  ·  {} pending  ·  {} passing",
+                    ci.failing, ci.pending, ci.passing
+                ),
+            ));
+        }
+    } else if let Some(reason) = &stats.ci_unavailable_reason {
+        counter_lines.push(("CI", format!("{}", reason.dimmed())));
+    }
+
+    if !counter_lines.is_empty() {
+        for (label, value) in &counter_lines {
+            println!("{:<11}{}", label, value);
+        }
+        println!();
+    }
+
+    // --- Attention ---
+    if !stats.attention.is_empty() {
+        println!("{}", "Attention".bold());
+        for item in &stats.attention {
+            println!(
+                "   {}  {:<10}{}",
+                item.glyph,
+                attention_label(item.kind),
+                item.detail
+            );
+        }
+        println!();
+    }
+
+    // --- Biggest stacks ---
+    if !stats.biggest_stacks.is_empty() {
+        println!("{}", "Biggest stacks".bold());
+        for summary in &stats.biggest_stacks {
+            let pr_range = match (summary.pr_low, summary.pr_high) {
+                (Some(low), Some(high)) if low == high => format!("#{}", low),
+                (Some(low), Some(high)) => format!("#{}\u{2013}#{}", low, high),
+                _ => "–".to_string(),
+            };
+            println!(
+                "   {:>2}  {:<20} {:>4}  {:<8}  {}",
+                summary.height,
+                summary.root,
+                format!("{}↑", summary.commits_ahead),
+                summary.label,
+                pr_range
+            );
+        }
+        println!();
+    }
+
+    // --- PR mix bar chart ---
+    let max = pr.ready.max(pr.draft).max(pr.no_pr);
+    if max > 0 {
+        println!("{}", "PR mix (open)".bold());
+        println!(
+            "   {:<5} {}  {}",
+            "ready",
+            stats::bar(pr.ready, max, 10),
+            pr.ready
+        );
+        println!(
+            "   {:<5} {}  {}",
+            "draft",
+            stats::bar(pr.draft, max, 10),
+            pr.draft
+        );
+        println!(
+            "   {:<5} {}  {}",
+            "none",
+            stats::bar(pr.no_pr, max, 10),
+            pr.no_pr
+        );
+        println!();
+    }
+
+    // --- Hygiene ---
+    let hygiene = &stats.hygiene;
+    if hygiene.merged_but_local > 0 || hygiene.upstream_gone > 0 || hygiene.stale > 0 {
+        println!("{}", "Hygiene".bold());
+        if hygiene.merged_but_local > 0 {
+            println!(
+                "   {:<17}  {:<2}  {}",
+                "merged-but-local",
+                hygiene.merged_but_local,
+                "st sweep --delete".dimmed()
+            );
+        }
+        if hygiene.upstream_gone > 0 {
+            println!("   {:<17}  {:<2}", "upstream-gone", hygiene.upstream_gone);
+        }
+        if hygiene.stale > 0 {
+            println!(
+                "   {:<17}  {:<2}",
+                format!("stale ({}d+)", hygiene.stale_days),
+                hygiene.stale
+            );
+        }
+        println!();
+    }
+
+    // --- Next actions ---
+    if !stats.next_actions.is_empty() {
+        println!("{}", "Next".bold());
+        for action in &stats.next_actions {
+            println!("   {}", action.cyan());
+        }
+    }
+}

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -280,13 +280,65 @@ fn gather_ci_facts(
 // Rendering
 // ---------------------------------------------------------------------------
 
+/// Width of the left-hand label column shared by the header and counter rows.
+const LABEL_WIDTH: usize = 11;
+const RULE_MIN: usize = 44;
+const RULE_MAX: usize = 74;
+
+fn rule_width() -> usize {
+    (console::Term::stdout().size().1 as usize).clamp(RULE_MIN, RULE_MAX)
+}
+
+/// Join value chunks with a dimmed separator so the values stay the bright part
+/// of each row.
+fn join_parts(parts: &[String]) -> String {
+    parts.join(&format!("{}", "  ·  ".dimmed()))
+}
+
+/// A count and its unit, e.g. a bright `3` followed by a dimmed `open`.
+fn metric(value: &str, label: &str, color: colored::Color) -> String {
+    format!("{} {}", value.color(color).bold(), label.dimmed())
+}
+
+/// The inverse of [`metric`], for values that read better after their name
+/// ("deepest 6" rather than "6 deepest").
+fn labeled(label: &str, value: &str) -> String {
+    format!("{} {}", label.dimmed(), value.bold())
+}
+
+/// Truncate to a visible width, appending an ellipsis. Only safe for strings
+/// that carry no ANSI codes (attention details are built plain by the engine).
+fn truncate(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let keep = max.saturating_sub(1);
+    let mut out: String = text.chars().take(keep).collect();
+    out.push('…');
+    out
+}
+
+/// Pad to a fixed width, truncating anything longer so the column never
+/// shifts. ANSI-free input only.
+fn cell(text: &str, width: usize) -> String {
+    format!("{:<width$}", truncate(text, width), width = width)
+}
+
+fn label_cell(label: &str) -> colored::ColoredString {
+    format!("{:<LABEL_WIDTH$}", label).dimmed()
+}
+
+fn heading(text: &str) -> colored::ColoredString {
+    text.bold().underline()
+}
+
 fn divergence_arrows(ahead: usize, behind: usize) -> String {
     let mut parts = Vec::new();
     if ahead > 0 {
-        parts.push(format!("{}", format!("{}↑", ahead).green()));
+        parts.push(format!("{}", format!("{}↑", ahead).green().bold()));
     }
     if behind > 0 {
-        parts.push(format!("{}", format!("{}↓", behind).red()));
+        parts.push(format!("{}", format!("{}↓", behind).red().bold()));
     }
     parts.join(" ")
 }
@@ -301,189 +353,290 @@ fn attention_label(kind: &str) -> &'static str {
     }
 }
 
-fn render_human(stats: &RepoStats) {
-    // --- Header ---
-    let mut header_parts: Vec<String> = Vec::new();
-    if let Some(repo) = &stats.repo {
-        header_parts.push(repo.clone());
+fn attention_color(kind: &str) -> colored::Color {
+    match kind {
+        "missing_parent" => colored::Color::Red,
+        "restack" | "no_pr" => colored::Color::Yellow,
+        _ => colored::Color::Cyan,
     }
-    header_parts.push(stats.trunk.clone());
+}
+
+/// `stats::bar` emits filled cells followed by empty ones; color the two runs
+/// separately so the empty track recedes.
+fn colored_bar(value: usize, max: usize, cells: usize, color: colored::Color) -> String {
+    let bar = stats::bar(value, max, cells);
+    let filled: String = bar.chars().filter(|c| *c == '█').collect();
+    let empty: String = bar.chars().filter(|c| *c != '█').collect();
+    format!("{}{}", filled.color(color), empty.dimmed())
+}
+
+fn render_human(stats: &RepoStats) {
+    println!();
+    render_header(stats);
+    render_counters(stats);
+    render_attention(stats);
+    render_biggest_stacks(stats);
+    render_pr_mix(stats);
+    render_hygiene(stats);
+    render_next(stats);
+    println!();
+}
+
+fn render_header(stats: &RepoStats) {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(repo) = &stats.repo {
+        parts.push(format!("{}", repo.bold()));
+    }
+    parts.push(format!("{}", stats.trunk.cyan().bold()));
     if let (Some(ahead), Some(behind)) = (stats.trunk_ahead, stats.trunk_behind) {
         if ahead == 0 && behind == 0 {
-            header_parts.push("in sync".to_string());
+            parts.push(format!("{}", "in sync".green()));
         } else {
-            header_parts.push(divergence_arrows(ahead, behind));
+            parts.push(divergence_arrows(ahead, behind));
         }
     }
+    if stats.scope == "current" {
+        parts.push(format!("{}", "current stack only".dimmed()));
+    }
+
+    println!("{}{}", label_cell("Repo"), join_parts(&parts));
     println!(
         "{}{}",
-        format!("{:<6}", "Stats").bold(),
-        header_parts.join(" · ")
+        label_cell("You"),
+        stats.current.bright_cyan().bold()
     );
-    println!("{}{}", format!("{:<6}", "You").bold(), stats.current.cyan());
-    println!();
+    println!("{}", "─".repeat(rule_width()).dimmed());
+}
 
-    // --- Counters ---
+fn render_counters(stats: &RepoStats) {
+    use colored::Color::{Blue, Cyan, Green, Red, White, Yellow};
+
+    let mut rows: Vec<(&str, String)> = Vec::new();
+
     let shape = &stats.stack_shape;
-    let mut counter_lines: Vec<(&str, String)> = Vec::new();
-
-    if shape.tracked > 0 || shape.independent > 0 || shape.deepest > 0 {
-        counter_lines.push((
+    if shape.tracked > 0 {
+        rows.push((
             "Stacks",
-            format!(
-                "{} tracked  ·  {} independent  ·  deepest {}  ·  avg {:.1}",
-                shape.tracked, shape.independent, shape.deepest, shape.avg_height
-            ),
+            join_parts(&[
+                metric(
+                    &shape.independent.to_string(),
+                    if shape.independent == 1 {
+                        "stack"
+                    } else {
+                        "stacks"
+                    },
+                    White,
+                ),
+                metric(&shape.tracked.to_string(), "tracked", White),
+                labeled("deepest", &shape.deepest.to_string()),
+                labeled("avg", &format!("{:.1}", shape.avg_height)),
+            ]),
         ));
     }
 
     let pr = &stats.pr_mix;
-    if pr.open > 0 || pr.no_pr > 0 || pr.frozen > 0 {
-        let mut parts = vec![
-            format!("{} open", pr.open),
-            format!("{} draft", pr.draft),
-            format!("{} no PR", pr.no_pr),
-        ];
-        if pr.frozen > 0 {
-            parts.push(format!("{} frozen", pr.frozen));
-        }
-        counter_lines.push(("PRs", parts.join("  ·  ")));
+    let mut pr_parts: Vec<String> = Vec::new();
+    if pr.ready > 0 {
+        pr_parts.push(metric(&pr.ready.to_string(), "ready", Green));
+    }
+    if pr.draft > 0 {
+        pr_parts.push(metric(&pr.draft.to_string(), "draft", Yellow));
+    }
+    if pr.no_pr > 0 {
+        pr_parts.push(metric(&pr.no_pr.to_string(), "no PR", Yellow));
+    }
+    if pr.frozen > 0 {
+        pr_parts.push(metric(&pr.frozen.to_string(), "frozen", Blue));
+    }
+    if !pr_parts.is_empty() {
+        rows.push(("PRs", join_parts(&pr_parts)));
     }
 
     let health = &stats.health;
-    if health.need_restack > 0
-        || health.missing_parent > 0
-        || health.dirty_worktrees.unwrap_or(0) > 0
+    let mut health_parts: Vec<String> = Vec::new();
+    if health.need_restack > 0 {
+        health_parts.push(metric(
+            &health.need_restack.to_string(),
+            "need restack",
+            Yellow,
+        ));
+    }
+    if health.missing_parent > 0 {
+        health_parts.push(metric(
+            &health.missing_parent.to_string(),
+            "missing parent",
+            Red,
+        ));
+    }
+    if let Some(dirty) = health.dirty_worktrees
+        && dirty > 0
     {
-        let mut parts = vec![
-            format!("{} need restack", health.need_restack),
-            format!("{} missing parent", health.missing_parent),
-        ];
-        if let Some(dirty) = health.dirty_worktrees {
-            parts.push(format!("{} dirty", dirty));
-        }
-        counter_lines.push(("Health", parts.join("  ·  ")));
+        health_parts.push(metric(&dirty.to_string(), "dirty", Yellow));
+    }
+    if health_parts.is_empty() && shape.tracked > 0 {
+        health_parts.push(format!("{} {}", "✓".green(), "all clear".dimmed()));
+    }
+    if !health_parts.is_empty() {
+        rows.push(("Health", join_parts(&health_parts)));
     }
 
     let wt = &stats.worktrees;
-    if wt.linked > 0 || wt.idle_slots > 0 {
-        counter_lines.push((
-            "Worktrees",
-            format!("{} linked  ·  {} idle", wt.linked, wt.idle_slots),
-        ));
+    let mut wt_parts: Vec<String> = Vec::new();
+    if wt.linked > 0 {
+        wt_parts.push(metric(&wt.linked.to_string(), "linked", Cyan));
+    }
+    if wt.idle_slots > 0 {
+        wt_parts.push(metric(&wt.idle_slots.to_string(), "idle", White));
+    }
+    if !wt_parts.is_empty() {
+        rows.push(("Worktrees", join_parts(&wt_parts)));
     }
 
     if let Some(ci) = &stats.ci {
-        if ci.failing > 0 || ci.pending > 0 || ci.passing > 0 {
-            counter_lines.push((
-                "CI",
-                format!(
-                    "{} failing  ·  {} pending  ·  {} passing",
-                    ci.failing, ci.pending, ci.passing
-                ),
-            ));
+        let mut ci_parts: Vec<String> = Vec::new();
+        if ci.failing > 0 {
+            ci_parts.push(metric(&ci.failing.to_string(), "failing", Red));
+        }
+        if ci.pending > 0 {
+            ci_parts.push(metric(&ci.pending.to_string(), "pending", Yellow));
+        }
+        if ci.passing > 0 {
+            ci_parts.push(metric(&ci.passing.to_string(), "passing", Green));
+        }
+        if !ci_parts.is_empty() {
+            rows.push(("CI", join_parts(&ci_parts)));
         }
     } else if let Some(reason) = &stats.ci_unavailable_reason {
-        counter_lines.push(("CI", format!("{}", reason.dimmed())));
+        rows.push(("CI", format!("{}", reason.dimmed())));
     }
 
-    if !counter_lines.is_empty() {
-        for (label, value) in &counter_lines {
-            println!("{:<11}{}", label, value);
-        }
-        println!();
+    if rows.is_empty() {
+        let hint = if stats.scope == "current" {
+            "No tracked branches in the current stack — run `st create` to start one."
+        } else {
+            "No tracked branches yet — run `st create` to start a stack."
+        };
+        println!("{}", hint.dimmed());
+        return;
     }
 
-    // --- Attention ---
-    if !stats.attention.is_empty() {
-        println!("{}", "Attention".bold());
-        for item in &stats.attention {
-            println!(
-                "   {}  {:<10}{}",
-                item.glyph,
-                attention_label(item.kind),
-                item.detail
-            );
-        }
-        println!();
+    for (label, value) in &rows {
+        println!("{}{}", label_cell(label), value);
     }
+}
 
-    // --- Biggest stacks ---
-    if !stats.biggest_stacks.is_empty() {
-        println!("{}", "Biggest stacks".bold());
-        for summary in &stats.biggest_stacks {
-            let pr_range = match (summary.pr_low, summary.pr_high) {
-                (Some(low), Some(high)) if low == high => format!("#{}", low),
-                (Some(low), Some(high)) => format!("#{}\u{2013}#{}", low, high),
-                _ => "–".to_string(),
-            };
-            println!(
-                "   {:>2}  {:<20} {:>4}  {:<8}  {}",
-                summary.height,
-                summary.root,
-                format!("{}↑", summary.commits_ahead),
-                summary.label,
-                pr_range
-            );
-        }
-        println!();
+fn render_attention(stats: &RepoStats) {
+    if stats.attention.is_empty() {
+        return;
     }
-
-    // --- PR mix bar chart ---
-    let max = pr.ready.max(pr.draft).max(pr.no_pr);
-    if max > 0 {
-        println!("{}", "PR mix (open)".bold());
+    println!();
+    println!("{}", heading("Attention"));
+    let detail_width = rule_width().saturating_sub(14);
+    for item in &stats.attention {
+        let color = attention_color(item.kind);
         println!(
-            "   {:<5} {}  {}",
-            "ready",
-            stats::bar(pr.ready, max, 10),
-            pr.ready
+            "  {} {} {}",
+            item.glyph.color(color).bold(),
+            format!("{:<9}", attention_label(item.kind)).color(color),
+            truncate(&item.detail, detail_width)
         );
-        println!(
-            "   {:<5} {}  {}",
-            "draft",
-            stats::bar(pr.draft, max, 10),
-            pr.draft
-        );
-        println!(
-            "   {:<5} {}  {}",
-            "none",
-            stats::bar(pr.no_pr, max, 10),
-            pr.no_pr
-        );
-        println!();
     }
+}
 
-    // --- Hygiene ---
+fn render_biggest_stacks(stats: &RepoStats) {
+    // With a single stack the table repeats the counters above, so it only
+    // earns its space once there is something to compare.
+    if stats.biggest_stacks.len() < 2 {
+        return;
+    }
+    println!();
+    println!("{}", heading("Biggest stacks"));
+    for (index, summary) in stats.biggest_stacks.iter().enumerate() {
+        let lane = crate::commands::stack_palette::lane_color(index);
+        let pr_range = match (summary.pr_low, summary.pr_high) {
+            (Some(low), Some(high)) if low == high => format!("#{}", low),
+            (Some(low), Some(high)) => format!("#{}\u{2013}#{}", low, high),
+            _ => "—".to_string(),
+        };
+        println!(
+            "  {} {} {} {} {}",
+            format!("{:>2}", summary.height).color(lane).bold(),
+            cell(&summary.root, 30).color(lane),
+            format!("{:>5}", format!("{}↑", summary.commits_ahead)).green(),
+            cell(&summary.label, 9).dimmed(),
+            pr_range.bright_magenta()
+        );
+    }
+}
+
+fn render_pr_mix(stats: &RepoStats) {
+    let pr = &stats.pr_mix;
+    let categories = [
+        ("ready", pr.ready, colored::Color::Green),
+        ("draft", pr.draft, colored::Color::Yellow),
+        ("none", pr.no_pr, colored::Color::BrightBlack),
+    ];
+    // A chart of one non-zero bar says nothing the PRs row did not.
+    if categories.iter().filter(|(_, value, _)| *value > 0).count() < 2 {
+        return;
+    }
+    let max = categories
+        .iter()
+        .map(|(_, value, _)| *value)
+        .max()
+        .unwrap_or(0);
+
+    println!();
+    println!("{}", heading("PR mix"));
+    for (label, value, color) in categories {
+        println!(
+            "  {} {}  {}",
+            format!("{:<5}", label).dimmed(),
+            colored_bar(value, max, 12, color),
+            value.to_string().color(color).bold()
+        );
+    }
+}
+
+fn render_hygiene(stats: &RepoStats) {
     let hygiene = &stats.hygiene;
-    if hygiene.merged_but_local > 0 || hygiene.upstream_gone > 0 || hygiene.stale > 0 {
-        println!("{}", "Hygiene".bold());
-        if hygiene.merged_but_local > 0 {
-            println!(
-                "   {:<17}  {:<2}  {}",
-                "merged-but-local",
-                hygiene.merged_but_local,
-                "st sweep --delete".dimmed()
-            );
-        }
-        if hygiene.upstream_gone > 0 {
-            println!("   {:<17}  {:<2}", "upstream-gone", hygiene.upstream_gone);
-        }
-        if hygiene.stale > 0 {
-            println!(
-                "   {:<17}  {:<2}",
-                format!("stale ({}d+)", hygiene.stale_days),
-                hygiene.stale
-            );
-        }
-        println!();
+    let rows = [
+        (
+            "merged-but-local".to_string(),
+            hygiene.merged_but_local,
+            "st sweep --delete",
+        ),
+        ("upstream-gone".to_string(), hygiene.upstream_gone, ""),
+        (format!("stale {}d+", hygiene.stale_days), hygiene.stale, ""),
+    ];
+    if rows.iter().all(|(_, count, _)| *count == 0) {
+        return;
     }
 
-    // --- Next actions ---
-    if !stats.next_actions.is_empty() {
-        println!("{}", "Next".bold());
-        for action in &stats.next_actions {
-            println!("   {}", action.cyan());
+    println!();
+    println!("{}", heading("Hygiene"));
+    for (label, count, hint) in rows.iter().filter(|(_, count, _)| *count > 0) {
+        let mut line = format!(
+            "  {} {}",
+            format!("{:<17}", label).dimmed(),
+            format!("{:>2}", count).yellow().bold()
+        );
+        if !hint.is_empty() {
+            line.push_str(&format!("   {}", hint.dimmed()));
         }
+        println!("{}", line);
     }
+}
+
+fn render_next(stats: &RepoStats) {
+    if stats.next_actions.is_empty() {
+        return;
+    }
+    let actions: Vec<String> = stats
+        .next_actions
+        .iter()
+        .map(|action| format!("{}", action.cyan().bold()))
+        .collect();
+    println!();
+    println!("{}{}", label_cell("Next"), join_parts(&actions));
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,7 +1,7 @@
 use crate::cache::CiCache;
 use crate::commands::stack_palette;
 use crate::config::Config;
-use crate::engine::{BranchMetadata, Stack, StackSnapshot};
+use crate::engine::{Stack, StackSnapshot};
 use crate::git::{GitRepo, command};
 use crate::remote::{self, RemoteInfo};
 use anyhow::Result;
@@ -647,22 +647,7 @@ fn collect_display_branches_with_nesting(
 }
 
 fn collect_missing_parent_branches(repo: &GitRepo, stack: &Stack) -> HashMap<String, String> {
-    let mut missing = HashMap::new();
-
-    for name in stack.branches.keys().filter(|name| *name != &stack.trunk) {
-        let Ok(Some(meta)) = BranchMetadata::read(repo.inner(), name) else {
-            continue;
-        };
-        let parent = meta.parent_branch_name.trim();
-        if parent.is_empty() || parent == stack.trunk {
-            continue;
-        }
-        if repo.branch_commit(parent).is_err() {
-            missing.insert(name.clone(), parent.to_string());
-        }
-    }
-
-    missing
+    crate::engine::collect_tracked_facts(repo, stack).missing_parent
 }
 
 /// Get line additions and deletions between parent and branch

--- a/src/engine/branch_detect.rs
+++ b/src/engine/branch_detect.rs
@@ -26,27 +26,18 @@ pub struct StaleBranchInfo {
     pub days_old: u64,
 }
 
-/// Find all local branches that are merged into trunk (ancestor or squash-merged).
+/// Find local branches that are ancestors of `trunk` (methods 1 and 1b of
+/// [`find_merged_branches_all`]).
 ///
-/// Unlike sync's private `find_merged_branches`, this operates on ALL local
-/// branches — not just stax-tracked ones. It uses only git-level merge detection
-/// (no metadata-based heuristics), so it works equally well for untracked branches.
-///
-/// Detection runs in two passes:
-///   1. `git branch --merged` against local trunk and (optionally) remote trunk —
-///      catches plain (fast-forward / merge-commit) integrations via ancestry.
-///   2. Patch-id provenance (`is_branch_merged_equivalent_to_trunk`) for branches
-///      not caught by ancestry — catches squash- and rebase-merges where the
-///      branch's commits were rewritten into trunk and are no longer ancestors.
-///
-/// `remote_trunk_ref` is e.g. `"origin/main"` — pass it if available for method 1b.
-pub fn find_merged_branches_all(
-    repo: &GitRepo,
+/// Runs plain `git branch --merged` ancestry checks against local `trunk` and,
+/// when available, the remote-tracking trunk ref (to catch a stale local
+/// trunk). Returns de-duplicated branch names, excluding `trunk` itself.
+pub fn find_ancestor_merged_branches(
     workdir: &Path,
     trunk: &str,
     remote_trunk_ref: Option<&str>,
-) -> Result<Vec<MergedBranchInfo>> {
-    let mut merged: Vec<MergedBranchInfo> = Vec::new();
+) -> Result<Vec<String>> {
+    let mut merged: Vec<String> = Vec::new();
 
     // Method 1: git branch --merged <trunk>
     let output = Command::new("git")
@@ -66,10 +57,7 @@ pub fn find_merged_branches_all(
         if branch.is_empty() || branch == trunk {
             continue;
         }
-        merged.push(MergedBranchInfo {
-            branch: branch.to_string(),
-            merge_type: MergeType::Ancestor,
-        });
+        merged.push(branch.to_string());
     }
 
     // Method 1b: git branch --merged <remote/trunk> (handles stale local trunk)
@@ -90,15 +78,45 @@ pub fn find_merged_branches_all(
                 if branch.is_empty() || branch == trunk {
                     continue;
                 }
-                if !merged.iter().any(|m| m.branch == branch) {
-                    merged.push(MergedBranchInfo {
-                        branch: branch.to_string(),
-                        merge_type: MergeType::Ancestor,
-                    });
+                if !merged.iter().any(|m| m == branch) {
+                    merged.push(branch.to_string());
                 }
             }
         }
     }
+
+    Ok(merged)
+}
+
+/// Find all local branches that are merged into trunk (ancestor or squash-merged).
+///
+/// Unlike sync's private `find_merged_branches`, this operates on ALL local
+/// branches — not just stax-tracked ones. It uses only git-level merge detection
+/// (no metadata-based heuristics), so it works equally well for untracked branches.
+///
+/// Detection runs in two passes:
+///   1. [`find_ancestor_merged_branches`] against local trunk and (optionally)
+///      remote trunk — catches plain (fast-forward / merge-commit) integrations
+///      via ancestry.
+///   2. Patch-id provenance (`is_branch_merged_equivalent_to_trunk`) for branches
+///      not caught by ancestry — catches squash- and rebase-merges where the
+///      branch's commits were rewritten into trunk and are no longer ancestors.
+///
+/// `remote_trunk_ref` is e.g. `"origin/main"` — pass it if available for method 1b.
+pub fn find_merged_branches_all(
+    repo: &GitRepo,
+    workdir: &Path,
+    trunk: &str,
+    remote_trunk_ref: Option<&str>,
+) -> Result<Vec<MergedBranchInfo>> {
+    let mut merged: Vec<MergedBranchInfo> =
+        find_ancestor_merged_branches(workdir, trunk, remote_trunk_ref)?
+            .into_iter()
+            .map(|branch| MergedBranchInfo {
+                branch,
+                merge_type: MergeType::Ancestor,
+            })
+            .collect();
 
     // Method 2: patch-id provenance for squash/rebase merges.
     //

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,8 +4,9 @@ pub mod picker;
 pub mod restack_preflight;
 pub mod snapshot;
 pub mod stack;
+pub mod stats;
 
 pub use metadata::{BranchMetadata, PrInfo};
 pub use picker::build_parent_candidates;
 pub use snapshot::StackSnapshot;
-pub use stack::Stack;
+pub use stack::{Stack, TrackedFacts, collect_tracked_facts};

--- a/src/engine/stack.rs
+++ b/src/engine/stack.rs
@@ -244,6 +244,47 @@ impl Stack {
     }
 }
 
+/// Facts read straight from branch metadata, gathered in a single pass over
+/// tracked branches (trunk excluded).
+#[derive(Debug, Clone, Default)]
+pub struct TrackedFacts {
+    pub frozen: HashSet<String>,
+    pub missing_parent: HashMap<String, String>,
+    pub imported: HashSet<String>,
+}
+
+/// Collect frozen/imported/missing-parent facts for every tracked branch in one pass.
+///
+/// The `missing_parent` rule is lifted verbatim from
+/// `status.rs::collect_missing_parent_branches`: a branch has a missing parent
+/// when its recorded parent name is non-empty, is not trunk, and no longer
+/// resolves to a local branch commit.
+pub fn collect_tracked_facts(repo: &GitRepo, stack: &Stack) -> TrackedFacts {
+    let mut facts = TrackedFacts::default();
+
+    for name in stack.branches.keys().filter(|name| *name != &stack.trunk) {
+        let Ok(Some(meta)) = BranchMetadata::read(repo.inner(), name) else {
+            continue;
+        };
+
+        if meta.frozen {
+            facts.frozen.insert(name.clone());
+        }
+        if meta.source_remote.is_some() {
+            facts.imported.insert(name.clone());
+        }
+
+        let parent = meta.parent_branch_name.trim();
+        if !parent.is_empty() && parent != stack.trunk && repo.branch_commit(parent).is_err() {
+            facts
+                .missing_parent
+                .insert(name.clone(), parent.to_string());
+        }
+    }
+
+    facts
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/engine/stats.rs
+++ b/src/engine/stats.rs
@@ -1,0 +1,824 @@
+//! Pure aggregation layer for `stax stats`.
+//!
+//! Everything in this module is repo-free: [`StatsFacts`] carries every input
+//! gathered by the command layer (`commands/stats.rs`), and [`compute`] turns
+//! those facts into a [`RepoStats`] snapshot with no I/O of its own. This keeps
+//! the shape/PR-mix/health/attention math unit-testable without a git repo.
+
+use crate::engine::stack::{Stack, TrackedFacts};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+/// A single worktree fact needed for the worktree counters and the "lanes"
+/// attention item. Gathered by the command layer from `GitRepo::list_worktrees`
+/// plus a bounded dirty-check pass.
+#[derive(Debug, Clone)]
+pub struct WorktreeFact {
+    pub name: String,
+    pub is_main: bool,
+    pub is_prunable: bool,
+    /// `None` when the dirty check was skipped (too many worktrees to check cheaply).
+    pub is_dirty: Option<bool>,
+}
+
+/// Local branch-hygiene counts, computed by the command layer using the same
+/// merged/upstream-gone/stale classification `stax sweep` uses (excluding
+/// trunk and the current branch).
+#[derive(Debug, Clone, Default)]
+pub struct HygieneFacts {
+    pub merged_but_local: usize,
+    pub upstream_gone: usize,
+    pub stale: usize,
+    pub stale_days: u64,
+}
+
+/// CI roll-up counts across the scoped branches, gathered only when `--ci` is
+/// passed.
+#[derive(Debug, Clone, Default)]
+pub struct CiFacts {
+    pub failing: usize,
+    pub pending: usize,
+    pub passing: usize,
+}
+
+/// All inputs [`compute`] needs. Gathered once by `commands/stats.rs::run`.
+#[derive(Debug, Clone)]
+pub struct StatsFacts {
+    pub stack: Stack,
+    pub current: String,
+    /// `true` for `--current` (scope to the current stack only).
+    pub current_only: bool,
+    pub repo_slug: Option<String>,
+    /// `(ahead, behind)` vs the trunk's remote-tracking branch; `None` when
+    /// there is no remote-tracking branch for trunk.
+    pub trunk_divergence: Option<(usize, usize)>,
+    pub tracked: TrackedFacts,
+    /// branch -> (ahead, behind) vs its recorded parent.
+    pub ahead_behind: HashMap<String, (usize, usize)>,
+    pub worktrees: Vec<WorktreeFact>,
+    /// Count of non-prunable worktrees that are dirty; repo-level, not scoped
+    /// by `--current`. `None` when the dirty check was skipped.
+    pub dirty_worktrees: Option<usize>,
+    pub idle_slots: usize,
+    pub hygiene: HygieneFacts,
+    pub ci: Option<CiFacts>,
+    pub ci_unavailable_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StackShape {
+    pub tracked: usize,
+    pub independent: usize,
+    pub deepest: usize,
+    pub avg_height: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PrMix {
+    pub open: usize,
+    pub draft: usize,
+    pub ready: usize,
+    pub no_pr: usize,
+    pub merged: usize,
+    pub closed: usize,
+    pub frozen: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthCounts {
+    pub need_restack: usize,
+    pub missing_parent: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dirty_worktrees: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeCounts {
+    pub linked: usize,
+    pub idle_slots: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CiCounts {
+    pub failing: usize,
+    pub pending: usize,
+    pub passing: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HygieneCounts {
+    pub merged_but_local: usize,
+    pub upstream_gone: usize,
+    pub stale: usize,
+    pub stale_days: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AttentionItem {
+    #[serde(skip)]
+    pub glyph: &'static str,
+    pub kind: &'static str,
+    pub detail: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StackSummary {
+    pub root: String,
+    pub height: usize,
+    pub commits_ahead: usize,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_low: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_high: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoStats {
+    pub scope: &'static str,
+    pub trunk: String,
+    pub current: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trunk_ahead: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trunk_behind: Option<usize>,
+    pub stack_shape: StackShape,
+    pub pr_mix: PrMix,
+    pub health: HealthCounts,
+    pub worktrees: WorktreeCounts,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci: Option<CiCounts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_unavailable_reason: Option<String>,
+    pub attention: Vec<AttentionItem>,
+    pub biggest_stacks: Vec<StackSummary>,
+    pub hygiene: HygieneCounts,
+    pub next_actions: Vec<String>,
+}
+
+/// Branches in `scope` whose parent is trunk, or whose parent is outside
+/// `scope` — i.e. the roots of independent stacks within the scope. Sorted
+/// ascending for deterministic ordering.
+pub fn stack_roots(stack: &Stack, scope: &HashSet<String>) -> Vec<String> {
+    let mut roots: Vec<String> = scope
+        .iter()
+        .filter(|name| {
+            let parent = stack.branches.get(*name).and_then(|b| b.parent.as_deref());
+            match parent {
+                Some(p) => p == stack.trunk || !scope.contains(p),
+                None => true,
+            }
+        })
+        .cloned()
+        .collect();
+    roots.sort();
+    roots
+}
+
+/// Members of `root`'s stack within `scope`, bottom-up (root first, then its
+/// children walked depth-first in name order). Cycle-safe.
+pub fn stack_members(stack: &Stack, root: &str, scope: &HashSet<String>) -> Vec<String> {
+    let mut result = Vec::new();
+    if !scope.contains(root) {
+        return result;
+    }
+
+    let mut frames = vec![root.to_string()];
+    let mut visited = HashSet::new();
+    while let Some(current) = frames.pop() {
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+        result.push(current.clone());
+
+        if let Some(info) = stack.branches.get(&current) {
+            let mut children: Vec<&String> = info
+                .children
+                .iter()
+                .filter(|c| scope.contains(*c))
+                .collect();
+            children.sort();
+            for child in children.into_iter().rev() {
+                frames.push(child.clone());
+            }
+        }
+    }
+
+    result
+}
+
+/// `1 + max chain length below root within scope`; a lone branch has height 1.
+/// Cycle-safe (a node cannot contribute to its own height twice).
+pub fn stack_height(stack: &Stack, root: &str, scope: &HashSet<String>) -> usize {
+    fn height_of(
+        stack: &Stack,
+        node: &str,
+        scope: &HashSet<String>,
+        visiting: &mut HashSet<String>,
+    ) -> usize {
+        if !scope.contains(node) || !visiting.insert(node.to_string()) {
+            return 0;
+        }
+        let max_child = stack
+            .branches
+            .get(node)
+            .map(|b| b.children.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .filter(|c| scope.contains(*c))
+            .map(|c| height_of(stack, c, scope, visiting))
+            .max()
+            .unwrap_or(0);
+        visiting.remove(node);
+        1 + max_child
+    }
+
+    if !scope.contains(root) {
+        return 0;
+    }
+    let mut visiting = HashSet::new();
+    height_of(stack, root, scope, &mut visiting)
+}
+
+/// Average of `heights`, or `0.0` when empty.
+pub fn avg_height(heights: &[usize]) -> f64 {
+    if heights.is_empty() {
+        return 0.0;
+    }
+    let sum: usize = heights.iter().sum();
+    sum as f64 / heights.len() as f64
+}
+
+/// Render a block-character bar of `cells` width. A non-zero `value` always
+/// gets at least one filled cell.
+pub fn bar(value: usize, max: usize, cells: usize) -> String {
+    if max == 0 || cells == 0 {
+        return "░".repeat(cells);
+    }
+    let mut filled = (value * cells) / max;
+    if value > 0 && filled == 0 {
+        filled = 1;
+    }
+    filled = filled.min(cells);
+    format!("{}{}", "█".repeat(filled), "░".repeat(cells - filled))
+}
+
+fn branch_pr_state_is_open(state: Option<&str>) -> bool {
+    state.is_some_and(|s| s.eq_ignore_ascii_case("open"))
+}
+
+fn branch_pr_state_is(state: Option<&str>, want: &str) -> bool {
+    state.is_some_and(|s| s.eq_ignore_ascii_case(want))
+}
+
+pub fn compute(facts: &StatsFacts) -> RepoStats {
+    let stack = &facts.stack;
+
+    let scope: HashSet<String> = if facts.current_only {
+        if stack.branches.contains_key(&facts.current) {
+            stack
+                .current_stack(&facts.current)
+                .into_iter()
+                .filter(|b| b != &stack.trunk)
+                .collect()
+        } else {
+            HashSet::new()
+        }
+    } else {
+        stack
+            .branches
+            .keys()
+            .filter(|b| *b != &stack.trunk)
+            .cloned()
+            .collect()
+    };
+
+    let roots = stack_roots(stack, &scope);
+    let heights: Vec<usize> = roots
+        .iter()
+        .map(|r| stack_height(stack, r, &scope))
+        .collect();
+    let deepest = heights.iter().copied().max().unwrap_or(0);
+
+    let stack_shape = StackShape {
+        tracked: scope.len(),
+        independent: roots.len(),
+        deepest,
+        avg_height: avg_height(&heights),
+    };
+
+    // --- PR mix ---
+    let mut open = 0usize;
+    let mut draft = 0usize;
+    let mut no_pr = 0usize;
+    let mut merged = 0usize;
+    let mut closed = 0usize;
+    for name in &scope {
+        let Some(info) = stack.branches.get(name) else {
+            continue;
+        };
+        let is_draft = info.pr_is_draft == Some(true);
+        if branch_pr_state_is_open(info.pr_state.as_deref()) || is_draft {
+            open += 1;
+        }
+        if is_draft {
+            draft += 1;
+        }
+        if info.pr_number.is_none() {
+            no_pr += 1;
+        }
+        if branch_pr_state_is(info.pr_state.as_deref(), "merged") {
+            merged += 1;
+        } else if branch_pr_state_is(info.pr_state.as_deref(), "closed") {
+            closed += 1;
+        }
+    }
+    let frozen = facts.tracked.frozen.intersection(&scope).count();
+    let pr_mix = PrMix {
+        open,
+        draft,
+        ready: open.saturating_sub(draft),
+        no_pr,
+        merged,
+        closed,
+        frozen,
+    };
+
+    // --- Health ---
+    let need_restack = scope
+        .iter()
+        .filter(|b| stack.branches.get(*b).is_some_and(|i| i.needs_restack))
+        .count();
+    let missing_parent = scope
+        .iter()
+        .filter(|b| facts.tracked.missing_parent.contains_key(*b))
+        .count();
+    let health = HealthCounts {
+        need_restack,
+        missing_parent,
+        dirty_worktrees: facts.dirty_worktrees,
+    };
+
+    // --- Worktrees ---
+    let linked_worktrees: Vec<&WorktreeFact> = facts
+        .worktrees
+        .iter()
+        .filter(|w| !w.is_main && !w.is_prunable)
+        .collect();
+    let worktree_counts = WorktreeCounts {
+        linked: linked_worktrees.len(),
+        idle_slots: facts.idle_slots,
+    };
+
+    // --- CI ---
+    let ci = facts.ci.as_ref().map(|c| CiCounts {
+        failing: c.failing,
+        pending: c.pending,
+        passing: c.passing,
+    });
+
+    // --- Biggest stacks ---
+    let mut biggest_stacks: Vec<StackSummary> = roots
+        .iter()
+        .map(|root| {
+            let members = stack_members(stack, root, &scope);
+            let height = stack_height(stack, root, &scope);
+            let commits_ahead: usize = members
+                .iter()
+                .filter_map(|m| facts.ahead_behind.get(m).map(|(ahead, _)| *ahead))
+                .sum();
+            let draft_count = members
+                .iter()
+                .filter(|m| stack.branches.get(*m).and_then(|i| i.pr_is_draft) == Some(true))
+                .count();
+            let no_pr_count = members
+                .iter()
+                .filter(|m| stack.branches.get(*m).is_none_or(|i| i.pr_number.is_none()))
+                .count();
+            let label = if draft_count > 0 {
+                format!("{} draft", draft_count)
+            } else if no_pr_count > 0 {
+                format!("{} no PR", no_pr_count)
+            } else {
+                "ready".to_string()
+            };
+            let pr_numbers: Vec<u64> = members
+                .iter()
+                .filter_map(|m| stack.branches.get(m).and_then(|i| i.pr_number))
+                .collect();
+            StackSummary {
+                root: root.clone(),
+                height,
+                commits_ahead,
+                label,
+                pr_low: pr_numbers.iter().min().copied(),
+                pr_high: pr_numbers.iter().max().copied(),
+            }
+        })
+        .collect();
+    biggest_stacks.sort_by(|a, b| b.height.cmp(&a.height).then_with(|| a.root.cmp(&b.root)));
+    biggest_stacks.truncate(3);
+
+    // --- Attention ---
+    let mut attention: Vec<AttentionItem> = Vec::new();
+
+    let mut restack_items = 0usize;
+    for root in &roots {
+        if restack_items >= 3 {
+            break;
+        }
+        let members = stack_members(stack, root, &scope);
+        let needing: Vec<String> = members
+            .into_iter()
+            .filter(|m| stack.branches.get(m).is_some_and(|i| i.needs_restack))
+            .collect();
+        if needing.is_empty() {
+            continue;
+        }
+        let mut detail = needing
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" → ");
+        if needing.len() > 3 {
+            detail.push_str(" …");
+        }
+        attention.push(AttentionItem {
+            kind: "restack",
+            glyph: "⇅",
+            detail,
+            count: needing.len(),
+        });
+        restack_items += 1;
+    }
+
+    if no_pr > 0 {
+        let mut names: Vec<&String> = scope
+            .iter()
+            .filter(|b| stack.branches.get(*b).is_none_or(|i| i.pr_number.is_none()))
+            .collect();
+        names.sort();
+        let mut detail = names
+            .iter()
+            .take(3)
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join("  ·  ");
+        if names.len() > 3 {
+            detail.push_str(&format!(" +{} more", names.len() - 3));
+        }
+        attention.push(AttentionItem {
+            kind: "no_pr",
+            glyph: "○",
+            detail,
+            count: no_pr,
+        });
+    }
+
+    let mut missing_names: Vec<&String> = scope
+        .iter()
+        .filter(|b| facts.tracked.missing_parent.contains_key(*b))
+        .collect();
+    missing_names.sort();
+    for branch in missing_names.into_iter().take(3) {
+        let parent = &facts.tracked.missing_parent[branch];
+        attention.push(AttentionItem {
+            kind: "missing_parent",
+            glyph: "⚑",
+            detail: format!("{}  (missing: {})", branch, parent),
+            count: 1,
+        });
+    }
+
+    if !linked_worktrees.is_empty() {
+        let detail = linked_worktrees
+            .iter()
+            .take(4)
+            .map(|w| {
+                let dirty = w.is_dirty.unwrap_or(false);
+                format!("{} ({})", w.name, if dirty { "dirty" } else { "clean" })
+            })
+            .collect::<Vec<_>>()
+            .join("  ·  ");
+        attention.push(AttentionItem {
+            kind: "lanes",
+            glyph: "⎇",
+            detail,
+            count: linked_worktrees.len(),
+        });
+    }
+
+    // --- Hygiene ---
+    let hygiene = HygieneCounts {
+        merged_but_local: facts.hygiene.merged_but_local,
+        upstream_gone: facts.hygiene.upstream_gone,
+        stale: facts.hygiene.stale,
+        stale_days: facts.hygiene.stale_days,
+    };
+
+    // --- Next actions ---
+    let mut next_actions: Vec<String> = Vec::new();
+    if need_restack > 0 {
+        next_actions.push("st restack --all".to_string());
+        next_actions.push("st ss".to_string());
+    }
+    if next_actions.len() < 2 && no_pr > 0 && !next_actions.iter().any(|a| a == "st ss") {
+        next_actions.push("st ss".to_string());
+    }
+    if next_actions.len() < 2 && (hygiene.merged_but_local + hygiene.upstream_gone) > 0 {
+        next_actions.push("st sweep".to_string());
+    }
+    next_actions.truncate(2);
+    if next_actions.is_empty() {
+        next_actions.push("st ls".to_string());
+    }
+
+    RepoStats {
+        scope: if facts.current_only { "current" } else { "all" },
+        trunk: stack.trunk.clone(),
+        current: facts.current.clone(),
+        repo: facts.repo_slug.clone(),
+        trunk_ahead: facts.trunk_divergence.map(|(ahead, _)| ahead),
+        trunk_behind: facts.trunk_divergence.map(|(_, behind)| behind),
+        stack_shape,
+        pr_mix,
+        health,
+        worktrees: worktree_counts,
+        ci,
+        ci_unavailable_reason: facts.ci_unavailable_reason.clone(),
+        attention,
+        biggest_stacks,
+        hygiene,
+        next_actions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::stack::StackBranch;
+    use std::collections::HashMap;
+
+    fn branch(parent: Option<&str>, children: Vec<&str>) -> StackBranch {
+        StackBranch {
+            name: String::new(),
+            parent: parent.map(str::to_string),
+            parent_revision: None,
+            children: children.into_iter().map(str::to_string).collect(),
+            needs_restack: false,
+            pr_number: None,
+            pr_state: None,
+            pr_is_draft: None,
+        }
+    }
+
+    /// main (trunk)
+    ///  ├── a
+    ///  │    └── a1
+    ///  │         └── a2
+    ///  └── b
+    fn two_stack_test_stack() -> Stack {
+        let mut branches = HashMap::new();
+        branches.insert("main".to_string(), branch(None, vec!["a", "b"]));
+        branches.insert("a".to_string(), branch(Some("main"), vec!["a1"]));
+        branches.insert("a1".to_string(), branch(Some("a"), vec!["a2"]));
+        branches.insert("a2".to_string(), branch(Some("a1"), vec![]));
+        branches.insert("b".to_string(), branch(Some("main"), vec![]));
+        Stack {
+            branches,
+            trunk: "main".to_string(),
+        }
+    }
+
+    fn scope_all(stack: &Stack) -> HashSet<String> {
+        stack
+            .branches
+            .keys()
+            .filter(|b| *b != &stack.trunk)
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn stack_roots_finds_direct_trunk_children() {
+        let stack = two_stack_test_stack();
+        let scope = scope_all(&stack);
+        assert_eq!(stack_roots(&stack, &scope), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn stack_roots_treats_out_of_scope_parent_as_root() {
+        let stack = two_stack_test_stack();
+        let mut scope = scope_all(&stack);
+        scope.remove("a");
+        let roots = stack_roots(&stack, &scope);
+        assert_eq!(roots, vec!["a1", "b"]);
+    }
+
+    #[test]
+    fn stack_members_are_bottom_up() {
+        let stack = two_stack_test_stack();
+        let scope = scope_all(&stack);
+        assert_eq!(stack_members(&stack, "a", &scope), vec!["a", "a1", "a2"]);
+    }
+
+    #[test]
+    fn stack_members_empty_when_root_out_of_scope() {
+        let stack = two_stack_test_stack();
+        let scope: HashSet<String> = HashSet::new();
+        assert!(stack_members(&stack, "a", &scope).is_empty());
+    }
+
+    #[test]
+    fn stack_height_lone_branch_is_one() {
+        let stack = two_stack_test_stack();
+        let scope = scope_all(&stack);
+        assert_eq!(stack_height(&stack, "b", &scope), 1);
+    }
+
+    #[test]
+    fn stack_height_counts_deepest_chain() {
+        let stack = two_stack_test_stack();
+        let scope = scope_all(&stack);
+        assert_eq!(stack_height(&stack, "a", &scope), 3);
+    }
+
+    #[test]
+    fn stack_height_is_cycle_safe() {
+        let mut branches = HashMap::new();
+        branches.insert("main".to_string(), branch(None, vec!["a"]));
+        branches.insert("a".to_string(), branch(Some("main"), vec!["b"]));
+        branches.insert("b".to_string(), branch(Some("a"), vec!["a"]));
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+        let scope = scope_all(&stack);
+        // Must terminate and return a finite height despite the a<->b cycle.
+        assert!(stack_height(&stack, "a", &scope) >= 1);
+    }
+
+    #[test]
+    fn avg_height_empty_is_zero() {
+        assert_eq!(avg_height(&[]), 0.0);
+    }
+
+    #[test]
+    fn avg_height_averages_values() {
+        assert_eq!(avg_height(&[1, 2, 3]), 2.0);
+    }
+
+    #[test]
+    fn bar_empty_at_zero_value() {
+        assert_eq!(bar(0, 10, 10), "░".repeat(10));
+    }
+
+    #[test]
+    fn bar_full_at_max_value() {
+        assert_eq!(bar(10, 10, 10), "█".repeat(10));
+    }
+
+    #[test]
+    fn bar_nonzero_value_gets_at_least_one_filled_cell() {
+        let rendered = bar(1, 100, 10);
+        assert_eq!(rendered.chars().filter(|c| *c == '█').count(), 1);
+    }
+
+    #[test]
+    fn bar_handles_zero_max() {
+        assert_eq!(bar(5, 0, 10), "░".repeat(10));
+    }
+
+    fn empty_facts(stack: Stack, current: &str) -> StatsFacts {
+        StatsFacts {
+            stack,
+            current: current.to_string(),
+            current_only: false,
+            repo_slug: None,
+            trunk_divergence: None,
+            tracked: TrackedFacts::default(),
+            ahead_behind: HashMap::new(),
+            worktrees: Vec::new(),
+            dirty_worktrees: None,
+            idle_slots: 0,
+            hygiene: HygieneFacts::default(),
+            ci: None,
+            ci_unavailable_reason: None,
+        }
+    }
+
+    #[test]
+    fn compute_reports_two_independent_stacks_and_deepest_height() {
+        let stack = two_stack_test_stack();
+        let facts = empty_facts(stack, "a2");
+        let stats = compute(&facts);
+
+        assert_eq!(stats.stack_shape.tracked, 4);
+        assert_eq!(stats.stack_shape.independent, 2);
+        assert_eq!(stats.stack_shape.deepest, 3);
+        assert_eq!(
+            stats.biggest_stacks.first().map(|s| s.root.as_str()),
+            Some("a")
+        );
+    }
+
+    #[test]
+    fn compute_current_scope_limits_to_current_stack() {
+        let stack = two_stack_test_stack();
+        let mut facts = empty_facts(stack, "a1");
+        facts.current_only = true;
+        let stats = compute(&facts);
+
+        assert_eq!(stats.scope, "current");
+        assert_eq!(stats.stack_shape.tracked, 3); // a, a1, a2
+        assert_eq!(stats.stack_shape.independent, 1);
+    }
+
+    #[test]
+    fn compute_current_scope_empty_when_current_untracked() {
+        let stack = two_stack_test_stack();
+        let mut facts = empty_facts(stack, "untracked");
+        facts.current_only = true;
+        let stats = compute(&facts);
+
+        assert_eq!(stats.stack_shape.tracked, 0);
+        assert_eq!(stats.stack_shape.independent, 0);
+        assert_eq!(stats.stack_shape.deepest, 0);
+    }
+
+    #[test]
+    fn compute_pr_mix_counts_draft_as_open_and_subtracts_for_ready() {
+        let mut branches = HashMap::new();
+        branches.insert("main".to_string(), branch(None, vec!["a", "b", "c"]));
+        let mut a = branch(Some("main"), vec![]);
+        a.pr_number = Some(1);
+        a.pr_state = Some("OPEN".to_string());
+        a.pr_is_draft = Some(true);
+        branches.insert("a".to_string(), a);
+        let mut b = branch(Some("main"), vec![]);
+        b.pr_number = Some(2);
+        b.pr_state = Some("OPEN".to_string());
+        b.pr_is_draft = Some(false);
+        branches.insert("b".to_string(), b);
+        branches.insert("c".to_string(), branch(Some("main"), vec![]));
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+        let facts = empty_facts(stack, "a");
+        let stats = compute(&facts);
+
+        assert_eq!(stats.pr_mix.open, 2);
+        assert_eq!(stats.pr_mix.draft, 1);
+        assert_eq!(stats.pr_mix.ready, 1);
+        assert_eq!(stats.pr_mix.no_pr, 1);
+    }
+
+    #[test]
+    fn compute_next_actions_always_non_empty() {
+        let stack = two_stack_test_stack();
+        let facts = empty_facts(stack, "a");
+        let stats = compute(&facts);
+
+        assert!(!stats.next_actions.is_empty());
+    }
+
+    #[test]
+    fn compute_next_actions_falls_back_to_ls_when_nothing_needs_attention() {
+        let mut branches = HashMap::new();
+        branches.insert("main".to_string(), branch(None, vec!["a"]));
+        let mut a = branch(Some("main"), vec![]);
+        a.pr_number = Some(1);
+        a.pr_state = Some("OPEN".to_string());
+        branches.insert("a".to_string(), a);
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+        let facts = empty_facts(stack, "a");
+        let stats = compute(&facts);
+
+        assert_eq!(stats.next_actions, vec!["st ls".to_string()]);
+    }
+
+    #[test]
+    fn compute_next_actions_pairs_restack_and_submit() {
+        let mut branches = HashMap::new();
+        branches.insert("main".to_string(), branch(None, vec!["a"]));
+        let mut a = branch(Some("main"), vec![]);
+        a.needs_restack = true;
+        branches.insert("a".to_string(), a);
+        let stack = Stack {
+            branches,
+            trunk: "main".to_string(),
+        };
+        let facts = empty_facts(stack, "a");
+        let stats = compute(&facts);
+
+        assert_eq!(stats.next_actions, vec!["st restack --all", "st ss"]);
+    }
+}

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -132,6 +132,8 @@ mod stack_test_tests;
 mod staging_menu_tests;
 #[path = "standup_tests.rs"]
 mod standup_tests;
+#[path = "stats_tests.rs"]
+mod stats_tests;
 #[path = "status_tests.rs"]
 mod status_tests;
 #[path = "submit_fetch_failure_tests.rs"]

--- a/tests/stats_tests.rs
+++ b/tests/stats_tests.rs
@@ -245,6 +245,61 @@ fn stats_json_counts_match_human_output() {
 }
 
 #[test]
+fn stats_omits_zero_valued_counters() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_stack(&["zero-noise-branch"]);
+
+    let out = repo.run_stax(&["stats"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+
+    for noise in ["0 draft", "0 missing parent", "0 open", "0 frozen"] {
+        assert!(
+            !stdout.contains(noise),
+            "expected '{}' to be omitted:\n{}",
+            noise,
+            stdout
+        );
+    }
+}
+
+#[test]
+fn stats_reports_all_clear_health_when_nothing_is_broken() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_stack(&["healthy-branch"]);
+
+    let out = repo.run_stax(&["stats"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+
+    assert!(
+        stdout.contains("all clear"),
+        "expected a clean health line:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn stats_hides_single_bar_pr_mix_chart() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_stack(&["only-one-category"]);
+
+    let out = repo.run_stax(&["stats"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+
+    // One non-zero category repeats the PRs row, so the chart is suppressed.
+    assert!(
+        !stdout.contains("PR mix"),
+        "expected the PR mix chart to be hidden for a single category:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn stats_ci_without_forge_auth_reports_unavailable_and_exits_zero() {
     let repo = TestRepo::new();
     repo.run_stax(&["init"]).assert_success();

--- a/tests/stats_tests.rs
+++ b/tests/stats_tests.rs
@@ -1,0 +1,277 @@
+use crate::common;
+
+use common::{OutputAssertions, TestRepo};
+use serde_json::Value;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Overwrite a tracked branch's metadata ref with an arbitrary parent name,
+/// mirroring `sweep_tests.rs`'s metadata helper.
+fn write_branch_parent_metadata(repo: &TestRepo, branch: &str, parent_branch: &str) {
+    let metadata = serde_json::json!({
+        "parentBranchName": parent_branch,
+        "parentBranchRevision": repo.get_commit_sha(branch),
+    });
+
+    let mut child = Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .current_dir(repo.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to hash metadata blob");
+    child
+        .stdin
+        .as_mut()
+        .expect("metadata hash stdin")
+        .write_all(metadata.to_string().as_bytes())
+        .expect("Failed to write metadata JSON");
+    let output = child.wait_with_output().expect("Failed to hash metadata");
+    assert!(
+        output.status.success(),
+        "git hash-object failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let blob_hash = String::from_utf8(output.stdout)
+        .expect("metadata hash UTF-8")
+        .trim()
+        .to_string();
+
+    let update_ref = repo.git(&[
+        "update-ref",
+        &format!("refs/branch-metadata/{}", branch),
+        &blob_hash,
+    ]);
+    assert!(
+        update_ref.status.success(),
+        "git update-ref failed: {}",
+        TestRepo::stderr(&update_ref)
+    );
+}
+
+fn run_stats_json(repo: &TestRepo, extra_args: &[&str]) -> Value {
+    let mut args = vec!["stats", "--json"];
+    args.extend_from_slice(extra_args);
+    let out = repo.run_stax(&args);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stats --json should output valid JSON: {}\n{}", e, stdout))
+}
+
+#[test]
+fn stats_on_repo_with_no_tracked_branches_exits_zero() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.run_stax(&["stats"]).assert_success();
+
+    let json = run_stats_json(&repo, &[]);
+    assert_eq!(json["stack_shape"]["tracked"], 0);
+    assert_eq!(json["stack_shape"]["independent"], 0);
+}
+
+#[test]
+fn stats_reports_two_independent_stacks_and_deepest_height() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.create_stack(&["stack-a-1", "stack-a-2"]);
+    repo.run_stax(&["t"]).assert_success();
+    repo.create_stack(&["stack-b-1"]);
+
+    let json = run_stats_json(&repo, &[]);
+    assert_eq!(json["stack_shape"]["tracked"], 3);
+    assert_eq!(json["stack_shape"]["independent"], 2);
+    assert_eq!(json["stack_shape"]["deepest"], 2);
+}
+
+#[test]
+fn stats_current_scopes_to_current_stack() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.create_stack(&["stack-a-1", "stack-a-2"]);
+    repo.run_stax(&["t"]).assert_success();
+    repo.create_stack(&["stack-b-1"]);
+
+    // Current branch is stack-b-1 after the second create_stack call.
+    let json = run_stats_json(&repo, &["--current"]);
+    assert_eq!(json["scope"], "current");
+    assert_eq!(json["stack_shape"]["tracked"], 1);
+    assert_eq!(json["stack_shape"]["independent"], 1);
+}
+
+#[test]
+fn stats_current_on_untracked_branch_is_graceful() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.git(&["checkout", "-b", "untracked-branch"]);
+
+    let out = repo.run_stax(&["stats", "--current"]);
+    out.assert_success();
+
+    let json = run_stats_json(&repo, &["--current"]);
+    assert_eq!(json["stack_shape"]["tracked"], 0);
+    assert_eq!(json["stack_shape"]["independent"], 0);
+    assert_eq!(json["stack_shape"]["deepest"], 0);
+}
+
+#[test]
+fn stats_reports_needs_restack_in_attention() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let branches = repo.create_stack(&["restack-parent", "restack-child"]);
+    let parent = &branches[0];
+
+    // Advance the parent branch without restacking the child.
+    repo.git(&["checkout", parent]);
+    repo.create_file("extra.txt", "extra parent work");
+    repo.commit("extra parent commit");
+
+    let json = run_stats_json(&repo, &[]);
+    assert_eq!(json["health"]["need_restack"], 1);
+
+    let attention = json["attention"]
+        .as_array()
+        .expect("attention should be an array");
+    assert!(
+        attention.iter().any(|item| item["kind"] == "restack"),
+        "expected a restack attention item:\n{}",
+        json
+    );
+}
+
+#[test]
+fn stats_reports_missing_parent_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.create_stack(&["orphan-child"]);
+    write_branch_parent_metadata(&repo, "orphan-child", "ghost-parent");
+
+    let json = run_stats_json(&repo, &[]);
+    assert_eq!(json["health"]["missing_parent"], 1);
+
+    let attention = json["attention"]
+        .as_array()
+        .expect("attention should be an array");
+    assert!(
+        attention.iter().any(|item| item["kind"] == "missing_parent"
+            && item["detail"]
+                .as_str()
+                .unwrap_or("")
+                .contains("ghost-parent")),
+        "expected a missing-parent attention item referencing ghost-parent:\n{}",
+        json
+    );
+}
+
+#[test]
+fn stats_counts_frozen_branch() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.create_stack(&["frozen-branch"]);
+    repo.run_stax(&["freeze"]).assert_success();
+
+    let json = run_stats_json(&repo, &[]);
+    assert_eq!(json["pr_mix"]["frozen"], 1);
+}
+
+#[test]
+fn stats_counts_branches_without_prs() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    repo.create_stack(&["no-pr-branch"]);
+
+    let json = run_stats_json(&repo, &[]);
+    assert_eq!(json["pr_mix"]["no_pr"], 1);
+    assert_eq!(json["pr_mix"]["open"], 0);
+}
+
+#[test]
+fn stats_json_has_expected_top_level_keys() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_stack(&["some-branch"]);
+
+    let json = run_stats_json(&repo, &[]);
+    let obj = json.as_object().expect("stats JSON should be an object");
+    for key in [
+        "scope",
+        "trunk",
+        "current",
+        "stack_shape",
+        "pr_mix",
+        "health",
+        "worktrees",
+        "attention",
+        "biggest_stacks",
+        "hygiene",
+        "next_actions",
+    ] {
+        assert!(
+            obj.contains_key(key),
+            "expected top-level key '{}':\n{}",
+            key,
+            json
+        );
+    }
+}
+
+#[test]
+fn stats_json_counts_match_human_output() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+    repo.create_stack(&["human-check-branch"]);
+
+    let json = run_stats_json(&repo, &[]);
+    let no_pr = json["pr_mix"]["no_pr"].as_u64().expect("no_pr count");
+
+    let human_out = repo.run_stax(&["stats"]);
+    human_out.assert_success();
+    let human_stdout = TestRepo::stdout(&human_out);
+
+    assert!(
+        human_stdout.contains(&format!("{} no PR", no_pr)),
+        "expected human output to mention '{} no PR':\n{}",
+        no_pr,
+        human_stdout
+    );
+}
+
+#[test]
+fn stats_ci_without_forge_auth_reports_unavailable_and_exits_zero() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["init"]).assert_success();
+
+    let json = run_stats_json(&repo, &["--ci"]);
+    assert!(
+        json.get("ci").is_none() || json["ci"].is_null(),
+        "expected ci to be absent/null without forge auth:\n{}",
+        json
+    );
+    let reason = json["ci_unavailable_reason"]
+        .as_str()
+        .expect("ci_unavailable_reason should be a string");
+    assert!(
+        reason.contains("forge") || reason.contains("remote"),
+        "unexpected ci_unavailable_reason: {}",
+        reason
+    );
+}
+
+#[test]
+fn stats_help_lists_current_json_and_ci_flags() {
+    let repo = TestRepo::new();
+    let out = repo.run_stax(&["stats", "--help"]);
+    out.assert_success();
+    let stdout = TestRepo::stdout(&out);
+    assert!(stdout.contains("--current"));
+    assert!(stdout.contains("--json"));
+    assert!(stdout.contains("--ci"));
+}


### PR DESCRIPTION
## Motivation

Add a local-fast `st stats` snapshot so you can see stack shape, PR mix, restack/parent/dirty health, worktree lanes, and local hygiene in one screen — without using `st ls` (tree), `st standup` (recent activity), `st doctor` (env), or `st ci` (per-check table).

## Description of changes / notes for reviewers

- New `stax stats` command with `--current`, `--json`, and opt-in `--ci` roll-up.
- Aggregation lives in `src/engine/stats.rs`; the command layer gathers facts locally (no network unless `--ci`).
- `collect_tracked_facts` shares missing-parent detection with `st status`.
- Hygiene uses ancestry-only merge detection (no patch-id), so `merged-but-local` can be lower than `st sweep`.
- Output uses semantic color (green healthy, yellow needs-work, red broken), reuses the `st ls` lane palette for stack rows, omits zero-valued counters, and hides the biggest-stacks table and PR mix chart until there are at least two things to compare.
- Docs updated in README, `docs/commands/stack-health.md`, `docs/commands/reference.md`, and `skills.md`.

## Test plan

- [x] `cargo check`
- [x] `make lint` (full gate)
- [x] `make test` — 2713 passed, 0 failed
- [x] `git diff --check`
- [x] `cargo nextest run --lib engine::stats` / `engine::stack`
- [x] `cargo nextest run stats_tests::` (15 tests, incl. zero-suppression, "all clear", hidden chart)
- [x] `cargo nextest run status_tests::` / `sweep_tests::` / `cli_tests::`

Verification evidence: full local gate (`make lint` + `make test`) on this PR head.