### PR TITLE
feat(ai): refresh LLM picker model IDs to current catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ When a rebase stops on a conflict, `st resolve` sends only the conflicted text f
 
 ```bash
 st resolve
-st resolve --agent codex --model gpt-5.3-codex
+st resolve --agent codex --model gpt-5.6-terra
 ```
 
 Before each rebase, stax also runs a **preflight repair** that compares the

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -107,7 +107,7 @@ single_stack = "on"    # "on" | "off"
 
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" | "pi" — global default
-# model = "claude-opus-4-8"
+# model = "claude-opus-5"
 
 # Per-feature overrides — optional, fall back to [ai] above
 [ai.generate]   # st create --ai, st gen / st generate, st submit --ai
@@ -118,7 +118,7 @@ single_stack = "on"    # "on" | "off"
 
 [ai.standup]    # st standup --ai
 # agent = "gemini"
-# model = "gemini-2.5-pro"
+# model = "gemini-3.8-flash"
 
 [ai.resolve]    # st resolve
 # agent = "claude"

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -18,7 +18,7 @@ Enables workflow assistance for stacked branch creation, submit flows, and relat
 st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent claude
-st generate --pr-body --agent claude --model claude-opus-4-8
+st generate --pr-body --agent claude --model claude-opus-5
 st gen --pr-title --agent claude
 st gen --commit-msg --agent claude
 ```

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -18,7 +18,7 @@ Enables workflow assistance for stacked branch creation, submit flows, and relat
 st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent codex
-st generate --pr-body --agent codex --model gpt-5.3-codex
+st generate --pr-body --agent codex --model gpt-5.6-terra
 st gen --pr-title --agent codex
 st gen --commit-msg --agent codex
 ```

--- a/docs/integrations/gemini-cli.md
+++ b/docs/integrations/gemini-cli.md
@@ -26,7 +26,7 @@ Gemini CLI loads hierarchical instructions from `GEMINI.md`, which gives it stax
 st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent gemini
-st generate --pr-body --agent gemini --model gemini-2.5-flash
+st generate --pr-body --agent gemini --model gemini-3.8-flash
 st gen --pr-title --agent gemini
 st gen --commit-msg --agent gemini
 ```

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -26,7 +26,7 @@ OpenCode loads skills from `~/.config/opencode/skills/<name>/SKILL.md`.
 st create --ai -a --yes
 st submit --ai
 st generate --pr-body --agent opencode
-st generate --pr-body --agent opencode --model opencode/gpt-5.5-fast
+st generate --pr-body --agent opencode --model opencode/gpt-5.6-terra
 st gen --pr-title --agent opencode
 st gen --commit-msg --agent opencode
 ```

--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -29,7 +29,7 @@ pi loads skills from `~/.pi/agent/skills/<name>/SKILL.md`.
 
 ```bash
 st generate --pr-body --agent pi
-st generate --pr-body --agent pi --model anthropic/claude-opus-4-8
+st generate --pr-body --agent pi --model anthropic/claude-opus-5
 st gen --pr-title --agent pi
 st gen --commit-msg --agent pi
 ```
@@ -38,7 +38,7 @@ st gen --commit-msg --agent pi
 
 ```bash
 st lane deep-dive --agent pi
-st lane deep-dive --agent pi --model anthropic/claude-opus-4-8 "trace the flaky test"
+st lane deep-dive --agent pi --model anthropic/claude-opus-5 "trace the flaky test"
 ```
 
 `--yolo` is not supported for pi (permission bypass is provided by opt-in

--- a/docs/integrations/pr-templates-and-ai.md
+++ b/docs/integrations/pr-templates-and-ai.md
@@ -159,9 +159,9 @@ stack_links = "body"   # or "both"
 ### More examples
 
 ```bash
-st generate --pr-body --agent codex --model gpt-5.3-codex
+st generate --pr-body --agent codex --model gpt-5.6-terra
 st generate --pr-body --agent claude --model claude-haiku-4-5
-st generate --pr-body --agent gemini --model gemini-2.5-flash
+st generate --pr-body --agent gemini --model gemini-3.8-flash
 st generate --pr-body --agent opencode
 st generate --pr-body --edit
 st generate --pr-body --template feature

--- a/docs/workflows/agent-worktrees.md
+++ b/docs/workflows/agent-worktrees.md
@@ -90,9 +90,9 @@ Supported `--agent` values: `claude`, `codex`, `gemini`, `opencode`, `pi`.
 
 ```bash
 st lane api-tests   --agent gemini
-st lane api-tests   --agent opencode --model opencode/gpt-5.5-fast
+st lane api-tests   --agent opencode --model opencode/gpt-5.6-terra
 st lane review-pass --agent codex "address the open PR comments"
-st lane deep-dive   --agent pi --model anthropic/claude-opus-4-8
+st lane deep-dive   --agent pi --model anthropic/claude-opus-5
 ```
 
 - `--model` requires `--agent`

--- a/skills.md
+++ b/skills.md
@@ -542,7 +542,7 @@ stax generate --pr-body --agent codex --model gpt-5
 stax lane                                         # Interactive lane picker (create or resume)
 stax lane add-dark-mode "Add dark mode"           # Start a named lane with a prompt
 stax lane add-dark-mode --agent codex             # Start a lane with a specific agent
-stax lane add-dark-mode --agent codex --model gpt-5.5-fast  # Override model too
+stax lane add-dark-mode --agent codex --model gpt-5.6-terra  # Override model too
 stax lane add-dark-mode                           # Re-enter the lane (reattaches tmux session)
 stax lane add-dark-mode "new prompt" --no-tmux    # Force direct terminal (no tmux)
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1192,7 +1192,7 @@ fn parse_model_version(model: &str) -> (i32, i32, i32) {
 }
 
 fn is_codex_picker_candidate(model: &str) -> bool {
-    model.starts_with("gpt-5") || model.starts_with("gpt-4.1")
+    model.starts_with("gpt-6") || model.starts_with("gpt-5") || model.starts_with("gpt-4.1")
 }
 
 fn model_matches_agent_family(agent: &str, model: &str) -> bool {
@@ -1491,31 +1491,36 @@ mod tests {
     #[test]
     fn known_models_include_gemini_defaults() {
         let models = known_models_for("gemini");
+        assert!(models.iter().any(|m| m.id == "gemini-3.8-flash"));
+        assert!(models.iter().any(|m| m.id == "gemini-3.5-flash-lite"));
         assert!(models.iter().any(|m| m.id == "gemini-2.5-pro"));
-        assert!(models.iter().any(|m| m.id == "gemini-2.5-flash"));
     }
 
     #[test]
     fn known_models_include_opencode_defaults() {
         let models = known_models_for("opencode");
-        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.5"));
-        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.5-fast"));
-        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.1-codex"));
+        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.6-sol"));
+        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.6-terra"));
+        assert!(models.iter().any(|m| m.id == "opencode/gpt-5.6-luna"));
     }
 
     #[test]
-    fn known_models_include_codex_gpt_5_5_defaults() {
+    fn known_models_include_codex_gpt_5_6_defaults() {
         let models = known_models_for("codex");
+        assert!(models.iter().any(|m| m.id == "gpt-6-astra"));
+        assert!(models.iter().any(|m| m.id == "gpt-5.6-sol"));
+        assert!(models.iter().any(|m| m.id == "gpt-5.6-terra"));
+        assert!(models.iter().any(|m| m.id == "gpt-5.6-luna"));
         assert!(models.iter().any(|m| m.id == "gpt-5.5"));
-        assert!(models.iter().any(|m| m.id == "gpt-5.5-fast"));
     }
 
     #[test]
     fn known_models_include_current_claude_defaults() {
         let models = known_models_for("claude");
-        assert!(models.iter().any(|m| m.id == "claude-opus-4-8"));
+        assert!(models.iter().any(|m| m.id == "claude-opus-5"));
         assert!(models.iter().any(|m| m.id == "claude-sonnet-5"));
         assert!(models.iter().any(|m| m.id == "claude-haiku-4-5"));
+        assert!(models.iter().any(|m| m.id == "claude-fable-5-1"));
     }
 
     #[test]
@@ -1550,6 +1555,9 @@ mod tests {
     fn live_codex_model_filter_keeps_latest_aliases() {
         let filtered = filter_live_codex_models(vec![
             OpenAiModel {
+                id: "gpt-6-astra".to_string(),
+            },
+            OpenAiModel {
                 id: "gpt-5.4-2026-03-05".to_string(),
             },
             OpenAiModel {
@@ -1567,7 +1575,7 @@ mod tests {
         ]);
 
         let ids: Vec<&str> = filtered.iter().map(|model| model.id.as_str()).collect();
-        assert_eq!(ids.first().copied(), Some("gpt-5.4"));
+        assert_eq!(ids.first().copied(), Some("gpt-6-astra"));
         assert!(ids.contains(&"gpt-5.4"));
         assert!(ids.contains(&"gpt-5.3-codex"));
         assert!(!ids.contains(&"gpt-5.4-2026-03-05"));
@@ -1596,7 +1604,7 @@ mod tests {
     #[test]
     fn resolve_model_ignores_opencode_model_for_other_agent() {
         let mut config = Config::default();
-        config.ai.model = Some("opencode/gpt-5.1-codex".to_string());
+        config.ai.model = Some("opencode/gpt-5.6-sol".to_string());
 
         let resolved = resolve_model(None, &config, "claude", "generate").unwrap();
         assert_eq!(resolved, None);
@@ -1623,17 +1631,21 @@ mod tests {
 
     #[test]
     fn known_agent_for_model_recognizes_newer_codex_family_models() {
+        assert_eq!(known_agent_for_model("gpt-6-astra"), Some("codex"));
+        assert_eq!(known_agent_for_model("gpt-5.6-sol"), Some("codex"));
         assert_eq!(known_agent_for_model("gpt-5.5"), Some("codex"));
-        assert_eq!(known_agent_for_model("gpt-5.5-fast"), Some("codex"));
         assert_eq!(known_agent_for_model("gpt-5.4"), Some("codex"));
         assert_eq!(known_agent_for_model("gpt-5.4-pro"), Some("codex"));
     }
 
     #[test]
-    fn known_agent_for_model_recognizes_opencode_gpt_5_5_models() {
-        assert_eq!(known_agent_for_model("opencode/gpt-5.5"), Some("opencode"));
+    fn known_agent_for_model_recognizes_opencode_gpt_5_6_models() {
         assert_eq!(
-            known_agent_for_model("opencode/gpt-5.5-fast"),
+            known_agent_for_model("opencode/gpt-5.6-sol"),
+            Some("opencode")
+        );
+        assert_eq!(
+            known_agent_for_model("opencode/gpt-5.6-terra"),
             Some("opencode")
         );
     }

--- a/src/commands/models.json
+++ b/src/commands/models.json
@@ -1,29 +1,29 @@
 {
   "claude": [
-    { "id": "claude-opus-4-8",   "description": "Opus 4.8 · most capable · recommended" },
+    { "id": "claude-opus-5",    "description": "Opus 5 · most capable · recommended" },
     { "id": "claude-sonnet-5",   "description": "Sonnet 5 · balanced · fast" },
     { "id": "claude-haiku-4-5",  "description": "Haiku 4.5 · fastest · cheapest" },
-    { "id": "claude-fable-5",    "description": "Fable 5 · deepest reasoning · premium" },
-    { "id": "claude-opus-4-7",   "description": "Opus 4.7 · previous gen" },
+    { "id": "claude-fable-5-1",  "description": "Fable 5.1 · deepest reasoning · premium" },
+    { "id": "claude-opus-4-8",   "description": "Opus 4.8 · previous gen" },
     { "id": "claude-sonnet-4-6", "description": "Sonnet 4.6 · previous gen" }
   ],
   "codex": [
-    { "id": "gpt-5.5",       "description": "GPT-5.5 · latest · balanced" },
-    { "id": "gpt-5.5-fast",  "description": "GPT-5.5 Fast · fast · balanced" },
-    { "id": "gpt-5.4",       "description": "GPT-5.4 · latest · balanced" },
-    { "id": "gpt-5.4-pro",   "description": "GPT-5.4 Pro · most capable · premium" },
-    { "id": "gpt-5.4-mini",  "description": "GPT-5.4 Mini · fast · balanced" },
-    { "id": "gpt-5.4-nano",  "description": "GPT-5.4 Nano · fastest · cheapest" },
-    { "id": "gpt-5.3-codex", "description": "GPT-5.3 Codex · code-focused · prev gen" }
+    { "id": "gpt-6-astra",          "description": "GPT-6 Astra · most capable · recommended" },
+    { "id": "gpt-5.6-sol",          "description": "GPT-5.6 Sol · flagship" },
+    { "id": "gpt-5.6-terra",        "description": "GPT-5.6 Terra · balanced" },
+    { "id": "gpt-5.6-luna",         "description": "GPT-5.6 Luna · fastest · cheapest" },
+    { "id": "gpt-5.5",              "description": "GPT-5.5 · previous gen" },
+    { "id": "gpt-5.3-codex-spark",  "description": "GPT-5.3 Codex Spark · near-instant · preview" }
   ],
   "gemini": [
-    { "id": "gemini-2.5-pro",        "description": "Gemini 2.5 Pro · most capable" },
-    { "id": "gemini-2.5-flash",      "description": "Gemini 2.5 Flash · fast · cheap" },
-    { "id": "gemini-2.5-flash-lite", "description": "Gemini 2.5 Flash-Lite · fastest · cheapest" }
+    { "id": "gemini-3.8-flash",      "description": "Gemini 3.8 Flash · most capable · recommended" },
+    { "id": "gemini-3.7-flash",      "description": "Gemini 3.7 Flash · previous Flash" },
+    { "id": "gemini-3.5-flash-lite", "description": "Gemini 3.5 Flash-Lite · fastest · cheapest" },
+    { "id": "gemini-2.5-pro",        "description": "Gemini 2.5 Pro · previous Pro family" }
   ],
   "opencode": [
-    { "id": "opencode/gpt-5.5",      "description": "GPT-5.5 via OpenCode" },
-    { "id": "opencode/gpt-5.5-fast", "description": "GPT-5.5 Fast via OpenCode" },
-    { "id": "opencode/gpt-5.1-codex", "description": "GPT-5.1 Codex via OpenCode" }
+    { "id": "opencode/gpt-5.6-sol",   "description": "GPT-5.6 Sol via OpenCode" },
+    { "id": "opencode/gpt-5.6-terra", "description": "GPT-5.6 Terra via OpenCode" },
+    { "id": "opencode/gpt-5.6-luna",  "description": "GPT-5.6 Luna via OpenCode" }
   ]
 }

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -62,7 +62,7 @@
 
 [ai]
 # agent = "claude" # "codex" | "gemini" | "opencode" | "pi" — global default
-# model = "claude-opus-4-8"
+# model = "claude-opus-5"
 
 # Per-feature overrides — optional, fall back to [ai] above
 [ai.generate]   # st create --ai, st gen / st generate, st submit --ai
@@ -73,7 +73,7 @@
 
 [ai.standup]    # st standup --ai
 # agent = "gemini"
-# model = "gemini-2.5-pro"
+# model = "gemini-3.8-flash"
 
 [ai.resolve]    # st resolve
 # agent = "claude"


### PR DESCRIPTION
## Motivation

The interactive AI model picker (and docs/examples) still listed last-generation IDs: Claude Opus 4.8, GPT-5.4/5.5-fast, Gemini 2.5 Flash, and deprecated OpenCode Codex IDs. Those no longer match current Anthropic, OpenAI Codex, Gemini, and OpenCode Console catalogs.

## Description of changes / notes for reviewers

- Refresh `src/commands/models.json` fallback lists for Claude, Codex, Gemini, and OpenCode.
- Accept `gpt-6*` in the live OpenAI Codex picker filter.
- Update unit tests, commented config examples, README, `skills.md`, and integration docs to the new IDs.
- Custom `--model` values are unchanged; this list is the interactive fallback when live APIs are unavailable.

## Test plan

- [x] `cargo nextest run known_models_include_ generate::tests:: --lib`
- [x] `make lint-fast`
- Scoped draft gate only (catalog/docs change; not shared `engine/` or `git/repo.rs`).