### PR TITLE
fix: lowercase generated branch names

### DIFF
--- a/docs/commands/core.md
+++ b/docs/commands/core.md
@@ -25,6 +25,8 @@ st create --below -am "fix: patch CVE-2026-0001"
 `--below` auto-stashes prepared tracked and untracked changes before moving to the lower base, then reapplies them on the inserted branch. With `-am`, those changes are staged and committed on the new lower branch.
 When `-m` or `--ai` derives a branch name that already exists, Stax stops instead of creating a suffixed duplicate; pass an explicit different name or checkout/reparent the existing branch.
 
+Branch names are lowercased — `st create -am "Bump Fastlane Version"` creates `bump-fastlane-version` and commits `Bump Fastlane Version` unchanged. Set [`branch.lowercase = false`](../configuration/index.md#branch-name-casing) to keep the original casing.
+
 ## Submit and merge
 
 | Command | What it does |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -60,6 +60,7 @@ single_stack = "on"    # "on" | "off"
 # user = "cesar"
 # date_format = "%m-%d"
 # replacement = "-"
+# lowercase = true # lowercase generated branch names (commit messages keep their casing)
 # stale_days = 30 # days without commits before `stax sweep` calls a branch stale
 
 [git]
@@ -243,6 +244,15 @@ date_format = "%m-%d"
 ```
 
 The legacy `prefix` field still works when `format` is unset.
+
+### Branch name casing
+
+Generated branch names are lowercased by default, so `st create -am "Bump Fastlane Version"` produces the branch `bump-fastlane-version` while committing the message exactly as typed. Set `lowercase = false` to keep the original casing:
+
+```toml
+[branch]
+lowercase = false
+```
 
 ## Stale-branch threshold
 

--- a/skills.md
+++ b/skills.md
@@ -204,6 +204,8 @@ stax create --below -am "message"  # Auto-stash/apply, stage all, commit on new 
 stax bc <name>                     # Hidden shortcut alias
 # create -m/-am commits before branch creation, including --from/--below,
 # so hook failures or interrupts do not leave orphan branches or -2 retries.
+# Generated branch names are lowercased ("Bump Fastlane" -> bump-fastlane);
+# the commit message keeps its original casing. Opt out with branch.lowercase = false.
 # -m/--ai derived branch names refuse collisions instead of creating -2 duplicates.
 # --below keeps prepared work in place by stashing before moving downstack,
 # then applying it on the inserted lower branch.

--- a/src/application/branch_name.rs
+++ b/src/application/branch_name.rs
@@ -7,6 +7,9 @@ pub(crate) struct BranchNameContext {
     pub legacy_date: bool,
     pub date_format: String,
     pub replacement: String,
+    /// Lowercase the generated branch name. Only affects the branch name —
+    /// callers keep the original text for commit messages.
+    pub lowercase: bool,
     pub user: Option<String>,
     pub date: chrono::NaiveDate,
 }
@@ -19,6 +22,7 @@ impl BranchNameContext {
             legacy_date: false,
             date_format: "%Y-%m-%d".into(),
             replacement: "-".into(),
+            lowercase: true,
             user: None,
             date: chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
         }
@@ -42,7 +46,7 @@ pub(crate) fn format_branch_name(
     input: &str,
     context: &BranchNameContext,
 ) -> Result<BranchNameResult, BranchNameError> {
-    let message = sanitize_branch_segment(input, &context.replacement);
+    let message = sanitize_segment(input, context);
     let mut candidate = if let Some(format) = &context.format {
         if !format.contains("{message}") {
             return Err(BranchNameError::MissingMessagePlaceholder {
@@ -62,6 +66,10 @@ pub(crate) fn format_branch_name(
         }
         apply_prefix(name, context.prefix.as_deref())
     };
+
+    if context.lowercase {
+        candidate = candidate.to_lowercase();
+    }
 
     if candidate.is_empty() {
         return Err(BranchNameError::Empty);
@@ -96,7 +104,7 @@ fn apply_format_template(template: &str, message: &str, context: &BranchNameCont
     let user = context
         .user
         .as_deref()
-        .map(|user| sanitize_branch_segment(user, &context.replacement))
+        .map(|user| sanitize_segment(user, context))
         .unwrap_or_default();
     if result.contains("{user}") {
         result = result.replace("{user}", &user);
@@ -128,6 +136,17 @@ fn apply_prefix(mut name: String, prefix: Option<&str>) -> String {
         name = format!("{prefix}{name}");
     }
     name
+}
+
+/// Sanitize a segment and apply the configured casing. Lowercasing the segments
+/// (not just the assembled name) keeps the `{user}` dedupe below comparable.
+fn sanitize_segment(segment: &str, context: &BranchNameContext) -> String {
+    let sanitized = sanitize_branch_segment(segment, &context.replacement);
+    if context.lowercase {
+        sanitized.to_lowercase()
+    } else {
+        sanitized
+    }
 }
 
 fn sanitize_branch_segment(segment: &str, replacement: &str) -> String {
@@ -190,18 +209,67 @@ mod tests {
             legacy_date: false,
             date_format: "%Y-%m-%d".into(),
             replacement: "-".into(),
+            lowercase: true,
+            user: Some("César Ferreira".into()),
+            date: chrono::NaiveDate::from_ymd_opt(2026, 7, 12).unwrap(),
+        };
+        let result = format_branch_name("  Fix GUI!  ", &context).unwrap();
+        assert_eq!(result.name, "césar-ferreira/fix-gui");
+        assert_eq!(
+            result.warnings,
+            vec![OperationWarning::BranchNameNormalized {
+                original: "  Fix GUI!  ".into(),
+                normalized: "césar-ferreira/fix-gui".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn format_branch_name_preserves_case_when_lowercase_is_disabled() {
+        let context = BranchNameContext {
+            format: Some("{user}/{message}".into()),
+            prefix: None,
+            legacy_date: false,
+            date_format: "%Y-%m-%d".into(),
+            replacement: "-".into(),
+            lowercase: false,
             user: Some("César Ferreira".into()),
             date: chrono::NaiveDate::from_ymd_opt(2026, 7, 12).unwrap(),
         };
         let result = format_branch_name("  Fix GUI!  ", &context).unwrap();
         assert_eq!(result.name, "César-Ferreira/Fix-GUI");
-        assert_eq!(
-            result.warnings,
-            vec![OperationWarning::BranchNameNormalized {
-                original: "  Fix GUI!  ".into(),
-                normalized: "César-Ferreira/Fix-GUI".into(),
-            }]
-        );
+    }
+
+    #[test]
+    fn format_branch_name_lowercases_prefix_and_template_literals() {
+        let context = BranchNameContext {
+            format: None,
+            prefix: Some("Cesar/Feature".into()),
+            legacy_date: false,
+            date_format: "%Y-%m-%d".into(),
+            replacement: "-".into(),
+            lowercase: true,
+            user: None,
+            date: chrono::NaiveDate::from_ymd_opt(2026, 7, 12).unwrap(),
+        };
+        let result = format_branch_name("Bump Fastlane Version", &context).unwrap();
+        assert_eq!(result.name, "cesar/feature/bump-fastlane-version");
+    }
+
+    #[test]
+    fn format_branch_name_dedupes_leading_user_segment_across_case() {
+        let context = BranchNameContext {
+            format: Some("{user}/{message}".into()),
+            prefix: None,
+            legacy_date: false,
+            date_format: "%Y-%m-%d".into(),
+            replacement: "-".into(),
+            lowercase: true,
+            user: Some("Cesar".into()),
+            date: chrono::NaiveDate::from_ymd_opt(2026, 7, 12).unwrap(),
+        };
+        let result = format_branch_name("cesar/Fix Thing", &context).unwrap();
+        assert_eq!(result.name, "cesar/fix-thing");
     }
 
     #[test]
@@ -212,6 +280,7 @@ mod tests {
             legacy_date: false,
             date_format: "%Y-%m-%d".into(),
             replacement: "-".into(),
+            lowercase: true,
             user: Some("cesar".into()),
             date: chrono::NaiveDate::from_ymd_opt(2026, 7, 12).unwrap(),
         };

--- a/src/commands/branch/create.rs
+++ b/src/commands/branch/create.rs
@@ -397,6 +397,7 @@ fn branch_name_context(
         legacy_date: config.branch.date,
         date_format: config.branch.date_format.clone(),
         replacement: config.branch.replacement.clone(),
+        lowercase: config.branch.lowercase,
         user,
         date: chrono::Local::now().date_naive(),
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -124,6 +124,10 @@ pub struct BranchConfig {
     /// Character to replace spaces and special chars (default: "-")
     #[serde(default = "default_replacement")]
     pub replacement: String,
+    /// Lowercase generated branch names (default: true). Commit messages are
+    /// never affected — only the branch name derived from them.
+    #[serde(default = "default_branch_lowercase")]
+    pub lowercase: bool,
     /// Branch name format template. Placeholders:
     /// - {user}: Git username (from config.branch.user or git user.name)
     /// - {date}: Current date (formatted by date_format)
@@ -487,6 +491,7 @@ impl Default for BranchConfig {
             date: false,
             date_format: default_date_format(),
             replacement: default_replacement(),
+            lowercase: default_branch_lowercase(),
             format: None,
             user: None,
             stale_days: default_stale_days(),
@@ -535,6 +540,10 @@ impl Default for AuthConfig {
 
 fn default_replacement() -> String {
     "-".to_string()
+}
+
+fn default_branch_lowercase() -> bool {
+    true
 }
 
 fn default_worktree_root_dir() -> String {
@@ -1078,6 +1087,15 @@ impl Config {
         name: &str,
         prefix_override: Option<&str>,
     ) -> String {
+        let formatted = self.build_branch_name(name, prefix_override);
+        if self.branch.lowercase {
+            formatted.to_lowercase()
+        } else {
+            formatted
+        }
+    }
+
+    fn build_branch_name(&self, name: &str, prefix_override: Option<&str>) -> String {
         // Sanitize the message/name first
         let sanitized_name = self.sanitize_branch_segment(name);
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1324,6 +1324,29 @@ fn test_format_branch_name_consecutive_replacements_collapsed() {
 }
 
 #[test]
+fn test_format_branch_name_lowercases_by_default() {
+    let mut config = Config::default();
+    config.branch.format = Some("{user}/{message}".to_string());
+    config.branch.user = Some("Cesar".to_string());
+    assert_eq!(
+        config.format_branch_name("Bump Fastlane Version"),
+        "cesar/bump-fastlane-version"
+    );
+}
+
+#[test]
+fn test_format_branch_name_lowercase_can_be_disabled() {
+    let mut config = Config::default();
+    config.branch.lowercase = false;
+    config.branch.format = Some("{user}/{message}".to_string());
+    config.branch.user = Some("Cesar".to_string());
+    assert_eq!(
+        config.format_branch_name("Bump Fastlane Version"),
+        "Cesar/Bump-Fastlane-Version"
+    );
+}
+
+#[test]
 fn test_token_priority_stax_env_first() {
     let _guard = env_lock();
 
@@ -2059,7 +2082,7 @@ fn test_format_template_sanitizes_user() {
     config.branch.user = Some("John Doe".to_string());
 
     let result = config.format_branch_name("feature");
-    assert_eq!(result, "John-Doe/feature");
+    assert_eq!(result, "john-doe/feature");
 }
 
 #[test]

--- a/tests/create_message_tests.rs
+++ b/tests/create_message_tests.rs
@@ -49,3 +49,46 @@ fn test_create_with_name_and_message_commits_with_that_message() {
         TestRepo::stderr(&show)
     );
 }
+
+#[test]
+fn test_create_with_message_lowercases_branch_but_not_commit_message() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    repo.create_file("fastlane.txt", "gem 'fastlane'\n");
+    repo.run_stax(&["create", "-a", "-m", "Bump Fastlane Version"])
+        .assert_success();
+
+    assert_eq!(repo.current_branch(), "bump-fastlane-version");
+
+    let subject = repo.git(&["log", "-1", "--pretty=%s"]);
+    assert_eq!(TestRepo::stdout(&subject).trim(), "Bump Fastlane Version");
+}
+
+#[test]
+fn test_create_lowercases_explicit_branch_name() {
+    let repo = TestRepo::new();
+    repo.run_stax(&["status"]).assert_success();
+
+    repo.run_stax(&["create", "My-Feature"]).assert_success();
+
+    assert_eq!(repo.current_branch(), "my-feature");
+}
+
+#[test]
+fn test_create_preserves_case_when_lowercase_disabled() {
+    let repo = TestRepo::new();
+    let home = std::path::PathBuf::from(repo.clean_home());
+    std::fs::write(
+        home.join(".config").join("stax").join("config.toml"),
+        "[branch]\nlowercase = false\n",
+    )
+    .expect("write stax config");
+    repo.run_stax(&["status"]).assert_success();
+
+    repo.create_file("fastlane.txt", "gem 'fastlane'\n");
+    repo.run_stax(&["create", "-a", "-m", "Bump Fastlane Version"])
+        .assert_success();
+
+    assert_eq!(repo.current_branch(), "Bump-Fastlane-Version");
+}

--- a/tests/guard_rail_tests.rs
+++ b/tests/guard_rail_tests.rs
@@ -13,7 +13,7 @@ use common::{OutputAssertions, TestRepo};
 #[test]
 fn undo_quiet_refuses_dirty_working_tree() {
     let repo = TestRepo::new();
-    repo.create_stack(&["A", "B"]);
+    repo.create_stack(&["a", "b"]);
 
     repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
     repo.run_stax(&["undo", "--yes"]).assert_success();
@@ -28,7 +28,7 @@ fn undo_quiet_refuses_dirty_working_tree() {
 #[test]
 fn redo_quiet_refuses_dirty_working_tree() {
     let repo = TestRepo::new();
-    repo.create_stack(&["A", "B"]);
+    repo.create_stack(&["a", "b"]);
 
     repo.run_stax(&["branch", "fold", "--yes"]).assert_success();
     repo.run_stax(&["undo", "--yes"]).assert_success();
@@ -43,9 +43,9 @@ fn redo_quiet_refuses_dirty_working_tree() {
 #[test]
 fn restack_quiet_refuses_dirty_working_tree() {
     let repo = TestRepo::new();
-    repo.create_stack(&["A", "B"]);
+    repo.create_stack(&["a", "b"]);
 
-    repo.run_stax(&["checkout", "A"]).assert_success();
+    repo.run_stax(&["checkout", "a"]).assert_success();
     repo.create_file("dirty.txt", "uncommitted");
 
     repo.run_stax(&["restack", "--quiet"])

--- a/tests/worktree_cli_tests.rs
+++ b/tests/worktree_cli_tests.rs
@@ -947,7 +947,7 @@ fn wt_ls_stays_compact_and_wt_ll_shows_status() {
 fn wt_ls_disambiguates_duplicate_leaf_names_with_branch_labels() {
     let repo = TestRepo::new();
 
-    repo.run_stax(&["create", "A"]).assert_success();
+    repo.run_stax(&["create", "a"]).assert_success();
     let branch_a = repo.current_branch();
     repo.run_stax(&["checkout", "main"]).assert_success();
 
@@ -970,7 +970,7 @@ fn wt_ls_disambiguates_duplicate_leaf_names_with_branch_labels() {
 
     let names = listed_worktree_names(&TestRepo::stdout(&ls));
     assert!(
-        names.iter().any(|name| name == "A"),
+        names.iter().any(|name| name == "a"),
         "expected branch leaf label for duplicate worktree, got {:?}",
         names
     );


### PR DESCRIPTION
## Motivation

`st create -am "Bump fastlane version"` produced the branch `cesar/Bump-fastlane-version`. Branch names should be lowercase; only the commit message should keep whatever casing was typed.

## Description of changes / notes for reviewers

- New `branch.lowercase` config (default `true`) lowercases generated branch names. Set it to `false` to keep the previous behaviour.
- `src/application/branch_name.rs`: `BranchNameContext` gains `lowercase`. Segments (`{message}`, `{user}`) are lowercased before assembly so the `{user}` dedupe still matches across case, and the assembled candidate is lowercased so prefixes and template literals are covered too.
- `src/config/mod.rs`: the legacy `Config::format_branch_name*` path applies the same casing after formatting (used by `rename` and worktree/lane branch names).
- Commit messages are untouched — `st create -am "Bump Fastlane Version"` creates `bump-fastlane-version` and commits `Bump Fastlane Version`.
- Docs updated: `docs/configuration/index.md` (new "Branch name casing" section + annotated template), `docs/commands/core.md`, `skills.md`.

## Verification

Full local gate (this change touches shared branch-naming logic used by create/rename/worktree):

- `make lint` — clean
- `make test` — 2738 passed, 0 failed
- New coverage: `create_message_tests::test_create_with_message_lowercases_branch_but_not_commit_message`, `::test_create_lowercases_explicit_branch_name`, `::test_create_preserves_case_when_lowercase_disabled`, plus unit tests in `branch_name.rs` and `config/tests.rs` for the default, the opt-out, prefix/template literals, and cross-case `{user}` dedupe.
- Three pre-existing tests asserted the old casing (`guard_rail_tests` stack names `A`/`B`, `worktree_cli_tests` leaf label `A`, `config::tests::test_format_template_sanitizes_user`); updated to the new expected behaviour.
