### PR TITLE
fix(skills): repair broken symlinks and keep per-harness failures non-fatal

### DIFF
--- a/docs/commands/reference.md
+++ b/docs/commands/reference.md
@@ -203,7 +203,7 @@ when it points at the same commit. `--all` conflicts with `--parent` and
 | `st open` | Open repository in browser |
 | `st demo` | Interactive tutorial — no auth or repo required |
 
-`st skills update` fetches the remote body and compares each fully rendered harness file byte-for-byte, rewriting instructions that differ even when the installed package-version marker matches. It leaves byte-identical files untouched; `--dry-run` reports the same decision without writing. `st skills list` is intentionally local-only: its current/stale indicator compares the installed package-version marker with this stax binary and does not verify fetched content.
+`st skills update` fetches the remote body and compares each fully rendered harness file byte-for-byte, rewriting instructions that differ even when the installed package-version marker matches. It leaves byte-identical files untouched; `--dry-run` reports the same decision without writing. `st skills list` is intentionally local-only: its current/stale indicator compares the installed package-version marker with this stax binary and does not verify fetched content. When a symlink at the skill directory or file position no longer resolves, `st skills update` removes it and replaces it with a real path (working symlinks are left intact and written through); if a harness cannot be written for any other reason it is reported and skipped so the remaining harnesses still update, and the command exits non-zero afterwards.
 
 ### `st tmux`
 

--- a/src/commands/shell_setup.rs
+++ b/src/commands/shell_setup.rs
@@ -602,11 +602,17 @@ fn maybe_install_skills(options: &SetupOptions) -> Result<()> {
     }
 
     println!();
-    skills::run_update_with(
+    if let Err(err) = skills::run_update_with(
         false,
         &HarnessSelection::Only(ids),
         skills::SkillsUpdateOrigin::Setup,
-    )
+    ) {
+        eprintln!(
+            "{}",
+            format!("Warning: some agent skill files could not be written: {err:#}").yellow()
+        );
+    }
+    Ok(())
 }
 
 fn maybe_setup_auth(options: &SetupOptions) -> Result<()> {

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const REMOTE_URL: &str = "https://raw.githubusercontent.com/cesarferreira/stax/main/skills.md";
@@ -280,6 +280,96 @@ fn skill_path(loc: &SkillLocation) -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(loc.relative_path))
 }
 
+/// Records broken symlinks that block writing a skill file.
+///
+/// `std::path::Path::is_symlink` / `symlink_metadata` do **not** follow the
+/// link; `is_dir` / `is_file` do.  A path that is a symlink but whose target
+/// does not resolve is therefore exactly the broken case we need to remove.
+/// A symlink that resolves correctly to an existing directory or file is
+/// intentional (a symlink farm) and must be left untouched.
+///
+/// At most one of `dir` and `file` is `Some` at any time: a broken directory
+/// symlink makes the leaf unobservable, so `file` is only populated when the
+/// directory chain is sound.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct BrokenLinks {
+    /// Shallowest broken directory symlink in the ancestor chain, if any.
+    dir: Option<PathBuf>,
+    /// Broken symlink at the skill-file position itself (only set when `dir` is
+    /// `None`), if any.
+    file: Option<PathBuf>,
+}
+
+impl BrokenLinks {
+    fn is_empty(&self) -> bool {
+        self.dir.is_none() && self.file.is_none()
+    }
+
+    fn paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.dir.iter().chain(self.file.iter())
+    }
+}
+
+/// Returns `true` when `path` is a symlink that does **not** resolve to a
+/// usable directory (i.e. it is broken or points at a non-directory target).
+///
+/// A symlink pointing at an existing regular file at a directory position is
+/// treated as broken because `create_dir_all` would fail on it regardless.
+/// Only the link itself is ever removed, never the file it points at.
+fn is_broken_dir_link(path: &Path) -> bool {
+    path.is_symlink() && !path.is_dir()
+}
+
+/// Returns `true` when `path` is a symlink that does **not** resolve to a
+/// usable regular file.
+fn is_broken_file_link(path: &Path) -> bool {
+    path.is_symlink() && !path.is_file()
+}
+
+/// Walk the ancestor chain of `dir` (shallowest first, bounded by `home`)
+/// and return the first broken directory symlink found.
+///
+/// `home` itself is never a repair candidate: we only consider paths that are
+/// strictly inside it.  A single broken link in the chain is the only
+/// observable case — if a shallower component is a dangling symlink,
+/// `symlink_metadata` on any deeper component fails with `ENOENT`, so
+/// `is_symlink()` returns `false` there.
+fn broken_dir_link(dir: &Path, home: &Path) -> Option<PathBuf> {
+    let mut chain: Vec<&Path> = dir
+        .ancestors()
+        .take_while(|p| p.starts_with(home) && *p != home)
+        .collect();
+    chain.reverse();
+    chain
+        .into_iter()
+        .find(|p| is_broken_dir_link(p))
+        .map(PathBuf::from)
+}
+
+/// Inspect `path` for broken symlinks that would prevent writing it.
+///
+/// The leaf is only inspected when the directory chain is sound: a broken
+/// directory link makes the leaf unobservable, and the repair recreates the
+/// subtree as real directories anyway.
+fn detect_broken_links(path: &Path, home: &Path) -> BrokenLinks {
+    let dir = path.parent().and_then(|p| broken_dir_link(p, home));
+    let file = (dir.is_none() && is_broken_file_link(path)).then(|| path.to_path_buf());
+    BrokenLinks { dir, file }
+}
+
+/// Remove all broken symlinks listed in `links`.
+///
+/// `std::fs::remove_file` on a symlink removes the link itself, never the
+/// target — so a valid symlink farm is never disturbed (valid links are never
+/// present in `links`).
+fn repair_broken_links(links: &BrokenLinks) -> Result<()> {
+    for p in links.paths() {
+        std::fs::remove_file(p)
+            .with_context(|| format!("Failed to remove broken symlink {}", p.display()))?;
+    }
+    Ok(())
+}
+
 /// Generate the content to write for a given location given the remote body.
 ///
 /// For `has_frontmatter = true` files we prepend a minimal YAML front-matter so
@@ -423,6 +513,99 @@ pub fn run_list() -> Result<()> {
     Ok(())
 }
 
+/// Outcome of a single per-harness update attempt.
+enum HarnessOutcome {
+    Updated,
+    Skipped,
+    Planned,
+}
+
+/// Attempt to install or refresh the skill file for a single harness location.
+///
+/// Broken symlinks at the directory or file position are detected and repaired
+/// before writing (in the non-dry-run path).  A valid symlink farm (symlinks
+/// resolving to existing targets) is left completely intact and written through.
+///
+/// The dry-run branch is strictly read-only: no `remove_file`, `create_dir_all`,
+/// or `write` calls are made.
+fn update_location(
+    loc: &SkillLocation,
+    remote_body: &str,
+    dry_run: bool,
+) -> Result<HarnessOutcome> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let path = home.join(loc.relative_path);
+
+    let content = build_content(remote_body, loc);
+    let file_exists = path.exists();
+    let needs_update = std::fs::read(&path)
+        .map(|installed| installed != content.as_bytes())
+        .unwrap_or(true);
+
+    if !needs_update && file_exists {
+        println!(
+            "{}  {} {}",
+            "✓".green(),
+            loc.name.cyan(),
+            "already up to date".dimmed(),
+        );
+        return Ok(HarnessOutcome::Skipped);
+    }
+
+    let action = if file_exists { "update" } else { "install" };
+    let result = if file_exists { "updated" } else { "installed" };
+    let broken = detect_broken_links(&path, &home);
+
+    if dry_run {
+        for p in broken.paths() {
+            println!(
+                "{}  {} {}",
+                "⚠".yellow(),
+                loc.name.cyan(),
+                format!(
+                    "would replace broken symlink {} with a real path",
+                    p.display()
+                )
+                .yellow(),
+            );
+        }
+        println!(
+            "{}  {} {}",
+            "→".cyan(),
+            loc.name.cyan(),
+            format!("would {action}: {}", path.display()).dimmed(),
+        );
+        return Ok(HarnessOutcome::Planned);
+    }
+
+    if !broken.is_empty() {
+        repair_broken_links(&broken)?;
+        for p in broken.paths() {
+            println!(
+                "{}  {} {}",
+                "⚠".yellow(),
+                loc.name.cyan(),
+                format!("replaced broken symlink {} with a real path", p.display()).yellow(),
+            );
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+    std::fs::write(&path, &content)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    println!(
+        "{}  {} {}",
+        "✓".green(),
+        loc.name.cyan(),
+        format!("{result}: {}", path.display()).dimmed(),
+    );
+    Ok(HarnessOutcome::Updated)
+}
+
 pub fn run_update(dry_run: bool) -> Result<()> {
     let (sel, origin) = configured_selection_with_origin();
     run_update_with(dry_run, &sel, origin)
@@ -442,6 +625,7 @@ pub fn run_update_with(
         return Ok(());
     }
 
+    let total = locations.len();
     let harness_ids: Vec<String> = locations.iter().map(|loc| loc.id.to_string()).collect();
 
     println!("{}", format_update_command_line(dry_run, &origin).bold());
@@ -470,76 +654,56 @@ pub fn run_update_with(
 
     let mut updated = 0usize;
     let mut skipped = 0usize;
+    let mut failed = 0usize;
+    let mut failed_names: Vec<&'static str> = Vec::new();
 
-    for loc in locations {
-        let Some(path) = skill_path(loc) else {
-            continue;
-        };
-
-        let content = build_content(&remote_body, loc);
-        let file_exists = path.exists();
-        let needs_update = std::fs::read(&path)
-            .map(|installed| installed != content.as_bytes())
-            .unwrap_or(true);
-
-        if !needs_update && file_exists {
-            println!(
-                "{}  {} {}",
-                "✓".green(),
-                loc.name.cyan(),
-                "already up to date".dimmed(),
-            );
-            skipped += 1;
-            continue;
-        }
-
-        let action = if file_exists { "update" } else { "install" };
-        let result = if file_exists { "updated" } else { "installed" };
-
-        if dry_run {
-            println!(
-                "{}  {} {}",
-                "→".cyan(),
-                loc.name.cyan(),
-                format!("would {action}: {}", path.display()).dimmed(),
-            );
-        } else {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)
-                    .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    for loc in &locations {
+        match update_location(loc, &remote_body, dry_run) {
+            Ok(HarnessOutcome::Updated) => updated += 1,
+            Ok(HarnessOutcome::Skipped) => skipped += 1,
+            Ok(HarnessOutcome::Planned) => {}
+            Err(err) => {
+                failed += 1;
+                failed_names.push(loc.name);
+                println!(
+                    "{}  {} {}",
+                    "✗".red(),
+                    loc.name.cyan(),
+                    format!("failed: {err:#}").red(),
+                );
             }
-            std::fs::write(&path, &content)
-                .with_context(|| format!("Failed to write {}", path.display()))?;
-
-            println!(
-                "{}  {} {}",
-                "✓".green(),
-                loc.name.cyan(),
-                format!("{result}: {}", path.display()).dimmed(),
-            );
-            updated += 1;
         }
     }
 
     println!();
+    let names = failed_names.join(", ");
     if dry_run {
         println!("{}", "Dry run complete — no files were written.".dimmed());
-    } else if updated == 0 {
+    } else if updated == 0 && failed == 0 {
         println!("{}", "All skill files are already up to date.".green());
-    } else {
+    } else if updated > 0 {
+        let skipped_part = if skipped > 0 {
+            format!(", {skipped} already current")
+        } else {
+            String::new()
+        };
+        let failed_part = if failed > 0 {
+            format!(", {failed} failed")
+        } else {
+            String::new()
+        };
         println!(
             "{}",
-            format!(
-                "Updated {} skill file(s){}.",
-                updated,
-                if skipped > 0 {
-                    format!(", {skipped} already current")
-                } else {
-                    String::new()
-                }
-            )
-            .green()
+            format!("Updated {updated} skill file(s){skipped_part}{failed_part}.").green()
         );
+    }
+
+    if failed > 0 {
+        println!(
+            "{}",
+            format!("Failed to update {failed} of {total} harness(es): {names}").red()
+        );
+        bail!("{failed} harness(es) failed to update: {names}");
     }
 
     Ok(())
@@ -629,6 +793,72 @@ pub fn propose_skills_update() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn detect_broken_links_flags_dangling_dir_symlink() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = root.path().to_path_buf();
+        // Create a skill directory as a broken symlink:
+        //   ~/.codex/skills exists (real dir), but ~/.codex/skills/stax → missing
+        let skills_dir = home.join(".codex/skills");
+        std::fs::create_dir_all(&skills_dir).expect("create skills dir");
+        let link = skills_dir.join("stax");
+        symlink(home.join("missing"), &link).expect("create broken symlink");
+
+        let path = link.join("SKILL.md");
+        let result = detect_broken_links(&path, &home);
+        assert_eq!(result.dir, Some(link));
+        assert!(result.file.is_none());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn detect_broken_links_ignores_valid_dir_symlink() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = root.path().to_path_buf();
+        // Create a real target directory and a symlink pointing at it.
+        let target = home.join("dotfiles/stax-skill");
+        std::fs::create_dir_all(&target).expect("create target");
+        let skills_dir = home.join(".codex/skills");
+        std::fs::create_dir_all(&skills_dir).expect("create skills dir");
+        let link = skills_dir.join("stax");
+        symlink(&target, &link).expect("create valid symlink");
+
+        let path = link.join("SKILL.md");
+        let result = detect_broken_links(&path, &home);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn detect_broken_links_flags_dangling_file_symlink() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = root.path().to_path_buf();
+        // Real directory, but the SKILL.md is a broken symlink.
+        let skill_dir = home.join(".codex/skills/stax");
+        std::fs::create_dir_all(&skill_dir).expect("create dir");
+        let path = skill_dir.join("SKILL.md");
+        symlink(home.join("nonexistent/SKILL.md"), &path).expect("create broken file symlink");
+
+        let result = detect_broken_links(&path, &home);
+        assert!(result.dir.is_none());
+        assert_eq!(result.file, Some(path));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn broken_dir_link_stops_at_home() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = root.path().to_path_buf();
+        // home itself is never a repair candidate, even if it is a dangling symlink.
+        // We call broken_dir_link with home as both dir and home — it should return None.
+        let result = broken_dir_link(&home, &home);
+        assert!(result.is_none());
+    }
 
     #[test]
     fn test_extract_html_comment_version() {

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -122,6 +122,8 @@ mod runtime_safety_tests;
 mod scoped_submit_tests;
 #[path = "skills_selection_tests.rs"]
 mod skills_selection_tests;
+#[path = "skills_symlink_tests.rs"]
+mod skills_symlink_tests;
 #[path = "split_hunk_tests.rs"]
 mod split_hunk_tests;
 #[path = "split_tests.rs"]

--- a/tests/skills_symlink_tests.rs
+++ b/tests/skills_symlink_tests.rs
@@ -1,0 +1,322 @@
+//! Integration tests for broken-symlink repair in `stax skills update`.
+
+use crate::common::stax_bin;
+use std::process::Command;
+use tempfile::tempdir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SKILLS_BODY: &str = "<!-- stax-skills-version: 0.51.0 -->\n# Stax Skills\n";
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn base_cmd(home: &std::path::Path, skills_url: &str, args: &[&str]) -> Command {
+    let config_dir = home.join(".config/stax");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    let mut cmd = Command::new(stax_bin());
+    cmd.args(args)
+        .current_dir(home)
+        .env("HOME", home)
+        .env("STAX_CONFIG_DIR", &config_dir)
+        .env("STAX_DISABLE_UPDATE_CHECK", "1")
+        .env("STAX_SKILLS_URL", skills_url);
+    cmd
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn skills_update_replaces_dangling_skill_dir_symlink() {
+    use std::os::unix::fs::symlink;
+
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SKILLS_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let home_dir = tempdir().expect("home");
+    let home = home_dir.path();
+    let skills_dir = home.join(".codex/skills");
+    std::fs::create_dir_all(&skills_dir).expect("create skills dir");
+    // Create a dangling symlink: .codex/skills/stax → missing target
+    let link = skills_dir.join("stax");
+    symlink(home.join("missing-dotfiles/stax"), &link).expect("create broken symlink");
+
+    let output = base_cmd(
+        home,
+        &format!("{}/skills.md", mock_server.uri()),
+        &["skills", "update", "--skills", "codex"],
+    )
+    .output()
+    .expect("run skills update");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        output.status.success(),
+        "exit status: {:?}\n{combined}",
+        output.status
+    );
+
+    let skill_file = home.join(".codex/skills/stax/SKILL.md");
+    // The symlink should have been removed and replaced with a real directory.
+    assert!(
+        !home.join(".codex/skills/stax").is_symlink(),
+        "stax should be a real dir, not a symlink"
+    );
+    assert!(
+        home.join(".codex/skills/stax").is_dir(),
+        "stax should now be a real directory"
+    );
+    assert!(skill_file.exists(), "SKILL.md should exist");
+    let content = std::fs::read_to_string(&skill_file).expect("read SKILL.md");
+    assert!(content.contains("# Stax Skills"), "content: {content}");
+    assert!(
+        stdout.contains("replaced broken symlink"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !combined.contains("File exists"),
+        "should not contain 'File exists': {combined}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn skills_update_writes_through_valid_dir_symlink() {
+    use std::os::unix::fs::symlink;
+
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SKILLS_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let home_dir = tempdir().expect("home");
+    let home = home_dir.path();
+    // Real target dir that the symlink will point at.
+    let target = home.join("dotfiles/stax-skill");
+    std::fs::create_dir_all(&target).expect("create target");
+    let skills_dir = home.join(".codex/skills");
+    std::fs::create_dir_all(&skills_dir).expect("create skills dir");
+    // Valid symlink: .codex/skills/stax → ~/dotfiles/stax-skill
+    let link = skills_dir.join("stax");
+    symlink(&target, &link).expect("create valid symlink");
+
+    let output = base_cmd(
+        home,
+        &format!("{}/skills.md", mock_server.uri()),
+        &["skills", "update", "--skills", "codex"],
+    )
+    .output()
+    .expect("run skills update");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        output.status.success(),
+        "exit status: {:?}\n{combined}",
+        output.status
+    );
+
+    // The symlink must still be a symlink (not replaced).
+    assert!(
+        link.is_symlink(),
+        ".codex/skills/stax should still be a symlink"
+    );
+    // The file should be written through the symlink into the real target.
+    assert!(
+        target.join("SKILL.md").exists(),
+        "SKILL.md should exist inside the target dir"
+    );
+    assert!(
+        !stdout.contains("replaced broken symlink"),
+        "must not report replacing a valid symlink; stdout: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn skills_update_continues_after_harness_failure_and_exits_nonzero() {
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SKILLS_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let home_dir = tempdir().expect("home");
+    let home = home_dir.path();
+    // Force a non-symlink failure for the first harness (Codex):
+    // create .codex/skills as a real dir, then write a regular *file* named
+    // .codex/skills/stax — create_dir_all on it will fail with ENOTDIR.
+    std::fs::create_dir_all(home.join(".codex/skills")).expect("create skills dir");
+    std::fs::write(home.join(".codex/skills/stax"), "not a dir").expect("write obstacle");
+
+    let output = base_cmd(
+        home,
+        &format!("{}/skills.md", mock_server.uri()),
+        &["skills", "update", "--all"],
+    )
+    .output()
+    .expect("run skills update --all");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    // Overall exit code must be non-zero.
+    assert!(
+        !output.status.success(),
+        "should exit non-zero; combined: {combined}"
+    );
+
+    // Codex failure must be reported.
+    assert!(
+        combined.contains("Codex"),
+        "should mention Codex; combined: {combined}"
+    );
+    assert!(
+        combined.contains("failed"),
+        "should mention failed; combined: {combined}"
+    );
+    assert!(
+        stderr.contains("harness(es) failed to update"),
+        "stderr: {stderr}"
+    );
+
+    // The obstacle file must not have been deleted (our repair only removes symlinks).
+    assert!(
+        home.join(".codex/skills/stax").is_file(),
+        ".codex/skills/stax should remain a regular file"
+    );
+
+    // All four later harnesses must have been written successfully.
+    assert!(
+        home.join(".config/opencode/skills/stax/SKILL.md").exists(),
+        "opencode skill missing"
+    );
+    assert!(
+        home.join(".claude/skills/stax/SKILL.md").exists(),
+        "claude skill missing"
+    );
+    assert!(
+        home.join(".cursor/skills/stax/SKILL.md").exists(),
+        "cursor skill missing"
+    );
+    assert!(
+        home.join(".pi/agent/skills/stax/SKILL.md").exists(),
+        "pi skill missing"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn skills_update_dry_run_leaves_broken_symlink_intact() {
+    use std::os::unix::fs::symlink;
+
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SKILLS_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let home_dir = tempdir().expect("home");
+    let home = home_dir.path();
+    let skills_dir = home.join(".codex/skills");
+    std::fs::create_dir_all(&skills_dir).expect("create skills dir");
+    let link = skills_dir.join("stax");
+    symlink(home.join("missing-dotfiles/stax"), &link).expect("create broken symlink");
+
+    let output = base_cmd(
+        home,
+        &format!("{}/skills.md", mock_server.uri()),
+        &["skills", "update", "--skills", "codex", "--dry-run"],
+    )
+    .output()
+    .expect("run skills update --dry-run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        output.status.success(),
+        "dry-run should exit 0; combined: {combined}"
+    );
+
+    // Symlink must still be a symlink and still broken.
+    assert!(link.is_symlink(), "link should still be a symlink");
+    assert!(!link.is_dir(), "link should still be broken (not a dir)");
+    assert!(
+        !home.join(".codex/skills/stax/SKILL.md").exists(),
+        "SKILL.md must not be written in dry-run"
+    );
+    assert!(
+        stdout.contains("would replace broken symlink"),
+        "stdout: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn skills_update_replaces_broken_skill_file_symlink() {
+    use std::os::unix::fs::symlink;
+
+    ensure_crypto_provider();
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/skills.md"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SKILLS_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let home_dir = tempdir().expect("home");
+    let home = home_dir.path();
+    let skill_dir = home.join(".codex/skills/stax");
+    std::fs::create_dir_all(&skill_dir).expect("create real skill dir");
+    let skill_file = skill_dir.join("SKILL.md");
+    // Broken file symlink: target's parent doesn't exist.
+    symlink(home.join("missing-dir/SKILL.md"), &skill_file).expect("create broken file symlink");
+
+    let output = base_cmd(
+        home,
+        &format!("{}/skills.md", mock_server.uri()),
+        &["skills", "update", "--skills", "codex"],
+    )
+    .output()
+    .expect("run skills update");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        output.status.success(),
+        "exit status: {:?}\n{combined}",
+        output.status
+    );
+
+    // The broken symlink should have been replaced by a real file.
+    assert!(
+        !skill_file.is_symlink(),
+        "SKILL.md should no longer be a symlink"
+    );
+    assert!(skill_file.is_file(), "SKILL.md should now be a real file");
+    let content = std::fs::read_to_string(&skill_file).expect("read SKILL.md");
+    assert!(content.contains("# Stax Skills"), "content: {content}");
+    assert!(
+        stdout.contains("replaced broken symlink"),
+        "stdout: {stdout}"
+    );
+}


### PR DESCRIPTION
## Motivation

`stax skills update` aborted the entire run with a confusing error when a harness skill directory was a symlink that no longer resolved:

```
Error: Failed to create directory /Users/me/.codex/skills/stax: File exists (os error 17)
```

Two separate problems produced that outcome:

1. **A dangling symlink is unrecoverable.** Before writing, we call `std::fs::create_dir_all` on the skill directory. `mkdir` returns `EEXIST` because the symlink occupies the name, and `create_dir_all` then decides whether to swallow that by testing `path.is_dir()` — which *follows* the link. For a dangling link that is `false`, so the `EEXIST` surfaces as a hard error. (Had the target existed, the write would have gone through the symlink fine.) This is easy to hit with a dotfiles symlink farm whose target directory isn't present on the current machine.

2. **One bad harness killed the whole run.** The `?` inside the per-harness loop propagated out of `run_update_with`, so the four harnesses after the failing one were silently never updated.

## Description of changes / notes for reviewers

- Detect broken symlinks at both the skill-directory and `SKILL.md` positions before writing. Detection uses `is_symlink()` (does not follow) combined with `is_dir()`/`is_file()` (do follow), so "is a link but does not resolve to a usable target" is exactly the case we repair.
- Repair removes only the link via `remove_file`, never the target, then creates a real path. A visible yellow line reports the replacement so a link disappearing from the user's dotfiles isn't silent.
- **Symlinks that resolve correctly are left completely untouched and written through**, preserving intentional symlink farms. This is locked in by a dedicated test rather than left to reasoning.
- `--dry-run` stays strictly read-only: it reports `would replace broken symlink …` and performs no `remove_file`/`create_dir_all`/`write`.
- Per-harness failures are now non-fatal. Each prints `✗ <Harness> failed: <full anyhow chain>`, the loop continues, the summary reports the failure count, and the command exits non-zero via a final `bail!`.
- `maybe_install_skills` in `shell_setup.rs` downgrades the new error to a yellow warning, matching the existing precedent two lines above, so one bad harness path can't fail the whole `stax setup` wizard.
- Directory-symlink ancestor scanning is bounded by `$HOME`, so nothing at or above the home directory is ever a repair candidate.
- Non-symlink obstacles (e.g. a regular file sitting where the skill directory should be) are reported as failures and never deleted.

Docs: added one sentence to `docs/commands/reference.md` covering both behaviours. `README.md` and `skills.md` need no change — no command, flag, or workflow surface changed.

## Verification

Scoped draft gate, run locally on this branch head:

- `cargo check` — pass
- `make lint` (full, not just `lint-fast`) and `cargo fmt --check` — pass
- `git diff --check` — pass
- `cargo nextest run --lib commands::skills::tests::` — 27 passed, including 4 new unit tests for `detect_broken_links` / `broken_dir_link`
- `cargo nextest run skills_symlink_tests:: skills_selection_tests::` — 11 passed

New integration tests in `tests/skills_symlink_tests.rs` (registered in `tests/all_tests.rs`, `#[cfg(unix)]`) cover the happy path, the bad path, and the edge cases:

| Test | Covers |
|---|---|
| `skills_update_replaces_dangling_skill_dir_symlink` | The reported bug; asserts the output never contains `File exists` |
| `skills_update_writes_through_valid_dir_symlink` | A working symlink stays a symlink and is written through |
| `skills_update_continues_after_harness_failure_and_exits_nonzero` | A regular-file obstacle on the first harness still lets the other four update; exit is non-zero and the obstacle is not deleted |
| `skills_update_dry_run_leaves_broken_symlink_intact` | Dry run mutates nothing |
| `skills_update_replaces_broken_skill_file_symlink` | Broken `SKILL.md` link whose target parent is missing (a plain `fs::write` would fail `ENOENT`) |

Also verified against a real affected machine, which had two dead links (`~/.codex/skills/stax` and `~/.claude/skills/stax`, both pointing into a directory that no longer exists). `--dry-run` reported both; the real run replaced them and updated all five harnesses.

`cargo clippy --all-targets` reports two pre-existing `items after a test module` errors in `src/web/routes.rs` and `src/web/templates.rs`, unrelated to this change and present on `main` — which is why the repo's own `make lint` scopes clippy to lib and bins.

## Risk

Low and contained to `stax skills update` / `stax setup`. The one destructive operation is `remove_file` on a path already proven to be a symlink that does not resolve, so no reachable data can be lost. The new non-zero exit on partial failure is a deliberate behaviour change: `cli/mod.rs` maps it to exit code 1, and the two other callers (`doctor.rs` repair actions, `propose_skills_update`) propagate it consistently with every other failure in those paths.
